### PR TITLE
Adds an (optional, but on by default) prompt before picking up redundant XP evokers

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -51,12 +51,12 @@ The contents of this text are:
 3-g     Command Enhancements.
                 auto_switch, travel_open_doors, easy_unequip, equip_unequip,
                 jewellery_prompt, easy_confirm, allow_self_target,
-                confirm_butcher, easy_eat_chunks, easy_quit_item_prompts,
-                easy_exit_menu, sort_menus, spell_slot, autofight_stop,
-                autofight_throw, autofight_throw_nomove, autofight_fire_stop,
-                autofight_caught, automagic_enable, automagic_slot,
-                automagic_fight, automagic_stop, fail_severity_to_confirm,
-                easy_door
+                confirm_butcher, confirm_pickup_redundant, easy_eat_chunks,
+                easy_quit_item_prompts, easy_exit_menu, sort_menus, spell_slot,
+                autofight_stop, autofight_throw, autofight_throw_nomove,
+                autofight_fire_stop, autofight_caught, automagic_enable,
+                automagic_slot, automagic_fight, automagic_stop,
+                fail_severity_to_confirm, easy_door
 3-h     Message and Display Improvements.
                 hp_warning, mp_warning, hp_colour, mp_colour, stat_colour,
                 status_caption_colour, enemy_hp_colour, clear_messages,
@@ -972,6 +972,10 @@ confirm_butcher = (always | never | auto)
         If never, you will automatically butcher the first available corpse,
         even if there are multiple corpses on the square. If always, you will
         be prompted before butchering any number of corpses.
+
+confirm_pickup_redundant = true
+        If false you will be not be required to confirm picking up redundant
+        evocable items that become inert and recharge as a set.
 
 easy_eat_chunks = false
         If this is set to true then when using the (e)at command, the

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -801,6 +801,7 @@ void game_options::reset_options()
     jewellery_prompt       = false;
     easy_door              = true;
     confirm_butcher        = CONFIRM_AUTO;
+    confirm_pickup_redundant = true;
     easy_eat_chunks        = false;
     auto_eat_chunks        = false;
     easy_confirm           = CONFIRM_SAFE_EASY;
@@ -2678,6 +2679,7 @@ void game_options::read_option_line(const string &str, bool runscript)
         else if (field == "auto")
             confirm_butcher = CONFIRM_AUTO;
     }
+    else BOOL_OPTION(confirm_pickup_redundant);
     else BOOL_OPTION(easy_eat_chunks);
     else BOOL_OPTION(auto_eat_chunks);
     else if (key == "lua_file" && runscript)

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1223,6 +1223,28 @@ bool any_items_of_type(int selector, int excluded_slot)
     return false;
 }
 
+/**
+ * Does the player have any item with this base type and subtype?
+ *
+ * @param base_type     The base type of the item
+ * @param sub_type      The subtype of the item
+ * @return              Whether there are any items matching the given base type
+ *                      and subtype in the player's inventory.
+ */
+bool any_item_matching(int base_type, int sub_type) {
+    for (int i = 0; i < ENDOFPACK; i++)
+    {
+        if (you.inv[i].defined() &&
+            you.inv[i].base_type == base_type &&
+            you.inv[i].sub_type == sub_type)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Use title = nullptr for stock Inventory title
 // type = MT_DROP allows the multidrop toggle
 static unsigned char _invent_select(const char *title = nullptr,

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -181,6 +181,7 @@ void get_class_hotkeys(const int type, vector<char> &glyphs);
 
 bool is_item_selected(const item_def &item, int selector);
 bool any_items_of_type(int type_expect, int excluded_slot = -1);
+bool any_item_matching(int base_type, int sub_type);
 string no_selectables_message(int item_selector);
 
 string slot_description();

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1205,7 +1205,8 @@ bool pickup_single_item(int link, int qty)
         return false;
     }
 
-    if (is_xp_evoker(*item) &&
+    if (Options.confirm_pickup_redundant &&
+        is_xp_evoker(*item) &&
         any_item_matching(item->base_type, item->sub_type))
     {
         const string prompt = make_stringf("Are you sure you want to carry an additional %s?",

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1204,6 +1204,19 @@ bool pickup_single_item(int link, int qty)
         canned_msg(MSG_OK);
         return false;
     }
+
+    if (is_xp_evoker(*item) &&
+        any_item_matching(item->base_type, item->sub_type))
+    {
+        const string prompt = make_stringf("Are you sure you want to carry an additional %s?",
+                                           item->name(DESC_PLAIN, false,
+                                                      false, false).c_str());
+        if (!yesno(prompt.c_str(), true, 'n')) {
+            canned_msg(MSG_OK);
+            return false;
+        }
+    }
+
     if (qty == 0 && item->quantity > 1 && item->base_type != OBJ_GOLD)
     {
         const string prompt

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -184,6 +184,7 @@ public:
     bool        jewellery_prompt; // Always prompt for slot when changing jewellery.
     bool        easy_door;       // 'O', 'C' don't prompt with just one door.
     int         confirm_butcher; // When to prompt for butchery
+    bool        confirm_pickup_redundant; // When to prompt for picking up redundant XP evokers.
     bool        easy_eat_chunks; // make 'e' auto-eat the oldest safe chunk
     bool        auto_eat_chunks; // allow eating chunks while resting or travelling
     skill_focus_mode skill_focus; // is the focus skills available


### PR DESCRIPTION
In a recent game I ended up carrying around two lamps of fire for a long time before I used one of them and saw that they *both* went inert.  It looks like that's by design, but I think it would be nice for the game to warn the player that they're about to use up an inventory slot for no benefit, so I added a prompt before picking up a redundant xp evoker.