### PR TITLE
Add tracking for defensive actions including:

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -370,11 +370,11 @@ int actor::apply_ac(int damage, int max_damage, ac_type ac_rule,
     saved = max(saved, min(gdr * max_damage / 100, ac / 2));
     if (for_real && (damage > 0) && (saved >= damage) && is_player())
     {
-        const item_def *body_armour = you.slot_item(EQ_BODY_ARMOUR);
+        const item_def *body_armour = slot_item(EQ_BODY_ARMOUR);
         if (body_armour)
             count_action(CACT_ARMOUR, body_armour->sub_type);
         else
-            count_action(CACT_ARMOUR, 0, 0); // unarmoured alttype
+            count_action(CACT_ARMOUR, 0, 0); // unarmoured auxtype
     }
 
     return max(damage - saved, 0);

--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -333,7 +333,7 @@ int actor::spirit_shield(bool calc_unid, bool items) const
 }
 
 int actor::apply_ac(int damage, int max_damage, ac_type ac_rule,
-                    int stab_bypass) const
+                    int stab_bypass, bool for_real) const
 {
     int ac = max(armour_class() - stab_bypass, 0);
     int gdr = gdr_perc();
@@ -368,7 +368,7 @@ int actor::apply_ac(int damage, int max_damage, ac_type ac_rule,
     }
 
     saved = max(saved, min(gdr * max_damage / 100, ac / 2));
-    if ((saved >= damage) && is_player())
+    if (for_real && (damage > 0) && (saved >= damage) && is_player())
     {
         const item_def *body_armour = you.slot_item(EQ_BODY_ARMOUR);
         if (body_armour)

--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -368,6 +368,15 @@ int actor::apply_ac(int damage, int max_damage, ac_type ac_rule,
     }
 
     saved = max(saved, min(gdr * max_damage / 100, ac / 2));
+    if ((saved >= damage) && is_player())
+    {
+        const item_def *body_armour = you.slot_item(EQ_BODY_ARMOUR);
+        if (body_armour)
+            count_action(CACT_ARMOUR, body_armour->sub_type);
+        else
+            count_action(CACT_ARMOUR, 0, 0); // unarmoured alttype
+    }
+
     return max(damage - saved, 0);
 }
 

--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -254,7 +254,7 @@ public:
     virtual int armour_class(bool calc_unid = true) const = 0;
     virtual int gdr_perc() const = 0;
     int apply_ac(int damage, int max_damage = 0, ac_type ac_rule = AC_NORMAL,
-                 int stab_bypass = 0) const;
+                 int stab_bypass = 0, bool for_real = true) const;
     virtual int evasion(ev_ignore_type ign = EV_IGNORE_NONE,
                         const actor *attacker = nullptr) const = 0;
     virtual bool shielded() const = 0;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4097,7 +4097,7 @@ int bolt::apply_AC(const actor *victim, int hurted)
         ac_rule = AC_NONE;
 
     // beams don't obey GDR -> max_damage is 0
-    return victim->apply_ac(hurted, 0, ac_rule);
+    return victim->apply_ac(hurted, 0, ac_rule, 0, !is_tracer);
 }
 
 void bolt::update_hurt_or_helped(monster* mon)

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3207,7 +3207,7 @@ void bolt::reflect()
     if (pos() == you.pos())
     {
         reflector = MID_PLAYER;
-        count_action(CACT_BLOCK, 0, 1); // alttype Reflected
+        count_action(CACT_BLOCK, 0, 1); // auxtype Reflected
     }
     else if (monster* m = monster_at(pos()))
         reflector = m->mid;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3205,7 +3205,10 @@ void bolt::reflect()
     bounce_pos.reset();
 
     if (pos() == you.pos())
+    {
         reflector = MID_PLAYER;
+        count_action(CACT_BLOCK, 0, 1); // alttype Reflected
+    }
     else if (monster* m = monster_at(pos()))
         reflector = m->mid;
     else
