### PR TITLE
Rework Powered By Death.

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2566,40 +2566,48 @@ int monster_die(monster* mons, killer_type killer,
             corpse = corpse2;
     }
 
-    if ((killer == KILL_YOU
-         || killer == KILL_YOU_MISSILE
-         || killer == KILL_YOU_CONF
-         || pet_kill)
-             && corpse >= 0
-             && mitm[corpse].base_type != OBJ_GOLD
-             && player_mutation_level(MUT_POWERED_BY_DEATH))
+    // Player Powered by Death
+    if (player_mutation_level(MUT_POWERED_BY_DEATH)
+        && (killer == KILL_YOU
+            || killer == KILL_YOU_MISSILE
+            || killer == KILL_YOU_CONF
+            || pet_kill))
     {
+        // Set duration
         const int pbd_dur = player_mutation_level(MUT_POWERED_BY_DEATH) * 8
                             + roll_dice(2, 8);
+        const int pbd_str = you.props["powered_by_death_strength"].get_int();
         if (pbd_dur * BASELINE_DELAY > you.duration[DUR_POWERED_BY_DEATH])
             you.set_duration(DUR_POWERED_BY_DEATH, pbd_dur);
+
+        // Maybe increase strength. The chance decreases with number of
+        // existing stacks. Chance is:
+        // (0->1) 100%, (1->2) 90%, 80%, ...
+        // This implies a maximum strength of 10.
+        if (x_chance_in_y(10 - pbd_str, 10))
+        {
+            you.props["powered_by_death_strength"] = pbd_str + 1;
+            dprf("Incrementing Powered by Death strength to %d", pbd_str + 1);
+        }
     }
 
