### PR TITLE
Deterministic Growth

### DIFF
--- a/crawl-ref/source/godabil.cc
+++ b/crawl-ref/source/godabil.cc
@@ -2938,7 +2938,6 @@ bool prioritise_adjacent(const coord_def &target, vector<coord_def>& candidates)
 
     if (mons_positions.empty())
     {
-        shuffle_array(candidates);
         return true;
     }
 

--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -96,7 +96,7 @@ static const map<species_type, species_def> species_data =
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     5, 12, 10, // 27
     { STAT_INT }, 4,
-    {},
+	{ { MUT_WILD_MAGIC, 1, 1} },
     {},
     {},
     { JOB_WIZARD, JOB_CONJURER, JOB_SUMMONER, JOB_NECROMANCER,

--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -96,7 +96,7 @@ static const map<species_type, species_def> species_data =
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     5, 12, 10, // 27
     { STAT_INT }, 4,
-	{ { MUT_WILD_MAGIC, 1, 1} },
+    {},
     {},
     {},
     { JOB_WIZARD, JOB_CONJURER, JOB_SUMMONER, JOB_NECROMANCER,


### PR DESCRIPTION
Currently using Fedhas's growth ability provides a different order of position priority every time it is used if no monsters are nearby; players can thus continuously cancel the ability until they get their preferred order. So make the order deterministic when no enemies are nearby.