### PR TITLE
Gozag artefactise

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -198,7 +198,7 @@ ability_type god_abilities[NUM_GODS][MAX_GOD_ABILITIES] =
       ABIL_NON_ABILITY, ABIL_DITHMENOS_SHADOW_FORM },
     // Gozag
     { ABIL_GOZAG_POTION_PETITION, ABIL_GOZAG_CALL_MERCHANT,
-      ABIL_GOZAG_BRIBE_BRANCH, ABIL_NON_ABILITY, ABIL_NON_ABILITY },
+      ABIL_GOZAG_BRIBE_BRANCH, ABIL_GOZAG_ARTEFACTISE_ITEM, ABIL_NON_ABILITY },
     // Qazlal
     { ABIL_NON_ABILITY, ABIL_QAZLAL_UPHEAVAL, ABIL_QAZLAL_ELEMENTAL_FORCE,
       ABIL_NON_ABILITY, ABIL_QAZLAL_DISASTER_AREA },
@@ -468,6 +468,8 @@ static const ability_def Ability_List[] =
       0, 0, 0, 0, abflag::GOLD },
     { ABIL_GOZAG_BRIBE_BRANCH, "Bribe Branch",
       0, 0, 0, 0, abflag::GOLD },
+    { ABIL_GOZAG_ARTEFACTISE_ITEM, "Artefactise Item",
+      0, 0, 0, 0, abflag::GOLD },
 
     // Qazlal
     { ABIL_QAZLAL_UPHEAVAL, "Upheaval", 4, 0, 0, 3, abflag::NONE },
@@ -559,6 +561,8 @@ int get_gold_cost(ability_type ability)
         return gozag_potion_price();
     case ABIL_GOZAG_BRIBE_BRANCH:
         return GOZAG_BRIBE_AMOUNT;
+    case ABIL_GOZAG_ARTEFACTISE_ITEM:
+        return gozag_artefactise_item_price();
     default:
         return 0;
     }
@@ -955,6 +959,7 @@ talent get_talent(ability_type ability, bool check_confused)
     case ABIL_GOZAG_POTION_PETITION:
     case ABIL_GOZAG_CALL_MERCHANT:
     case ABIL_GOZAG_BRIBE_BRANCH:
+    case ABIL_GOZAG_ARTEFACTISE_ITEM:
     case ABIL_RU_DRAW_OUT_POWER:
     case ABIL_RU_POWER_LEAP:
     case ABIL_RU_APOCALYPSE:
@@ -1546,6 +1551,9 @@ static bool _check_ability_possible(const ability_def& abil,
 
     case ABIL_GOZAG_BRIBE_BRANCH:
         return gozag_check_bribe_branch(quiet);
+
+    case ABIL_GOZAG_ARTEFACTISE_ITEM:
+        return gozag_check_artefactise_item(quiet);
 
     case ABIL_RU_SACRIFICE_EXPERIENCE:
         if (you.experience_level <= RU_SAC_XP_LEVELS)
@@ -2794,6 +2802,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_GOZAG_BRIBE_BRANCH:
         fail_check();
         if (!gozag_bribe_branch())
+            return SPRET_ABORT;
+        break;
+
+    case ABIL_GOZAG_ARTEFACTISE_ITEM:
+        fail_check();
+        if (!gozag_artefactise_item())
             return SPRET_ABORT;
         break;
 

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -118,7 +118,7 @@ int artefact_known_property(const item_def &item, artefact_prop_type prop);
 
 void artefact_learn_prop(item_def &item, artefact_prop_type prop);
 
-bool make_item_randart(item_def &item, bool force_mundane = false);
+bool make_item_randart(item_def &item, bool force_mundane = false, int quality = 0);
 bool make_item_unrandart(item_def &item, int unrand_index);
 void setup_unrandart(item_def &item, bool creating = true);
 

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -1349,7 +1349,7 @@ int list_wizard_commands(bool do_redraw_screen)
                        "<w>s</w>      gain 20000 skill points\n"
                        "<w>S</w>      set skill to level\n"
                        "<w>x</w>      gain an experience level\n"
-                       "<w>$</w>      get 1000 gold\n"
+                       "<w>$</w>      get 10000 gold\n"
                        "<w>n</w>      lose all gold\n"
                        "<w>]</w>      get a mutation\n"
                        "<w>_</w>      gain religion\n"

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -378,6 +378,7 @@ enum ability_type
     ABIL_GOZAG_POTION_PETITION = 1180,
     ABIL_GOZAG_CALL_MERCHANT,
     ABIL_GOZAG_BRIBE_BRANCH,
+    ABIL_GOZAG_ARTEFACTISE_ITEM,
     // Qazlal
     ABIL_QAZLAL_UPHEAVAL = 1190,
     ABIL_QAZLAL_ELEMENTAL_FORCE,
@@ -513,6 +514,7 @@ enum attribute_type
 #endif
     ATTR_GOZAG_SHOPS,          // Number of shops you've funded from Gozag.
     ATTR_GOZAG_SHOPS_CURRENT,  // As above, but since most recent time worshipping.
+    ATTR_GOZAG_ARTEFACTS,      // Number of items Gozag has artefactised for you.
 #if TAG_MAJOR_VERSION == 34
     ATTR_DIVINE_FIRE_RES,      // Divine fire resistance (Qazlal).
     ATTR_DIVINE_COLD_RES,      // Divine cold resistance (Qazlal).

--- a/crawl-ref/source/godabil.h
+++ b/crawl-ref/source/godabil.h
@@ -38,6 +38,7 @@ const char * const GOZAG_SHOP_COST_KEY       = "gozag_shop_cost_%d";
 #define GOZAG_BRIBE_AMOUNT 3000
 #define GOZAG_MAX_BRIBABILITY 8
 #define GOZAG_MAX_POTIONS 3
+#define GOZAG_ARTEFACT_ITEM_AMOUNT 5000
 
 #define RU_SAC_XP_LEVELS 2
 
@@ -146,6 +147,9 @@ bool gozag_branch_bribable(branch_type branch);
 void gozag_deduct_bribe(branch_type br, int amount);
 bool gozag_check_bribe_branch(bool quiet = false);
 bool gozag_bribe_branch();
+int gozag_artefactise_item_price();
+bool gozag_check_artefactise_item(bool quiet = false);
+bool gozag_artefactise_item();
 
 spret_type qazlal_upheaval(coord_def target, bool quiet = false,
                            bool fail = false);

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -864,8 +864,8 @@ static void _do_wizard_command(int wiz_command)
     case '@': wizard_set_stats(); break;
     case '#': wizard_load_dump_file(); break;
     case '$':
-        mpr("Adding 1000 gold.");
-        you.add_gold(1000);
+        mpr("Adding 10000 gold.");
+        you.add_gold(10000);
         break;
     case '%': wizard_create_spec_object_by_name(); break;
     case '^': wizard_set_piety(); break;

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -196,6 +196,13 @@ static bool _try_make_item_unrand(item_def& item, int force_type)
     return false;
 }
 
