### PR TITLE
Halve attribute values.

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -667,7 +667,7 @@ struct artefact_prop_data
 static int _gen_good_stat_artp() { return 1 + random2(3); }
 
 /// Generate 'bad' values for stat artps (e.g. ARTP_STRENGTH)
-static int _gen_bad_stat_artp() { return -2 - random2(4); }
+static int _gen_bad_stat_artp() { return -1 - random2(3); }
 
 /// Generate 'good' values for resist-ish artps (e.g. ARTP_FIRE)
 static int _gen_good_res_artp() { return 1; }

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1353,14 +1353,14 @@ int attack::calc_stat_to_hit_base()
 
     // dex is modified by strength towards the average, by the
     // weighted amount weapon_str_weight() / 20.
-    return you.dex() + (you.strength() - you.dex()) * weight / 20;
+    return you.dex() + (you.strength() - you.dex()) * weight / 10;
 }
 
 // weighted average of strength and dex, between str and (str+dex)/2
 int attack::calc_stat_to_dam_base()
 {
     const int weight = weapon ? 10 - weapon_str_weight(*weapon) : 6;
-    return you.strength() + (you.dex() - you.strength()) * weight / 20;
+    return you.strength() + (you.dex() - you.strength()) * weight / 10;
 }
 
 int attack::calc_damage()
