### PR TITLE
Give minotaurs growing horns.

### DIFF
--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -527,7 +527,7 @@ static const map<species_type, species_def> species_data =
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     12, 5, 5, // 22
     { STAT_STR, STAT_DEX }, 4,
-    { { MUT_HORNS, 2, 1 }, },
+    { { MUT_HORNS, 1, 1 }, { MUT_HORNS, 1, 7 }, { MUT_HORNS, 1, 14 }, },
     { "You reflexively headbutt those who attack you in melee." },
     { "retaliatory headbutt" },
     { JOB_FIGHTER, JOB_GLADIATOR, JOB_MONK, JOB_HUNTER, JOB_BERSERKER },


### PR DESCRIPTION
Horns 1 at XL 1, 2 @ 7, 3 @ 14.

Biggest effect is no hat in lategame, but they'll be weaker before
D:5 too:
<Sequell> 288 games for * (trunk month mi d xl=7): 7x D:3,
75x D:4, 129x D:5, 59x D:6, 10x D:7, 8x D:8

Level 14 is about end-of-lair:
<Sequell> 88 games for * (trunk month mi xl=14): 17x Lair:8, 10x
Orc:4, 7x Abyss:1, 6x Lair:7, 5x Shoals:1, 5x Shoals:4, ...