### PR TITLE
Numerous tweaks to monster spawns and map layout

### DIFF
--- a/crawl-ref/source/dat/des/branches/spider.des
+++ b/crawl-ref/source/dat/des/branches/spider.des
@@ -1665,69 +1665,6 @@ xxcc-.i.5...""...h...."".......-"c
   xc----@-"-----x------""-@----ccx
 ENDMAP
 
-#Tomb flavoring, death scarabs
-NAME: floodkiller_spider_rune_tomb
-PLACE: Spider:$
-TAGS: no_monster_gen
-ORIENT: south
-KITEM:  O = potion of ambrosia ident:type, gossamer rune of Zot
-KFEAT: C = stone_wall
-TILE: c = wall_sandstone
-TILE: C = wall_tomb
-TILE: G = dngn_sarcophagus_pedestal_left
-FTILE: 123+$O.EHG = floor_sandstone:20 / none
-MONS: death scarab
-MONS: wolf spider spectre / wolf spider zombie / demonic crawler / emperor scorpion spectre w:2
-MONS: jumping spider spectre w:20 / tarantella spectre w:20 / redback spectre w:20 / hornet spectre / jumping spider zombie / tarantella zombie / redback zombie / hornet zombie w:5
-MONS: wolf spider / emperor scorpion w:2 / ghost moth w:1 / moth of wrath w:1
-MONS: jumping spider / tarantella / redback / hornet w:5 / orb spider w:1 / spark wasp w:1
-SUBST: E = 3 5:25
-SUBST: H = 2 4:25
-: set_feature_name("granite_statue", "sarcophagus")
-MAP
-             @@@@@@@@@
-             E.WWWWW.E
-             .WWWWWWW.
-     xxxxxxxxcccWWWWccxxxxxxxx
-   xxxxxxxxxxccccWWcccxxxxxxxxxx
- xxxxxxxxxxxxccccWWcccxxxxxxxxxxxx
-xxxxxxxxxxxxxcccWWccccxxxxxxxxxxxxx
-xxxxxxxxxxxxxcccWWccccxxxxxxxxxxxxx
-xxcccccccccccccWWWWccccccccccccccxx
-xxcWW.E..x...WWWWWWWW..ExE.WWW..cxx
-xxcWW.x.......WWWWWx......WWWW..cxx
-xxcWW.E.....Wx........x...WWWWx.cxx
-xxcxWW.....................WW...cxx
-xxc.WW.......E.EHE.E.......x....cxx
-xxc.WWx.ccccccccccccccccccc....Wcxx
-xxcEWWW.c......x........x.c.E.WWcxx
-xxc..WW.c.x..E..E..E......c..WWWcxx
-xxcE..WWc...H....H....H...cE.WxWcxx
-xxc...Wxc...CCC+++++CCC...c..WWWcxx
-xxc.H.WWc...C.........C..xc.H.WWcxx
-xxc.xWWWc...C.3.....3.C...c..x.Wcxx
-xxc..WWWc...C..3...3..C...c....Wcxx
-xxc.EWWWc..xC23..3..32C...c..E..cxx
-xxc.WWW.c...C...2.2...Cx..c.....cxx
-xxcHWW.xc...C11.....11C...cW.x.Hcxx
-xxcEWW..c...C1xxxGxxx1C...cW...Ecxx
-xxcWxW..cx..C$1..O..1$C...cWW...cxx
-xxcWWW..c..ECCCCCCCCCCCEH.cxW...cxx
-xxcWW...c....E.c...cxE.E..cWW...cxx
-xxcW.x..c.H.E..c...c..E.x.cWWW.xcxx
-xxc.....c.x...Wc...c...EH.cWWWW.cxx
-xxc....xc.....Wc...cWW....c.WWW.cxx
-xxc.....cccccccWWWWWccccccc.WxWWcxx
-xxc.H........WWWWWWWW........WWWcxx
-xxc.....xWWWWWWxWWWWWWWx.......Hcxx
-xxc..WWWWWWWWWWWWWWxWWWW........cxx
-xxcWWxWWW..E..WWW.E......E.....xcxx
-xxcWWWWE..H.x.E.......E.H..xE...cxx
-xxcccccccccccccccccccccccccccccccxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-ENDMAP
-
 ##########################################
 #Arachne Lair Rune Vault
 NAME:   johnstein_spider_rune_arachne_lair
@@ -1815,4 +1752,77 @@ xcc.1''''_""???""_''''1.ccx
      .cc.Occo.occO.cc.
      ..ccccc...ccccc..
       .....@@@@@.....