-    if (corpse >= 0 && mitm[corpse].base_type != OBJ_GOLD)
+    // Monster Powered by Death.
+    // Find nearby putrid demonspawn.
+    for (monster_near_iterator mi(mons->pos()); mi; ++mi)
     {
-        // Powered by death.
-        // Find nearby putrid demonspawn.
-        for (monster_near_iterator mi(mons->pos()); mi; ++mi)
+        monster* mon = *mi;
+        if (mon->alive()
+            && mons_is_demonspawn(mon->type)
+            && draco_or_demonspawn_subspecies(mon)
+               == MONS_PUTRID_DEMONSPAWN)
         {
-            monster* mon = *mi;
-            if (mon->alive()
-                && mons_is_demonspawn(mon->type)
-                && draco_or_demonspawn_subspecies(mon)
-                   == MONS_PUTRID_DEMONSPAWN)
+            // Rather than regen over time, the expected 24 + 2d8 duration
+            // is given as an instant health bonus.
+            // These numbers may need to be adjusted.
+            if (mon->heal(random2avg(24, 2) + roll_dice(2, 8)))
             {
-                // Rather than regen over time, the expected 24 + 2d8 duration
-                // is given as an instant health bonus.
-                // These numbers may need to be adjusted.
-                if (mon->heal(random2avg(24, 2) + roll_dice(2, 8)))
-                {
-                    simple_monster_message(mon,
-                                           " regenerates before your eyes!");
-                }
+                simple_monster_message(mon,
+                                       " regenerates before your eyes!");
             }
         }
     }

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2583,13 +2583,14 @@ int monster_die(monster* mons, killer_type killer,
         // Maybe increase strength. The chance decreases with number of
         // existing stacks. Chance is:
         // (0->1) 100%, (1->2) 90%, 80%, ...
-        // This implies a maximum strength of 10 (though you might get to 12
-        // with lucky rolls).
+        // The increase amount scales with mutation level.
+        // This implies a maximum strength of 10/11/12, though you'd have to be
+        // lucky to cap out!
         if (x_chance_in_y(10 - pbd_str, 10))
         {
-            const int pbd_inc = random2(pbd_level + 1)
+            const int pbd_inc = random_range(1, pbd_level);
             you.props["powered_by_death_strength"] = pbd_str + pbd_inc;
-            dprf("Incrementing Powered by Death strength to %d",
+            dprf("Powered by Death strength +%d=%d", pbd_inc,
                  pbd_str + pbd_inc);
         }
     }

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2574,8 +2574,8 @@ int monster_die(monster* mons, killer_type killer,
             || pet_kill))
     {
         // Set duration
-        const int pbd_dur = player_mutation_level(MUT_POWERED_BY_DEATH) * 8
-                            + roll_dice(2, 8);
+        const int pbd_level = player_mutation_level(MUT_POWERED_BY_DEATH);
+        const int pbd_dur = level * 8 + roll_dice(2, 8);
         const int pbd_str = you.props["powered_by_death_strength"].get_int();
         if (pbd_dur * BASELINE_DELAY > you.duration[DUR_POWERED_BY_DEATH])
             you.set_duration(DUR_POWERED_BY_DEATH, pbd_dur);
@@ -2583,11 +2583,14 @@ int monster_die(monster* mons, killer_type killer,
         // Maybe increase strength. The chance decreases with number of
         // existing stacks. Chance is:
         // (0->1) 100%, (1->2) 90%, 80%, ...
-        // This implies a maximum strength of 10.
+        // This implies a maximum strength of 10 (though you might get to 12
+        // with lucky rolls).
         if (x_chance_in_y(10 - pbd_str, 10))
         {
-            you.props["powered_by_death_strength"] = pbd_str + 1;
-            dprf("Incrementing Powered by Death strength to %d", pbd_str + 1);
+            const int pbd_inc = random2(level + 1)
+            you.props["powered_by_death_strength"] = pbd_str + pbd_inc;
+            dprf("Incrementing Powered by Death strength to %d",
+                 pbd_str + pbd_inc);
         }
     }
 

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2575,7 +2575,7 @@ int monster_die(monster* mons, killer_type killer,
     {
         // Set duration
         const int pbd_level = player_mutation_level(MUT_POWERED_BY_DEATH);
-        const int pbd_dur = level * 8 + roll_dice(2, 8);
+        const int pbd_dur = pbd_level * 8 + roll_dice(2, 8);
         const int pbd_str = you.props["powered_by_death_strength"].get_int();
         if (pbd_dur * BASELINE_DELAY > you.duration[DUR_POWERED_BY_DEATH])
             you.set_duration(DUR_POWERED_BY_DEATH, pbd_dur);
@@ -2587,7 +2587,7 @@ int monster_die(monster* mons, killer_type killer,
         // with lucky rolls).
         if (x_chance_in_y(10 - pbd_str, 10))
         {
-            const int pbd_inc = random2(level + 1)
+            const int pbd_inc = random2(pbd_level + 1)
             you.props["powered_by_death_strength"] = pbd_str + pbd_inc;
             dprf("Incrementing Powered by Death strength to %d",
                  pbd_str + pbd_inc);

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1240,9 +1240,9 @@ static const mutation_def mut_data[] =
 { MUT_POWERED_BY_DEATH, 0, 3, MUTFLAG_GOOD, false,
   "powered by death",
 
-  {"You can steal the life force of nearby defeated enemies.",
-   "You can steal the life force of defeated enemies.",
-   "You can steal the life force of all defeated enemies in sight."},
+  {"You regenerate a little health from kills.",
+   "You regenerate health from kills.",
+   "You regenerate a lot of health from kills."},
 
   {"A wave of death washes over you.",
    "The wave of death grows in power.",

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2378,28 +2378,6 @@ void check_monster_detect()
     }
 }
 
-int handle_pbd_corpses()
-{
-    int corpse_count = 0;
-
-    for (radius_iterator ri(you.pos(),
-         player_mutation_level(MUT_POWERED_BY_DEATH) * 3, C_ROUND, LOS_DEFAULT);
-         ri; ++ri)
-    {
-        for (stack_iterator j(*ri); j; ++j)
-        {
-            if (j->is_type(OBJ_CORPSES, CORPSE_BODY))
-            {
-                ++corpse_count;
-                if (corpse_count == 7)
-                    break;
-            }
-        }
-    }
-
-    return corpse_count;
-}
-
 int augmentation_amount()
 {
     int amount = 0;

--- a/crawl-ref/source/mutation.h
+++ b/crawl-ref/source/mutation.h
@@ -66,7 +66,6 @@ int how_mutated(bool innate = false, bool levels = false, bool temp = true);
 
 void check_demonic_guardian();
 void check_monster_detect();
-int handle_pbd_corpses();
 equipment_type beastly_slot(int mut);
 bool physiology_mutation_conflict(mutation_type mutat);
 int augmentation_amount();

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -660,10 +660,15 @@ static void _decrement_durations()
         you.redraw_evasion = true;
     }
 
+    // Powered by Death strength is handled below, search for:
+    // you.props["powered_by_death_strength"]
     if (_decrement_a_duration(DUR_POWERED_BY_DEATH, delay))
     {
-        if (handle_pbd_corpses() > 0)
+        if (you.props["powered_by_death_strength"].get_int() > 0)
+        {
             mprf(MSGCH_DURATION, "You feel less regenerative.");
+            you.props["powered_by_death_strength"] = 0;
+        }
     }
 
     _decrement_a_duration(DUR_TELEPATHY, delay, "You feel less empathic.");
@@ -1190,6 +1195,20 @@ static void _decrement_durations()
 
     for (int i = 0; i < delay; ++i)
         you.maybe_degrade_bone_armour(1);
+
+    // Decay Powered by Death strength over time.
+    // PbD duration is handled above, search for DUR_POWERED_BY_DEATH.
+    int pbd_str = you.props["powered_by_death_strength"].get_int();
+    if (pbd_str > 1)
+    {
+        // Roll to decrement (on average) 1 per-10 aut.
+        const int decrement_rolls = div_rand_round(delay, 10);
+        const int dec = binomial(decrement_rolls, 1, 4);
+        pbd_str -= dec;
+        you.props["powered_by_death_strength"] = pbd_str;
+        if (dec > 0)
+            dprf("Decrementing Powered by Death strength to %d", pbd_str);
+    }
 
     if (!env.sunlight.empty())
         process_sunlights();

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -1204,7 +1204,7 @@ static void _decrement_durations()
         // Roll to decrement (on average) 1 per-10 aut.
         const int decrement_rolls = div_rand_round(delay, 10);
         const int dec = binomial(decrement_rolls, 1, 4);
-        pbd_str -= dec;
+        pbd_str = max(pbd_str - dec, 0);
         you.props["powered_by_death_strength"] = pbd_str;
         if (dec > 0)
             dprf("Decrementing Powered by Death strength to %d", pbd_str);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1124,12 +1124,10 @@ static int _player_bonus_regen()
     // Fast heal mutation.
     rr += player_mutation_level(MUT_REGENERATION) * 20;
 
-    // Powered By Death mutation, boosts regen by 10 per corpse in
-    // a mutation_level * 3 (3/6/9) radius, to a maximum of 7
-    // corpses. If and only if the duration of the effect is
-    // still active.
+    // Powered By Death mutation, boosts regen by variable strength
+    // if the duration of the effect is still active.
     if (you.duration[DUR_POWERED_BY_DEATH])
-        rr += handle_pbd_corpses() * 100;
+        rr += you.props["powered_by_death_strength"].get_int() * 100;
 
     return rr;
 }

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -315,10 +315,11 @@ bool fill_status_info(int status, status_info* inf)
         break;
 
     case DUR_POWERED_BY_DEATH:
-        if (handle_pbd_corpses() > 0)
+        if (you.props["powered_by_death_strength"].get_int() > 0)
         {
             inf->light_colour = LIGHTMAGENTA;
-            inf->light_text   = "Regen+";
+            inf->light_text   = make_stringf("Regen (%d)",
+                                you.props["powered_by_death_strength"].get_int());
         }
         break;
 


### PR DESCRIPTION
Old PbD relied on corpses in LoS to determine regen strength, which
encouraged kiting and waiting around in corpse LoS to heal up. The bonus
was strongest at the end of a fight which wasn't very interesting.
Finally it didn't work with Gozag, which annoyed me.

New PbD works without corpses. On kill, PbD is activated for a random
number of turns (this is unchanged). However the strength is a player
property that's (possibly) incremented with each kill, rather than being
dependant on corpses in LoS. The strength degrades with time.

Note that new PbD starts and increases strength on any kill, not just
those that leave a corpse. This is a significant buff in low-corpse
areas and has been balanced by reducing the chance a kill will increase
the buff strength.

This is a simplified implementation of a stacking buff, the current
numbers are some what arbitrary and will probably need further tweaks.
They are:
duration: mutlevel*8 + 2d8
strength: increases per-kill with chance 100%->30% decreasing with
    number of stacks. Decreases by 1 on 1/4 turns, no maximum.