### PR TITLE
Allow selection of visible layers with '|'.

### DIFF
--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -507,10 +507,10 @@ static void _update_monster(monster* mons)
 
 /**
  * Update map knowledge and set the map tiles at a location.
- * @param gp            The location to update.
- * @param terrain_only  If True, only the feature information/tiles are updated.
+ * @param gp      The location to update.
+ * @param layers  The information layers to display.
 **/
-void show_update_at(const coord_def &gp, bool terrain_only)
+void show_update_at(const coord_def &gp, layers_type layers)
 {
     if (you.see_cell(gp))
         env.map_knowledge(gp).clear_data();
@@ -523,22 +523,29 @@ void show_update_at(const coord_def &gp, bool terrain_only)
 
     // If there's items on the boundary (shop inventory),
     // we don't show them.
-    if (!terrain_only && in_bounds(gp))
+    if (in_bounds(gp))
     {
-        monster* mons = monster_at(gp);
-        if (mons && mons->alive())
-            _update_monster(mons);
-        else if (env.map_knowledge(gp).flags & MAP_INVISIBLE_UPDATE)
-            _mark_invisible_at(gp);
-
-        const int cloud = env.cgrid(gp);
-        if (cloud != EMPTY_CLOUD && env.cloud[cloud].type != CLOUD_NONE
-            && env.cloud[cloud].pos == gp)
+        if (layers & LAYER_MONSTERS)
         {
-            _update_cloud(cloud);
+            monster* mons = monster_at(gp);
+            if (mons && mons->alive())
+                _update_monster(mons);
+            else if (env.map_knowledge(gp).flags & MAP_INVISIBLE_UPDATE)
+                _mark_invisible_at(gp);
         }
 
-        update_item_at(gp);
+        if (layers & LAYER_CLOUDS)
+        {
+            const int cloud = env.cgrid(gp);
+            if (cloud != EMPTY_CLOUD && env.cloud[cloud].type != CLOUD_NONE
+                && env.cloud[cloud].pos == gp)
+            {
+                _update_cloud(cloud);
+            }
+        }
+
+        if (layers & LAYER_ITEMS)
+            update_item_at(gp);
     }
 
 #ifdef USE_TILE
@@ -549,14 +556,14 @@ void show_update_at(const coord_def &gp, bool terrain_only)
 #endif
 }
 
-void show_init(bool terrain_only)
+void show_init(layers_type layers)
 {
     clear_terrain_visibility();
     if (crawl_state.game_is_arena())
     {
         for (rectangle_iterator ri(crawl_view.vgrdc, LOS_MAX_RANGE); ri; ++ri)
         {
-            show_update_at(*ri, terrain_only);
+            show_update_at(*ri, layers);
             // Invis indicators and update flags not used in Arena.
             env.map_knowledge(*ri).flags &= ~MAP_INVISIBLE_UPDATE;
         }
@@ -566,7 +573,7 @@ void show_init(bool terrain_only)
     vector <coord_def> update_locs;
     for (radius_iterator ri(you.pos(), you.xray_vision ? LOS_NONE : LOS_DEFAULT); ri; ++ri)
     {
-        show_update_at(*ri, terrain_only);
+        show_update_at(*ri, layers);
         update_locs.push_back(*ri);
     }
 

--- a/crawl-ref/source/show.h
+++ b/crawl-ref/source/show.h
@@ -1,6 +1,8 @@
 #ifndef SHOW_H
 #define SHOW_H
 
+#include "enum.h"
+
 // same order as DCHAR_*
 enum show_item_type
 {
@@ -67,9 +69,20 @@ struct show_info
 
 class monster;
 
-void show_init(bool terrain_only = false);
+enum layer_type
+{
+    LAYERS_NONE    = 0,
+    LAYER_MONSTERS = (1 << 0),
+    LAYER_PLAYER   = (1 << 1),
+    LAYER_ITEMS    = (1 << 2),
+    LAYER_CLOUDS   = (1 << 3),
+    LAYERS_ALL     = ~(-1 << 4),
+};
+DEF_BITFIELD(layers_type, layer_type, 3);
+
+void show_init(layers_type layers = LAYERS_ALL);
 void update_item_at(const coord_def &gp, bool detected = false);
-void show_update_at(const coord_def &gp, bool terrain_only = false);
+void show_update_at(const coord_def &gp, layers_type layers = LAYERS_ALL);
 void show_update_emphasis();
 
 #endif

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -53,6 +53,7 @@
 #include "random.h"
 #include "religion.h"
 #include "shout.h"
+#include "show.h"
 #include "showsymb.h"
 #include "state.h"
 #include "stringutil.h"
@@ -73,7 +74,8 @@
 
 //#define DEBUG_PANE_BOUNDS
 
-static bool _show_terrain = false;
+static layers_type _layers = LAYERS_ALL;
+static layers_type _layers_saved = LAYERS_NONE;
 
 crawl_view_geometry crawl_view;
 
@@ -766,12 +768,7 @@ string screenshot()
 
 int viewmap_flash_colour()
 {
-    if (_show_terrain)
-        return BLACK;
-    else if (you.berserk())
-        return RED;
-
-    return BLACK;
+    return _layers & LAYERS_ALL && you.berserk() ? RED : BLACK;
 }
 
 // Updates one square of the view area. Should only be called for square
@@ -1300,7 +1297,7 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a)
         mcache.clear_nonref();
 #endif
 
-    if (show_updates || _show_terrain)
+    if (show_updates || _layers != LAYERS_ALL)
     {
         if (!is_map_persistent())
             ash_detect_portals(false);
@@ -1311,7 +1308,7 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a)
         tiles.clear_overlays();
 #endif
 
-        show_init(_show_terrain);
+        show_init(_layers);
     }
 
     if (show_updates)
@@ -1323,7 +1320,7 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a)
     if (run_dont_draw || you.asleep())
     {
         // Reset env.show if we munged it.
-        if (_show_terrain)
+        if (_layers != LAYERS_ALL)
             show_init();
         return;
     }