@@ -3367,18 +3370,23 @@ bool bolt::misses_player()
     int defl = you.missile_deflection();
 
     if (!_test_beam_hit(real_tohit, dodge_less, pierce, 0, r))
+    {
         mprf("The %s misses you.", name.c_str());
+        count_action(CACT_DODGE, DODGE_EVASION);
+    }
     else if (defl && !_test_beam_hit(real_tohit, dodge_less, pierce, defl, r))
     {
         // active voice to imply stronger effect
         mprf(defl == 1 ? "The %s is repelled." : "You deflect the %s!",
              name.c_str());
         you.ablate_deflection();
+        count_action(CACT_DODGE, DODGE_DEFLECT);
     }
     else if (!_test_beam_hit(real_tohit, dodge, pierce, defl, r))
     {
         mprf("You momentarily phase out as the %s "
              "passes through you.", name.c_str());
+        count_action(CACT_DODGE, DODGE_PHASE);
     }
     else
     {

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -34,6 +34,7 @@
 #include "items.h"
 #include "kills.h"
 #include "libutil.h"
+#include "melee_attack.h"
 #include "message.h"
 #include "mutation.h"
 #include "notes.h"
@@ -1001,6 +1002,12 @@ static string _describe_action(caction_type type)
         return " Fire";
     case CACT_THROW:
         return "Throw";
+    case CACT_ARMOUR:
+        return "Armor"; // "Armour" is too long
+    case CACT_BLOCK:
+        return "Block";
+    case CACT_DODGE:
+        return "Dodge";
     case CACT_CAST:
         return " Cast";
     case CACT_INVOKE:
@@ -1035,25 +1042,45 @@ static const char* _stab_names[] =
     "Betrayed ally",
 };
 
-static string _describe_action_subtype(caction_type type, int subtype)
+static const char* _aux_attack_names[1 + UNAT_LAST_ATTACK] =
 {
+    "No attack",
+    "Constrict",
+    "Kick",
+    "Headbutt",
+    "Peck",
+    "Tailslap",
+    "Punch",
+    "Bite",
+    "Pseudopods",
+    "Tentacles",
+};
+
+static string _describe_action_subtype(caction_type type, int compound_subtype)
+{
+    int subtype;
+    int auxtype;
+    count_action_get_types(&subtype, &auxtype, compound_subtype);
+
     switch (type)
     {
     case CACT_THROW:
     {
-        int basetype = subtype >> 16;
-        subtype = (short)(subtype & 0xFFFF);
-
-        if (basetype == OBJ_MISSILES)
+        if (auxtype == OBJ_MISSILES)
             return uppercase_first(item_base_name(OBJ_MISSILES, subtype));
-        else if (basetype == OBJ_WEAPONS)
-            ; // fallthrough
         else
-            return "other";
+            return "Other";
     }
     case CACT_MELEE:
     case CACT_FIRE:
-        if (subtype >= UNRAND_START)
+        if (auxtype == 0)
+            return "Unarmed";
+        else if (auxtype > 0)
+        {
+            ASSERT_RANGE(auxtype - 1, 0, 1 + UNAT_LAST_ATTACK);
+            return _aux_attack_names[auxtype - 1];
+        }
+        else if (subtype >= UNRAND_START)
         {
             // Paranoia: an artefact may lose its specialness.
             const char *tn = get_unrand_entry(subtype)->type_name;
@@ -1061,8 +1088,38 @@ static string _describe_action_subtype(caction_type type, int subtype)
                 return uppercase_first(tn);
             subtype = get_unrand_entry(subtype)->sub_type;
         }
-        return (subtype == -1) ? "Unarmed"
-               : uppercase_first(item_base_name(OBJ_WEAPONS, subtype));
+        return uppercase_first(item_base_name(OBJ_WEAPONS, subtype));
+    case CACT_ARMOUR:
+        return (auxtype > -1) ? "Skin"
+               : uppercase_first(item_base_name(OBJ_ARMOUR, subtype));
+    case CACT_BLOCK:
+    {
+        switch (auxtype)
+        {
+        case -1:
+            return uppercase_first(item_base_name(OBJ_ARMOUR, subtype));
+        case 0:
+            return "Other";
+        case 1:
+            return "Reflected";
+        default:
+            return "Error";
+        }
+    }
+    case CACT_DODGE:
+    {
+        switch ((dodge_type)subtype)
+        {
+        case DODGE_EVASION:
+            return "Dodged";
+        case DODGE_DEFLECT:
+            return "Deflected";
+        case DODGE_PHASE:
+            return "Phased";
+        default:
+            return "Error";
+        }
+    }
     case CACT_CAST:
         return spell_title((spell_type)subtype);
     case CACT_INVOKE:
@@ -1072,11 +1129,11 @@ static string _describe_action_subtype(caction_type type, int subtype)
         if (subtype >= UNRAND_START && subtype <= UNRAND_LAST)
             return uppercase_first(get_unrand_entry(subtype)->name);
 
-        if (subtype >= 1 << 16)
+        if (auxtype > -1)
         {
             item_def dummy;
-            dummy.base_type = (object_class_type)(subtype >> 16);
-            dummy.sub_type  = subtype & 0xffff;
+            dummy.base_type = (object_class_type)(auxtype);
+            dummy.sub_type  = subtype;
             dummy.quantity  = 1;
             return uppercase_first(dummy.name(DESC_DBNAME, true));
         }
@@ -1105,8 +1162,8 @@ static string _describe_action_subtype(caction_type type, int subtype)
         ASSERT_RANGE(subtype, 1, NUM_STAB);
         return _stab_names[subtype];
     case CACT_EAT:
-        return subtype >= 0 ? uppercase_first(food_type_name(subtype))
-                            : "Corpse";
+        return (auxtype > -1) ? "Corpse"
+                            : uppercase_first(food_type_name(subtype));
     default:
         return "Error";
     }

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -781,20 +781,35 @@ enum branch_type                // you.where_are_you
     NUM_BRANCHES
 };
 
