### PR TITLE
Note branch staircases when revealed with magic mapping

### DIFF
--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -614,6 +614,9 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
             {
                 set_terrain_mapped(*ri);
 
+                if (get_cell_map_feature(env.map_knowledge(*ri)) == MF_STAIR_BRANCH)
+                    seen_notable_thing(feat, *ri);
+
                 if (get_feature_dchar(feat) == DCHAR_ALTAR)
                     num_altars++;
                 else if (get_feature_dchar(feat) == DCHAR_ARCH)


### PR DESCRIPTION
This allows magic-mapped branches to be displayed in the dungeon
overview window and to be set as autotravel destinations.  The new Xv
behavior allows the specific branch to be determined already, so no
additional information is leaked by this change.