### PR TITLE
Register presence of un-mimicable notable features when magic mapping

### DIFF
--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -600,7 +600,7 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
             if (emphasise(*ri))
                 env.map_knowledge(*ri).flags |= MAP_EMPHASIZE;
 
-            if (is_notable_terrain(feat) && !feat_is_mimicable(feat))
+            if (is_notable_terrain(feat) && (wizard_map || !feat_is_mimicable(feat)))
                 seen_notable_thing(feat, *ri);
 
             if (wizard_map)

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -600,11 +600,11 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
             if (emphasise(*ri))
                 env.map_knowledge(*ri).flags |= MAP_EMPHASIZE;
 
+            if (is_notable_terrain(feat) && !feat_is_mimicable(feat))
+                seen_notable_thing(feat, *ri);
+
             if (wizard_map)
             {
-                if (is_notable_terrain(feat))
-                    seen_notable_thing(feat, *ri);
-
                 set_terrain_seen(*ri);
 #ifdef USE_TILE
                 tile_wizmap_terrain(*ri);


### PR DESCRIPTION
This allows branch entrances to be added to the dungeon overview screen
and autotravel, even when only seen via a scroll of magic mapping.