### PR TITLE
Check for MUT_NO_LOVE before making Pikel's slaves neutral

### DIFF
--- a/crawl-ref/source/dactions.cc
+++ b/crawl-ref/source/dactions.cc
@@ -227,8 +227,10 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
 
         case DACT_HOLY_PETS_GO_NEUTRAL:
         case DACT_PIKEL_SLAVES:
+        {
             // monster changes attitude
-            mon->attitude = ATT_GOOD_NEUTRAL;
+            bool hostile = player_mutation_level(MUT_NO_LOVE);
+            mon->attitude = hostile ? ATT_HOSTILE : ATT_GOOD_NEUTRAL;
             mons_att_changed(mon);
 
             if (act == DACT_PIKEL_SLAVES)
@@ -238,10 +240,10 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
                 mon->mname = "freed slave";
             }
             else if (local)
-                simple_monster_message(mon, " becomes indifferent.");
-            mon->behaviour = BEH_WANDER;
+                simple_monster_message(mon, hostile ? " turns on you!" : " becomes indifferent.");
+            mon->behaviour = hostile ? BEH_SEEK : BEH_WANDER;
             break;
-
+        }
         case DACT_KIRKE_HOGS:
             _daction_hog_to_human(mon, in_transit);
             break;

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3077,11 +3077,20 @@ void pikel_band_neutralise()
         }
     }
     const char* final_msg = nullptr;
-    if (visible_slaves == 1)
-        final_msg = "With Pikel's spell broken, the former slave thanks you for freedom.";
-    else if (visible_slaves > 1)
-        final_msg = "With Pikel's spell broken, the former slaves thank you for their freedom.";
-
+    if (player_mutation_level(MUT_NO_LOVE))
+    {
+        if (visible_slaves == 1)
+            final_msg = "Pikel's spell is broken, but the former slave can only feel hate for you!";
+        else if (visible_slaves > 1)
+            final_msg = "Pikel's spell is broken, but the former slaves can only feel hate for you!";
+    }
+    else
+    {
+        if (visible_slaves == 1)
+            final_msg = "With Pikel's spell broken, the former slave thanks you for freedom.";
+        else if (visible_slaves > 1)
+            final_msg = "With Pikel's spell broken, the former slaves thank you for their freedom.";
+    }
     delayed_action_fineff::schedule(DACT_PIKEL_SLAVES, final_msg);
 }
 


### PR DESCRIPTION
Since the pikel-death code is shared with the code for making holy allies turn neutral when you leave TSO, I updated that message too. It will probably never come up (you get MUT_NO_LOVE, switch to TSO, summon some hostile "allies", and then abandon TSO?), but it seemed like the message should match the behavior just in case.