### PR TITLE
Don't ask ghouls for potions of cMut (celerity)

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -118,8 +118,7 @@ function trove.get_trove_item(e, value, base_item)
     end
   end
 
-  local pots = {
-       {base="potion", type="cure mutation", quant=2} }
+  local pots = { }
 
   local heal_pots = {
        {base="potion", type="curing", quant=12+d(4)+d(4)},
@@ -134,6 +133,10 @@ function trove.get_trove_item(e, value, base_item)
     if you.race() ~= "Formicid" then
       table.insert(pots, {base="potion", type="haste", quant=3+d(3)+d(2)})
     end
+    if you.race() ~= "Ghoul" then
+      table.insert(pots, {base="potion", type="cure mutation", quant=2})
+    end
+
     for _, toll in ipairs(pots) do
       table.insert(prices, toll)
     end


### PR DESCRIPTION
Troves shouldn't ask for totally race-useless items, and that includes cMut for ghouls.