### PR TITLE
Adjust cure mutation trove entry fee

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -134,7 +134,7 @@ function trove.get_trove_item(e, value, base_item)
       table.insert(pots, {base="potion", type="haste", quant=3+d(3)+d(2)})
     end
     if you.race() ~= "Ghoul" then
-      table.insert(pots, {base="potion", type="cure mutation", quant=2})
+      table.insert(pots, {base="potion", type="cure mutation", quant=1+d(3)})
     end
 
     for _, toll in ipairs(pots) do


### PR DESCRIPTION
To account for the potion being ~50% more common, change fixed cost of 2
to 1+d3.