### PR TITLE
Optionally wait for full HP and MP before exploring

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -47,7 +47,7 @@ The contents of this text are:
                 tc_excluded, tc_exclude_circle,
                 runrest_ignore_message, runrest_stop_message,
                 runrest_safe_poison, runrest_ignore_monster,
-                rest_wait_both, auto_exclude
+                rest_wait_both, auto_exclude, explore_auto_rest
 3-g     Command Enhancements.
                 auto_switch, travel_open_doors, easy_unequip, equip_unequip,
                 jewellery_prompt, easy_confirm, allow_self_target,
@@ -916,6 +916,10 @@ auto_exclude += <monster name>, <monster name>, ...
         automatically set centered on this monster, meaning autoexplore won't
         ever bring you into its line of sight. If the monster dies or wakes up
         while you are in sight, this exclusion is automatically removed again.
+
+explore_auto_rest = false
+        Wait until your HP and MP are at the rest wait percentage before
+        exploring.
 
 3-g     Command Enhancements.
 -----------------------------

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -899,6 +899,7 @@ void game_options::reset_options()
     explore_greedy         = true;
 
     explore_wall_bias      = 0;
+    explore_auto_rest      = false;
     explore_improved       = false;
     travel_key_stop        = true;
     auto_sacrifice         = AS_NO;
@@ -3512,6 +3513,7 @@ void game_options::read_option_line(const string &str, bool runscript)
             explore_wall_bias = 0;
     }
     else BOOL_OPTION(explore_improved);
+    else BOOL_OPTION(explore_auto_rest);
     else BOOL_OPTION(travel_key_stop);
     else if (key == "auto_sacrifice")
     {

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -317,6 +317,9 @@ public:
     // How much autoexplore favors visiting squares next to walls.
     int         explore_wall_bias;
 
+    // Wait for rest wait percent HP and MP before exploring.
+    bool        explore_auto_rest;
+
     // Some experimental improvements to explore
     bool        explore_improved;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5427,6 +5427,12 @@ bool player::is_banished() const
     return banished;
 }
 
+bool player::is_completely_rested() const
+{
+    return should_stop_resting(hp, hp_max)
+           && should_stop_resting(magic_points, max_magic_points);
+}
+
 bool player::in_water() const
 {
     return ground_level() && !beogh_water_walk()

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -457,6 +457,7 @@ public:
     int visible_igrd(const coord_def&) const;
     bool can_cling_to_walls() const;
     bool is_banished() const;
+    bool is_completely_rested() const;
     bool is_web_immune() const;
     bool cannot_speak() const;
     bool invisible() const;

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -939,6 +939,10 @@ command_type travel()
 
     if (you.running.is_explore())
     {
+        if (Options.explore_auto_rest && !you.is_completely_rested())
+        {
+            return CMD_WAIT;
+        }
         // Exploring.
         if (grd(you.pos()) == DNGN_ENTER_SHOP
             && you.running == RMODE_EXPLORE_GREEDY)


### PR DESCRIPTION
A minor improvement to auto explore. The option defaults to false. (my flatmate wanted it to be like the ToME auto-explore)