### PR TITLE
Rework Gozag incite.

### DIFF
--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -2081,6 +2081,7 @@ enum enchant_type
 #endif
     ENCH_BRILLIANCE_AURA, // emanating a brilliance aura
     ENCH_EMPOWERED_SPELLS, // affected by above
+    ENCH_GOZAG_INCITE,
     // Update enchantment names in mon-ench.cc when adding or removing
     // enchantments.
     NUM_ENCHANTMENTS

--- a/crawl-ref/source/godwrath.cc
+++ b/crawl-ref/source/godwrath.cc
@@ -2024,37 +2024,21 @@ void gozag_incite(monster *mon)
     behaviour_event(mon, ME_ALERT, &you);
 
     bool success = false;
-    const mon_attack_def attk = mons_attack_spec(mon, 0);
 
-    int tries = 3;
-    do
+    if (mon->needs_berserk(true, true))
     {
-        switch (random2(3))
-        {
-            case 0:
-                if (attk.type == AT_NONE || attk.damage == 0)
-                    break;
-                if (mon->has_ench(ENCH_MIGHT))
-                    break;
-                enchant_actor_with_flavour(mon, mon, BEAM_MIGHT);
-                success = true;
-                break;
-            case 1:
-                if (mon->has_ench(ENCH_HASTE))
-                    break;
-                enchant_actor_with_flavour(mon, mon, BEAM_HASTE);
-                success = true;
-                break;
-            case 2:
-                if (!mon->can_go_berserk())
-                    break;
-                mon->go_berserk(true);
-                success = true;
-                break;
-        }
+        mon->go_berserk(true);
+        success = true;
     }
-    while (!success && --tries > 0);
+    else if (!mon->has_ench(ENCH_HASTE))
+    {
+        enchant_actor_with_flavour(mon, mon, BEAM_HASTE);
+        success = true;
+    }
 
     if (success)
+    {
+        mon->add_ench(ENCH_GOZAG_INCITE);
         view_update_at(mon->pos());
+    }
 }

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1015,6 +1015,13 @@ bool monster::decay_enchantment(enchant_type en, bool decay_degree)
     if (me.duration >= INFINITE_DURATION)
         return false;
 
+    if (has_ench(ENCH_GOZAG_INCITE)
+        && (en == ENCH_HASTE || en == ENCH_BERSERK))
+    {
+        dprf("Not decrementing haste/berserk because the monster is incited.");
+        return false;
+    }
+
     // Faster monsters can wiggle out of the net more quickly.
     const int spd = (me.ench == ENCH_HELD) ? speed :
                                              10;
@@ -2122,7 +2129,7 @@ static const char *enchant_names[] =
 #if TAG_MAJOR_VERSION == 34
     "chanting_fire_storm", "chanting_word_of_entropy",
 #endif
-    "aura_of_brilliance", "empowered_spells",
+    "aura_of_brilliance", "empowered_spells", "gozag_incite",
     "buggy",
 };
 
@@ -2393,6 +2400,8 @@ int mon_enchant::calc_duration(const monster* mons,
     case ENCH_EMPOWERED_SPELLS:
         cturn = 2 * BASELINE_DELAY;
         break;
+    case ENCH_GOZAG_INCITE:
+        cturn = 100; // is never decremented
     default:
         break;
     }

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -110,6 +110,7 @@ static map<enchant_type, monster_info_flags> trivial_ench_mb_mappings = {
     { ENCH_BONE_ARMOUR,     MB_BONE_ARMOUR },
     { ENCH_BRILLIANCE_AURA, MB_BRILLIANCE_AURA },
     { ENCH_EMPOWERED_SPELLS, MB_EMPOWERED_SPELLS },
+    { ENCH_GOZAG_INCITE,    MB_GOZAG_INCITED },
 };
 
 static monster_info_flags ench_to_mb(const monster& mons, enchant_type ench)
@@ -1564,6 +1565,8 @@ vector<string> monster_info::attributes() const
         v.emplace_back("partially charged");
     if (is(MB_FULLY_CHARGED))
         v.emplace_back("fully charged");
+    if (is(MB_GOZAG_INCITED))
+        v.emplace_back("incited by Gozag");
     return v;
 }
 

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -151,6 +151,7 @@ enum monster_info_flags
     MB_READY_TO_HOWL,
     MB_PARTIALLY_CHARGED,
     MB_FULLY_CHARGED,
+    MB_GOZAG_INCITED,
     NUM_MB_FLAGS
 };
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5215,7 +5215,7 @@ bool monster::berserk_or_insane() const
     return berserk() || has_ench(ENCH_INSANE);
 }
 
-bool monster::needs_berserk(bool check_spells) const
+bool monster::needs_berserk(bool check_spells, bool ignore_distance) const
 {
     if (!can_go_berserk())
         return false;
@@ -5223,7 +5223,7 @@ bool monster::needs_berserk(bool check_spells) const
     if (has_ench(ENCH_HASTE) || has_ench(ENCH_TP))
         return false;
 
-    if (foe_distance() > 3)
+    if (!ignore_distance && foe_distance() > 3)
         return false;
 
     if (check_spells)

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -145,7 +145,7 @@ public:
     kill_category kill_alignment() const override;
 
     int  foe_distance() const;
-    bool needs_berserk(bool check_spells = true) const;
+    bool needs_berserk(bool check_spells = true, bool ignore_distance = false) const;
 
     // Has a hydra-like variable number of attacks based on num_heads.
     bool has_hydra_multi_attack() const;


### PR DESCRIPTION
Currently you can avoid most Gozag wrath by walking backwards whenever
an enemy is incited. This changes makes the buffs permanent and removes
the relatively weak effect of might.

Incited monsters get an 'incited by Gozag' enchantment indicator so the
player can tell what's up.

Now, spellcasters are hasted and everything else gets berserked.