### PR TITLE
Sometimes upgrade plain decks for Nem worshipers

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1353,6 +1353,10 @@ static int _get_power_level(int power, deck_rarity_type rarity)
     switch (rarity)
     {
     case DECK_RARITY_COMMON:
+//give nemelex worshipers a small chance for an upgrade
+//approx 1/2 ORNATE chance (plain decks don't get the +150 power boost)
+        if (in_good_standing(GOD_NEMELEX_XOBEH) && (x_chance_in_y(power, 1000)))
+            ++power_level;
         break;
     case DECK_RARITY_LEGENDARY:
         if (x_chance_in_y(power, 500))


### PR DESCRIPTION
Currently, Nemelex worshipers get a card power bonus based on Piety, but
plain decks can NEVER be upgraded past level 0, making this bonus 100%
worthless for plain decks.

While there are more serious criticisms of the current Nemelex
implementation, it seems odd that the God of Decks doesn't provide any
bonus at all to plain decks (besides gifting them a bunch).

This update provides a very small chance for plain decks to be upgraded
to level 1.  This is roughly 1/2 the chance of an ornate deck to be
upgraded (remember that plain decks do not get the +150 bonus to power).