### PR TITLE
Fix abort when tweaking artefacts in wizmode

### DIFF
--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -260,7 +260,7 @@ static void _tweak_randart(item_def &item)
 #endif
         choice_to_prop.push_back(i);
         if (choice_num % 8 == 0 && choice_num != 0)
-            *(prompt.rend()) = '\n'; // Replace the space
+            *(prompt.end() - 1) = '\n'; // Replace the space
 
         char choice;
         char buf[80];


### PR DESCRIPTION
This code was doubly wrong:

* It should have been end() rather than rend() to modify the end of the string. (rend() is reverse end, which is actually the beginning.)
* end() points *past* the end of the string and dereferencing it is undefined behavior. We want the last character.