### PR TITLE
Allow demonspawn warmongers to spawn with shields

### DIFF
--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -1388,7 +1388,7 @@ static void _give_weapon(monster* mon, int level, bool melee_only = false,
     case MONS_WARMONGER:
         level = ISPEC_GOOD_ITEM;
         item.base_type = OBJ_WEAPONS;
-        if (!melee_only)
+        if (!melee_only && one_chance_in(3))
         {
             item.sub_type = random_choose_weighted(10, WPN_LONGBOW,
                                                    9, WPN_ARBALEST,


### PR DESCRIPTION
There are already lines in the existing code that allow warmongers to 
spawn with shields. However, warmongers currently have guaranteed 
launchers at spawn (possibly due to the interaction with Grand Avatar,
which has since been removed). Since launchers preclude shields, 
reducing the chance of generating a launcher to one in three will allow 
shield generation.