### PR TITLE
Make growth deterministic with no nearby enemies

### DIFF
--- a/crawl-ref/source/godabil.cc
+++ b/crawl-ref/source/godabil.cc
@@ -2938,7 +2938,6 @@ bool prioritise_adjacent(const coord_def &target, vector<coord_def>& candidates)
 
     if (mons_positions.empty())
     {
-        shuffle_array(candidates);
         return true;
     }
 

--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -1495,7 +1495,7 @@ static bool _fedhas_summon_plants()
     {
         // Randomize the order so that plants don't always appear
         // in the same places when no enemies are nearby
-        shuffle_array(radius_points);
+        shuffle_array(radius_points[0]);
         unsigned target_count = random_range(2, 8);
         if (target_count < radius_points[0].size())
             prioritise_adjacent(you.pos(), radius_points[0]);

--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -1495,7 +1495,7 @@ static bool _fedhas_summon_plants()
     {
         // Randomize the order so that plants don't always appear
         // in the same places when no enemies are nearby
-        shuffle_array(radius_points[0].begin(), radius_points[0].end());
+        shuffle_array(radius_points);
         unsigned target_count = random_range(2, 8);
         if (target_count < radius_points[0].size())
             prioritise_adjacent(you.pos(), radius_points[0]);

--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -1493,6 +1493,9 @@ static bool _fedhas_summon_plants()
     // (assuming the player isn't already surrounded).
     else if (!radius_points[0].empty())
     {
+        // Randomize the order so that plants don't always appear
+        // in the same places when no enemies are nearby
+        shuffle_array(radius_points[0].begin(), radius_points[0].end());
         unsigned target_count = random_range(2, 8);
         if (target_count < radius_points[0].size())
             prioritise_adjacent(you.pos(), radius_points[0]);


### PR DESCRIPTION
Currently players can get any order of plant priority when using growth
by repeatedly activating and cancelling the ability for no cost, so
make growth always use the same order when no monsters are nearby.