### PR TITLE
Interpret '!', '#', and Tab as "re-roll the random character"

### DIFF
--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -401,7 +401,7 @@ static bool _reroll_random(newgame_def& ng)
 #endif
         game_ended();
     }
-    return toalower(c) == 'n';
+    return toalower(c) == 'n' || c == '\t' || c == '!' || c == '#';
 }
 
 static void _choose_char(newgame_def& ng, newgame_def& choice,


### PR DESCRIPTION
At present, answering the "Do you want to play this combination?" with
anything besides 'n', 'q', or Esc (interpreted as 'q') is interpreted as
'y'.  This change allows the player to re-press the key that meant "give
me a random combination" to do it again.