@@ -1375,7 +1372,7 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a)
     you.flash_where = 0;
 
     // Reset env.show if we munged it.
-    if (_show_terrain)
+    if (_layers != LAYERS_ALL)
         show_init();
 
     _debug_pane_bounds();
@@ -1393,7 +1390,8 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
         _draw_out_of_bounds(cell);
     else if (!crawl_view.in_los_bounds_g(gc))
         _draw_outside_los(cell, gc);
-    else if (gc == you.pos() && you.on_current_level && !_show_terrain
+    else if (gc == you.pos() && you.on_current_level
+             && _layers & LAYER_PLAYER
              && !crawl_state.game_is_arena()
              && !crawl_state.arena_suspended)
     {
@@ -1472,10 +1470,10 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
     tile_apply_properties(gc, cell->tile);
 #endif
 #ifndef USE_TILE_LOCAL
-    if ((_show_terrain || Options.always_show_exclusions)
+    if ((_layers != LAYERS_ALL || Options.always_show_exclusions)
         && you.on_current_level
         && map_bounds(gc)
-        && (_show_terrain
+        && (_layers == LAYERS_NONE
             || gc != you.pos()
                && (env.map_knowledge(gc).monster() == MONS_NO_MONSTER
                    || !you.see_cell(gc)))
@@ -1489,21 +1487,83 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
 #endif
 }
 
+// Hide view layers. The player can toggle certain layers back on
+// and the resulting configuration will be remembered for the
+// remainder of the game session.
+// Pressing | again will return to normal view. Leaving the prompt
+// by any other means will give back control of the keys, but the
+// view will remain in its altered state until the | key is pressed
+// again or the player performs an action.
+static void _config_layers_menu()
+{
+    bool exit = false;
+
+    _layers = _layers_saved;
+
+    msgwin_set_temporary(true);
+    while (!exit)
+    {
+        viewwindow();
+        mprf(MSGCH_PROMPT, "Select layers to display: "
+                           "<%s>(m)onsters</%s>|"
+                           "<%s>(p)layer</%s>|"
+                           "<%s>(i)tems</%s>|"
+                           "<%s>(c)louds</%s>",
+           _layers & LAYER_MONSTERS ? "lightgrey" : "darkgrey",
+           _layers & LAYER_MONSTERS ? "lightgrey" : "darkgrey",
+           _layers & LAYER_PLAYER   ? "lightgrey" : "darkgrey",
+           _layers & LAYER_PLAYER   ? "lightgrey" : "darkgrey",
+           _layers & LAYER_ITEMS    ? "lightgrey" : "darkgrey",
+           _layers & LAYER_ITEMS    ? "lightgrey" : "darkgrey",
+           _layers & LAYER_CLOUDS   ? "lightgrey" : "darkgrey",
+           _layers & LAYER_CLOUDS   ? "lightgrey" : "darkgrey"
+        );
+        mprf(MSGCH_PROMPT, "Press <w>%s</w> to return to normal view. "
+                           "Press any other key to exit.",
+                           command_to_string(CMD_SHOW_TERRAIN).c_str());
+
+        switch (get_ch())
+        {
+        case 'm': _layers_saved = _layers ^= LAYER_MONSTERS; break;
+        case 'p': _layers_saved = _layers ^= LAYER_PLAYER;   break;
+        case 'i': _layers_saved = _layers ^= LAYER_ITEMS;    break;
+        case 'c': _layers_saved = _layers ^= LAYER_CLOUDS;   break;
+
+        // Remaining cases fall through to exit.
+        case '|':
+            _layers = LAYERS_ALL;
+        default:
+            exit = true;
+            break;
+        }
+
+        msgwin_clear_temporary();
+    }
+    msgwin_set_temporary(false);
+
+    canned_msg(MSG_OK);
+    if (_layers != LAYERS_ALL)
+    {
+        mprf(MSGCH_PLAIN, "Press <w>%s</w> or perform an action "
+                          "to restore all view layers.",
+                          command_to_string(CMD_SHOW_TERRAIN).c_str());
+    }
+}
+
 void toggle_show_terrain()
 {
-    _show_terrain = !_show_terrain;
-    if (_show_terrain)
-    {
-        mprf("Showing terrain only. Press <w>%s</w> to return to normal view.",
-             command_to_string(CMD_SHOW_TERRAIN).c_str());
-    }
+    if (_layers == LAYERS_ALL)
+        _config_layers_menu();
     else
-        mpr("Returning to normal view.");
+        reset_show_terrain();
 }
 
 void reset_show_terrain()
 {
-    _show_terrain = false;
+    if (_layers != LAYERS_ALL)
+        mprf(MSGCH_PROMPT, "Restoring view layers.");
+
+    _layers = LAYERS_ALL;
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Toggle (m)onsters, (p)layer, (i)tems, and (c)louds visibility.

If you use only the '|' key, the functionality is exactly the same as
the original "show terrain".  However, you may now toggle certain layers
back on and that configuration will be remembered for the next time you
press '|'.