### PR TITLE
Change the 'safe option' for using unorthodox stairs to 'no'

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -165,7 +165,7 @@ bool deviant_route_warning::warn_continue_travel(
     // If the user says "Yes, shut up and take me there", we won't ask
     // again for that destination. If the user says "No", we will
     // prompt again.
-    return warned = yesno(prompt.c_str(), true, 'y', true, false);
+    return warned = yesno(prompt.c_str(), true, 'n', true, false);
 }
 
 static deviant_route_warning _Route_Warning;


### PR DESCRIPTION
When crawl asks me "do you really want to use those stairs" and I hit escape, that should mean "no", not "yes".