### PR TITLE
Make Controlled Blink a level 8 spell

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -294,9 +294,9 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Akashic Record
     SPELL_DISPERSAL,
-    SPELL_CONTROLLED_BLINK,
     SPELL_MALIGN_GATEWAY,
     SPELL_DISJUNCTION,
+    SPELL_CONTROLLED_BLINK,
 },
 
 {   // Book of Debilitation

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -258,7 +258,7 @@ static const struct spell_desc spelldata[] =
     SPELL_CONTROLLED_BLINK, "Controlled Blink",
     SPTYP_TRANSLOCATION,
     SPFLAG_ESCAPE | SPFLAG_EMERGENCY | SPFLAG_UTILITY,
-    7,
+    8,
     0,
     -1, -1,
     2, 0, // Not noisier than Blink, to keep this spell relevant


### PR DESCRIPTION
With the removal of cTele, controlled blinking (both scroll and spell)
has become much more powerful and abusable in endgame areas that were
formerly -cTele. While the scrolls are at least limited in quantity, the
spell has no deterrent other than a middling amount of magic contamination.

Disjunction isn't used very often as it fills a similar purpose to
Controlled Blink while being harder to get castable. With CBlink at level 8,
it should see more use by players as they share the same book.

PR note: This was discussed some in IRC following cTele removal. The
issue of reworking/replacing the spell didn't reach a solid consensus,
so I propose this for 0.17 in hopes that it will be better addressed later
in development.