### PR TITLE
Small adjustment to orb spider generation on the sack of spiders

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1022,7 +1022,7 @@ static const pop_entry pop_spiders[] =
   {  0,  15,  100, FALL, MONS_SPIDER },
   {  7,  18,   80, PEAK, MONS_TRAPDOOR_SPIDER },
   {  9,  25,   90, PEAK, MONS_REDBACK },
-  { 10,  27,   10, SEMI, MONS_ORB_SPIDER },
+  { 10,  25,   10, FLAT, MONS_ORB_SPIDER },
   { 12,  27,  100, PEAK, MONS_JUMPING_SPIDER },
   { 13,  27,  110, PEAK, MONS_TARANTELLA },
   { 15,  27,  120, PEAK, MONS_WOLF_SPIDER },


### PR DESCRIPTION
PR note: This is a change I wanted to make but forgot about, their
range should stop at 25 like redbacks since they show up too much
at 27, and in retrospect flat is better than semi.