### PR TITLE
Swap weapon lists for naga mages and naga warriors

### DIFF
--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -342,7 +342,7 @@ static void _give_weapon(monster* mon, int level, bool melee_only = false,
 
     case MONS_GNOLL:
     case MONS_OGRE_MAGE:
-    case MONS_NAGA_WARRIOR:
+    case MONS_NAGA_MAGE:
     case MONS_GREATER_NAGA:
         if (!one_chance_in(5))
         {
@@ -539,7 +539,7 @@ static void _give_weapon(monster* mon, int level, bool melee_only = false,
         // deliberate fall-through
 
     case MONS_NAGA:
-    case MONS_NAGA_MAGE:
+    case MONS_NAGA_WARRIOR:
     case MONS_ORC_WARRIOR:
     case MONS_ORC_HIGH_PRIEST:
     case MONS_BLORK_THE_ORC:


### PR DESCRIPTION
Greater naga and naga warriors shared a weapon list made up of
generally inferior weapons. This made sense for greater nagas
since they have Haste Self and offensive conjurations, but warriors 
shouldn't have an inferior weapon list to nagas and naga mages.
Swapping the weapon lists for naga mages and naga warriors.

This is a buff to warriors and will make Snake more dangerous, but
naga warriors are slow and there is no reason people shouldn't be 
cautious of them anyway.