### PR TITLE
Upgrade Qaz wrath.

### DIFF
--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -1681,20 +1681,17 @@ static void _qazlal_elemental_vulnerability()
  */
 static bool _qazlal_retribution()
 {
-    switch (random2(3))
+    if (coinflip())
     {
-    case 0:
-        _qazlal_summon_elementals();
-        break;
-    case 1:
-        _qazlal_elemental_vulnerability();
-        break;
-    case 2:
         simple_god_message(" causes a mighty clap of thunder!",
                            GOD_QAZLAL);
         noisy(25, you.pos());
-        break;
     }
+
+    if (coinflip())
+        _qazlal_summon_elementals();
+    else
+        _qazlal_elemental_vulnerability();
 
     return true;
 }

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -431,7 +431,7 @@ static const mutation_def mut_data[] =
 },
 
 { MUT_DEFORMED, 8, 1,
-  mutflag::BAD | mutflag::XOM | mutflag::CORRUPT | mutflag::QAZLAL,
+  mutflag::BAD | mutflag::XOM | mutflag::CORRUPT,
   true,
   "deformed body",
 


### PR DESCRIPTION
Causing noise is pretty poor wrath, so instead of choosing that wrath
1/3 of the time, do it 50% of the time before the other two wrath types.
Note: this commit does not make Qaz wrath as dangerous as it should be.