### PR TITLE
Fix for issues related to no-device-heal + rot.

### DIFF
--- a/crawl-ref/source/itemname.cc
+++ b/crawl-ref/source/itemname.cc
@@ -3561,7 +3561,8 @@ bool is_useless_item(const item_def &item, bool temp)
         if (item.sub_type == WAND_HEAL_WOUNDS
             && item_type_known(item)
             && !you.can_device_heal()
-            && player_mutation_level(MUT_NO_LOVE))
+            && player_mutation_level(MUT_NO_LOVE)
+            && !player_rotted())
         {
             return true;
         }
@@ -3642,7 +3643,7 @@ bool is_useless_item(const item_def &item, bool temp)
             return you.species == SP_FORMICID;
 #endif
         case POT_HEAL_WOUNDS:
-            return !you.can_device_heal();
+            return !you.can_device_heal() && !player_rotted();
         case POT_INVISIBILITY:
             return _invisibility_is_useless(temp);
         case POT_AMBROSIA:

--- a/crawl-ref/source/itemname.cc
+++ b/crawl-ref/source/itemname.cc
@@ -3561,8 +3561,7 @@ bool is_useless_item(const item_def &item, bool temp)
         if (item.sub_type == WAND_HEAL_WOUNDS
             && item_type_known(item)
             && !you.can_device_heal()
-            && player_mutation_level(MUT_NO_LOVE)
-            && !player_rotted())
+            && player_mutation_level(MUT_NO_LOVE))
         {
             return true;
         }
@@ -3643,7 +3642,7 @@ bool is_useless_item(const item_def &item, bool temp)
             return you.species == SP_FORMICID;
 #endif
         case POT_HEAL_WOUNDS:
-            return !you.can_device_heal() && !player_rotted();
+            return !you.can_device_heal();
         case POT_INVISIBILITY:
             return _invisibility_is_useless(temp);
         case POT_AMBROSIA:

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -106,7 +106,9 @@ public:
             int amount = 5 + random2(7);
             if (is_device && !you.can_device_heal() && player_rotted())
             {
-                amount = unrot_hp(amount);
+                // Treat the effectiveness of rot removal as if the player
+                // had two levels of MUT_NO_DEVICE_HEAL
+                unrot_hp(div_rand_round(amount,3));
                 unrotted = true;
             }
             else
@@ -151,7 +153,7 @@ public:
 
     bool can_quaff(string *reason = nullptr) const override
     {
-        if (!you.can_device_heal() && player_rotted() == 0)
+        if (!you.can_device_heal())
         {
             if (reason)
                 *reason = "That would not heal you.";
@@ -179,19 +181,13 @@ public:
             mpr("You feel queasy.");
             return false;
         }
-        int amount = 10 + random2avg(28, 3);
-        if (!you.can_device_heal() && player_rotted() && is_device)
-        {
-            unrot_hp(amount);
-            mpr("You feel much better.");
-                return true;
-        }
         if (!you.can_device_heal() && is_device)
         {
             mpr("That seemed strangely inert.");
             return false;
         }
 
+        int amount = 10 + random2avg(28, 3);
         if (is_device)
             amount = you.scale_device_healing(amount);
         // Pay for rot right off the top.


### PR DESCRIPTION
Allow players to heal rot even with no device heal mutation. All of the other statuses are fixed by potions of curing even with no device heal, so fix this as well. Also let players use potions of heal wounds to heal rot, since they heal rot in the same way as curing.