### PR TITLE
Ignore splash damage for reach attacks.

### DIFF
--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -2105,6 +2105,10 @@ void melee_attack::attacker_sustain_passive_damage()
     if (attacker->res_acid() >= 3)
         return;
 
+    // Ignore splash damage for reach attacks.
+    if (!adjacent(attacker->position, defender->position))
+        return;
+
     const int acid_strength = resist_adjust_damage(attacker, BEAM_ACID, 5);
 
     // Spectral weapons can't be corroded (but can take acid damage).


### PR DESCRIPTION
Currently if you attack a jelly with a polearm from distance, you still get a message "your hands burn". That doesn't make much sense for me. I mean, if I get burned from distance 2 attacking jelly, why can't jelly just spit acid from distance 2 actively? I guess the idea about this monster was that it was only close range.

Also, all other player auxiliary/monster flavour melee attacks require being adjacent except from this one piece.