### PR TITLE
Don't give IceCv necromancer a wand of fire

### DIFF
--- a/crawl-ref/source/dat/des/portals/icecave.des
+++ b/crawl-ref/source/dat/des/portals/icecave.des
@@ -640,8 +640,8 @@ MONS:    freezing wraith
 : mocking_simulacrum(_G)
 : mons(mocking_ice)
 : mons("necromancer / necromancer ; robe " .. coldres ..
-:   " / necromancer ; robe " .. coldres .. " . wand of fire " ..
-:   " / necromancer ; robe " .. coldres .. " . wand of flame")
+:   " / necromancer ; robe " .. coldres .. " . wand of cold " ..
+:   " / necromancer ; robe " .. coldres .. " . wand of draining")
 : savage_simulacrum(_G)
 : mons(savage_ice)
 MONS:    ice statue


### PR DESCRIPTION
Ice_cave_small_necro's necromancer can already have a b.fire spellset,
so it's not necessary to give it a wand of fire that it will spam and punish rF-
even more.

Also replace wand of flame chance with wand of draining  - a portal boss
shouldn't spawn with a low-tier wand.