+enum dodge_type    // subtype for counted actions
+{
+    DODGE_EVASION,
+    DODGE_DEFLECT,
+    DODGE_PHASE,
+    NUM_DODGES
+};
+
 enum caction_type    // Primary categorization of counted actions.
-{                    // A subtype will also be given in each case:
+{                    // A subtype and auxtype will also be given in each case:
+                     // if an auxillary type is used it will be > -1
     CACT_MELEE,      // weapon subtype or unrand index
+                     //   auxtype = 0 for unarmed
+                     //   auxtype = (unarmed_attack_type + 1) for aux attacks
     CACT_FIRE,       // weapon subtype or unrand index
-    CACT_THROW,      // item basetype << 16 | subtype
+    CACT_THROW,      // auxtype = item basetype, subtype = item subtype
     CACT_CAST,       // spell_type
     CACT_INVOKE,     // ability_type
     CACT_ABIL,       // ability_type
-    CACT_EVOKE,      // evoc_type
-                     //   or item.basetype << 16 | subtype
-                     //   or unrand index
+    CACT_EVOKE,      // evoc_type or unrand index
+                     //   auxtype = item basetype, subtype = item subtype
     CACT_USE,        // object_class_type
     CACT_STAB,       // stab_type
-    CACT_EAT,        // food_type, or -1 for corpse
+    CACT_EAT,        // food_type, or auxtype = 0 for corpse
+    CACT_ARMOUR,     // armour subtype or auxtype = 0 for unarmoured
+    CACT_DODGE,      // dodge_type
+    CACT_BLOCK,      // armour subtype or
+                     //   auxtype = 0 for other blocks (god ability, spell, etc)
+                     //   auxtype = 1 for reflection
     NUM_CACTIONS,
 };
 

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -2195,7 +2195,7 @@ bool evoke_item(int slot, bool check_range)
             make_hungry(50, false, true);
             pract = 1;
             did_work = true;
-            count_action(CACT_EVOKE, OBJ_STAVES << 16 | STAFF_ENERGY);
+            count_action(CACT_EVOKE, STAFF_ENERGY, OBJ_STAVES);
         }
         break;
 
