### PR TITLE
Re-add Gozag duplication.

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -198,7 +198,7 @@ ability_type god_abilities[NUM_GODS][MAX_GOD_ABILITIES] =
       ABIL_NON_ABILITY, ABIL_DITHMENOS_SHADOW_FORM },
     // Gozag
     { ABIL_GOZAG_POTION_PETITION, ABIL_GOZAG_CALL_MERCHANT,
-      ABIL_GOZAG_BRIBE_BRANCH, ABIL_NON_ABILITY, ABIL_NON_ABILITY },
+      ABIL_GOZAG_BRIBE_BRANCH, ABIL_GOZAG_DUPLICATE_ITEM, ABIL_NON_ABILITY },
     // Qazlal
     { ABIL_NON_ABILITY, ABIL_QAZLAL_UPHEAVAL, ABIL_QAZLAL_ELEMENTAL_FORCE,
       ABIL_NON_ABILITY, ABIL_QAZLAL_DISASTER_AREA },
@@ -468,6 +468,8 @@ static const ability_def Ability_List[] =
       0, 0, 0, 0, abflag::GOLD },
     { ABIL_GOZAG_BRIBE_BRANCH, "Bribe Branch",
       0, 0, 0, 0, abflag::GOLD },
+    { ABIL_GOZAG_DUPLICATE_ITEM, "Duplicate Item",
+      0, 0, 0, 0, abflag::GOLD },
 
     // Qazlal
     { ABIL_QAZLAL_UPHEAVAL, "Upheaval", 4, 0, 0, 3, abflag::NONE },
@@ -559,6 +561,8 @@ int get_gold_cost(ability_type ability)
         return gozag_potion_price();
     case ABIL_GOZAG_BRIBE_BRANCH:
         return GOZAG_BRIBE_AMOUNT;
+    case ABIL_GOZAG_DUPLICATE_ITEM:
+        return gozag_duplicate_item_price();
     default:
         return 0;
     }
@@ -955,6 +959,7 @@ talent get_talent(ability_type ability, bool check_confused)
     case ABIL_GOZAG_POTION_PETITION:
     case ABIL_GOZAG_CALL_MERCHANT:
     case ABIL_GOZAG_BRIBE_BRANCH:
+    case ABIL_GOZAG_DUPLICATE_ITEM:
     case ABIL_RU_DRAW_OUT_POWER:
     case ABIL_RU_POWER_LEAP:
     case ABIL_RU_APOCALYPSE:
@@ -1546,6 +1551,9 @@ static bool _check_ability_possible(const ability_def& abil,
 
     case ABIL_GOZAG_BRIBE_BRANCH:
         return gozag_check_bribe_branch(quiet);
+
+    case ABIL_GOZAG_DUPLICATE_ITEM:
+        return gozag_check_duplicate_item(quiet);
 
     case ABIL_RU_SACRIFICE_EXPERIENCE:
         if (you.experience_level <= RU_SAC_XP_LEVELS)
@@ -2794,6 +2802,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_GOZAG_BRIBE_BRANCH:
         fail_check();
         if (!gozag_bribe_branch())
+            return SPRET_ABORT;
+        break;
+
+    case ABIL_GOZAG_DUPLICATE_ITEM:
+        fail_check();
+        if (!gozag_duplicate_item())
             return SPRET_ABORT;
         break;
 

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -378,6 +378,7 @@ enum ability_type
     ABIL_GOZAG_POTION_PETITION = 1180,
     ABIL_GOZAG_CALL_MERCHANT,
     ABIL_GOZAG_BRIBE_BRANCH,
+    ABIL_GOZAG_DUPLICATE_ITEM,
     // Qazlal
     ABIL_QAZLAL_UPHEAVAL = 1190,
     ABIL_QAZLAL_ELEMENTAL_FORCE,
@@ -513,6 +514,7 @@ enum attribute_type
 #endif
     ATTR_GOZAG_SHOPS,          // Number of shops you've funded from Gozag.
     ATTR_GOZAG_SHOPS_CURRENT,  // As above, but since most recent time worshipping.
+    ATTR_GOZAG_DUPLICATES,     // Number of items Gozag has duplicated for you.
 #if TAG_MAJOR_VERSION == 34
     ATTR_DIVINE_FIRE_RES,      // Divine fire resistance (Qazlal).
     ATTR_DIVINE_COLD_RES,      // Divine cold resistance (Qazlal).

--- a/crawl-ref/source/godabil.cc
+++ b/crawl-ref/source/godabil.cc
@@ -4986,6 +4986,50 @@ bool gozag_bribe_branch()
     return false;
 }
 
