### PR TITLE
Update another xl_rank_name

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4018,7 +4018,7 @@ static const char* xl_rank_names[] =
     "amateur",
     "novice",
     "journeyman",
-    "experienced",
+    "adept",
     "veteran",
     "master",
     "legendary"


### PR DESCRIPTION
To avoid reusing "experienced" for a different level bracket than
it was previously.