@@ -1888,7 +1888,8 @@ int attack::player_stab_weapon_bonus(int damage)
     {
         // We might be unarmed if we're using the boots of the Assassin.
         const bool extra_good = using_weapon() && weapon->sub_type == WPN_DAGGER;
-        int bonus = you.dex() * (stab_skill + 100) / (extra_good ? 500 : 1000);
+        int bonus = you.dex() * 2 * (stab_skill + 100) / (extra_good ? 500
+                                                                     : 1000);
 
         bonus   = stepdown_value(bonus, 10, 10, 30, 30);
         damage += bonus;
@@ -1986,7 +1987,7 @@ void attack::player_stab_check()
     {
         stab_attempt = x_chance_in_y(you.skill_rdiv(wpn_skill, 1, 2)
                                      + you.skill_rdiv(SK_STEALTH, 1, 2)
-                                     + you.dex() + 1,
+                                     + (you.dex() * 2) + 1,
                                      roll);
     }
 

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1157,7 +1157,7 @@ static bool _ball_of_energy()
     int use = random2(you.skill(SK_EVOCATIONS, 6));
 
     if (use < 2)
-        lose_stat(STAT_INT, 1 + random2avg(7, 2));
+        lose_stat(STAT_INT, 1 + random2avg(4, 2));
     else if (use < 5 && enough_mp(1, true))
     {
         mpr("You feel your power drain away!");

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -418,7 +418,7 @@ void ghost_demon::init_player_ghost(bool actual_ghost)
     damage *= 30 + you.skills[SK_FIGHTING];
     damage /= 30;
 
-    damage += you.strength() / 4;
+    damage += you.strength() / 2;
 
     if (damage > MAX_GHOST_DAMAGE)
         damage = MAX_GHOST_DAMAGE;

--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -852,7 +852,7 @@ static bool _trog_retribution()
 
         case 1:
         case 2:
-            lose_stat(STAT_STR, 1 + random2(you.strength() / 5));
+            lose_stat(STAT_STR, 1 + random2(you.strength() / 3));
             break;
 
         case 3:
@@ -1034,7 +1034,7 @@ static bool _sif_muna_retribution()
     {
     case 0:
     case 1:
-        lose_stat(STAT_INT, 1 + random2(you.intel() / 5));
+        lose_stat(STAT_INT, 1 + random2(you.intel() / 3));
         break;
 
     case 2:

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -24,7 +24,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ABYSSAL_KNIGHT, {
     "AK", "Abyssal Knight",
-    4, 4, 4,
+    2, 2, 2,
     { SP_HILL_ORC, SP_SPRIGGAN, SP_TROLL, SP_MERFOLK, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
     { "leather armour" },
@@ -35,7 +35,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_AIR_ELEMENTALIST, {
     "AE", "Air Elementalist",
-    0, 7, 5,
+    0, 4, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_TENGU, SP_BASE_DRACONIAN, SP_NAGA,
       SP_VINE_STALKER, },
     { "robe", "book of Air" },
@@ -46,7 +46,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ARCANE_MARKSMAN, {
     "AM", "Arcane Marksman",
-    3, 5, 4,
+    1, 3, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_KOBOLD, SP_SPRIGGAN, SP_TROLL, SP_CENTAUR, },
     { "robe", "book of Debilitation" },
     WCHOICE_RANGED,
@@ -56,7 +56,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ARTIFICER, {
     "Ar", "Artificer",
-    3, 4, 5,
+    1, 2, 3,
     { SP_DEEP_DWARF, SP_HALFLING, SP_KOBOLD, SP_SPRIGGAN, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
     { "short sword", "leather armour", "wand of flame charges:15",
@@ -68,7 +68,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ASSASSIN, {
     "As", "Assassin",
-    3, 3, 6,
+    1, 2, 3,
     { SP_TROLL, SP_HALFLING, SP_SPRIGGAN, SP_DEMONSPAWN, SP_VAMPIRE,
       SP_VINE_STALKER, },
     { "dagger plus:2", "blowgun", "robe", "cloak", "needle ego:poisoned q:8",
@@ -80,7 +80,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_BERSERKER, {
     "Be", "Berserker",
-    9, -1, 4,
+    5, -1, 2,
     { SP_HILL_ORC, SP_HALFLING, SP_OGRE, SP_MERFOLK, SP_MINOTAUR, SP_GARGOYLE,
       SP_DEMONSPAWN, },
     { "animal skin" },
@@ -90,7 +90,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CHAOS_KNIGHT, {
     "CK", "Chaos Knight",
-    4, 4, 4,
+    2, 2, 2,
     { SP_HILL_ORC, SP_TROLL, SP_CENTAUR, SP_MERFOLK, SP_MINOTAUR,
       SP_BASE_DRACONIAN, SP_DEMONSPAWN, },
     { "leather armour plus:2" },
@@ -101,7 +101,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CONJURER, {
     "Cj", "Conjurer",
-    0, 7, 5,
+    0, 4, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_NAGA, SP_TENGU, SP_BASE_DRACONIAN,
       SP_DEMIGOD, },
     { "robe", "book of Conjurations" },
@@ -112,7 +112,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_EARTH_ELEMENTALIST, {
     "EE", "Earth Elementalist",
-    0, 7, 5,
+    0, 4, 2,
     { SP_DEEP_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_GARGOYLE, SP_DEMIGOD,
       SP_GHOUL, SP_OCTOPODE, },
     { "stone q:20", "robe", "book of Geomancy" },
@@ -123,7 +123,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ENCHANTER, {
     "En", "Enchanter",
-    0, 7, 5,
+    0, 4, 2,
     { SP_DEEP_ELF, SP_FELID, SP_KOBOLD, SP_SPRIGGAN, SP_NAGA, SP_VAMPIRE, },
     { "dagger plus:1", "robe plus:1", "book of Maledictions" },
     WCHOICE_NONE,
@@ -133,7 +133,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_FIGHTER, {
     "Fi", "Fighter",
-    8, 0, 4,
+    4, 0, 2,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_TROLL, SP_MINOTAUR, SP_GARGOYLE,
       SP_CENTAUR, },
     { "scale mail", "shield", "potion of might" },
@@ -144,7 +144,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_FIRE_ELEMENTALIST, {
     "FE", "Fire Elementalist",
-    0, 7, 5,
+    0, 4, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_HILL_ORC, SP_NAGA, SP_TENGU, SP_DEMIGOD,
       SP_GARGOYLE, },
     { "robe", "book of Flames" },
@@ -155,7 +155,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_GLADIATOR, {
     "Gl", "Gladiator",
-    7, 0, 5,
+    4, 0, 2,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_MERFOLK, SP_MINOTAUR, SP_GARGOYLE,
       SP_CENTAUR, },
     { "leather armour", "helmet", "throwing net q:3" },
@@ -166,7 +166,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_HUNTER, {
     "Hu", "Hunter",
-    4, 3, 5,
+    2, 1, 3,
     { SP_HIGH_ELF, SP_HILL_ORC, SP_HALFLING, SP_KOBOLD, SP_OGRE, SP_TROLL,
       SP_CENTAUR, },
     { "short sword", "leather armour" },
@@ -177,7 +177,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ICE_ELEMENTALIST, {
     "IE", "Ice Elementalist",
-    0, 7, 5,
+    0, 4, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_MERFOLK, SP_NAGA, SP_BASE_DRACONIAN,
       SP_DEMIGOD, SP_GARGOYLE, },
     { "robe", "book of Frost" },
@@ -188,7 +188,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_MONK, {
     "Mo", "Monk",
-    3, 2, 7,
+    2, 1, 4,
     { SP_HILL_ORC, SP_TROLL, SP_MINOTAUR, SP_GARGOYLE, SP_GHOUL, SP_MERFOLK,
       SP_VAMPIRE, },
     { "robe" },
@@ -199,7 +199,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_NECROMANCER, {
     "Ne", "Necromancer",
-    0, 7, 5,
+    0, 4, 2,
     { SP_DEEP_ELF, SP_DEEP_DWARF, SP_HILL_ORC, SP_DEMONSPAWN, SP_MUMMY,
       SP_VAMPIRE, },
     { "robe", "book of Necromancy" },
@@ -210,7 +210,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_SKALD, {
     "Sk", "Skald",
-    4, 4, 4,
+    2, 2, 2,
     { SP_HIGH_ELF, SP_HALFLING, SP_CENTAUR, SP_MERFOLK, SP_BASE_DRACONIAN,
       SP_VAMPIRE, },
     { "leather armour", "book of Battle" },
@@ -221,7 +221,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_SUMMONER, {
     "Su", "Summoner",
-    0, 7, 5,
+    0, 4, 2,
     { SP_DEEP_ELF, SP_HILL_ORC, SP_VINE_STALKER, SP_MERFOLK, SP_TENGU,
       SP_VAMPIRE, },
     { "robe", "book of Callings" },
@@ -232,7 +232,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_TRANSMUTER, {
     "Tm", "Transmuter",
-    2, 5, 5,
+    1, 3, 2,
     { SP_NAGA, SP_MERFOLK, SP_BASE_DRACONIAN, SP_DEMIGOD, SP_DEMONSPAWN,
       SP_TROLL, },
     { "arrow q:12", "robe", "book of Changes" },
@@ -243,7 +243,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_VENOM_MAGE, {
     "VM", "Venom Mage",
-    0, 7, 5,
+    0, 4, 2,
     { SP_DEEP_ELF, SP_SPRIGGAN, SP_NAGA, SP_MERFOLK, SP_TENGU, SP_FELID,
       SP_DEMONSPAWN, },
     { "robe", "Young Poisoner's Handbook" },
@@ -264,7 +264,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_WARPER, {
     "Wr", "Warper",
-    3, 5, 4,
+    1, 3, 2,
     { SP_HALFLING, SP_HIGH_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_CENTAUR,
       SP_BASE_DRACONIAN, },
     { "leather armour", "book of Spatial Translocations", "scroll of blinking",
@@ -277,7 +277,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_WIZARD, {
     "Wz", "Wizard",
-    -1, 10, 3,
+    -1, 5, 2,
     { SP_HIGH_ELF, SP_DEEP_ELF, SP_NAGA, SP_BASE_DRACONIAN, SP_OCTOPODE,
       SP_HUMAN, SP_MUMMY, },
     { "robe", "hat", "book of Minor Magic" },

--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -1102,7 +1102,7 @@ public:
         if (player_mutation_level(MUT_ANTIMAGIC_BITE))
             return fang_damage + div_rand_round(you.get_hit_dice(), 3);
 
-        const int str_damage = div_rand_round(max(you.strength()-10, 0), 5);
+        const int str_damage = div_rand_round(max(you.strength()-5, 0), 5);
 
         if (player_mutation_level(MUT_ACIDIC_BITE))
             return fang_damage + str_damage + roll_dice(2,4);
@@ -1477,7 +1477,7 @@ int melee_attack::player_aux_stat_modify_damage(int damage)
 {
     int dammod = 20;
     // Use the same str/dex weighting that unarmed combat does, for now.
-    const int dam_stat_val = (7 * you.strength() + 3 * you.dex())/10;
+    const int dam_stat_val = (7 * you.strength() + 3 * you.dex())/5;
 
     if (dam_stat_val > 10)
         dammod += random2(dam_stat_val - 9);
@@ -2314,7 +2314,7 @@ int melee_attack::calc_to_hit(bool random)
     {
         // Just trying to touch is easier than trying to damage.
         if (you.duration[DUR_CONFUSING_TOUCH])
-            mhit += maybe_random2(you.dex(), random);
+            mhit += maybe_random2(you.dex() * 2, random);
 
         // TODO: Review this later (transformations getting extra hit
         // almost across the board seems bad) - Cryp71c
@@ -3287,8 +3287,8 @@ void melee_attack::mons_do_tendril_disarm()
 
     if (player_mutation_level(MUT_TENDRILS)
         && one_chance_in(5)
-        && (random2(you.dex()) > adj_mon_hd
-            || random2(you.strength()) > adj_mon_hd))
+        && (random2(you.dex() * 2) > adj_mon_hd
+            || random2(you.strength() * 2) > adj_mon_hd))
     {
         item_def* mons_wpn = mon->disarm();
         if (mons_wpn)
@@ -3431,7 +3431,7 @@ void melee_attack::do_minotaur_retaliation()
     // This will usually be 2, but could be 3 if the player mutated more.
     const int mut = player_mutation_level(MUT_HORNS);
 
-    if (5 * you.strength() + 7 * you.dex() > random2(600))
+    if (5 * you.strength() + 7 * you.dex() > random2(300))
     {
         // Use the same damage formula as a regular headbutt.
         int dmg = 5 + mut * 3;
@@ -3568,7 +3568,7 @@ void melee_attack::chaos_affect_actor(actor *victim)
 bool melee_attack::_extra_aux_attack(unarmed_attack_type atk)
 {
     if (atk != UNAT_CONSTRICT
-        && you.strength() + you.dex() <= random2(50))
+        && you.strength() + you.dex() <= random2(25))
     {
         return false;
     }
@@ -3623,8 +3623,8 @@ int melee_attack::calc_your_to_hit_unarmed(int uattack, bool vampiric)
     int your_to_hit;
 
     your_to_hit = 1300
-                + you.dex() * 60
-                + you.strength() * 15
+                + you.dex() * 120
+                + you.strength() * 30
                 + you.skill(SK_FIGHTING, 30);
     your_to_hit /= 100;
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5116,7 +5116,7 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
 
     case SPELL_BRAIN_FEED:
         if (one_chance_in(3)
-            && lose_stat(STAT_INT, 1 + random2(3)))
+            && lose_stat(STAT_INT, 1 + coinflip()))
         {
             mpr("Something feeds on your intellect!");
             xom_is_stimulated(50);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -6614,7 +6614,7 @@ bool monster::attempt_escape(int attempts)
         randfact += roll_dice(1, themonst->get_hit_dice());
     }
     else
-        randfact = roll_dice(1, you.strength());
+        randfact = roll_dice(1, you.strength() * 2);
 
     if (attfactor > randfact)
     {

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -39,34 +39,34 @@ static const mutation_def mut_data[] =
 { MUT_STRONG, 7, 2, mutflag::GOOD, false,
   "strong",
 
-  {"Your muscles are strong. (Str +2)",
-   "Your muscles are very strong. (Str +4)", ""},
+  {"Your muscles are strong. (Str +1)",
+   "Your muscles are very strong. (Str +2)", ""},
   {"", "", ""},
   {"", "", ""},
 
-  "strong muscles (Str +2)",
+  "strong muscles (Str +1)",
 },
 
 { MUT_CLEVER, 7, 2, mutflag::GOOD, false,
   "clever",
 
-  {"Your mind is acute. (Int +2)",
-   "Your mind is very acute. (Int +4)", ""},
+  {"Your mind is acute. (Int +1)",
+   "Your mind is very acute. (Int +2)", ""},
   {"", "", ""},
   {"", "", ""},
 
-  "mental acuity (Int +2)",
+  "mental acuity (Int +1)",
 },
 
 { MUT_AGILE, 7, 2, mutflag::GOOD, false,
   "agile",
 
-  {"You are agile. (Dex +2)",
-   "You are very agile. (Dex +4)", ""},
+  {"You are agile. (Dex +1)",
+   "You are very agile. (Dex +2)", ""},
   {"", "", ""},
   {"", "", ""},
 
-  "agility (Dex +2)",
+  "agility (Dex +1)",
 },
 
 { MUT_POISON_RESISTANCE, 4, 1, mutflag::GOOD, true,
@@ -302,18 +302,18 @@ static const mutation_def mut_data[] =
 
 { MUT_WEAK, 8, 2, mutflag::BAD | mutflag::XOM, false,
   "weak",
-  {"You are weak. (Str -2)",
-   "You are very weak. (Str -4)", ""},
+  {"You are weak. (Str -1)",
+   "You are very weak. (Str -2)", ""},
   {"", "", ""},
   {"", "", ""},
 
-  "weak muscles (Str -2)",
+  "weak muscles (Str -1)",
 },
 
 { MUT_DOPEY, 8, 2, mutflag::BAD | mutflag::XOM, false,
   "dopey",
-  {"You are dopey. (Int -2)",
-   "You are very dopey. (Int -4)", ""},
+  {"You are dopey. (Int -1)",
+   "You are very dopey. (Int -2)", ""},
   {"", "", ""},
   {"", "", ""},
 
@@ -322,12 +322,12 @@ static const mutation_def mut_data[] =
 
 { MUT_CLUMSY, 8, 2, mutflag::BAD | mutflag::XOM, false,
   "clumsy",
-  {"You are clumsy. (Dex -2)",
-   "You are very clumsy. (Dex -4)", ""},
+  {"You are clumsy. (Dex -1)",
+   "You are very clumsy. (Dex -2)", ""},
   {"", "", ""},
   {"", "", ""},
 
-  "clumsiness (Dex -2)",
+  "clumsiness (Dex -1)",
 },
 
 #if TAG_MAJOR_VERSION == 34

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -30,7 +30,7 @@
 #include "spl-util.h"
 #include "state.h"
 
-#define MIN_START_STAT       3
+#define MIN_START_STAT       2
 
 static void _init_player()
 {
@@ -39,7 +39,6 @@ static void _init_player()
 }
 
 // Make sure no stats are unacceptably low
-// (currently possible only for GhBe - 1KB)
 static void _unfocus_stats()
 {
     int needed;

--- a/crawl-ref/source/player-stats.cc
+++ b/crawl-ref/source/player-stats.cc
@@ -391,8 +391,8 @@ static int _strength_modifier(bool innate_only)
     }
 
     // mutations
-    result += 2 * (_mut_level(MUT_STRONG, innate_only)
-                   - _mut_level(MUT_WEAK, innate_only));
+    result += _mut_level(MUT_STRONG, innate_only)
+              - _mut_level(MUT_WEAK, innate_only);
 #if TAG_MAJOR_VERSION == 34
     result += _mut_level(MUT_STRONG_STIFF, innate_only)
               - _mut_level(MUT_FLEXIBLE_WEAK, innate_only);
@@ -426,8 +426,8 @@ static int _int_modifier(bool innate_only)
     }
 
     // mutations
-    result += 2 * (_mut_level(MUT_CLEVER, innate_only)
-                   - _mut_level(MUT_DOPEY, innate_only));
+    result += _mut_level(MUT_CLEVER, innate_only)
+              - _mut_level(MUT_DOPEY, innate_only);
 
     return result;
 }
@@ -460,13 +460,13 @@ static int _dex_modifier(bool innate_only)
     }
 
     // mutations
-    result += 2 * (_mut_level(MUT_AGILE, innate_only)
-                  - _mut_level(MUT_CLUMSY, innate_only));
+    result += _mut_level(MUT_AGILE, innate_only)
+              - _mut_level(MUT_CLUMSY, innate_only);
 #if TAG_MAJOR_VERSION == 34
     result += _mut_level(MUT_FLEXIBLE_WEAK, innate_only)
               - _mut_level(MUT_STRONG_STIFF, innate_only);
 #endif
-    result += 2 * _mut_level(MUT_THIN_SKELETAL_STRUCTURE, innate_only);
+    result += _mut_level(MUT_THIN_SKELETAL_STRUCTURE, innate_only);
     result -= _mut_level(MUT_ROUGH_BLACK_SCALES, innate_only);
 
     return result;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2283,7 +2283,7 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
  */
 static int _player_armour_adjusted_dodge_bonus(int scale)
 {
-    const int ev_dex = stepdown_value(you.dex(), 10, 24, MAX_STAT_VALUE,
+    const int ev_dex = stepdown_value(you.dex() * 2, 10, 24, MAX_STAT_VALUE,
             MAX_STAT_VALUE);
 
     const int dodge_bonus =
@@ -2294,7 +2294,7 @@ static int _player_armour_adjusted_dodge_bonus(int scale)
     if (armour_dodge_penalty <= 0)
         return dodge_bonus;
 
-    const int str = max(1, you.strength());
+    const int str = max(1, you.strength() * 2);
     if (armour_dodge_penalty >= str)
         return dodge_bonus * str / (armour_dodge_penalty * 2);
     return dodge_bonus - dodge_bonus * armour_dodge_penalty / (str * 2);
@@ -2399,11 +2399,11 @@ int player_shield_class()
 
         int stat = 0;
         if (item.sub_type == ARM_BUCKLER)
-            stat = you.dex() * 38;
+            stat = you.dex() * 76;
         else if (item.sub_type == ARM_LARGE_SHIELD)
-            stat = you.dex() * 12 + you.strength() * 26;
+            stat = you.dex() * 24 + you.strength() * 52;
         else
-            stat = you.dex() * 19 + you.strength() * 19;
+            stat = you.dex() * 38 + you.strength() * 38;
         stat = stat * (base_shield + 13) / 26;
 
         shield += stat;
@@ -2800,7 +2800,7 @@ void level_change(bool skip_attribute_increase)
                      new_exp);
             }
 
-            const bool manual_stat_level = new_exp % 3 == 0;  // 3,6,9,12...
+            const bool manual_stat_level = new_exp % 4 == 0 || new_exp == 27;
 
             // Must do this before actually changing experience_level,
             // so we will re-prompt on load if a hup is received.
@@ -3133,7 +3133,7 @@ int check_stealth()
         return 0;
     }
 
-    int stealth = you.dex() * 3;
+    int stealth = you.dex() * 6;
 
     if (you.form == TRAN_BLADE_HANDS && you.species == SP_FELID
         && !you.airborne())

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -884,7 +884,7 @@ public:
     bool effect(bool=true, int=40, bool=true) const override
     {
         mpr("There was something very wrong with that liquid.");
-        return lose_stat(STAT_RANDOM, 1 + random2avg(4, 2));
+        return lose_stat(STAT_RANDOM, 1 + coinflip());
     }
 
     bool quaff(bool was_known) const override

--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -54,8 +54,8 @@ static const map<species_type, species_def> species_data =
     9, 3,
     MONS_CENTAUR,
     HT_LAND, US_ALIVE, SIZE_LARGE,
-    10, 7, 4, // 21
-    { STAT_STR, STAT_DEX }, 4,
+    5, 3, 2, // 10
+    { STAT_STR, STAT_DEX }, 5,
     { { MUT_TOUGH_SKIN, 3, 1 }, { MUT_FAST, 2, 1 },  { MUT_DEFORMED, 1, 1 },
       { MUT_HOOVES, 3, 1 }, },
     {},
@@ -73,8 +73,8 @@ static const map<species_type, species_def> species_data =
     15, 6,
     MONS_DEEP_DWARF,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    11, 8, 8, // 27
-    { STAT_STR, STAT_INT }, 4,
+    5, 4, 4, // 13
+    { STAT_STR, STAT_INT }, 5,
     { { MUT_SLOW_REGENERATION, 3, 1 }, { MUT_PASSIVE_MAPPING, 1, 1 },
       { MUT_PASSIVE_MAPPING, 1, 9 }, { MUT_PASSIVE_MAPPING, 1, 18 },
       { MUT_NEGATIVE_ENERGY_RESISTANCE, 1, 14 }, },
@@ -94,8 +94,8 @@ static const map<species_type, species_def> species_data =
     15, 4,
     MONS_ELF,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    5, 12, 10, // 27
-    { STAT_INT }, 4,
+    2, 6, 5, // 13
+    { STAT_INT }, 5,
     {},
     {},
     {},
@@ -113,7 +113,7 @@ static const map<species_type, species_def> species_data =
     15, 4,
     MONS_DEMIGOD,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    11, 12, 11, // 34
+    5, 6, 5, // 16
     set<stat_type>(), 28, // No natural stat gain (double chosen instead)
     { { MUT_SUSTAIN_ATTRIBUTES, 1, 1 }, {MUT_HIGH_MAGIC, 1, 1} },
     {},
@@ -132,8 +132,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, },
     {},
     {},
@@ -152,8 +152,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_RED_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_HEAT_RESISTANCE, 1, 7 }, },
     { "You can breathe blasts of fire." },
     { "breathe fire" },
@@ -169,8 +169,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_WHITE_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_COLD_RESISTANCE, 1, 7 }, },
     { "You can breathe waves of freezing cold.",
       "You can buffet flying creatures when you breathe cold." },
@@ -187,8 +187,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_GREEN_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_POISON_RESISTANCE, 1, 7 },
       { MUT_STINGER, 1, 14 }, },
     { "You can breathe blasts of noxious fumes." },
@@ -205,8 +205,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_YELLOW_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_ACIDIC_BITE, 1, 14 }, },
     { "You can spit globs of acid.", "You are resistant to acid." },
     { "spit acid", "acid resistance" },
@@ -222,8 +222,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_GREY_DRACONIAN,
     HT_AMPHIBIOUS, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_UNBREATHING, 1, 7 }, },
     { "You can walk through water." },
     { "walk through water" },
@@ -239,8 +239,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_BLACK_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, { MUT_SHOCK_RESISTANCE, 1, 7 },
       { MUT_BIG_WINGS, 1, 14 }, },
     { "You can breathe wild blasts of lightning." },
@@ -257,8 +257,8 @@ static const map<species_type, species_def> species_data =
     12, 6,
     MONS_PURPLE_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, },
     { "You can breathe bolts of dispelling energy." },
     { "breathe power" },
@@ -274,8 +274,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_MOTTLED_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, },
     { "You can spit globs of burning liquid.",
       "You can ignite nearby creatures when you spit burning liquid." },
@@ -292,8 +292,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_PALE_DRACONIAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_COLD_BLOODED, 1, 1 }, },
     { "You can breathe blasts of scalding, opaque steam." },
     { "breathe steam" },
@@ -309,8 +309,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_DEMONSPAWN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    8, 9, 8, // 25
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    4, 4, 4, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     {},
     {},
     {},
@@ -329,8 +329,8 @@ static const map<species_type, species_def> species_data =
     18, 6,
     MONS_FELID,
     HT_LAND, US_ALIVE, SIZE_LITTLE,
-    4, 9, 11, // 24
-    { STAT_INT, STAT_DEX }, 5,
+    2, 4, 5, // 11
+    { STAT_INT, STAT_DEX }, 6,
     { { MUT_CARNIVOROUS, 3, 1 }, { MUT_FAST, 1, 1 }, { MUT_FANGS, 3, 1 },
       { MUT_SHAGGY_FUR, 1, 1 }, { MUT_ACUTE_VISION, 1, 1 }, { MUT_PAWS, 1, 1 },
       { MUT_SLOW_METABOLISM, 1, 1 }, { MUT_CLAWS, 1, 1 },
@@ -351,8 +351,8 @@ static const map<species_type, species_def> species_data =
     15, 4,
     MONS_FORMICID,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    12, 7, 6, // 25
-    { STAT_STR, STAT_INT }, 4,
+    6, 3, 3, // 12
+    { STAT_STR, STAT_INT }, 5,
     { { MUT_ANTENNAE, 3, 1 }, },
     { "You are under a permanent stasis effect.",
       "You can dig through walls and to a lower floor.",
@@ -372,8 +372,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_GHOUL,
     HT_LAND, US_HUNGRY_DEAD, SIZE_MEDIUM,
-    11, 3, 4, // 18
-    { STAT_STR }, 5,
+    5, 1, 2, // 8
+    { STAT_STR }, 6,
     { { MUT_CARNIVOROUS, 3, 1 }, { MUT_NEGATIVE_ENERGY_RESISTANCE, 3, 1 },
       { MUT_TORMENT_RESISTANCE, 1, 1 },
       { MUT_SLOW_REGENERATION, 1, 1 }, { MUT_COLD_RESISTANCE, 1, 1 },
@@ -394,8 +394,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_GARGOYLE,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    11, 8, 5, // 24
-    { STAT_STR, STAT_INT }, 4,
+    5, 4, 2, // 11
+    { STAT_STR, STAT_INT }, 5,
     { { MUT_ROT_IMMUNITY, 1, 1 }, { MUT_NEGATIVE_ENERGY_RESISTANCE, 1, 1 },
       { MUT_PETRIFICATION_RESISTANCE, 1, 1 }, { MUT_SHOCK_RESISTANCE, 1, 1 },
       { MUT_UNBREATHING, 1, 1 }, { MUT_BIG_WINGS, 1, 14 }, },
@@ -415,8 +415,8 @@ static const map<species_type, species_def> species_data =
     18, 3,
     MONS_HALFLING,
     HT_LAND, US_ALIVE, SIZE_SMALL,
-    8, 7, 9, // 24
-    { STAT_DEX }, 5,
+    4, 3, 4, // 11
+    { STAT_DEX }, 6,
     { { MUT_MUTATION_RESISTANCE, 1, 1 }, },
     {},
     {},
@@ -433,8 +433,8 @@ static const map<species_type, species_def> species_data =
     15, 4,
     MONS_ELF,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    7, 11, 10, // 28
-    { STAT_INT, STAT_DEX }, 3,
+    3, 5, 5, // 13
+    { STAT_INT, STAT_DEX }, 4,
     {},
     {},
     {},
@@ -451,8 +451,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_ORC,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_STR }, 5,
+    5, 4, 3, // 12
+    { STAT_STR }, 6,
     {},
     {},
     {},
@@ -469,8 +469,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_HUMAN,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    8, 8, 8, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    4, 4, 4, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     {},
     {},
     {},
@@ -488,8 +488,8 @@ static const map<species_type, species_def> species_data =
     18, 3,
     MONS_KOBOLD,
     HT_LAND, US_ALIVE, SIZE_SMALL,
-    6, 6, 11, // 23
-    { STAT_STR, STAT_DEX }, 5,
+    3, 3, 5, // 11
+    { STAT_STR, STAT_DEX }, 6,
     { { MUT_CARNIVOROUS, 3, 1 }, },
     {},
     {},
@@ -506,8 +506,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_MERFOLK,
     HT_WATER, US_ALIVE, SIZE_MEDIUM,
-    8, 7, 9, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 5,
+    4, 3, 4, // 11
+    { STAT_STR, STAT_INT, STAT_DEX }, 6,
     {},
     { "You revert to your normal form in water.",
       "You are very nimble and swift while swimming." },
@@ -525,8 +525,8 @@ static const map<species_type, species_def> species_data =
     12, 3,
     MONS_MINOTAUR,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    12, 5, 5, // 22
-    { STAT_STR, STAT_DEX }, 4,
+    6, 2, 2, // 10
+    { STAT_STR, STAT_DEX }, 5,
     { { MUT_HORNS, 2, 1 }, },
     { "You reflexively headbutt those who attack you in melee." },
     { "retaliatory headbutt" },
@@ -543,8 +543,8 @@ static const map<species_type, species_def> species_data =
     15, 5,
     MONS_MUMMY,
     HT_LAND, US_UNDEAD, SIZE_MEDIUM,
-    11, 7,  7, // 25
-    { STAT_STR, STAT_INT, STAT_DEX }, 5,
+    5, 3, 3, // 11
+    { STAT_STR, STAT_INT, STAT_DEX }, 6,
     { { MUT_NEGATIVE_ENERGY_RESISTANCE, 3, 1 }, { MUT_COLD_RESISTANCE, 1, 1 },
       { MUT_TORMENT_RESISTANCE, 1, 1 },
       { MUT_UNBREATHING, 1, 1 },
@@ -567,8 +567,8 @@ static const map<species_type, species_def> species_data =
     18, 5,
     MONS_NAGA,
     HT_LAND, US_ALIVE, SIZE_LARGE,
-    10, 8, 6, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    5, 4, 3, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_ACUTE_VISION, 1, 1 }, { MUT_SLOW, 2, 1 },  { MUT_DEFORMED, 1, 1 },
       { MUT_SPIT_POISON, 2, 1 },  { MUT_POISON_RESISTANCE, 1, 1 },
       { MUT_SLOW_METABOLISM, 1, 1 }, { MUT_CONSTRICTING_TAIL, 1, 13 } },
@@ -588,8 +588,8 @@ static const map<species_type, species_def> species_data =
     9, 4,
     MONS_OGRE,
     HT_LAND, US_ALIVE, SIZE_LARGE,
-    12, 7, 5, // 24
-    { STAT_STR }, 3,
+    6, 3, 2, // 11
+    { STAT_STR }, 4,
     { { MUT_TOUGH_SKIN, 1, 1 }, },
     {},
     {},
@@ -606,8 +606,8 @@ static const map<species_type, species_def> species_data =
     18, 3,
     MONS_OCTOPODE,
     HT_WATER, US_ALIVE, SIZE_MEDIUM,
-    7, 10, 7, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 5,
+    3, 5, 3, // 11
+    { STAT_STR, STAT_INT, STAT_DEX }, 6,
     { { MUT_CAMOUFLAGE, 1, 1 }, { MUT_GELATINOUS_BODY, 1, 1 }, },
     { "You cannot wear most types of armour.",
       "You are amphibious." },
@@ -627,8 +627,8 @@ static const map<species_type, species_def> species_data =
     18, 7,
     MONS_SPRIGGAN,
     HT_LAND, US_ALIVE, SIZE_LITTLE,
-    4, 9, 11, // 24
-    { STAT_INT, STAT_DEX }, 5,
+    2, 4, 5, // 11
+    { STAT_INT, STAT_DEX }, 6,
     { { MUT_FAST, 3, 1 }, { MUT_HERBIVOROUS, 3, 1 },
       { MUT_ACUTE_VISION, 1, 1 }, { MUT_SLOW_METABOLISM, 2, 1 }, },
     {},
@@ -646,8 +646,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_TENGU,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    8, 8, 9, // 25
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    4, 4, 4, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_BEAK, 1, 1 }, { MUT_TALONS, 3, 1 },
       { MUT_TENGU_FLIGHT, 1, 5 }, { MUT_TENGU_FLIGHT, 1, 14 }, },
     {},
@@ -666,8 +666,8 @@ static const map<species_type, species_def> species_data =
     9, 3,
     MONS_TROLL,
     HT_LAND, US_ALIVE, SIZE_LARGE,
-    15, 4, 5, // 24
-    { STAT_STR }, 3,
+    7, 2, 2, // 11
+    { STAT_STR }, 4,
     { { MUT_TOUGH_SKIN, 2, 1 }, { MUT_REGENERATION, 2, 1 }, { MUT_CLAWS, 3, 1 },
       { MUT_GOURMAND, 1, 1 }, { MUT_FAST_METABOLISM, 3, 1 },
       { MUT_SHAGGY_FUR, 1, 1 }, },
@@ -686,8 +686,8 @@ static const map<species_type, species_def> species_data =
     18, 4,
     MONS_VAMPIRE,
     HT_LAND, US_SEMI_UNDEAD, SIZE_MEDIUM,
-    7, 10, 9, // 26
-    { STAT_INT, STAT_DEX }, 5,
+    3, 5, 4, // 12
+    { STAT_INT, STAT_DEX }, 6,
     { { MUT_FANGS, 3, 1 }, { MUT_ACUTE_VISION, 1, 1 },
       { MUT_UNBREATHING, 1, 1 }, },
     {},
@@ -706,8 +706,8 @@ static const map<species_type, species_def> species_data =
     15, 5,
     MONS_VINE_STALKER,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 9, // 27
-    { STAT_STR, STAT_DEX }, 4,
+    5, 4, 4, // 13
+    { STAT_STR, STAT_DEX }, 5,
     { { MUT_FANGS, 2, 1 }, { MUT_FANGS, 1, 8 },
       { MUT_MANA_SHIELD, 1, 1 }, { MUT_ANTIMAGIC_BITE, 1, 1 },
       { MUT_NO_DEVICE_HEAL, 3, 1 }, { MUT_ROT_IMMUNITY, 1, 1 },
@@ -729,8 +729,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_ELF,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    8, 8, 8, // 24
-    { STAT_INT, STAT_DEX }, 4,
+    4, 4, 4, // 12
+    { STAT_INT, STAT_DEX }, 5,
     {},
     {},
     {},
@@ -746,8 +746,8 @@ static const map<species_type, species_def> species_data =
     15, 3,
     MONS_LAVA_ORC,
     HT_AMPHIBIOUS_LAVA, US_ALIVE, SIZE_MEDIUM,
-    10, 8, 6, // 24
-    { STAT_INT, STAT_DEX }, 5,
+    5, 4, 3, // 12
+    { STAT_INT, STAT_DEX }, 6,
     {},
     {},
     {},
@@ -763,8 +763,8 @@ static const map<species_type, species_def> species_data =
     9, 3,
     MONS_DJINNI,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    8, 8, 8, // 24
-    { STAT_STR, STAT_INT, STAT_DEX }, 4,
+    4, 4, 4, // 12
+    { STAT_STR, STAT_INT, STAT_DEX }, 5,
     { { MUT_NEGATIVE_ENERGY_RESISTANCE, 3, 1 }, },
     { "You are immune to all types of fire, even holy and hellish.",
       "You are vulnerable to cold.",

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -314,7 +314,7 @@ int raw_spell_fail(spell_type spell)
 
     // Don't cap power for failure rate purposes.
     chance -= 6 * calc_spell_power(spell, false, true, false);
-    chance -= (you.intel() * 2);
+    chance -= (you.intel() * 4);
 
     const int armour_shield_penalty = player_armour_shield_spell_penalty();
     dprf("Armour+Shield spell failure penalty: %d", armour_shield_penalty);
@@ -417,7 +417,7 @@ int calc_spell_power(spell_type spell, bool apply_intel, bool fail_rate_check,
             power += 600;
 
         if (apply_intel)
-            power = (power * you.intel()) / 10;
+            power = (power * you.intel()) / 5;
 
         // [dshaligram] Enhancers don't affect fail rates any more, only spell
         // power. Note that this does not affect Vehumet's boost in castability.

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -1611,7 +1611,7 @@ void MiscastEffect::_divination_you(int severity)
         switch (random2(2))
         {
         case 0:
-            if (lose_stat(STAT_INT, 1 + random2(3)))
+            if (lose_stat(STAT_INT, 1 + coinflip()))
             {
                 if (you.undead_state())
                     mpr("You suddenly recall your previous life!");
@@ -1654,7 +1654,7 @@ void MiscastEffect::_divination_you(int severity)
             }
             break;
         case 1:
-            if (lose_stat(STAT_INT, 3 + random2(3)))
+            if (lose_stat(STAT_INT, 3 + coinflip()))
             {
                 if (you.undead_state())
                     mpr("You suddenly recall your previous life!");
@@ -1962,7 +1962,7 @@ void MiscastEffect::_necromancy(int severity)
                 break;
 
         case 5:
-            lose_stat(STAT_RANDOM, 1 + random2avg(7, 2));
+            lose_stat(STAT_RANDOM, 1 + random2(3));
             break;
         }
         break;
@@ -3028,7 +3028,7 @@ void MiscastEffect::_poison(int severity)
             if (player_res_poison() > 0)
                 canned_msg(MSG_NOTHING_HAPPENS);
             else
-                lose_stat(STAT_RANDOM, 1 + random2avg(5, 2));
+                lose_stat(STAT_RANDOM, 1 + random2(3));
             break;
         }
         break;
@@ -3261,7 +3261,7 @@ void MiscastEffect::_zot()
             break;
         }
         case 11:
-            lose_stat(STAT_RANDOM, 1 + random2avg((coinflip() ? 7 : 4), 2));
+            lose_stat(STAT_RANDOM, 1 + random2(3));
             break;
         case 12:
             mpr("An unnatural silence engulfs you.");

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -364,7 +364,7 @@ spret_type cast_intoxicate(int pow, bool fail)
     if (x_chance_in_y(60 - pow/3, 100))
         confuse_player(3+random2(10 + (100 - pow) / 10));
 
-    if (one_chance_in(20) && lose_stat(STAT_INT, 1 + random2(3)))
+    if (one_chance_in(20) && lose_stat(STAT_INT, 1 + coinflip()))
         mpr("Your head spins!");
 
     apply_area_visible(_intoxicate_monsters, pow, &you);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1360,7 +1360,7 @@ spret_type cast_summon_horrible_things(int pow, god_type god, bool fail)
     {
         // if someone deletes the db, no message is ok
         mpr(getMiscString("SHT_int_loss"));
-        lose_stat(STAT_INT, 1 + random2(2));
+        lose_stat(STAT_INT, 1 + coinflip());
     }
 
     int num_abominations = random_range(2, 4) + x_chance_in_y(pow, 200);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -348,7 +348,7 @@ int spell_hunger(spell_type which_spell, bool rod)
         hunger = max(hunger, level * 5);
     }
     else
-        hunger -= you.skill(SK_SPELLCASTING, you.intel());
+        hunger -= you.skill(SK_SPELLCASTING, you.intel() * 2);
 
     if (hunger < 0)
         hunger = 0;

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -491,7 +491,7 @@ public:
      */
     int get_base_unarmed_damage() const override
     {
-        return 8 + div_rand_round(you.strength() + you.dex(), 3);
+        return 8 + div_rand_round((you.strength() + you.dex()) * 2, 3);
     }
 
     /**
@@ -562,7 +562,7 @@ public:
      */
     int get_base_unarmed_damage() const override
     {
-        return 6 + div_rand_round(you.strength(), 3);
+        return 6 + div_rand_round((you.strength() * 2), 3);
     }
 
     /**
@@ -694,7 +694,7 @@ public:
     int get_base_unarmed_damage() const override
     {
         // You also get another 6 damage from claws.
-        return 12 + div_rand_round(you.strength() * 2, 3);
+        return 12 + div_rand_round(you.strength() * 4, 3);
     }
 
     /**

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -1186,9 +1186,9 @@ static int damage_or_escape_net(int hold)
         damage += 2;
 
     // Check stats.
-    if (x_chance_in_y(you.strength(), 18))
+    if (x_chance_in_y(you.strength(), 9))
         damage++;
-    if (x_chance_in_y(you.dex(), 12))
+    if (x_chance_in_y(you.dex(), 6))
         escape++;
     if (x_chance_in_y(you.evasion(), 20))
         escape++;


### PR DESCRIPTION
Not ready for merge, ànd maybe not for 0.17, but thought I'd open this up for comments. The game works but significantly more balance work is required.
- If previously something used strength, now it uses strength \* 2, and
  similar for intelligence & dexterity.
- Reduces species starting stats (rounding down, for odd numbers)
  and job starting stats (rounding inconsistently to give +6 stats
  overall).
- Change +/-2 str/int/dex mutations to +/-1
- Reduce stat loss amounts from most sources (minimum of one, stat
  recovery time is unchanged)
- Reduce minimum stat to 2
- Slightly reduce -stat attributes on artifacts.

TODO:
- Stat drain / recovery numbers
