### PR TITLE
Improve message on refusing to butcher under Zin

### DIFF
--- a/crawl-ref/source/butcher.cc
+++ b/crawl-ref/source/butcher.cc
@@ -189,7 +189,7 @@ void butchery(item_def* specific_corpse)
         if (Options.confirm_butcher == CONFIRM_NEVER
             && !_should_butcher(*corpses[0].first))
         {
-            mprf("There isn't anything suitable to %sbutcher here.",
+            mprf("It would be a sin to %sbutcher this!",
                  bottle_blood ? "bottle or " : "");
             return;
         }


### PR DESCRIPTION
This message triggers when you have butchering set to NEVER_CONFIRM and your god forbids butchering. It used to simply say "There isn't anything suitable to butcher here." which for a bit I thought was a bug... This message makes it clear it's a god restriction.