### PR TITLE
Tweak an arrival vault

### DIFF
--- a/crawl-ref/source/dat/des/arrival/simple.des
+++ b/crawl-ref/source/dat/des/arrival/simple.des
@@ -1424,18 +1424,17 @@ ENDMAP
 NAME:    ldierk_water_garden
 TAGS:    arrival no_monster_gen no_pool_fixup
 ORIENT:  float
-SHUFFLE: 123t
 SUBST:   W : wW
-MONS:    plant, toadstool, bush
+MONS:    toadstool
 MAP
   W       W
- W1W     W2W
-W1T1WWWWW2T2W
-.W1.......2W.
+ WtW     WtW
+WtTtWWWWWtTtW
+.Wt.......tW.
 @.W...{...W.@
-.W3.......tW.
-W3T3WWWWWtTtW
- W3W     WtW
+.Wt.......1W.
+WtTtWWWWW1T1W
+ WtW     W1W
   W       W
 ENDMAP
 


### PR DESCRIPTION
ldierk_water_garden placed toadstools, bushes, plants, and trees in four
corners.

A player unfamiliar with the nuances of stationary plant monsters may
choose to attack the plant or bush corner, and if this character has no
weapon or using untrained UC this will take hundreds of turns.

Change it to spawn trees in 3 corners with one toadstool exit, which the
dungeon builder flip/rotate will randomize.