### PR TITLE
Differentiate sack of spiders and rod of the swarm

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1009,11 +1009,10 @@ string manual_skill_names(bool short_text)
 
 static const pop_entry pop_spiders[] =
 { // Sack of Spiders
-  {  0,   7,   10, FALL, MONS_GIANT_COCKROACH },
-  {  0,  10,   10, FALL, MONS_SCORPION },
-  {  0,  15,  100, FALL, MONS_KILLER_BEE },
-  {  7,  18,   80, PEAK, MONS_TRAPDOOR_SPIDER },
-  {  9,  27,   90, PEAK, MONS_REDBACK },
+  {  0,  13,   40, FALL, MONS_WORKER_ANT },
+  {  0,  13,   80, FALL, MONS_SOLDIER_ANT },
+  {  6,  19,   80, PEAK, MONS_TRAPDOOR_SPIDER },
+  {  8,  27,   90, PEAK, MONS_REDBACK },
   { 10,  27,   10, SEMI, MONS_ORB_SPIDER },
   { 12,  29,  100, PEAK, MONS_JUMPING_SPIDER },
   { 13,  29,  110, PEAK, MONS_TARANTELLA },

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -207,11 +207,10 @@ spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
 
 monster_type pick_swarmer()
 {
-    return random_choose_weighted(3, MONS_KILLER_BEE,
-                                  3, MONS_WORKER_ANT,
-                                  3, MONS_WASP,
-                                  1, MONS_SCORPION,
-                                  1, MONS_WORM,
+    return random_choose_weighted(4, MONS_KILLER_BEE,
+                                  3, MONS_SCORPION,
+                                  2, MONS_RIVER_RAT,
+                                  1, MONS_WASP,
                                   1, MONS_VAMPIRE_MOSQUITO,
                                   1, MONS_BUTTERFLY,
                                   0);


### PR DESCRIPTION
Tweak the distributions on both items so they don't share any common monsters, and try to make both items more unique from each other.

This is done by giving the rod more killer bees and scorpions, and the sack worker and soldier ants instead of killer bees/scorpions/giant cockroaches. There is a higher proportion of worker ants to soldier ants than there was of the two chaff monsters to killer bees, and more spiders overall (their numbers scale up faster in the 6-15 evo range)

Rod of the swarm loses worker ants and 2/3 of its wasps (af_para). Also worms as they don't feel sufficiently swarmy. River rats were added at weight 2 to replace some of the variety lost.