### PR TITLE
Explicitly reveal mindelay skill to the player.

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -797,18 +797,24 @@ void append_weapon_stats(string &description, const item_def &item)
     const int ammo_type = fires_ammo_type(item);
     const int ammo_dam = ammo_type == MI_NONE ? 0 :
                                                 ammo_type_damage(ammo_type);
+    const skill_type skill = item_attack_skill(item);
+    const float skill_level = (float) you.skill(skill, 10) / 10;
+
     description += "Base damage: ";
     _append_value(description, base_dam + ammo_dam, false);
     description += "  ";
-
     description += "Base attack delay: ";
-    _append_value(description, property(item, PWPN_SPEED) / 10.0f, false);
-    description += "  ";
+    _append_value(description, (float) property(item, PWPN_SPEED) / 10, false);
+    description += "\n";
+    description += "This weapon's minimum attack delay of ";
+    _append_value(description, (float) weapon_min_delay(item) / 10, false);
+    description += " is reached at skill level ";
+    _append_value(description, weapon_min_delay_skill(item), false);
+    description += ". (Your skill: ";
+    _append_value(description, skill_level, false);
+    description += ")";
 
-    description += "Minimum delay: ";
-    _append_value(description, weapon_min_delay(item) / 10.0f, false);
-
-    if (item_attack_skill(item) == SK_SLINGS)
+    if (skill == SK_SLINGS)
     {
         description += make_stringf("\nFiring bullets:    Base damage: %d",
                                     base_dam +

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -676,6 +676,18 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
 }
 
 /**
+ * What skill is required to reach mindelay with a weapon? May be >27.
+ * @param weapon The weapon to be considered.
+ * @returns The level of the relevant skill you must reach.
+ */
+int weapon_min_delay_skill(const item_def &weapon)
+{
+    const int speed = property(weapon, PWPN_SPEED);
+    const int mindelay = weapon_min_delay(weapon);
+    return (speed - mindelay) * 2;
+}
+
+/**
  * How fast will this weapon get from your skill training?
  *
  * Does NOT take speed brand into account, since the brand shouldn't affect how

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -41,6 +41,7 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
                            int attack_number = 0,
                            int effective_attack_number = 0);
 
+int weapon_min_delay_skill(const item_def &weapon);
 int weapon_min_delay(const item_def &weapon);
 int finesse_adjust_delay(int delay);
 


### PR DESCRIPTION
Previously base & minimum delay was revealed to the player, which
required maths to make use of. Now the base delay is hidden and instead
is shown mindelay and the skill required to reach it.

For weapons that cannot reach mindelay (eg Dark Maul), the level shown
is 28, which I think is nice :).

This commit would break for any weapons that require an odd skill level
to reach mindelay, but I don't think any such weapons do/can exist.