### PR TITLE
Treat abandon+worship as direct switching, for E/Z/1.

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2824,7 +2824,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             && yesno("Are you sure you won't change your mind later?",
                      false, 'n'))
         {
-            excommunication();
+            excommunication(GOD_NO_GOD, false, true);
         }
         else
         {

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2824,7 +2824,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             && yesno("Are you sure you won't change your mind later?",
                      false, 'n'))
         {
-            excommunication(GOD_NO_GOD, false, true);
+            excommunication(true);
         }
         else
         {

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5211,6 +5211,8 @@ void player::init()
     piety            = 0;
     piety_hysteresis = 0;
     gift_timeout     = 0;
+    saved_good_god_piety = 0;
+    previous_good_god = GOD_NO_GOD;
     penance.init(0);
     worshipped.init(0);
     num_current_gifts.init(0);

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -217,6 +217,8 @@ public:
   uint8_t piety;
   uint8_t piety_hysteresis;       // amount of stored-up docking
   uint8_t gift_timeout;
+  uint8_t saved_good_god_piety;   // for if you "switch" between E/Z/1 by abandoning one first
+  god_type previous_good_god;
   FixedVector<uint8_t, NUM_GODS>  penance;
   FixedVector<uint8_t, NUM_GODS>  worshipped;
   FixedVector<short,   NUM_GODS>  num_current_gifts;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2717,7 +2717,7 @@ static string _god_hates_your_god_reaction(god_type god, god_type your_god)
     return "";
 }
 
-void excommunication(god_type new_god, bool immediate, bool voluntary)
+void excommunication(bool voluntary, god_type new_god, bool immediate)
 {
     const god_type old_god = you.religion;
     ASSERT(old_god != new_god);
@@ -3360,7 +3360,7 @@ void join_religion(god_type which_god, bool immediate)
 
     // Leave your prior religion first.
     if (!you_worship(GOD_NO_GOD))
-        excommunication(which_god, immediate, true);
+        excommunication(true, which_god, immediate);
 
     // Welcome to the fold!
     you.religion = static_cast<god_type>(which_god);

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -43,7 +43,7 @@ bool xp_penance(god_type god);
 void dec_penance(int val);
 void dec_penance(god_type god, int val);
 
-void excommunication(god_type new_god = GOD_NO_GOD, bool immediate = false, bool voluntary = false);
+void excommunication(bool voluntary = false, god_type new_god = GOD_NO_GOD, bool immediate = false);
 
 bool gain_piety(int pgn, int denominator = 1, bool should_scale_piety = true);
 void dock_piety(int pietyloss, int penance);

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -43,7 +43,7 @@ bool xp_penance(god_type god);
 void dec_penance(int val);
 void dec_penance(god_type god, int val);
 
-void excommunication(god_type new_god = GOD_NO_GOD, bool immediate = false);
+void excommunication(god_type new_god = GOD_NO_GOD, bool immediate = false, bool voluntary = false);
 
 bool gain_piety(int pgn, int denominator = 1, bool should_scale_piety = true);
 void dock_piety(int pietyloss, int penance);

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -168,6 +168,7 @@ enum tag_minor_version
     TAG_MINOR_RU_DELAY_STACKING,   // Let Ru delay timers stack again
     TAG_MINOR_NO_TWISTER,          // Remove ARTP_TWISTER
     TAG_MINOR_NO_ZOTDEF,           // remove zotdef, along with zot_points and zotdef_wave_name
+    TAG_MINOR_SAVED_PIETY,         // allowed good-god piety to survive through an atheist period
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1493,6 +1493,8 @@ static void tag_construct_you(writer &th)
         marshallByte(th, you.piety_max[i]);
 
     marshallByte(th, you.gift_timeout);
+    marshallUByte(th, you.saved_good_god_piety);
+    marshallByte(th, you.previous_good_god);
 
     for (int i = 0; i < NUM_GODS; i++)
         marshallInt(th, you.exp_docked[i]);
@@ -2902,6 +2904,11 @@ static void tag_read_you(reader &th)
     you.gift_timeout   = unmarshallByte(th);
 
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_SAVED_PIETY)
+    {
+        you.saved_good_god_piety = unmarshallUByte(th);
+        you.previous_good_god = static_cast<god_type>(unmarshallByte(th));
+    }
     if (th.getMinorVersion() < TAG_MINOR_BRANCH_ENTRY)
     {
         int depth = unmarshallByte(th);

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2902,13 +2902,18 @@ static void tag_read_you(reader &th)
 #endif
 
     you.gift_timeout   = unmarshallByte(th);
-
-#if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() >= TAG_MINOR_SAVED_PIETY)
     {
         you.saved_good_god_piety = unmarshallUByte(th);
         you.previous_good_god = static_cast<god_type>(unmarshallByte(th));
     }
+    else
+    {
+        you.saved_good_god_piety = 0;
+        you.previous_good_god = GOD_NO_GOD;
+    }
+
+#if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() < TAG_MINOR_BRANCH_ENTRY)
     {
         int depth = unmarshallByte(th);


### PR DESCRIPTION
The religion screen isn't clear about *how* you should switch
between the good gods, so we should really treat aXp the same
as just p.