### PR TITLE
Remove increased metabolism from some regen items.

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -34,8 +34,7 @@ This amulet enables its wearer to attempt to enter a state of berserk rage.
 %%%%
 amulet of regeneration
 
-This amulet greatly increases the recuperative powers of its wearer, but also
-considerably speeds their metabolism while doing so.
+This amulet greatly increases the recuperative powers of its wearer.
 %%%%
 amulet of resist corrosion
 
@@ -1436,7 +1435,7 @@ may be turned into armour by magical means.
 troll leather armour
 
 Armour made from the stiff and knobbly skin of a common troll. It magically
-regenerates its wearer's flesh at a fairly slow rate.
+regenerates its wearer's flesh.
 %%%%
 wand of cold
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1265,20 +1265,6 @@ int player_hunger_rate(bool temp)
                 - player_mutation_level(MUT_SLOW_METABOLISM);
     }
 
-    if (you.hp < you.hp_max
-        && player_mutation_level(MUT_SLOW_REGENERATION) < 3)
-    {
-        // jewellery
-        hunger += 3 * you.wearing(EQ_AMULET, AMU_REGENERATION);
-
-        // troll leather
-        if (you.wearing(EQ_BODY_ARMOUR, ARM_TROLL_LEATHER_ARMOUR)
-            || you.wearing(EQ_BODY_ARMOUR, ARM_TROLL_HIDE))
-        {
-            hunger += coinflip() ? 2 : 1;
-        }
-    }
-
     // If Cheibriados has slowed your life processes, you will hunger less.
     if (you_worship(GOD_CHEIBRIADOS) && you.piety >= piety_breakpoint(0))
         hunger /= 2;


### PR DESCRIPTION
Amulets and TLA increased regeneration (both a different amount) while
other artifacts with Regen+ did not. It wasn't a very noticable
tradeoff.