### PR TITLE
Make sure vault-produced escape hatches aren't erased

### DIFF
--- a/crawl-ref/source/branch-data.h
+++ b/crawl-ref/source/branch-data.h
@@ -12,7 +12,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_DUNGEON, NUM_BRANCHES, 0, 0, 15, 0,
       BFLAG_NONE,
-      NUM_FEATURES, DNGN_EXIT_DUNGEON,
+      NUM_FEATURES, DNGN_EXIT_DUNGEON, NUM_FEATURES,
       "Dungeon", "the Dungeon", "D",
       nullptr,
       LIGHTGREY, BROWN,
@@ -20,7 +20,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_TEMPLE, BRANCH_DUNGEON, 4, 7, 1, 5,
       BFLAG_NO_ITEMS,
-      DNGN_ENTER_TEMPLE, DNGN_EXIT_TEMPLE,
+      DNGN_ENTER_TEMPLE, DNGN_EXIT_TEMPLE, NUM_FEATURES,
       "Temple", "the Ecumenical Temple", "Temple",
       nullptr,
       LIGHTGREY, BROWN,
@@ -28,7 +28,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ORC, BRANCH_DUNGEON, 9, 12, 2, 10,
       BFLAG_SPOTTY,
-      DNGN_ENTER_ORC, DNGN_EXIT_ORC,
+      DNGN_ENTER_ORC, DNGN_EXIT_ORC, NUM_FEATURES,
       "Orcish Mines", "the Orcish Mines", "Orc",
       nullptr,
       BROWN, BROWN,
@@ -36,7 +36,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ELF, BRANCH_ORC, 2, 2, 3, 15,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_ELF, DNGN_EXIT_ELF,
+      DNGN_ENTER_ELF, DNGN_EXIT_ELF, NUM_FEATURES,
       "Elven Halls", "the Elven Halls", "Elf",
       nullptr,
       WHITE, ETC_ELVEN_BRICK,
