### PR TITLE
Reduce !cure mutation shop price

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -677,7 +677,7 @@ unsigned int item_value(item_def item, bool ident)
                 break;
 
             case POT_CURE_MUTATION:
-                valued += 250;
+                valued += 200;
                 break;
 
             case POT_RESISTANCE:


### PR DESCRIPTION
By 20%.

Strategic consumables should be more expensive than tactical ones, and the cost to fix a mistake/roulette should be high, but the old price is still too high for their rarity.