### PR TITLE
make monsters have better self-preservation around clouds

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -1516,8 +1516,10 @@ static bool _mons_avoids_cloud(const monster* mons, const cloud_struct& cloud,
         const int hp_threshold = clouds[cloud.type].expected_base_damage +
                                  random2avg(rand_dam, trials);
 
+        // intelligent monsters want a larger margin of safety
+        int safety_mult = (mons_intel(mons) > I_ANIMAL) ? 2 : 1;
         // dare we risk the damage?
-        const bool hp_ok = mons->hit_points >= hp_threshold;
+        const bool hp_ok = mons->hit_points > safety_mult * hp_threshold;
         // dare we risk the status effects?
         const bool sfx_ok = cloud.type != CLOUD_MEPHITIC
                             || x_chance_in_y(mons->get_hit_dice() - 1, 5);

--- a/crawl-ref/source/dat/des/test/suite.des
+++ b/crawl-ref/source/dat/des/test/suite.des
@@ -38,3 +38,24 @@ x2PPx
 x.1xx
 xxxxx
 ENDMAP
+
+NAME:    monster_avoids_cloud
+DEPTH:   D:1
+TAGS:    no_monster_gen
+KMONS:   1 = generate_awake goblin
+MARKER:  F = lua:fog_machine { cloud_type = "flame", \
+             pow_min = 1000, pow_max = 1000, delay = 1, \
+             size = 1, walk_dist = 0, start_clouds = 1, excl_rad = 0 }
+MAP
+xxxxxxxxx
+x.......x
+x...F...x
+x..FFF..x
+x...F...x
+x...1...x
+xFFFFFFFx
+xmmmmmmmx
+.........
+ENDMAP
+
+

--- a/crawl-ref/source/mon-movetarget.cc
+++ b/crawl-ref/source/mon-movetarget.cc
@@ -747,6 +747,9 @@ void set_random_target(monster* mon)
         if (!summon_can_attack(mon, newtarget))
             continue;
 
+        if (!mon->is_location_safe(newtarget))
+            continue;
+
         mon->target = newtarget;
         break;
     }
@@ -804,6 +807,9 @@ static bool _band_wander_target(monster * mon)
         if (!in_bounds(*r_it))
             continue;
 
+        if (!band_leader->is_location_safe(*r_it))
+            continue;
+
         int dist = grid_distance(*r_it, band_leader->pos());
         if (dist < HERD_COMFORT_RANGE)
             positions.push_back(*r_it);
@@ -844,6 +850,9 @@ static bool _herd_wander_target(monster * mon)
     for (radius_iterator r_it(mon->pos(), LOS_NO_TRANS, true); r_it; ++r_it)
     {
         if (!in_bounds(*r_it))
+            continue;
+
+        if (!mon->is_location_safe(*r_it))
             continue;
 
         int count = 0;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4898,6 +4898,12 @@ bool monster::is_trap_safe(const coord_def& where, bool just_check) const
     return true;
 }
 
+bool monster::is_cloud_safe(const coord_def &place)
+{
+    int cl = env.cgrid(place);
+    return cl == EMPTY_CLOUD || !mons_avoids_cloud(this, cl);
+}
+
 bool monster::check_set_valid_home(const coord_def &place,
                                     coord_def &chosen,
                                     int &nvalid) const
@@ -4916,6 +4922,21 @@ bool monster::check_set_valid_home(const coord_def &place,
 
     if (one_chance_in(++nvalid))
         chosen = place;
+
+    return true;
+}
+
+
+bool monster::is_location_safe(const coord_def &place)
+{
+    if (!monster_habitable_grid(this, grd(place)))
+        return false;
+
+    if (!is_trap_safe(place, true))
+        return false;
+
+    if (!is_cloud_safe(place))
+        return false;
 
     return true;
 }

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -209,6 +209,7 @@ public:
     bool needs_abyss_transit() const;
     void set_transit(const level_id &destination);
     bool is_trap_safe(const coord_def& where, bool just_check = false) const;
+    bool is_location_safe(const coord_def &place);
     bool find_place_to_live(bool near_player = false);
     bool find_home_near_place(const coord_def &c);
     bool find_home_near_player();
@@ -598,6 +599,7 @@ private:
                               coord_def &chosen,
                               int &nvalid) const;
     bool search_spells(function<bool (spell_type)> func) const;
+    bool is_cloud_safe(const coord_def &place);
 };
 
 #endif


### PR DESCRIPTION
Fixes bugs involving monster movement near clouds. Wandering monsters no longer path into clouds. Intelligent monsters want more HP before entering a damaging cloud; in other words, friendly monsters are less likely to do walk into a friendly cloud & die.

https://crawl.develz.org/mantis/view.php?id=2980
https://crawl.develz.org/mantis/view.php?id=9759