### PR TITLE
Start the Orb run when you apport the Orb

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1255,14 +1255,14 @@ void dgn_reset_level(bool enable_random_maps)
     // Set default random monster generation rate (smaller is more often,
     // except that 0 == no random monsters).
     if (player_in_branch(BRANCH_TEMPLE)
-        && !player_has_orb() // except for the Orb run
+        && !player_on_orb_run() // except for the Orb run
         || crawl_state.game_is_tutorial())
     {
         // No random monsters in tutorial or ecu temple
         env.spawn_random_rate = 0;
     }
     else if (player_in_connected_branch()
-             || (player_has_orb() && !player_in_branch(BRANCH_ABYSS)))
+             || (player_on_orb_run() && !player_in_branch(BRANCH_ABYSS)))
         env.spawn_random_rate = 240;
     else if (player_in_branch(BRANCH_ABYSS)
              || player_in_branch(BRANCH_PANDEMONIUM))

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -1295,11 +1295,13 @@ enum evoc_type
 #endif
 };
 
-enum game_direction_type
+enum game_chapter
 {
-    GDT_GAME_START = 0,
-    GDT_DESCENDING,
-    GDT_ASCENDING,
+    CHAPTER_POCKET_ABYSS = 0, // an AK who hasn't yet entered the dungeon
+    CHAPTER_ORB_HUNTING, // entered the dungeon but not found the orb yet
+    CHAPTER_ESCAPING, // ascending with the orb
+    CHAPTER_ANGERED_PANDEMONIUM, // moved the orb without picking it up
+    NUM_CHAPTERS,
 };
 
 enum game_type

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1143,13 +1143,13 @@ static void _make_level(dungeon_feature_type stair_taken,
 
     env.turns_on_level = -1;
 
-    if (you.char_direction == GDT_GAME_START
+    if (you.chapter == CHAPTER_POCKET_ABYSS
         && player_in_branch(BRANCH_DUNGEON))
     {
         // If we're leaving the Abyss for the first time as a Chaos
         // Knight of Lugonu (who start out there), enable normal monster
         // generation.
-        you.char_direction = GDT_DESCENDING;
+        you.chapter = CHAPTER_ORB_HUNTING;
     }
 
     tile_init_default_flavour();

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1729,6 +1729,21 @@ static void _get_rune(const item_def& it, bool quiet)
         unset_level_flags(LFLAG_NO_TELE_CONTROL);
 }
 
+void start_orb_run(game_chapter chapter, const char* message)
+{
+    if (you.chapter != CHAPTER_ANGERED_PANDEMONIUM)
+    {
+        mprf(MSGCH_WARN, "The lords of Pandemonium are not amused. Beware!");
+        if (you_worship(GOD_CHEIBRIADOS))
+          simple_god_message(" tells them not to hurry.");
+    }
+
+    mprf(MSGCH_ORB, "%s", message);
+    you.chapter = chapter;
+    xom_is_stimulated(200, XM_INTRIGUED);
+    invalidate_agrid(true);
+}
+
 /**
  * Place the Orb of Zot into the player's inventory.
  *
@@ -1740,7 +1755,6 @@ static void _get_orb(const item_def &it, bool quiet)
     run_animation(ANIMATION_ORB, UA_PICKUP);
 
     mprf(MSGCH_ORB, "You pick up the Orb of Zot!");
-    you.chapter = CHAPTER_ESCAPING;
 
     env.orb_pos = you.pos(); // can be wrong in wizmode
     orb_pickup_noise(you.pos(), 30);
@@ -1751,15 +1765,7 @@ static void _get_orb(const item_def &it, bool quiet)
         you.increase_duration(DUR_TELEPORT, 5 + random2(5));
     }
 
-    mprf(MSGCH_WARN, "The lords of Pandemonium are not amused. Beware!");
-
-    if (you_worship(GOD_CHEIBRIADOS))
-        simple_god_message(" tells them not to hurry.");
-
-    mprf(MSGCH_ORB, "Now all you have to do is get back out of the dungeon!");
-
-    xom_is_stimulated(200, XM_INTRIGUED);
-    invalidate_agrid(true);
+    start_orb_run(CHAPTER_ESCAPING, "Now all you have to do is get back out of the dungeon!");
 }
 
 /**

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1729,21 +1729,6 @@ static void _get_rune(const item_def& it, bool quiet)
         unset_level_flags(LFLAG_NO_TELE_CONTROL);
 }
 
-void start_orb_run(game_chapter chapter, const char* message)
-{
-    if (you.chapter != CHAPTER_ANGERED_PANDEMONIUM)
-    {
-        mprf(MSGCH_WARN, "The lords of Pandemonium are not amused. Beware!");
-        if (you_worship(GOD_CHEIBRIADOS))
-          simple_god_message(" tells them not to hurry.");
-    }
-
-    mprf(MSGCH_ORB, "%s", message);
-    you.chapter = chapter;
-    xom_is_stimulated(200, XM_INTRIGUED);
-    invalidate_agrid(true);
-}
-
 /**
  * Place the Orb of Zot into the player's inventory.
  *

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1740,7 +1740,7 @@ static void _get_orb(const item_def &it, bool quiet)
     run_animation(ANIMATION_ORB, UA_PICKUP);
 
     mprf(MSGCH_ORB, "You pick up the Orb of Zot!");
-    you.char_direction = GDT_ASCENDING;
+    you.chapter = CHAPTER_ESCAPING;
 
     env.orb_pos = you.pos(); // can be wrong in wizmode
     orb_pickup_noise(you.pos(), 30);

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -154,6 +154,8 @@ bool maybe_identify_base_type(item_def &item);
 coord_def orb_position();
 int count_movable_items(int obj);
 
+void start_orb_run(game_chapter new_chapter, const char* message);
+
 // stack_iterator guarantees validity so long as you don't manually
 // mess with item_def.link: i.e., you can kill the item you're
 // examining but you can't kill the item linked to it.

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1704,6 +1704,17 @@ static bool _prompt_stairs(dungeon_feature_type ygrd, bool down)
         return false;
     }
 
+    if (!down && player_in_branch(BRANCH_ZOT) && you.depth == 5
+              && you.chapter == CHAPTER_ANGERED_PANDEMONIUM)
+    {
+        if (!yesno("Really leave the Orb behind? Pandemonium will still be angry with you!",
+                   false, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return false;
+        }
+      }
+
     // Escaping.
     if (!down && ygrd == DNGN_EXIT_DUNGEON && !player_has_orb())
     {

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -344,7 +344,7 @@ void spawn_random_monsters()
     if (crawl_state.game_is_arena()
         || (crawl_state.game_is_sprint()
             && player_in_connected_branch()
-            && you.char_direction == GDT_DESCENDING))
+            && you.chapter == CHAPTER_ORB_HUNTING))
     {
         return;
     }

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -364,7 +364,7 @@ void spawn_random_monsters()
     if (player_in_branch(BRANCH_VESTIBULE))
         rate = _vestibule_spawn_rate();
 
-    if (player_has_orb())
+    if (player_on_orb_run())
         rate = you_worship(GOD_CHEIBRIADOS) ? 16 : 8;
     else if (!player_in_starting_abyss())
         rate = _scale_spawn_parameter(rate, 6 * rate, 0);
@@ -391,7 +391,7 @@ void spawn_random_monsters()
     // spawns in Abyss to show some mercy to players that get banished there on
     // the orb run.
     if (player_in_connected_branch()
-        || (player_has_orb() && !player_in_branch(BRANCH_ABYSS)))
+        || (player_on_orb_run() && !player_in_branch(BRANCH_ABYSS)))
     {
         dprf(DIAG_MONPLACE, "Placing monster, rate: %d, turns here: %d",
              rate, env.turns_on_level);
@@ -399,12 +399,12 @@ void spawn_random_monsters()
                                                  : PROX_AWAY_FROM_PLAYER);
 
         // The rules change once the player has picked up the Orb...
-        if (player_has_orb())
+        if (player_on_orb_run())
             prox = (one_chance_in(3) ? PROX_CLOSE_TO_PLAYER : PROX_ANYWHERE);
 
         mgen_data mg(WANDERING_MONSTER);
         mg.proximity = prox;
-        mg.foe = (player_has_orb()) ? MHITYOU : MHITNOT;
+        mg.foe = (player_on_orb_run()) ? MHITYOU : MHITNOT;
         mons_place(mg);
         viewwindow();
         return;
@@ -3709,7 +3709,7 @@ monster* mons_place(mgen_data mg)
 
     // This gives a slight challenge to the player as they ascend the
     // dungeon with the Orb.
-    if (_is_random_monster(mg.cls) && player_has_orb()
+    if (_is_random_monster(mg.cls) && player_on_orb_run()
         && !player_in_branch(BRANCH_ABYSS) && !mg.summoned())
     {
 #ifdef DEBUG_MON_CREATION

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -372,7 +372,7 @@ static void _give_items_skills(const newgame_def& ng)
     case JOB_ABYSSAL_KNIGHT:
         you.religion = GOD_LUGONU;
         if (!crawl_state.game_is_sprint())
-            you.char_direction = GDT_GAME_START;
+            you.chapter = CHAPTER_POCKET_ABYSS;
         you.piety = 38;
 
         newgame_make_item(OBJ_WEAPONS, ng.weapon, 1, +1);

--- a/crawl-ref/source/orb.cc
+++ b/crawl-ref/source/orb.cc
@@ -10,6 +10,10 @@
 #include "areas.h"
 #include "shout.h"
 #include "view.h"
+#include "religion.h"
+#include "message.h"
+#include "xom.h"
+
 
 /**
  * Make a "noise" caused by the orb.
@@ -68,4 +72,19 @@ void orb_pickup_noise(const coord_def& where, int loudness, const char* msg, con
         else
             mprf(MSGCH_ORB, "The Orb lets out a furious burst of light!");
     }
+}
+
+void start_orb_run(game_chapter chapter, const char* message)
+{
+    if (you.chapter != CHAPTER_ANGERED_PANDEMONIUM)
+    {
+        mprf(MSGCH_WARN, "The lords of Pandemonium are not amused. Beware!");
+        if (you_worship(GOD_CHEIBRIADOS))
+          simple_god_message(" tells them not to hurry.");
+    }
+
+    mprf(MSGCH_ORB, "%s", message);
+    you.chapter = chapter;
+    xom_is_stimulated(200, XM_INTRIGUED);
+    invalidate_agrid(true);
 }

--- a/crawl-ref/source/orb.h
+++ b/crawl-ref/source/orb.h
@@ -4,4 +4,6 @@
 void orb_pickup_noise(const coord_def& where, int loudness = 30,
                       const char* msg = nullptr, const char* msg2 = nullptr);
 
+void start_orb_run(game_chapter new_chapter, const char* message);
+
 #endif

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -568,7 +568,7 @@ bool player_in_hell()
  */
 bool player_in_starting_abyss()
 {
-    return you.char_direction == GDT_GAME_START
+    return you.chapter == CHAPTER_POCKET_ABYSS
            && player_in_branch(BRANCH_ABYSS) && you.depth <= 1;
 }
 
@@ -5150,7 +5150,7 @@ void player::init()
     old_vehumet_gifts.clear();
     spell_no        = 0;
     vehumet_gifts.clear();
-    char_direction  = GDT_DESCENDING;
+    chapter  = CHAPTER_ORB_HUNTING;
     royal_jelly_dead = false;
     transform_uncancellable = false;
     fishtail = false;
@@ -7854,12 +7854,20 @@ int player_monster_detect_radius()
 }
 
 /**
+ * Return true if the player has angered Pandemonium by picking up or moving the Orb of Zot.
+ */
+bool player_on_orb_run()
+{
+    return you.chapter == CHAPTER_ESCAPING || you.chapter == CHAPTER_ANGERED_PANDEMONIUM;
+}
+
+/**
  * Return true if the player has the Orb of Zot.
  * @return  True if the player has the Orb, false otherwise.
  */
 bool player_has_orb()
 {
-    return you.char_direction == GDT_ASCENDING;
+    return you.chapter == CHAPTER_ESCAPING;
 }
 
 bool player::form_uses_xl() const

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -134,7 +134,7 @@ public:
   set<spell_type> old_vehumet_gifts, vehumet_gifts;
 
   uint8_t spell_no;
