### PR TITLE
Make ring of shadows stack with Dith and Yred

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3239,11 +3239,10 @@ int check_stealth()
             umbra_mul = you.piety + MAX_PIETY;
             umbra_div = MAX_PIETY;
         }
-        if (player_equip_unrand(UNRAND_SHADOWS)
-            && 2 * umbra_mul < 3 * umbra_div)
+        if (player_equip_unrand(UNRAND_SHADOWS))
         {
-            umbra_mul = 3;
-            umbra_div = 2;
+            umbra_mul *= 3;
+            umbra_div *= 2;
         }
         stealth *= umbra_mul;
         stealth /= umbra_div;


### PR DESCRIPTION
Currently, one of the more interesting stabby unrands in the game is incompatible with the stealth god (and with the undead miniony death god; but he's mostly a side point). This would make their effects stack manipulatively, so ring of shadows + dith max piety gives you 3* the stealth instead of 2*. That's good, but probably not too broken considering:
A) You get stabs on everything you want to already. Stealth apts are quite high, and your payoff is doubled, plus you have shadow step (ignoring yred).
B) Your primary threat is going to be noise, not your own unstealthiness.
C) You give up a ring slot for *invis, rN+ and SInv; not the worst ring by a long shot, but not something you'd generally be wearing late-game either.

I think this change would make the choice more interesting on some characters.