### PR TITLE
Rework Spiny mutation.

### DIFF
--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -3289,19 +3289,14 @@ void melee_attack::mons_do_eyeball_confusion()
 
 void melee_attack::do_spines()
 {
-    // Monsters only get struck on their first attack per round
-    if (attacker->is_monster() && effective_attack_number > 0)
-        return;
-
     if (defender->is_player())
     {
         const int mut = (you.form == TRAN_PORCUPINE) ? 3
                         : player_mutation_level(MUT_SPINY);
 
-        if (mut && attacker->alive()
-            && x_chance_in_y(2, (13 - (mut * 2)) * 3))
+        if (mut && attacker->alive())
         {
-            int dmg = roll_dice(2 + div_rand_round(mut - 1, 2), 5);
+            int dmg = roll_dice(1 + mut, 5);
             int hurt = attacker->apply_ac(dmg);
 
             dprf(DIAG_COMBAT, "Spiny: dmg = %d hurt = %d", dmg, hurt);


### PR DESCRIPTION
Previously had a 1/33-1/22 chance of doing 2-3d5 damage to each
attacker once per round. Now applies (1+mut)d5 damage after each attack.

Numbers might need tweaking, it's substantially better now. But old
spiny was very terrible, so.