### PR TITLE
Reword spellbook description, so non-spells don't sound spell-y

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3329,7 +3329,7 @@ static string _monster_spells_description(const monster_info& mi)
 
     formatted_string description;
     describe_spellset(monster_spellset(mi), nullptr, description);
-    description.cprintf("Select a spell to read its description.\n");
+    description.cprintf("To read a description, press the key listed above.\n");
     return description.tostring();
 }
 


### PR DESCRIPTION
It shouldn't say "a spell's description" for things that aren't spells. This rephrasing avoids calling them anything at all; it might be cleverer to say "ability" or "spell" as appropriate.