+ENDMAP
+
+#Tomb flavoring, death scarabs
+NAME:   floodkiller_spider_rune_tomb
+PLACE:  Spider:$
+TAGS:   no_monster_gen
+ORIENT: south
+NSUBST: N = 4:. / *:c
+TILE:   M = wall_tomb
+COLOUR: M = yellow
+KFEAT:  M = stone_wall
+KFEAT:  P = clear_rock_wall
+TILE:   c = wall_sandstone
+TILE:   P = dngn_sarcophagus_pedestal_left
+FTILE:  1234567+$O.EGHKNPS = floor_sandstone:20 / none
+ITEM:   gold w:40 / potion of ambrosia ident:type
+KITEM:  O = potion of ambrosia ident:type, gossamer rune of Zot
+MONS:   death scarab
+MONS:   wolf spider spectre / wolf spider zombie w:5 / demonic crawler w:5 \
+        / emperor scorpion spectre w:2
+MONS:   jumping spider spectre w:20 / tarantella spectre w:20 \
+        / redback spectre w:20 / hornet spectre / jumping spider zombie \
+        / tarantella zombie / redback zombie / hornet zombie w:5
+MONS:   jumping spider / tarantella / redback / wolf spider w:5 \
+        / hornet w:5 / orb spider w:3 / spark wasp w:2
+MONS:   emperor scorpion
+MONS:   ghost moth
+MONS:   moth of wrath
+NSUBST: S = 8:1 / *:.
+NSUBST: H = 2:5 / 1:6 / 1:7 / *:K
+SUBST:  K = 2 5:4 6:2 7:2 E:20
+SUBST:  E = 3 4:30
+: set_feature_name("clear_rock_wall", "sarcophagus")
+MAP
+         @@@@@@@@@@@@@@@
+         ...EWWWWWWWE...
+.............ccWWWWc.............
+.G..G..G..G.ccccWWccc.G..G..G..G.
+............ccccWWccc............
+.G..G..G..G..ccWWcccc.G..G..G..G.
+............cccWWccc.............
+xcccccccccccccWWWWccccccccccccccx
+xcWW.E..x...WWWWWWWW..ExE.WWW..cx
+xcWW.x.......WWWWWx......WWWW..cx
+xcWW.E.....Wx........x...WWWWx.cx
+xcxWW.....................WW...cx
+xc.WW.......E.EHE.E.......x....cx
+xc.WWx.ccccccccccccccccccc....Wcx
+xcEWWW.c......x........x.c.E.WWcx
+xc..WW.c.x..E..E..E......c..WWWcx
+xcE..WWc...H....H....H...cE.WxWcx
+xc...Wxc...MMM+++++MMM...c..WWWcx
+xc.H.WWc...MS.......SM..xc.H.WWcx
+xc.xWWWc...M.3.S.S.3.M...c..x.Wcx
+xc..WWWc...M.S3.S.3S.M...c....Wcx
+xc.EWWWc..xM23.S3S.32M...c..E..cx
+xc.WWW.c...MS..2.2..SMx..c.....cx
+xcHWW.xc...M.S.S.S.S.M...cW.x.Hcx
+xcEWW..c...MSMMMPMMMSM...cW...Ecx
+xcWxW..cx..MdSddOddSdM...cWW...cx
+xcWWW..c.HEMMMMMMMMMMMEH.cxW...cx
+xcWW...c..E...N...Nx..E..cWW...cx
+xcW.x..c.H.E..N...N..E.x.cWWW.xcx
+xc.....c.x...WN...N....H.cWWWW.cx
+xc....xc.E...WN...NWW.E..c.WWW.cx
+xc.....ccccccNNWWWNNcccccc.WxWWcx
+xc.H........WWWWWWWW........WWWcx
+xc.....xWWWWWWxWWWWWWWx.......Hcx
+xc..WWWWWWWWWWWWWWxWWWW........cx
+xcWWxWWW..E..WWW.E......E.....xcx
+xcWWWWE..H.x.E.......E.H..xE...cx
+xcccccccccccccccccccccccccccccccx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ENDMAP


### PR DESCRIPTION
Randomize the placement of the death scarabs within the rune chamber to
prevent bunching/immediate LRDing of half the swarm.  Normalize placement
of harder monsters (moths of wrath/ghost moths/emperor scorpions) so that
there randomly it isn't likely to have 10 of them.  Adjust ratios of other
monster spawns as well.  Randomize entrance to inner loop to limit kill
corner/funneling in addition to increasing variability in layout.  Change
"rock statues" outside entrance to actual granite statues, and change
sarcophagus to clear_rock_wall so that the statues aren't called
"sacophogi" while keeping rune preview effect.  Change anti-apport wall
around sarcophagus into stone Tomb wall to better match aesthetic of inner
chamber.