### PR TITLE
Another attempt at make_fiery_weapon (volcano)

### DIFF
--- a/crawl-ref/source/dat/des/portals/volcano.des
+++ b/crawl-ref/source/dat/des/portals/volcano.des
@@ -185,12 +185,13 @@ function setup_loot (e)
     e.item([[potion of berserk rage w:22 / potion of might w:5 /
              potion of brilliance w:5 / potion of agility w:5 /
              potion of experience w:1 / potion of resistance]])
-    e.item(make_fiery_weapon(e, {"demon whip w:2", "dire flail w:4", "rapier w:20",
-                                 "scimitar w:20", "demon blade w:2", "triple sword w:1",
-                                 "broad axe w:20", "battleaxe", "executioner's axe w:1",
-                                 "spear w:20", "trident w:20", "demon trident w:1",
-                                 "glaive", "halberd", "lajatang w:1",
-                                 "longbow w:5", "arbalest w:5"}))
+    e.item(make_fiery_weapon(e, {"rapier w:20", "demon whip w:2", "dire flail w:4", 
+                                 "great mace w:1", "scimitar w:20", "great sword",
+                                 "demon blade w:1", "triple sword w:1", "broad axe w:20",
+                                 "battleaxe", "executioner's axe w:1", "trident w:20",
+                                 "glaive w:5", "halberd w:5", "demon trident w:1",
+                                 "bardiche w:1", "longbow w:5", "arbalest w:5", 
+                                 "greatsling w:5", "lajatang w:1"}))
     e.item("any")
 end
 


### PR DESCRIPTION
Bumping up glaive made it overly weighted towards polearms, which bothered me, so removed spear since it had no equivalent in the other weapon classes, and tweaked the weights to be around 30 for LBl, Polearms, and Axes. Left the other types about where they were and added some basetypes I felt should be included. This shouldn't be a buff to volcano loot overall in light of the previous commit reducing lajatang weight from 10 to 1.