@@ -2347,7 +2347,7 @@ bool evoke_item(int slot, bool check_range)
             break;
         }
         if (did_work && !unevokable)
-            count_action(CACT_EVOKE, OBJ_MISCELLANY << 16 | item.sub_type);
+            count_action(CACT_EVOKE, item.sub_type, OBJ_MISCELLANY);
         break;
 
     default:

--- a/crawl-ref/source/food.cc
+++ b/crawl-ref/source/food.cc
@@ -435,7 +435,7 @@ bool eat_item(item_def &food)
 
         if (_vampire_consume_corpse(link, in_inventory(food)))
         {
-            count_action(CACT_EAT, 0, 0); // alttype Corpse
+            count_action(CACT_EAT, 0, 0); // auxtype Corpse
             you.turn_is_over = true;
             return true;
         }

--- a/crawl-ref/source/food.cc
+++ b/crawl-ref/source/food.cc
@@ -435,7 +435,7 @@ bool eat_item(item_def &food)
 
         if (_vampire_consume_corpse(link, in_inventory(food)))
         {
-            count_action(CACT_EAT, -1);
+            count_action(CACT_EAT, 0, 0); // alttype Corpse
             you.turn_is_over = true;
             return true;
         }

--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -160,7 +160,7 @@ bool melee_attack::handle_phase_attempted()
                 count_action(CACT_MELEE, WPN_STAFF);
         }
         else
