### PR TITLE
Ashenzari boosts UC when shield hand is bound.

### DIFF
--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -612,6 +612,7 @@ map<skill_type, int8_t> ash_get_boosted_skills(eq_type type)
     case (ET_SHIELD):
         if (bondage == 2)
             boost[SK_SHIELDS] = 1;
+            boost[SK_UNARMED_COMBAT] = 1;
         break;
 
     // Bonus for bounded armour depends on body armour type.


### PR DESCRIPTION
In some ways this is a problem -- Ash gives a skill boost to UCers who
can freely swap to other weapons. On the other hand, this gives UC
fighters a weapon boost from Ash.