### PR TITLE
use unwind_bool typedef

### DIFF
--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1815,7 +1815,7 @@ void save_messages(writer& outf)
 
 void load_messages(reader& inf)
 {
-    unwind_var<bool> save_more(crawl_state.show_more_prompt, false);
+    unwind_bool save_more(crawl_state.show_more_prompt, false);
 
     int num = unmarshallInt(inf);
     for (int i = 0; i < num; ++i)

--- a/crawl-ref/source/uncancel.cc
+++ b/crawl-ref/source/uncancel.cc
@@ -27,7 +27,7 @@ void run_uncancels()
     // Run uncancels iteratively rather than recursively.
     if (running)
         return;
-    unwind_var<bool> run(running, true);
+    unwind_bool run(running, true);
 
     while (!you.uncancel.empty() && !crawl_state.seen_hups)
     {


### PR DESCRIPTION
Replaces the two remaining uses of unwind_var\<bool\> with the appropriate typedef