### PR TITLE
Remove the +9 bonus EV cap for Mf & Te.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2264,19 +2264,17 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
     else if (you.duration[DUR_GRASPING_ROOTS])
         prescaled_ev = prescaled_ev * 2 / 3;
 
-    // Merfolk get an evasion bonus in water.
+    // Merfolk get a 25% evasion bonus in water.
     if (you.fishtail)
     {
-        const int ev_bonus = min(9 * scale,
-                                 max(2 * scale, prescaled_ev / 4));
+        const int ev_bonus = max(2 * scale, prescaled_ev / 4);
         return prescaled_ev + ev_bonus;
     }
 
-    // Flying Tengu get an evasion bonus.
+    // Flying Tengu get a 20% evasion bonus.
     if (you.tengu_flight())
     {
-        const int ev_bonus = min(9 * scale,
-                                 max(1 * scale, prescaled_ev / 5));
+        const int ev_bonus = max(1 * scale, prescaled_ev / 5);
         return prescaled_ev + ev_bonus;
     }
 


### PR DESCRIPTION
The effect of removing this cap is very small -- few games hit it and
not by much when they do.

<chequers> !lg * te current / ev>54
<Sequell> 5/5906 games for * (te current): N=5/5906 (0.08%)
<chequers> !lg * mf current / ev>49
<Sequell> 6/7832 games for * (mf current): N=6/7832 (0.08%)

<chequers> !lg * te current ev>54 s=ev
<Sequell> 5 games for * (te current ev>54): 2x 55, 2x 59, 71
<chequers> !lg * mf current ev>49 s=ev
<Sequell> 6 games for * (mf current ev>49): 3x 51, 58, 59, 56