@@ -45,7 +45,7 @@ const Branch branches[NUM_BRANCHES] =
 #if TAG_MAJOR_VERSION == 34
     { BRANCH_DWARF, BRANCH_ELF, -1, -1, 0, 17,
       BFLAG_NONE,
-      DNGN_ENTER_DWARF, DNGN_EXIT_DWARF,
+      DNGN_ENTER_DWARF, DNGN_EXIT_DWARF, NUM_FEATURES,
       "Dwarven Hall", "the Dwarven Hall", "Dwarf",
       nullptr,
       BROWN, BROWN,
@@ -54,7 +54,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_LAIR, BRANCH_DUNGEON, 8, 11, 8, 10,
       BFLAG_NONE,
-      DNGN_ENTER_LAIR, DNGN_EXIT_LAIR,
+      DNGN_ENTER_LAIR, DNGN_EXIT_LAIR, NUM_FEATURES,
       "Lair", "the Lair of Beasts", "Lair",
       nullptr,
       GREEN, BROWN,
@@ -62,7 +62,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SWAMP, BRANCH_LAIR, 3, 6, 4, 15,
       BFLAG_DANGEROUS_END | BFLAG_SPOTTY,
-      DNGN_ENTER_SWAMP, DNGN_EXIT_SWAMP,
+      DNGN_ENTER_SWAMP, DNGN_EXIT_SWAMP, NUM_FEATURES,
       "Swamp", "the Swamp", "Swamp",
       nullptr,
       BROWN, BROWN,
@@ -70,7 +70,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SHOALS, BRANCH_LAIR, 3, 6, 4, 15,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_SHOALS, DNGN_EXIT_SHOALS,
+      DNGN_ENTER_SHOALS, DNGN_EXIT_SHOALS, NUM_FEATURES,
       "Shoals", "the Shoals", "Shoals",
       nullptr,
       BROWN, BROWN,
@@ -78,7 +78,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SNAKE, BRANCH_LAIR, 3, 6, 4, 15,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_SNAKE, DNGN_EXIT_SNAKE,
+      DNGN_ENTER_SNAKE, DNGN_EXIT_SNAKE, NUM_FEATURES,
       "Snake Pit", "the Snake Pit", "Snake",
       nullptr,
       LIGHTGREEN, YELLOW,
@@ -86,7 +86,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SPIDER, BRANCH_LAIR, 3, 6, 4, 15,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_SPIDER, DNGN_EXIT_SPIDER,
+      DNGN_ENTER_SPIDER, DNGN_EXIT_SPIDER, NUM_FEATURES,
       "Spider Nest", "the Spider Nest", "Spider",
       nullptr,
       BROWN, YELLOW,
@@ -94,7 +94,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SLIME, BRANCH_LAIR, 6, 8, 6, 17,
       BFLAG_NO_ITEMS | BFLAG_DANGEROUS_END | BFLAG_SPOTTY,
-      DNGN_ENTER_SLIME, DNGN_EXIT_SLIME,
+      DNGN_ENTER_SLIME, DNGN_EXIT_SLIME, NUM_FEATURES,
       "Slime Pits", "the Pits of Slime", "Slime",
       nullptr,
       GREEN, BROWN,
@@ -102,7 +102,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_VAULTS, BRANCH_DUNGEON, 13, 14, 5, 19,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_VAULTS, DNGN_EXIT_VAULTS,
+      DNGN_ENTER_VAULTS, DNGN_EXIT_VAULTS, NUM_FEATURES,
       "Vaults", "the Vaults", "Vaults",
       nullptr,
       LIGHTGREY, BROWN,
@@ -110,7 +110,7 @@ const Branch branches[NUM_BRANCHES] =
 #if TAG_MAJOR_VERSION == 34
     { BRANCH_BLADE, BRANCH_VAULTS, 3, 4, 1, 21,
       BFLAG_NO_ITEMS,
-      DNGN_ENTER_BLADE, DNGN_EXIT_BLADE,
+      DNGN_ENTER_BLADE, DNGN_EXIT_BLADE, NUM_FEATURES,
       "Hall of Blades", "the Hall of Blades", "Blade",
       nullptr,
       LIGHTGREY, BROWN,
@@ -119,7 +119,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_CRYPT, BRANCH_VAULTS, 2, 3, 3, 19,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_CRYPT, DNGN_EXIT_CRYPT,
+      DNGN_ENTER_CRYPT, DNGN_EXIT_CRYPT, NUM_FEATURES,
       "Crypt", "the Crypt", "Crypt",
       nullptr,
       LIGHTGREY, BROWN,
@@ -127,7 +127,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_TOMB, BRANCH_CRYPT, 3, 3, 3, 21,
       BFLAG_ISLANDED | BFLAG_DANGEROUS_END | BFLAG_NO_SHAFTS,
-      DNGN_ENTER_TOMB, DNGN_EXIT_TOMB,
+      DNGN_ENTER_TOMB, DNGN_EXIT_TOMB, NUM_FEATURES,
       "Tomb", "the Tomb of the Ancients", "Tomb",
       nullptr,
       BROWN, BROWN,
@@ -135,7 +135,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_VESTIBULE, NUM_BRANCHES, 27, 27, 1, 27,
       BFLAG_NO_ITEMS,
-      DNGN_ENTER_HELL, DNGN_EXIT_HELL,
+      DNGN_ENTER_HELL, DNGN_EXIT_HELL, NUM_FEATURES,
       "Hell", "the Vestibule of Hell", "Hell",
       "Welcome to Hell!\nPlease enjoy your stay.",
       LIGHTGREY, LIGHTRED,
@@ -143,7 +143,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_DIS, BRANCH_VESTIBULE, 1, 1, 7, 28,
       BFLAG_NO_ITEMS | BFLAG_DANGEROUS_END,
-      DNGN_ENTER_DIS, DNGN_ENTER_HELL,
+      DNGN_ENTER_DIS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Dis", "the Iron City of Dis", "Dis",
       nullptr,
       CYAN, BROWN,
@@ -151,7 +151,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_GEHENNA, BRANCH_VESTIBULE, 1, 1, 7, 28,
       BFLAG_NO_ITEMS | BFLAG_DANGEROUS_END,
-      DNGN_ENTER_GEHENNA, DNGN_ENTER_HELL,
+      DNGN_ENTER_GEHENNA, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Gehenna", "Gehenna", "Geh",
       nullptr,
       BROWN, RED,
@@ -159,7 +159,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_COCYTUS, BRANCH_VESTIBULE, 1, 1, 7, 28,
       BFLAG_NO_ITEMS | BFLAG_DANGEROUS_END,
-      DNGN_ENTER_COCYTUS, DNGN_ENTER_HELL,
+      DNGN_ENTER_COCYTUS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Cocytus", "Cocytus", "Coc",
       nullptr,
       LIGHTBLUE, LIGHTCYAN,
@@ -167,7 +167,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_TARTARUS, BRANCH_VESTIBULE, 1, 1, 7, 28,
       BFLAG_NO_ITEMS | BFLAG_DANGEROUS_END,
-      DNGN_ENTER_TARTARUS, DNGN_ENTER_HELL,
+      DNGN_ENTER_TARTARUS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Tartarus", "Tartarus", "Tar",
       nullptr,
       MAGENTA, MAGENTA,
@@ -175,7 +175,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ZOT, BRANCH_DEPTHS, 5, 5, 5, 27,
       BFLAG_DANGEROUS_END,
-      DNGN_ENTER_ZOT, DNGN_EXIT_ZOT,
+      DNGN_ENTER_ZOT, DNGN_EXIT_ZOT, NUM_FEATURES,
       "Zot", "the Realm of Zot", "Zot",
       nullptr,
       BLACK, BLACK, // set per-map
@@ -183,7 +183,7 @@ const Branch branches[NUM_BRANCHES] =
 #if TAG_MAJOR_VERSION == 34
     { BRANCH_FOREST, BRANCH_VAULTS, 2, 3, 5, 19,
       BFLAG_SPOTTY,
-      DNGN_ENTER_FOREST, DNGN_EXIT_FOREST,
+      DNGN_ENTER_FOREST, DNGN_EXIT_FOREST, NUM_FEATURES,
       "Forest", "the Enchanted Forest", "Forest",
       nullptr,
       BROWN, BROWN,
@@ -192,7 +192,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ABYSS, NUM_BRANCHES, -1, -1, 5, 24,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_MAP,
-      DNGN_ENTER_ABYSS, DNGN_EXIT_ABYSS,
+      DNGN_ENTER_ABYSS, DNGN_EXIT_ABYSS, DNGN_FLOOR, // can't get trapped in abyss
       "Abyss", "the Abyss", "Abyss",
       nullptr,
       BLACK, BLACK, // set specially
@@ -200,7 +200,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_PANDEMONIUM, NUM_BRANCHES, -1, -1, 1, 24,
       BFLAG_NO_XLEV_TRAVEL,
-      DNGN_ENTER_PANDEMONIUM, DNGN_EXIT_PANDEMONIUM,
+      DNGN_ENTER_PANDEMONIUM, DNGN_EXIT_PANDEMONIUM, DNGN_TRANSIT_PANDEMONIUM,
       "Pandemonium", "Pandemonium", "Pan",
       "You enter the halls of Pandemonium!\n"
       "To return, you must find a gate leading back.",
@@ -210,7 +210,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ZIGGURAT, BRANCH_DEPTHS, 1, 5, 27, 27,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_ZIGGURAT, DNGN_EXIT_ZIGGURAT,
+      DNGN_ENTER_ZIGGURAT, DNGN_EXIT_ZIGGURAT, DNGN_FLOOR,
       "Ziggurat", "a ziggurat", "Zig",
       "You land on top of a ziggurat so tall you cannot make out the ground.",
       BLACK, BLACK,
@@ -218,7 +218,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_LABYRINTH, NUM_BRANCHES, -1, -1, 1, 15,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS | BFLAG_NO_MAP,
-      DNGN_ENTER_LABYRINTH, DNGN_EXIT_LABYRINTH,
+      DNGN_ENTER_LABYRINTH, DNGN_EXIT_LABYRINTH, DNGN_EXIT_THROUGH_ABYSS,
       "Labyrinth", "a labyrinth", "Lab",
       // XXX: Ideally, we want to hint at the wall rule (rock > metal),
       //      and that the walls can shift occasionally.
@@ -230,7 +230,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_BAZAAR, NUM_BRANCHES, -1, -1, 1, 18,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_BAZAAR, DNGN_EXIT_BAZAAR,
+      DNGN_ENTER_BAZAAR, DNGN_EXIT_BAZAAR, NUM_FEATURES,
       "Bazaar", "a bazaar", "Bazaar",
       "You enter an inter-dimensional bazaar!",
       BLUE, YELLOW,
@@ -238,7 +238,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_TROVE, NUM_BRANCHES, -1, -1, 1, 18,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_TROVE, DNGN_EXIT_TROVE,
+      DNGN_ENTER_TROVE, DNGN_EXIT_TROVE, NUM_FEATURES,
       "Trove", "a treasure trove", "Trove",
       "You enter a treasure trove!",
       DARKGREY, BLUE,
@@ -246,7 +246,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_SEWER, NUM_BRANCHES, -1, -1, 1, 4,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_SEWER, DNGN_EXIT_SEWER,
+      DNGN_ENTER_SEWER, DNGN_EXIT_SEWER, NUM_FEATURES,
       "Sewer", "a sewer", "Sewer",
       "You enter a sewer!",
       LIGHTGREY, BLUE,
@@ -254,7 +254,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_OSSUARY, NUM_BRANCHES, -1, -1, 1, 6,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_OSSUARY, DNGN_EXIT_OSSUARY,
+      DNGN_ENTER_OSSUARY, DNGN_EXIT_OSSUARY, NUM_FEATURES,
       "Ossuary", "an ossuary", "Ossuary",
       "You enter an ossuary!",
       WHITE, YELLOW,
@@ -262,7 +262,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_BAILEY, NUM_BRANCHES, -1, -1, 1, 11,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_BAILEY, DNGN_EXIT_BAILEY,
+      DNGN_ENTER_BAILEY, DNGN_EXIT_BAILEY, NUM_FEATURES,
       "Bailey", "a bailey", "Bailey",
       "You enter a bailey!",
       WHITE, LIGHTRED,
@@ -270,7 +270,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_ICE_CAVE, NUM_BRANCHES, -1, -1, 1, 15,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_ICE_CAVE, DNGN_EXIT_ICE_CAVE,
+      DNGN_ENTER_ICE_CAVE, DNGN_EXIT_ICE_CAVE, NUM_FEATURES,
       "Ice Cave", "an ice cave", "IceCv",
       "You enter an ice cave!",
       BLUE, WHITE,
@@ -278,7 +278,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_VOLCANO, NUM_BRANCHES, -1, -1, 1, 14,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_VOLCANO, DNGN_EXIT_VOLCANO,
+      DNGN_ENTER_VOLCANO, DNGN_EXIT_VOLCANO, NUM_FEATURES,
       "Volcano", "a volcano", "Volcano",
       "You enter a volcano!",
       RED, RED,
@@ -286,7 +286,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_WIZLAB, NUM_BRANCHES, -1, -1, 1, 24,
       BFLAG_NO_XLEV_TRAVEL | BFLAG_NO_ITEMS,
-      DNGN_ENTER_WIZLAB, DNGN_EXIT_WIZLAB,
+      DNGN_ENTER_WIZLAB, DNGN_EXIT_WIZLAB, NUM_FEATURES,
       "Wizlab", "a wizard's laboratory", "WizLab",
       "You enter a wizard's laboratory!",
       LIGHTGREY, BROWN, // set per-map
@@ -294,7 +294,7 @@ const Branch branches[NUM_BRANCHES] =
 
     { BRANCH_DEPTHS, BRANCH_DUNGEON, 15, 15, 5, 22,
       BFLAG_NONE,
-      DNGN_ENTER_DEPTHS, DNGN_EXIT_DEPTHS,
+      DNGN_ENTER_DEPTHS, DNGN_EXIT_DEPTHS, NUM_FEATURES,
       "Depths", "the Depths", "Depths",
       nullptr,
       LIGHTGREY, BROWN,

--- a/crawl-ref/source/branch.h
+++ b/crawl-ref/source/branch.h
@@ -37,6 +37,7 @@ struct Branch
 
     dungeon_feature_type entry_stairs;
     dungeon_feature_type exit_stairs;
+    dungeon_feature_type escape_feature; // for branches with no up hatches allowed
     const char* shortname;      // "Slime Pits"
     const char* longname;       // "The Pits of Slime"
     const char* abbrevname;     // "Slime"

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1371,12 +1371,16 @@ static void _fixup_branch_stairs()
     const bool top = you.depth == 1;
     const bool bottom = at_branch_bottom();
 
+    const dungeon_feature_type exit =
+        root ? DNGN_EXIT_DUNGEON
+             : branch.exit_stairs;
     const dungeon_feature_type escape =  root ? DNGN_EXIT_DUNGEON :
         branch.escape_feature == NUM_FEATURES ? DNGN_ESCAPE_HATCH_UP :
                                                 branch.escape_feature;
     const dungeon_feature_type up_hatch =
-        (top && !bottom) ? DNGN_ESCAPE_HATCH_DOWN :
-                           escape;
+        top &&  bottom ? exit :
+        top && !bottom ? DNGN_ESCAPE_HATCH_DOWN :
+                         escape;
 
 #ifdef DEBUG_DIAGNOSTICS
     int count = 0;
@@ -1385,9 +1389,6 @@ static void _fixup_branch_stairs()
     // Prefer stairs that are placed in vaults for picking an exit at
     // random.
     vector<coord_def> vault_stairs, normal_stairs;
-    const dungeon_feature_type exit =
-        root ? DNGN_EXIT_DUNGEON
-             : branch.exit_stairs;
     for (rectangle_iterator ri(1); ri; ++ri)
     {
         const bool vault = map_masked(*ri, MMT_VAULT);

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1392,16 +1392,17 @@ static void _fixup_branch_stairs()
     for (rectangle_iterator ri(1); ri; ++ri)
     {
         const bool vault = map_masked(*ri, MMT_VAULT);
+        const auto escape_replacement = vault ? up_hatch : DNGN_FLOOR;
         if (bottom && (feat_is_stone_stair_down(grd(*ri))
                        || grd(*ri) == DNGN_ESCAPE_HATCH_DOWN))
         {
-            _set_grd(*ri, vault ? escape : DNGN_FLOOR);
+            _set_grd(*ri, escape_replacement);
         }
 
         if (top)
         {
             if (grd(*ri) == DNGN_ESCAPE_HATCH_UP)
-                _set_grd(*ri, vault ? up_hatch : DNGN_FLOOR);
+                _set_grd(*ri, escape_replacement);
             else if (feat_is_stone_stair_up(grd(*ri)))
             {
 #ifdef DEBUG_DIAGNOSTICS

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1352,6 +1352,18 @@ void fixup_misplaced_items()
     }
 }
 
+/*
+ * At the top or bottom of a branch, adjust or remove illegal stairs:
+ *
+ * - non-vault escape hatches pointing outside the branch are removed
+ * - non-vault stone stairs down from X:$ are removed
+ * - stone stairs up from X:1 are replaced with branch exit feature
+ *   - if there is more than one such stair, an error is logged
+ * - vault-specified hatches or stairs are replaced with appropriate features
+ *   - hatches down from X:$ are pointed up instead, and vice versa on X:1
+ *   - for single-level branches, all hatches turn into the branch exit feature
+ *   - if the branch has an "escape feature", it is used instead of hatches up
+ */
 static void _fixup_branch_stairs()
 {
     const auto& branch = your_branch();

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1354,23 +1354,17 @@ void fixup_misplaced_items()
 
 static void _fixup_branch_stairs()
 {
-    auto& branch = your_branch();
-    bool root = player_in_branch(root_branch);
-    dungeon_feature_type escape = branch.escape_feature;
-    if (root)
-        escape = DNGN_EXIT_DUNGEON;
-    else if (escape == NUM_FEATURES)
-        escape = DNGN_ESCAPE_HATCH_UP;
+    const auto& branch = your_branch();
+    const bool root = player_in_branch(root_branch);
+    const bool top = you.depth == 1;
+    const bool bottom = at_branch_bottom();
 
-    bool top = you.depth == 1;
-    bool bottom = at_branch_bottom();
-
-    dungeon_feature_type up_hatch = escape;
-    if (top && !bottom)
-        up_hatch = DNGN_ESCAPE_HATCH_DOWN;
-
-    // Top level of branch levels - replaces up stairs with stairs back to
-    // dungeon or wherever:
+    const dungeon_feature_type escape =  root ? DNGN_EXIT_DUNGEON :
+        branch.escape_feature == NUM_FEATURES ? DNGN_ESCAPE_HATCH_UP :
+                                                branch.escape_feature;
+    const dungeon_feature_type up_hatch =
+        (top && !bottom) ? DNGN_ESCAPE_HATCH_DOWN :
+                           escape;
 
 #ifdef DEBUG_DIAGNOSTICS
     int count = 0;
@@ -1379,12 +1373,12 @@ static void _fixup_branch_stairs()
     // Prefer stairs that are placed in vaults for picking an exit at
     // random.
     vector<coord_def> vault_stairs, normal_stairs;
-    dungeon_feature_type exit = branch.exit_stairs;
-    if (root)
-        exit = DNGN_EXIT_DUNGEON;
+    const dungeon_feature_type exit =
+        root ? DNGN_EXIT_DUNGEON
+             : branch.exit_stairs;
     for (rectangle_iterator ri(1); ri; ++ri)
     {
-        bool vault = map_masked(*ri, MMT_VAULT);
+        const bool vault = map_masked(*ri, MMT_VAULT);
         if (bottom && (feat_is_stone_stair_down(grd(*ri))
                        || grd(*ri) == DNGN_ESCAPE_HATCH_DOWN))
         {


### PR DESCRIPTION
`>` placed at branch ends, and `<` at branch entrances, used to be deleted
because those features aren't legal in those places. This could lead to
players being trapped, eg if an 'island' vault with a hatch down
generated on Lair:8. Now, we replace any vault-mandated escape hatches
with whatever escape feature is appropriate for the current branch/floor.

Could use some review, particularly from @neilmoore, who suggested the implementation some time ago but I never got around to it.