### PR TITLE
Uniques always corpsify

### DIFF
--- a/crawl-ref/source/butcher.cc
+++ b/crawl-ref/source/butcher.cc
@@ -334,8 +334,15 @@ static void _create_monster_hide(const item_def corpse)
 
 void maybe_drop_monster_hide(const item_def corpse)
 {
-    if (mons_class_leaves_hide(corpse.mon_type) && !one_chance_in(3))
+    const monster_type montype =
+        static_cast<monster_type>(corpse.orig_monnum);
+    bool uniq = !invalid_monster_type(montype) && mons_is_unique(montype);
+
+    if (mons_class_leaves_hide(corpse.mon_type) && !one_chance_in(3)
+        || uniq)
+    {
         _create_monster_hide(corpse);
+    }
 }
 
 /** Skeletonise this corpse.

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -419,9 +419,10 @@ item_def* place_monster_corpse(const monster& mons, bool silent, bool force)
         || force
         || goldify
         || mons_class_flag(mons.type, M_ALWAYS_CORPSE)
-        || mons_is_demonspawn(mons.type)
-           && mons_class_flag(draco_or_demonspawn_subspecies(&mons),
-                              M_ALWAYS_CORPSE);
+        || mons_is_or_was_unique(mons)
+        || (mons_is_demonspawn(mons.type)
+            && mons_class_flag(draco_or_demonspawn_subspecies(&mons),
+                               M_ALWAYS_CORPSE));
 
     // 50/50 chance of getting a corpse, usually.
     if (!no_coinflip && coinflip())


### PR DESCRIPTION
Or at least they don't coinflip() any more.

Also corpses from uniques always create hides when possible -- affects Purgy, Snorg and XTAHUA.