### PR TITLE
Tweak panlord brand distribution.

### DIFF
--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -159,18 +159,21 @@ void ghost_demon::reset()
  */
 static brand_type _random_special_pan_lord_brand()
 {
-    return random_choose(SPWPN_FLAMING,
-                         SPWPN_FREEZING,
-                         SPWPN_ELECTROCUTION,
-                         SPWPN_VENOM,
-                         SPWPN_DRAINING,
-                         SPWPN_SPEED,
-                         SPWPN_VORPAL,
-                         SPWPN_VAMPIRISM,
-                         SPWPN_PAIN,
-                         SPWPN_ANTIMAGIC,
-                         SPWPN_DISTORTION,
-                         SPWPN_CHAOS);
+    return random_choose_weighted(10, SPWPN_FLAMING,
+                                  10, SPWPN_FREEZING,
+                                  10, SPWPN_ELECTROCUTION,
+                                  10, SPWPN_VENOM,
+                                  10, SPWPN_SPEED,
+                                  // Lower chance
+                                  5, SPWPN_DRAINING,
+                                  5, SPWPN_VORPAL,
+                                  // Higher chance
+                                  20, SPWPN_VAMPIRISM,
+                                  20, SPWPN_PAIN,
+                                  20, SPWPN_ANTIMAGIC,
+                                  20, SPWPN_DISTORTION,
+                                  20, SPWPN_CHAOS,
+                                  0);
 }
 
 #define ADD_SPELL(which_spell) \


### PR DESCRIPTION
Make unusual (for the player) brands more common, and weaker brands less
common.

Not tied to my lists of "strong" and "weak" brands at all, if people want to dispute my categorisation :P I just like the idea of making certain brands more and less common.