### PR TITLE
Add ecumenical altars (bugzilla)

### DIFF
--- a/crawl-ref/source/dat/des/altar/altar.des
+++ b/crawl-ref/source/dat/des/altar/altar.des
@@ -393,3 +393,33 @@ MAP
 ..1..
 .....
 ENDMAP
+
+### Ecumenical altars ########################################################
+
+NAME:   ecumenical_altar_1
+DEPTH:  D:2-3
+TAGS:  uniq_ecumenical_altar
+KFEAT:  _ = altar_ecumenical
+CHANCE: 50 : 50%
+MAP
+.....
+..x..
+.x_x.
+..x..
+.....
+ENDMAP
+
+NAME: ecumenical_altar_2
+DEPTH: D:2-3
+TAGS:  uniq_ecumenical_altar
+KFEAT:  _ = altar_ecumenical
+CHANCE: 50 : 50%
+MAP
+.......
+...G...
+..G.G..
+.G._.G.
+..G.G..
+...G...
+.......
+ENDMAP

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -1583,6 +1583,7 @@ enum dungeon_feature_type
     DNGN_ALTAR_GOZAG,
     DNGN_ALTAR_QAZLAL,
     DNGN_ALTAR_RU,
+    DNGN_ALTAR_ECUMENICAL,
 #endif
 
     DNGN_FOUNTAIN_BLUE,
@@ -1646,6 +1647,7 @@ enum dungeon_feature_type
 
     DNGN_TRAP_SHADOW,
     DNGN_TRAP_SHADOW_DORMANT,
+    DNGN_ALTAR_ECUMENICAL,
 #endif
 
     NUM_FEATURES
@@ -2095,6 +2097,7 @@ enum god_type
 
     GOD_RANDOM = 100,
     GOD_NAMELESS,                      // for monsters with non-player gods
+    GOD_ECUMENICAL,                    // Temporary
     GOD_VIABLE,
 };
 

--- a/crawl-ref/source/feature-data.h
+++ b/crawl-ref/source/feature-data.h
@@ -495,6 +495,7 @@ ALTAR(DNGN_ALTAR_DITHMENOS, "shadowy altar of Dithmenos", "altar_dithmenos", ETC
 ALTAR(DNGN_ALTAR_GOZAG, "opulent altar of Gozag", "altar_gozag", ETC_GOLD), // for the Gold God!
 ALTAR(DNGN_ALTAR_QAZLAL, "stormy altar of Qazlal", "altar_qazlal", ETC_ELEMENTAL),
 ALTAR(DNGN_ALTAR_RU, "sacrificial altar of Ru", "altar_ru", BROWN),
+ALTAR(DNGN_ALTAR_ECUMENICAL, "faded altar to an unknown god", "altar_ecumenical", ETC_DARK),
 
 #define FOUNTAIN(enum, name, vaultname, colour)\
 {\

--- a/crawl-ref/source/godprayer.cc
+++ b/crawl-ref/source/godprayer.cc
@@ -312,9 +312,10 @@ static bool _altar_pray_or_convert()
         {
             altar_god = _altar_identify_ecumenical_altar();
             mprf(MSGCH_GOD, "%s accepts your prayer!", god_name(altar_god).c_str());
-            join_religion(altar_god);
+            if (!you_worship(altar_god))
+                join_religion(altar_god);
 
-            gain_piety(20, 1, false);
+            gain_piety(20, 1, false); // You get this piety even if you didn't change religion
             if (you_worship(GOD_RU))
                 you.props["ru_progress_to_next_sacrifice"] = 9999;
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2047,6 +2047,7 @@ string god_name(god_type which_god, bool long_name)
     case GOD_QAZLAL:        return "Qazlal";
     case GOD_RU:            return "Ru";
     case GOD_JIYVA: // This is handled at the beginning of the function
+    case GOD_ECUMENICAL:    return "an unknown god";
     case NUM_GODS:          return "Buggy";
     }
     return "";
@@ -3351,6 +3352,8 @@ static void _make_empty_vec(CrawlStoreValue &v, store_val_type vectype)
 void join_religion(god_type which_god, bool immediate)
 {
     ASSERT(which_god != GOD_NO_GOD);
+    ASSERT(which_god != GOD_ECUMENICAL);
+    ASSERT(you.species != SP_DEMIGOD);
 
     redraw_screen();
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -464,9 +464,10 @@ static int _god_altars[][2] =
     { GOD_GOZAG, DNGN_ALTAR_GOZAG },
     { GOD_QAZLAL, DNGN_ALTAR_QAZLAL },
     { GOD_RU, DNGN_ALTAR_RU },
+    { GOD_ECUMENICAL, DNGN_ALTAR_ECUMENICAL },
 };
 
-COMPILE_CHECK(ARRAYSZ(_god_altars) == NUM_GODS - 1);
+COMPILE_CHECK(ARRAYSZ(_god_altars) == NUM_GODS );
 
 /** Whose altar is this feature?
  *

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -435,6 +435,8 @@ tileidx_t tileidx_feature_base(dungeon_feature_type feat)
         return TILE_DNGN_ALTAR_QAZLAL;
     case DNGN_ALTAR_RU:
         return TILE_DNGN_ALTAR_RU;
+    case DNGN_ALTAR_ECUMENICAL:
+        return TILE_DNGN_UNKNOWN_ALTAR;
     case DNGN_FOUNTAIN_BLUE:
         return TILE_DNGN_BLUE_FOUNTAIN;
     case DNGN_FOUNTAIN_SPARKLING:

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -1036,6 +1036,11 @@ void wizard_transform()
 
 void wizard_join_religion()
 {
+    if (you.species == SP_DEMIGOD)
+    {
+        mpr("Not even in wizmode may Demigods worship a god!");
+        return;
+    }
     god_type god = choose_god();
     if (god == NUM_GODS)
         mpr("That god doesn't seem to exist!");


### PR DESCRIPTION
Random altars appearing occasionally on d:2 or d:3 that worship an
unknown god. Using one grants a small amount of initial piety.

Also forbids Demigods gaining religion in wizmode, to guard an assert.

Original code by 'bugzilla', see mantis#9454.

PR notes:
Changes from bugzilla's version:
* After praying at the altar once, change it to the god's real altar, to prevent god-scumming
* Add another des vault
* If you already worship the god the altar is for, gain a bit of free piety!