### PR TITLE
Fix message when you become a white draconian

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2877,8 +2877,8 @@ void level_change(bool skip_attribute_increase)
                     redraw_screen();
 
                     mprf(MSGCH_INTRINSIC_GAIN,
-                         "Your scales start taking on a %s colour.",
-                         scale_type(you.species));
+                         "Your scales start taking on %s colour.",
+                         article_a(scale_type(you.species)).c_str());
                 }
                 break;
 


### PR DESCRIPTION
It used to say, "a icy white colour"; now it uses "an" instead.