### PR TITLE
Clean up and tweak Frances's spell list

### DIFF
--- a/crawl-ref/source/mon-spell.h
+++ b/crawl-ref/source/mon-spell.h
@@ -1257,11 +1257,10 @@ static const mon_spellbook mspell_list[] =
 
     {  MST_FRANCES,
       {
-       { SPELL_THROW_ICICLE, 11, MON_SPELL_WIZARD },
-       { SPELL_SUMMON_DEMON, 11, MON_SPELL_WIZARD },
-       { SPELL_HASTE, 21, MON_SPELL_WIZARD },
-       { SPELL_IRON_SHOT, 11, MON_SPELL_WIZARD },
-       { SPELL_SUMMON_DEMON, 11, MON_SPELL_WIZARD },
+       { SPELL_THROW_ICICLE, 12, MON_SPELL_WIZARD },
+       { SPELL_SUMMON_DEMON, 16, MON_SPELL_WIZARD },
+       { SPELL_HASTE, 24, MON_SPELL_WIZARD },
+       { SPELL_IRON_SHOT, 12, MON_SPELL_WIZARD },
       }
     },
 

--- a/crawl-ref/source/mon-spell.h
+++ b/crawl-ref/source/mon-spell.h
@@ -1258,8 +1258,8 @@ static const mon_spellbook mspell_list[] =
     {  MST_FRANCES,
       {
        { SPELL_THROW_ICICLE, 12, MON_SPELL_WIZARD },
-       { SPELL_SUMMON_DEMON, 16, MON_SPELL_WIZARD },
-       { SPELL_HASTE, 24, MON_SPELL_WIZARD },
+       { SPELL_SUMMON_DEMON, 20, MON_SPELL_WIZARD },
+       { SPELL_HASTE, 20, MON_SPELL_WIZARD },
        { SPELL_IRON_SHOT, 12, MON_SPELL_WIZARD },
       }
     },


### PR DESCRIPTION
Summon Demon was listed twice, so split the duplicate SD's chance into
the other spells with a preference for SD itself and Haste (the other
spell with increased cast frequency).