### PR TITLE
Enhance and expand upon the captain's cutlass

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -637,7 +637,7 @@ ENUM:     CAPTAIN
 NAME:     captain's cutlass
 OBJ:      OBJ_WEAPONS/WPN_CUTLASS
 INSCRIP:  disarm
-PLUS:     +5
+PLUS:     +7
 COLOUR:   DARKGREY
 TILE:     urand_cutlass
 TILE_EQ:  capt_cutlass

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1274,25 +1274,44 @@ static void _OCTOPUS_KING_world_reacts(item_def *item)
 
 ///////////////////////////////////////////////////
 
+static void _CAPTAIN_equip(item_def *item, bool *show_msgs, bool unmeld)
+{
+    if (you_worship(GOD_SHINING_ONE))
+    {
+        _equip_mpr(show_msgs,
+                   "You feel dishonourable wielding this.");
+    }
+    else
+    {
+        _equip_mpr(show_msgs,
+                   "You feel a cutthroat vibe.");
+    }
+}
+
 static void _CAPTAIN_melee_effects(item_def* weapon, actor* attacker,
-                                   actor* defender, bool mondied, int dam)
+                                actor* defender, bool mondied, int dam)
 {
     // Player disarming sounds like a bad idea; monster-on-monster might
     // work but would be complicated.
-    if (!attacker->is_player() || !defender->is_monster() || mondied)
-        return;
-
-    if (x_chance_in_y(dam, 75))
+    if (coinflip()
+        && dam >= (3 + random2(defender->get_hit_dice()))
+        && !x_chance_in_y(defender->get_hit_dice(), random2(20) + dam*4)
+        && attacker->is_player()
+        && defender->is_monster()
+        && !mondied)
     {
         item_def *wpn = defender->as_monster()->disarm();
         if (wpn)
         {
-            mprf("You knock %s %s to the ground with your cutlass!",
-                 apostrophise(defender->name(DESC_THE)).c_str(),
-                 wpn->name(DESC_PLAIN).c_str());
+            mprf("The captain's cutlass flashes! You lacerate %s!!",
+                defender->name(DESC_THE).c_str());
+            mprf("%s %s falls to the floor!",
+                apostrophise(defender->name(DESC_THE)).c_str(),
+                wpn->name(DESC_PLAIN).c_str());
+            defender->hurt(attacker, 18 + random2(18));
+            did_god_conduct(DID_UNCHIVALRIC_ATTACK, 3);
         }
     }
-
 }
 
 ///////////////////////////////////////////////////

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -1,4 +1,4 @@
-%%%%
+﻿%%%%
 Singing Sword
 
 An enchanted blade which loves nothing more than to sing to its owner, whether
@@ -262,8 +262,8 @@ An infamous weapon, once used by a vile pirate captain to slaughter countless
 innocents. He finally met his destiny when a kraken swallowed his ship, and the
 cutlass was thought to be lost with him.
 
-This weapon is perfectly suited for relieving opponents of their weapons, just
-before it relieves them of their lives.
+This blade has the capability to suddenly relieve opponents of their weapons,
+dealing extra damage in the process.
 %%%%
 storm bow
 

--- a/crawl-ref/source/goditem.cc
+++ b/crawl-ref/source/goditem.cc
@@ -585,6 +585,8 @@ conduct_type god_hates_item_handling(const item_def &item)
     case GOD_SHINING_ONE:
         if (item_type_known(item) && is_poisoned_item(item))
             return DID_POISON;
+        if (is_unrandom_artefact(item, UNRAND_CAPTAIN))
+            return DID_UNCHIVALRIC_ATTACK;
         break;
 
     case GOD_YREDELEMNUL:


### PR DESCRIPTION
The formula for disarming success has been changed and it is now based
on target HD. Disarming should be nominally easier to pull off.

Enchantment has been improved from +5 to +7. (was +10 pre-disarm)

There is now a chance when disarming to deal 18-35 (average 26.5)
non-elemental damage. This is akin to having a powerful flat damage
brand versus monsters wielding a weapon, but it will only trigger while
disarming.

TSO followers are still allowed to wield the weapon, but they won't use
the disarm feature.

PR notes: This seemed more interesting than just giving it +10 slay again.
The idea behind the attack is a disarmed monster is probably going to
be off-balance or trip/stumble, etc. so he's briefly vulnerable to your stabber
persona. Damage is a bit less than 2 elec brands, which seems to be about
right from testing it vs. orc and vaults.

The damage was made fairly substantial to make it rewarding, I don't have 
a strong feeling about randart power balance. It's certainly better than any 
past iteration of this specific unrand (vs monsters with weapons anyways) but
imo not as good as, for instance, arc blade.

Other goals were to have better disarm success formulas in general, by
incorporating HD and resolving inflated stab damage with one_chance_ins
instead. (it seems bad to have it work every time in a stab scenario against
uniques etc.)