### PR TITLE
Add rc option to prompt before using escape hatches

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -59,7 +59,7 @@ The contents of this text are:
                 autofight_caught, autofight_wait, autofight_prompt_range,
                 automagic_enable, automagic_slot, automagic_fight,
                 automagic_stop, fail_severity_to_confirm, easy_door,
-                enable_recast_spell
+                warn_hatches, enable_recast_spell
 3-h     Message and Display Improvements.
                 hp_warning, mp_warning, hp_colour, mp_colour, stat_colour,
                 status_caption_colour, enemy_hp_colour, clear_messages,
@@ -1264,6 +1264,9 @@ easy_door = true
         When (O)pening or (C)losing doors, do not prompt for a direction
         if there is only one adjacent door. This option does not affect
         opening doors by walking into them.
+
+warn_hatches = false
+        Ask for confirmation before using a one-way escape hatch.
 
 enable_recast_spell = true
         If enabled, allows recasting the previously cast spell by pressing

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1266,7 +1266,7 @@ easy_door = true
         opening doors by walking into them.
 
 warn_hatches = false
-        Ask for confirmation before using a one-way escape hatch.
+        Ask for confirmation before using a one-way escape hatch or shaft.
 
 enable_recast_spell = true
         If enabled, allows recasting the previously cast spell by pressing

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -790,6 +790,7 @@ void game_options::reset_options()
     equip_unequip          = false;
     jewellery_prompt       = false;
     easy_door              = true;
+    warn_hatches           = false;
     enable_recast_spell    = true;
     confirm_butcher        = CONFIRM_AUTO;
     easy_eat_chunks        = false;
@@ -2645,6 +2646,7 @@ void game_options::read_option_line(const string &str, bool runscript)
     else BOOL_OPTION_NAMED("easy_armour", easy_unequip);
     else BOOL_OPTION_NAMED("easy_armor", easy_unequip);
     else BOOL_OPTION(easy_door);
+    else BOOL_OPTION(warn_hatches);
     else BOOL_OPTION(enable_recast_spell);
     else if (key == "confirm_butcher")
     {

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1588,6 +1588,12 @@ static bool _can_take_stairs(dungeon_feature_type ftype, bool down,
         return false;
     }
 
+    if (feat_is_escape_hatch(ftype))
+    {
+        return !Options.warn_hatches || yesno("Really go through this one-way escape hatch?",
+                                              true, 'n');
+    }
+
     // bidirectional, but not actually a portal
     if (ftype == DNGN_PASSAGE_OF_GOLUBRIA)
         return true;

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1588,12 +1588,6 @@ static bool _can_take_stairs(dungeon_feature_type ftype, bool down,
         return false;
     }
 
-    if (feat_is_escape_hatch(ftype))
-    {
-        return !Options.warn_hatches || yesno("Really go through this one-way escape hatch?",
-                                              true, 'n');
-    }
-
     // bidirectional, but not actually a portal
     if (ftype == DNGN_PASSAGE_OF_GOLUBRIA)
         return true;
@@ -1697,7 +1691,7 @@ static bool _prompt_unique_pan_rune(dungeon_feature_type ygrd)
     return true;
 }
 
-static bool _prompt_stairs(dungeon_feature_type ygrd, bool down)
+static bool _prompt_stairs(dungeon_feature_type ygrd, bool down, bool shaft)
 {
     // Certain portal types always carry warnings.
     if (!_prompt_dangerous_portal(ygrd))
@@ -1759,6 +1753,14 @@ static bool _prompt_stairs(dungeon_feature_type ygrd, bool down)
         }
     }
 
+    if (Options.warn_hatches)
+    {
+        if (feat_is_escape_hatch(ygrd))
+            return yesno("Really go through this one-way escape hatch?", true, 'n');
+        if (down && shaft) // voluntary shaft usage
+            return yesno("Really dive through this shaft in the floor?", true, 'n');
+    }
+
     return true;
 }
 
@@ -1772,14 +1774,12 @@ static void _take_stairs(bool down)
     const bool shaft = (down && get_trap_type(you.pos()) == TRAP_SHAFT
                              && ygrd != DNGN_UNDISCOVERED_TRAP);
 
-    if (!_can_take_stairs(ygrd, down, shaft))
+    if (!(_can_take_stairs(ygrd, down, shaft)
+          && _prompt_stairs(ygrd, down, shaft)
+          && you.attempt_escape())) // false means constricted and don't escape
+    {
         return;
-
-    if (!_prompt_stairs(ygrd, down))
-        return;
-
-    if (!you.attempt_escape()) // false means constricted and don't escape
-        return;
+    }
 
     you.stop_constricting_all(true);
     you.stop_being_constricted();

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -208,6 +208,7 @@ public:
     bool        equip_unequip;   // Make 'W' = 'T', and 'P' = 'R'.
     bool        jewellery_prompt; // Always prompt for slot when changing jewellery.
     bool        easy_door;       // 'O', 'C' don't prompt with just one door.
+    bool        warn_hatches;    // offer a y/n prompt when the player uses an escape hatch
     bool        enable_recast_spell; // Allow recasting spells with 'z' Enter.
     int         confirm_butcher; // When to prompt for butchery
     bool        easy_eat_chunks; // make 'e' auto-eat the oldest safe chunk


### PR DESCRIPTION
I've had some close calls accidentally using a hatch that I thought was a stair.