-            count_action(CACT_MELEE, 0, 0); // unarmed alttype
+            count_action(CACT_MELEE, 0, 0); // unarmed auxtype
     }
     else
     {
@@ -1315,7 +1315,7 @@ bool melee_attack::player_aux_apply(unarmed_attack_type atk)
 {
     did_hit = true;
 
-    count_action(CACT_MELEE, 0, atk + 1); // aux_attack alttype
+    count_action(CACT_MELEE, 0, atk + 1); // aux_attack auxtype
 
     aux_damage  = player_aux_stat_modify_damage(aux_damage);
 

--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -160,7 +160,7 @@ bool melee_attack::handle_phase_attempted()
                 count_action(CACT_MELEE, WPN_STAFF);
         }
         else
-            count_action(CACT_MELEE, -1);
+            count_action(CACT_MELEE, 0, 0); // unarmed alttype
     }
     else
     {
@@ -254,6 +254,8 @@ bool melee_attack::handle_phase_dodged()
 
     if (ev_margin + (ev - ev_nophase) > 0)
     {
+        if (defender->is_player())
+            count_action(CACT_DODGE, DODGE_PHASE);
         if (needs_message && defender_visible)
         {
             mprf("%s momentarily %s out as %s "
@@ -267,6 +269,8 @@ bool melee_attack::handle_phase_dodged()
     }
     else
     {
+        if (defender->is_player())
+            count_action(CACT_DODGE, DODGE_EVASION);
         if (needs_message)
         {
             // TODO: Unify these, placed player_warn_miss here so I can remove
@@ -1310,6 +1314,8 @@ bool melee_attack::player_aux_unarmed()
 bool melee_attack::player_aux_apply(unarmed_attack_type atk)
 {
     did_hit = true;
+
+    count_action(CACT_MELEE, 0, atk + 1); // aux_attack alttype
 
     aux_damage  = player_aux_stat_modify_damage(aux_damage);
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5676,6 +5676,11 @@ void player::shield_block_succeeded(actor *foe)
 
     shield_blocks++;
     practise(EX_SHIELD_BLOCK);
+    const item_def *shield = you.slot_item(EQ_SHIELD);
+    if (shield)
+        count_action(CACT_BLOCK, shield->sub_type);
+    else
+        count_action(CACT_BLOCK, 0, 0); // alttype Other
 }
 
 int player::missile_deflection() const
@@ -5729,7 +5734,7 @@ void player::ablate_deflection()
 }
 
 /**
- * What's the base value of the penalties the player recieves from their
+ * What's the base value of the penalties the player receives from their
  * body armour?
  *
  * Used as the base for adjusted armour penalty calculations, as well as for
@@ -7770,6 +7775,24 @@ void count_action(caction_type type, int subtype)
     if (!you.action_count.count(pair))
         you.action_count[pair].init(0);
     you.action_count[pair][you.experience_level - 1]++;
+}
+
+/**
+ *   The alternate type is stored in the higher bytes.
+**/
+void count_action(caction_type type, int subtype, int auxtype)
+{
+    subtype = ((1 + auxtype) << 16) | subtype;
+    count_action(type, subtype);
+}
+
+/**
+ *   If there was no original auxtype it will be returned as -1
+**/
+void count_action_get_types(int *subtype, int *auxtype, int compound_subtype)
+{
+    *subtype = (short)(compound_subtype & 0xFFFF);
+    *auxtype = (compound_subtype >> 16) - 1;
 }
 
 /**

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5676,11 +5676,11 @@ void player::shield_block_succeeded(actor *foe)
 
     shield_blocks++;
     practise(EX_SHIELD_BLOCK);
-    const item_def *shield = you.slot_item(EQ_SHIELD);
+    const item_def *shield = slot_item(EQ_SHIELD);
     if (shield)
         count_action(CACT_BLOCK, shield->sub_type);
     else
-        count_action(CACT_BLOCK, 0, 0); // alttype Other
+        count_action(CACT_BLOCK, 0, 0); // auxtype Other
 }
 
 int player::missile_deflection() const

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1076,6 +1076,9 @@ bool need_expiration_warning(duration_type dur, coord_def p = you.pos());
 bool need_expiration_warning(coord_def p = you.pos());
 
 void count_action(caction_type type, int subtype = 0);
+void count_action(caction_type type, int subtype, int auxtype);
+void count_action_get_types(int *subtype, int *auxtype, int compound_subtype);
+
 bool player_has_orb();
 bool player_on_orb_run();
 

--- a/crawl-ref/source/ranged_attack.cc
+++ b/crawl-ref/source/ranged_attack.cc
@@ -236,6 +236,9 @@ bool ranged_attack::handle_phase_dodged()
             defender->ablate_deflection();
         }
 
+        if (defender->is_player())
+            count_action(CACT_DODGE, DODGE_DEFLECT);
+
         return true;
     }
 
@@ -243,6 +246,9 @@ bool ranged_attack::handle_phase_dodged()
 
     if (ev_margin + (ev - ev_nophase) > 0)
     {
+        if (defender->is_player())
+            count_action(CACT_DODGE, DODGE_PHASE);
+
         if (needs_message && defender_visible)
         {
             mprf("%s momentarily %s out as %s "
@@ -256,6 +262,9 @@ bool ranged_attack::handle_phase_dodged()
 
         return true;
     }
+
+    if (defender->is_player())
+        count_action(CACT_DODGE, DODGE_EVASION);
 
     if (needs_message)
     {

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -835,7 +835,7 @@ bool throw_it(bolt &pbolt, int throw_2, dist *target)
     }
     case LRET_THROWN:
         practise(EX_WILL_THROW_MSL, wepType);
-        count_action(CACT_THROW, wepType | (OBJ_MISSILES << 16));
+        count_action(CACT_THROW, wepType, OBJ_MISSILES);
         break;
     case LRET_FUMBLED:
         practise(EX_WILL_THROW_OTHER);


### PR DESCRIPTION
  Armour types
  Dodged, Phased, or Deflected attacks
  Blocked and Reflected attacks
Add tracking of auxillary attacks.
Rework count_action() to have a standard way to store auxillary information instead
of doing manual bit shifting.