+int get_randart_weapon_plus()
+{
+    // Mean +6.
+    int i = 12 - biased_random2(7,2) - biased_random2(7,2) - biased_random2(7,2);
+    return max(i, random2(2));
+}
+
 // Return whether we made an artefact.
 static bool _try_make_weapon_artefact(item_def& item, int force_type,
                                       int item_level, bool force_randart = false)
@@ -217,8 +224,7 @@ static bool _try_make_weapon_artefact(item_def& item, int force_type,
         if (item.sub_type == WPN_CLUB)
             return false;
 
-        // Mean enchantment +6.
-        item.plus = 12 - biased_random2(7,2) - biased_random2(7,2) - biased_random2(7,2);
+        item.plus = get_randart_weapon_plus();
 
         bool cursed = false;
         if (one_chance_in(5))
@@ -228,9 +234,6 @@ static bool _try_make_weapon_artefact(item_def& item, int force_type,
         }
         else if (item.plus < 0 && !one_chance_in(3))
             cursed = true;
-
-        // On weapons, an enchantment of less than 0 is never viable.
-        item.plus = max(static_cast<int>(item.plus), random2(2));
 
         // The rest are normal randarts.
         make_item_randart(item);

--- a/crawl-ref/source/makeitem.h
+++ b/crawl-ref/source/makeitem.h
@@ -34,3 +34,4 @@ void squash_plusses(int item_slot);
 void makeitem_tests();
 #endif
 #endif
+int get_randart_weapon_plus();

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -349,7 +349,7 @@ const char* god_gain_power_messages[NUM_GODS][MAX_GOD_ABILITIES] =
     { "petition Gozag for potion effects",
       "fund merchants seeking to open stores in the dungeon",
       "bribe branches to halt enemies' attacks and recruit allies",
-      "",
+      "artefactise an item",
       ""
     },
     // Qazlal
@@ -494,7 +494,7 @@ const char* god_lose_power_messages[NUM_GODS][MAX_GOD_ABILITIES] =
     { "petition Gozag for potion effects",
       "fund merchants seeking to open stores in the dungeon",
       "bribe branches to halt enemies' attacks and recruit followers",
-      "",
+      "artefactise an item",
       ""
     },
     // Qazlal


### PR DESCRIPTION
See also #143 -- this is an alternate gozag "capstone".

Add Gozag artefactisation. This is an ability that costs increasing gold with each use, and
works very similarly to wizmode &+.

Based on current gold generation rates, typical three-runer can use this
ability a couple of times in a game:

Runes | avg(goldfound) | avg(goldspent)
3     | 33k            | 10k
15    | 70k            | 13k

TODO:
* doesn't add plusses for non-weapons
* should we allow creating mega-artefacts by stacking new properties on
  top of an existing artefacts?