### PR TITLE
Make Blink a single-level mutation

### DIFF
--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -761,9 +761,8 @@ public:
     }
 
 #ifdef USE_TILE_WEB
-    void send(int old_msgs = 0)
+    void send()
     {
-        unsent += old_msgs;
         if (unsent == 0 || (send_ignore_one && unsent == 1)) return;
 
         if (client_rollback > 0)
@@ -771,8 +770,6 @@ public:
             tiles.json_write_int("rollback", client_rollback);
             client_rollback = 0;
         }
-        if (old_msgs > 0)
-            tiles.json_write_int("old_msgs", old_msgs);
         tiles.json_open_array("messages");
         for (int i = -unsent; i < (send_ignore_one ? -1 : 0); ++i)
         {
@@ -811,7 +808,7 @@ void webtiles_send_last_messages(int n)
         tiles.json_write_bool("more", _more);
         _last_more = _more;
     }
-    buffer.send(n);
+    buffer.send();
     tiles.json_close_object(true);
     tiles.finish_message();
 }

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -174,6 +174,7 @@ enum tag_minor_version
     TAG_MINOR_MON_HD_INFO,         // store player-known monster HD info
     TAG_MINOR_NO_LEVEL_FLAGS,      // remove a field of env
     TAG_MINOR_EXORCISE,            // liches, a. liches, & spellforged servitors are no longer ghost_demons
+    TAG_MINOR_BLINK_MUT,           // 1-level blink mutation
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2806,6 +2806,12 @@ static void tag_read_you(reader &th)
             you.mutation[MUT_DETERIORATION] = 2;
     }
 
+    if (th.getMinorVersion() < TAG_MINOR_BLINK_MUT)
+    {
+        if (you.mutation[MUT_BLINK] > 1)
+            you.mutation[MUT_BLINK] = 1;
+    }
+
     // Fixup for Sacrifice XP from XL 27 (#9895). No minor tag, but this
     // should still be removed on a major bump.
     const int xl_remaining = you.get_max_xl() - you.experience_level;

--- a/crawl-ref/source/webserver/game_data/static/messages.js
+++ b/crawl-ref/source/webserver/game_data/static/messages.js
@@ -38,11 +38,22 @@ function ($, comm, client, util, options) {
             set_last_prefix_glyph("_", "command_marker");
     }
 
+    /**
+    * Remove all message elements from the player messages window save for the
+    * last 15.
+
+    * This is necessary to prevent <div> elements from messages no longer in
+    * view from pilling up over longer WebTiles session and thus slowing down
+    * the browser.
+    */
     function remove_old_messages()
     {
         var all_messages = $("#messages .game_message");
-        var messages_to_remove = all_messages.slice(0, -15);
-        messages_to_remove.remove();
+        if (all_messages.length > 15)
+        {
+            var messages_to_remove = all_messages.slice(0, -15);
+            messages_to_remove.remove();
+        }
     }
 
     function add_message(data)


### PR DESCRIPTION
Extra levels only serve to reduce the fail rate, leaving the HP cost
and range the same. It's also a fairly low-weight mutation, so extra
levels, when they do occur, tend to do so later in the game - when
the fail rate reduction is less significant due to the player's higher
XL and likelihood of having other sources of Blink. Therefore, getting
extra level(s) in Blink is one of the least interesting results of being
mutated.

Given that the mutation provides a simple ability with fixed properties,
it seems more logical and expected that it would be only one level.

Also clarify the message received upon losing the mutation.

PR: A fail rate tweak seemed necessary since the current values seem
balanced around having higher levels actually do something. At
mutlevel 1 the current fail rate feels too high at the XLs when the
ability is most likely to be used, especially taking into account the
additional cost of 5% MHP. The tweak is approximately equivalent to
the mutation becoming level 1.4. Having said that, I'd be fine with
not merging the 2nd commit if it's not desired.