+int gozag_duplicate_item_price()
+{
+    return GOZAG_DUPLICATE_ITEM_AMOUNT
+        * (you.attribute[ATTR_GOZAG_DUPLICATES] + 1);
+}
+bool gozag_check_duplicate_item(bool quiet)
+{
+    const int cost = gozag_duplicate_item_price();
+    if (you.gold < cost)
+    {
+        if (!quiet)
+            mprf("Gozag charges %d to duplicate an item.", cost);
+        return false;
+    }
+    return true;
+}
+
+bool gozag_duplicate_item()
+{
+    int price = gozag_duplicate_item_price();
+    ASSERT(you.gold >= price);
+    int item_slot = prompt_invent_item("Duplicate which item?", MT_INVLIST,
+        OSEL_ANY, true, true, false);
+    if (item_slot == PROMPT_NOTHING || item_slot == PROMPT_ABORT)
+        return false;
+
+    item_def i = you.inv[item_slot];
+    if (!copy_item_to_grid(i, you.pos()))
+    {
+        simple_god_message(" refuses to duplicate this!");
+        return false;
+    }
+    you.del_gold(price);
+    you.attribute[ATTR_GOZAG_DUPLICATES]++;
+
+    string message = " duplicates " + i.name(DESC_YOUR) + "!";
+    simple_god_message(message.c_str());
+
+    take_note(Note(NOTE_ID_ITEM, 0, 0,
+              i.name(DESC_A).c_str(), "duplicated by Gozag"));
+
+    return true;
+}
+
 static int _upheaval_radius(int pow)
 {
     return pow >= 100 ? 2 : 1;

--- a/crawl-ref/source/godabil.h
+++ b/crawl-ref/source/godabil.h
@@ -38,6 +38,7 @@ const char * const GOZAG_SHOP_COST_KEY       = "gozag_shop_cost_%d";
 #define GOZAG_BRIBE_AMOUNT 3000
 #define GOZAG_MAX_BRIBABILITY 8
 #define GOZAG_MAX_POTIONS 3
+#define GOZAG_DUPLICATE_ITEM_AMOUNT 5000
 
 #define RU_SAC_XP_LEVELS 2
 
@@ -146,6 +147,9 @@ bool gozag_branch_bribable(branch_type branch);
 void gozag_deduct_bribe(branch_type br, int amount);
 bool gozag_check_bribe_branch(bool quiet = false);
 bool gozag_bribe_branch();
+int gozag_duplicate_item_price();
+bool gozag_check_duplicate_item(bool quiet = false);
+bool gozag_duplicate_item();
 
 spret_type qazlal_upheaval(coord_def target, bool quiet = false,
                            bool fail = false);

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -349,7 +349,7 @@ const char* god_gain_power_messages[NUM_GODS][MAX_GOD_ABILITIES] =
     { "petition Gozag for potion effects",
       "fund merchants seeking to open stores in the dungeon",
       "bribe branches to halt enemies' attacks and recruit allies",
-      "",
+      "duplicate an item",
       ""
     },
     // Qazlal
@@ -494,7 +494,7 @@ const char* god_lose_power_messages[NUM_GODS][MAX_GOD_ABILITIES] =
     { "petition Gozag for potion effects",
       "fund merchants seeking to open stores in the dungeon",
       "bribe branches to halt enemies' attacks and recruit followers",
-      "",
+      "duplicate an item",
       ""
     },
     // Qazlal


### PR DESCRIPTION
This is now an ability that costs increasing gold with each use, and
duplicates a single item rather than a stack.

Based on current gold generation rates, typical three-runer can use this
ability a couple of times in a game:

    Runes | avg(goldfound) | avg(goldspent)
    3     | 33k            | 10k
    15    | 70k            | 13k