### PR TITLE
A trio of Pakellas Overflow Altar Vaults

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1565,6 +1565,49 @@ MAP
 .............
 ENDMAP
 
+# high evo !apt band takes down filthy low evo !apt brute
+# 2/3  chance of a kobold or corpse with a wand
+# 3/10 chance for a troll corpse (i.e. chance for early troll hide)
+NAME:    johnstein_pakellas_death_squad
+DEPTH:   D:2-
+TAGS:    temple_overflow_pakellas uniq_altar_pakellas
+KFEAT:   _ = altar_pakellas
+KPROP:   xcmnvbt' = bloody / nothing w:80
+NSUBST:  ' = 2:g / 1:G / 1:h / *:.
+SUBST:   G = GG.
+SHUFFLE: xcmnvbt 
+{{
+  local  mon = crawl.random_element({
+    ['kobold']   = 1,
+    ['spriggan'] = 1,
+    ['felid']    = 1,
+  })
+  local corpse = mon .. ' corpse'
+  local wands   = 'wand of flame charges:0 / ' ..
+                  'wand of frost charges:0 / ' ..
+                  'wand of magic darts charges:0 '
+
+  if (mon == 'kobold' and crawl.coinflip()) then
+    kmons("G = kobold; any wand charges:1")
+  else
+    dgn.delayed_decay_extra(_G, 'G', corpse, wands )
+  end
+
+  dgn.delayed_decay_extra(_G, 'g', corpse )
+  dgn.delayed_decay_extra(_G, 'h', 'troll corpse w:3 / ogre corpse' )
+}}
+MAP
+.........
+.xxx+xxx.
+.x'''''x.
+.x'''''x.
+.+''_''+.
+.x'''''x.
+.x'''''x.
+.xxx+xxx.
+.........
+ENDMAP
+
 ### Qazlal overflow altars ####################################################
 
 # There's always a safe path to the altar.

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1627,22 +1627,18 @@ MAP
 ENDMAP
 
 #P altar with gadget shop
-#almost always gives a basic wand (frost, flame, darts)
-#very small chance of any wand
-#tiny chance of any misc
-#even if the ANYs are generated, they will be very expensive
+#90% basic wands (frost, flame, darts)
+#10% any wand and  will be very expensive
 NAME:    johnstein_pakellas_shop 
 DEPTH:   D:2-
 TAGS:    temple_overflow_pakellas uniq_altar_pakellas
 KFEAT:   _ = altar_pakellas
 KFEAT:   S = gadget shop name:Pakellas type:Ersatz suffix:Instruments \ 
-             count:3 greed:2000 ;\
-             wand of flame charges:0 w:200 |\
-             wand of frost charges:0 w:200 |\
-             wand of magic darts charges:0 w:200 |\
-             wand of random effects charges:0 |\
-             any wand charges:0 w:5 |\
-             any misc w:1 
+             count:3 ;\
+             wand of flame charges:5 w:30 |\
+             wand of frost charges:5 w:30 |\
+             wand of magic darts charges:5 w:30 |\
+             any wand
 MAP
  .......
 .mxxxxxm.

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1627,17 +1627,17 @@ MAP
 ENDMAP
 
 #P altar with gadget shop
-#90% basic wands (frost, flame, darts)
-#10% any wand and  will be very expensive
+#90% basic wands (frost, flame, darts). ~150 to 250 gold
+#10% any wand and will be expensive
 NAME:    johnstein_pakellas_shop 
 DEPTH:   D:2-
 TAGS:    temple_overflow_pakellas uniq_altar_pakellas
 KFEAT:   _ = altar_pakellas
 KFEAT:   S = gadget shop name:Pakellas type:Ersatz suffix:Instruments \ 
-             count:3 ;\
-             wand of flame charges:5 w:30 |\
-             wand of frost charges:5 w:30 |\
-             wand of magic darts charges:5 w:30 |\
+             greed:30 count:3 ;\
+             wand of flame charges:15 w:30 |\
+             wand of frost charges:15 w:30 |\
+             wand of magic darts charges:15 w:30 |\
              any wand
 MAP
  .......

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1608,6 +1608,24 @@ MAP
 .........
 ENDMAP
 
+#dig wand with a single charge that could be used to get to P's altar
+NAME:    johnstein_pakellas_dig
+DEPTH:   D:2-
+TAGS:    temple_overflow_pakellas uniq_altar_pakellas
+KFEAT:   _ = altar_pakellas
+KITEM:   ' = wand of digging charges:1
+MAP
+.......
+.xxxxx.
+.xcccx.
+.xc_cx.
+.xxmxx.
+.x.'.x.
+.x...x.
+.xx+xx.
+.......
+ENDMAP
+
 ### Qazlal overflow altars ####################################################
 
 # There's always a safe path to the altar.

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1626,6 +1626,33 @@ MAP
 .......
 ENDMAP
 
+#P altar with gadget shop
+#almost always gives a basic wand (frost, flame, darts)
+#very small chance of any wand
+#tiny chance of any misc
+#even if the ANYs are generated, they will be very expensive
+NAME:    johnstein_pakellas_shop 
+DEPTH:   D:2-
+TAGS:    temple_overflow_pakellas uniq_altar_pakellas
+KFEAT:   _ = altar_pakellas
+KFEAT:   S = gadget shop name:Pakellas type:Ersatz suffix:Instruments \ 
+             count:3 greed:2000 ;\
+             wand of flame charges:0 w:200 |\
+             wand of frost charges:0 w:200 |\
+             wand of magic darts charges:0 w:200 |\
+             wand of random effects charges:0 |\
+             any wand charges:0 w:5 |\
+             any misc w:1 
+MAP
+ .......
+.mxxxxxm.
+.xx.S.xx.
+.x.._..x.
+.xx...xx.
+ .xx+xx.
+ .......
+ENDMAP
+
 ### Qazlal overflow altars ####################################################
 
 # There's always a safe path to the altar.


### PR DESCRIPTION
1)  Death Squad: high evo !apt band takes down filthy low evo !apt brute.
2/3 chance of a wand with 0 charges (occasionally will spawn a kobold with a wand with 1 charge)
3/10 chance of a troll corpse (early troll hide chance)
Only low-level wands will spawn (frost, flame, m. darts)
A dash of blood was sparingly used for thematic effect.
The walls vary in material, somewhat referencing the current blinking P altar.

2) Dig!
a wand of digging with a single charge with a transparent rock wall that hides a P altar.
I wasn't sure if this was against the rules for an overflow vault, but seems like the player has a very clear choice on whether to use the wand to get to the altar, or take it (and recharge it the hard way later).

3) Pakellas's Ersatz Instruments!
90% basic wands with 15 charges
10% any wand with normal charges
greed:30 and only 3 wands

the basic wands cost between 150-250. 
the good wands like hw and haste are >1k
cold/fire, etc are around 600
