### PR TITLE
Accidentally a word

### DIFF
--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -1013,7 +1013,7 @@ blessed fire cloud
 A cloud of divine fire, imbued with holy power. Those in the service of one of
 the good gods will be unaffected by it. All others will take substantial
 damage, with fire resistance offering no protection. Those following evil gods
-will take increased damage, and the undead and demonic are even more.
+will take increased damage, and the undead and demonic even more.
 %%%%
 foul pestilence cloud
 


### PR DESCRIPTION
The "are" in this sentence was probably left over from some earlier wording; it doesn't make sense anymore.