### PR TITLE
Fix unsuitable-weapon-warning behaviour with transforms

### DIFF
--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -2014,10 +2014,11 @@ void untransform(bool skip_move)
 {
     const bool was_flying = you.airborne();
 
-    you.redraw_quiver       = true;
-    you.redraw_evasion      = true;
-    you.redraw_armour_class = true;
-    you.wield_change        = true;
+    you.redraw_quiver           = true;
+    you.redraw_evasion          = true;
+    you.redraw_armour_class     = true;
+    you.wield_change            = true;
+    you.received_weapon_warning = false;
     if (you.props.exists(TRANSFORM_POW_KEY))
         you.props.erase(TRANSFORM_POW_KEY);
     if (you.props.exists(HYDRA_FORM_HEADS_KEY))


### PR DESCRIPTION
If you say 'yes' to attack barehanded while you're a hydra, that
doesn't mean you're also saying 'yes' to attacking with whatever
you have wielded once you un-transform.