### PR TITLE
Swap the weighting for storm cloud/acid cloud on the Rod of Clouds

### DIFF
--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -468,8 +468,8 @@ random_pick_entry<cloud_type> cloud_cone_clouds[] =
   { 0,  100, 100, PEAK, CLOUD_COLD },
   { 0,  100, 100, PEAK, CLOUD_POISON },
   { 30, 100, 125, RISE, CLOUD_NEGATIVE_ENERGY },
-  { 40, 100, 135, RISE, CLOUD_ACID },
-  { 50, 100, 175, RISE, CLOUD_STORM },
+  { 40, 100, 135, RISE, CLOUD_STORM },
+  { 50, 100, 175, RISE, CLOUD_ACID },
   { 0,0,0,FLAT,CLOUD_NONE }
 };
 


### PR DESCRIPTION
Storm cloud is arguably not more powerful than even mid-tier clouds
(fire, cold) on this rod unless the enemy has a lot of AC. With low AC,
the damage is comparable with the trade-offs of a lack of consistency
and a lot of noise. Acid has a very good extra effect in corrosion and
few enemies resist it, so it's certainly better than storm - arguably
negative energy is as well, but there's at least the issue of rN+ being
more common here, and storm cloud seems too exotic to show up that
early.

PR note: As discussed in IRC, storm deals approx 4x the damage 1/4
of the time and makes a lot of noise with no extra effect.