### PR TITLE
Reduce the AC of rolling enemies.

### DIFF
--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -687,7 +687,7 @@ dragon's fearsome breath was lost in the process.
 boulder beetle
 
 A huge grey beetle with an almost impenetrable rocky carapace, capable of
-rolling at its foes at high speed.
+rolling at its foes at high speed. When rolling, it's vulnerable to attack.
 %%%%
 briar patch
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3430,6 +3430,10 @@ int monster::armour_class(bool calc_unid) const
     if (has_ench(ENCH_CORROSION))
         ac /= 2;
 
+    // Rolling boulder beetles are vulnerable
+    if (this->rolling())
+        ac /= 2;
+
     return max(ac, 0);
 }
 


### PR DESCRIPTION
Should encourage players to make bad decisions around the
easy-to-mispredict motion of rolling boulder beetles.