### PR TITLE
Ashenzari "curse hands"

### DIFF
--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -213,6 +213,9 @@ void ash_check_bondage(bool msg)
         else
             s = ET_JEWELS;
 
+        // Ashenzari bound hands
+        if (i == EQ_WEAPON && player_hands_cursed())
+            cursed[ET_WEAPON] = 3;
         // transformed away slots are still considered to be possibly bound
         if (you_can_wear(i))
         {
@@ -583,8 +586,12 @@ map<skill_type, int8_t> ash_get_boosted_skills(eq_type type)
     switch (type)
     {
     case (ET_WEAPON):
-        ASSERT(wpn);
-
+        // Cursed hands.
+        if (!wpn)
+        {
+            boost[SK_UNARMED_COMBAT] = 2;
+            break;
+        }
         // Boost weapon skill. Plain "staff" means an unrand magical staff,
         // boosted later.
         if (wpn->base_type == OBJ_WEAPONS

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -8393,6 +8393,10 @@ void player_close_door(coord_def doorpos)
      you.turn_is_over = true;
 }
 
+bool player_hands_cursed() {
+    return you.props["ASHENZARI_HANDS_CURSED"];
+}
+
 /**
  * Return a string describing the player's hand(s) taking a given verb.
  *

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1057,6 +1057,7 @@ void float_player();
 bool land_player(bool quiet = false);
 void player_open_door(coord_def doorpos);
 void player_close_door(coord_def doorpos);
+bool player_hands_cursed();
 
 void dec_disease_player(int delay);
 


### PR DESCRIPTION
This is my second attempt at improving Ash for UC users (see #65).

Cursing your hands gives a UC boost but prevents (w)ielding items. Uncursing your hands removes the boost and restrictions. Cursing and uncursing uses a curse weapon or remove curse scroll respectively.

The code is not great quality right now (no idea what happens with felids/similar, the boost amount needs consideration, etc etc) but I want to see if it would be accepted before working further.