### PR TITLE
Update Volcano armour loot distribution

### DIFF
--- a/crawl-ref/source/dat/des/portals/volcano.des
+++ b/crawl-ref/source/dat/des/portals/volcano.des
@@ -176,12 +176,12 @@ function make_fiery_weapon (e, weapon)
 end
 
 function setup_loot (e)
-    e.item(make_fiery_armour(e,  {"robe w:30", "animal skin w:30", "leather armour w:30",
-                                  "ring mail w:30", "scale mail w:20", "chain mail w:40",
-                                  "plate armour w:10", "pair of gloves w:5",
-                                  "helmet w:6", "pair of boots w:3", "hat w:4",
-                                  "shield w:1", "cloak w:4", "buckler w:3"}) ..
-                                  " / fire dragon armour w:5")
+    e.item(make_fiery_armour(e,  {"robe w:50", "leather armour w:50", "ring mail w:50",
+                                  "scale mail w:35", "chain mail w:35",
+                                  "plate armour w:15", "pair of gloves w:6", "helmet w:4",
+                                  "hat w:2", "pair of boots w:6", "cloak w:6",
+                                  "large shield w:1", "shield w:2", "buckler w:3"}) ..
+                                  " / fire dragon armour w:7")
     e.item([[potion of berserk rage w:22 / potion of might w:5 /
              potion of brilliance w:5 / potion of agility w:5 /
              potion of experience q:1 w:1 / potion of resistance]])


### PR DESCRIPTION
To be more in line with armour loot generation elsewhere. Note the
absence of animal skins.

PR note: Similar to what was done with volcano weapons, adjusted
the weights to be in line with normal item generation, keeping the
aux armour-body armour ratio the same (approx 1:8)