### PR TITLE
Make the heading of Ash's skill-boost table stand out

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -365,9 +365,11 @@ static string _describe_ash_skill_boost()
     static const char* bonus_level[3] = { "Low", "Medium", "High" };
     ostringstream desc;
     desc.setf(ios::left);
+    desc << "<red>";
     desc << setw(18) << "Bound part";
     desc << setw(30) << "Boosted skills";
     desc << "Bonus\n";
+    desc << "</red>";
 
     for (int i = ET_WEAPON; i < NUM_ET; i++)
     {


### PR DESCRIPTION
A player noted that when it looks like all the other rows, it is hard to immediately tell what this table is all about. So, I made it red. Some ascii art lines could also work, or even just a single line like 

    -------------------

between heading and body rows.