-  game_direction_type char_direction;
+  game_chapter chapter;
   bool royal_jelly_dead;
   bool transform_uncancellable;
   bool fishtail; // Merfolk fishtail transformation

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1078,6 +1078,7 @@ bool need_expiration_warning(coord_def p = you.pos());
 
 void count_action(caction_type type, int subtype = 0);
 bool player_has_orb();
+bool player_on_orb_run();
 
 #if TAG_MAJOR_VERSION == 34
 enum temperature_level

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1034,6 +1034,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
             orb_pickup_noise(where, 30,
                 "The Orb shrieks as your magic touches it!",
                 "The Orb lets out a furious burst of light as your magic touches it!");
+            start_orb_run(CHAPTER_ANGERED_PANDEMONIUM, "Now pick up the Orb and get out of here!");
         }
     }
 

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -591,7 +591,7 @@ void take_stairs(dungeon_feature_type force_stair, bool going_up,
         take_note(Note(NOTE_MESSAGE, 0, 0, "Took an exit into the Abyss."), true);
     }
     else if (stair_find == DNGN_EXIT_ABYSS
-             && you.char_direction != GDT_GAME_START)
+             && you.chapter != CHAPTER_POCKET_ABYSS)
     {
         mark_milestone("abyss.exit", "escaped from the Abyss!");
         you.attribute[ATTR_BANISHMENT_IMMUNITY] = you.elapsed_time + 100
@@ -669,7 +669,7 @@ void take_stairs(dungeon_feature_type force_stair, bool going_up,
         && old_level.branch != you.where_are_you)
     {
         mprf("Welcome %sto %s!",
-             you.char_direction == GDT_GAME_START ? "" : "back ",
+             you.chapter == CHAPTER_POCKET_ABYSS ? "" : "back ",
              branches[you.where_are_you].longname);
     }
 
@@ -929,7 +929,7 @@ level_id stair_destination(dungeon_feature_type feat, const string &dst,
         return level_id(BRANCH_VESTIBULE);
 
     case DNGN_EXIT_ABYSS:
-        if (you.char_direction == GDT_GAME_START)
+        if (you.chapter == CHAPTER_POCKET_ABYSS)
             return level_id(BRANCH_DUNGEON, 1);
 #if TAG_MAJOR_VERSION == 34
     case DNGN_EXIT_PORTAL_VAULT:

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -261,7 +261,7 @@ static void _post_init(bool newc)
     run_map_local_preludes();
 
     // Abyssal Knights start out in the Abyss.
-    if (newc && you.char_direction == GDT_GAME_START)
+    if (newc && you.chapter == CHAPTER_POCKET_ABYSS)
         you.where_are_you = BRANCH_ABYSS;
     else if (newc)
         you.where_are_you = root_branch;
@@ -278,7 +278,7 @@ static void _post_init(bool newc)
                newc               ? LOAD_START_GAME : LOAD_RESTART_GAME,
                old_level);
 
-    if (newc && you.char_direction == GDT_GAME_START)
+    if (newc && you.chapter == CHAPTER_POCKET_ABYSS)
         generate_abyss();
 
 #ifdef DEBUG_DIAGNOSTICS

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1324,7 +1324,7 @@ static void tag_construct_you(writer &th)
     marshallByte(th, you.max_level);
     marshallByte(th, you.where_are_you);
     marshallByte(th, you.depth);
-    marshallByte(th, you.char_direction);
+    marshallByte(th, you.chapter);
     marshallByte(th, you.royal_jelly_dead);
     marshallByte(th, you.transform_uncancellable);
     marshallByte(th, you.berserk_penalty);
@@ -2125,8 +2125,8 @@ static void tag_read_you(reader &th)
     ASSERT(you.where_are_you < NUM_BRANCHES);
     you.depth             = unmarshallByte(th);
     ASSERT(you.depth > 0);
-    you.char_direction    = static_cast<game_direction_type>(unmarshallUByte(th));
-    ASSERT(you.char_direction <= GDT_ASCENDING);
+    you.chapter           = static_cast<game_chapter>(unmarshallUByte(th));
+    ASSERT(you.chapter < NUM_CHAPTERS);
 
 #if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() < TAG_MINOR_ZOT_OPEN)


### PR DESCRIPTION
As discussed in crawl-dev. Currently it just prompts you if you try to leave zot:5 without the Orb after apporting it; we can possibly add something more flavourful, like a Pandemonium Lord appearing and taunting you for leaving behind the the Orb.