### PR TITLE
fix for expose_to_element not being called properly (10293)

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1588,11 +1588,17 @@ bool attack::apply_damage_brand(const char *what)
         calc_elemental_brand_damage(BEAM_FIRE,
                                     defender->is_icy() ? "melt" : "burn",
                                     what);
+        defender->expose_to_element(BEAM_FIRE, 2);
+        if (defender->is_player())
+        {
+            maybe_melt_player_enchantments(BEAM_FIRE, special_damage);
+        }
         attacker->god_conduct(DID_FIRE, 1);
         break;
 
     case SPWPN_FREEZING:
         calc_elemental_brand_damage(BEAM_COLD, "freeze", what);
+        defender->expose_to_element(BEAM_COLD, 2);
         break;
 
     case SPWPN_HOLY_WRATH:
@@ -1621,6 +1627,7 @@ bool attack::apply_damage_brand(const char *what)
                 :  "There is a sudden explosion of sparks!";
             special_damage = 8 + random2(13);
             special_damage_flavour = BEAM_ELECTRICITY;
+            defender->expose_to_element(BEAM_ELECTRICITY, 2);
         }
 
         break;
@@ -1815,22 +1822,6 @@ bool attack::apply_damage_brand(const char *what)
 
     if (special_damage > 0)
         inflict_damage(special_damage, special_damage_flavour);
-
-    if (defender->alive())
-    {
-        switch (brand)
-        {
-        case SPWPN_FLAMING:
-            defender->expose_to_element(BEAM_FIRE);
-            break;
-
-        case SPWPN_FREEZING:
-            defender->expose_to_element(BEAM_COLD, 2);
-            break;
-        default:
-            break;
-        }
-    }
 
     if (obvious_effect && attacker_visible && using_weapon())
     {

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4018,6 +4018,14 @@ void bolt::affect_player()
         }
     }
 
+    // need to trigger qaz resists after reducing damage from ac/resists.
+    //    for some reason, strength 2 is the standard.  This leads to qaz's resists triggering 2 in 5 times at max piety.
+    //    perhaps this should scale with damage?
+    // what to do for hybrid damage?  E.g. bolt of magma, icicle, poison arrow?  Right now just ignore the physical component.
+    // what about acid?
+    you.expose_to_element(flavour, 2, false);
+
+
     // Manticore spikes
     if (origin_spell == SPELL_THROW_BARBS && hurted > 0)
     {

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -920,6 +920,12 @@ static bool _actor_apply_cloud_side_effects(actor *act,
     monster *mons = !player? act->as_monster() : nullptr;
     switch (cloud.type)
     {
+    case CLOUD_FIRE:
+    case CLOUD_STEAM:
+        if (player)
+        {
+            maybe_melt_player_enchantments(BEAM_FIRE, final_damage);
+        }
     case CLOUD_RAIN:
     case CLOUD_STORM:
         if (act->is_fiery() && final_damage > 0)

--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -1006,6 +1006,14 @@ void qazlal_storm_clouds()
     }
 }
 
+/**
+ * Handle Qazlal's elemental adaptation.
+ * This should be called (exactly once) for physical, fire, cold, and electrical damage.
+ * Right now, it is called only from expose_player_to_element.  This may merit refactoring.
+ *
+ * @param flavour the beam type.
+ * @param strength The adaptations will trigger strength in (11 - piety_rank()) times.  In practice, this is mostly called with a value of 2.
+ */
 void qazlal_element_adapt(beam_type flavour, int strength)
 {
     if (strength <= 0
@@ -1039,6 +1047,7 @@ void qazlal_element_adapt(beam_type flavour, int strength)
             dur = DUR_QAZLAL_ELEC_RES;
             descript = "electricity";
             break;
+        case BEAM_MMISSILE: // for LCS, iron shot
         case BEAM_MISSILE:
         case BEAM_FRAG:
             what = BEAM_MISSILE;
@@ -1077,7 +1086,9 @@ void qazlal_element_adapt(beam_type flavour, int strength)
     mprf(MSGCH_GOD, "You feel %sprotected from %s.",
          you.duration[dur] > 0 ? "more " : "", descript.c_str());
 
-    you.increase_duration(dur, 10 * strength, 80);
+    // was scaled by 10 * strength.  But the strength parameter is used so inconsistently that
+    // it seems like a constant would be better, based on the typical value of 2.
+    you.increase_duration(dur, 20, 80);
 
     if (what == BEAM_MISSILE)
         you.redraw_armour_class = true;

--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -2110,7 +2110,7 @@ void melee_attack::apply_staff_damage()
     if (!weapon)
         return;
 
-    if (player_mutation_level(MUT_NO_ARTIFICE))
+    if (attacker->is_player() && player_mutation_level(MUT_NO_ARTIFICE))
         return;
 
     if (weapon->base_type != OBJ_STAVES)
@@ -2184,6 +2184,8 @@ void melee_attack::apply_staff_damage()
                     defender->name(DESC_THE).c_str());
             special_damage_flavour = BEAM_FIRE;
         }
+        if (attacker->is_player())
+            maybe_melt_player_enchantments(BEAM_FIRE, special_damage);
         break;
 
     case STAFF_POISON:

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -337,16 +337,6 @@ int check_your_resists(int hurted, beam_type flavour, string source,
  * elemental adaptation, it should also be called (exactly once) with BEAM_MISSILE when 
  * receiving physical damage.  Hybrid damage (brands) should call it twice with appropriate
  * flavours.  
- * 
- * Notes:
- *  - qazlal_element_adapt will not necessarily react to all relevant beam_types so you should check.
- *  - if it is double-called, this will potentially make cold-blooded creatures slow longer, and boost
- *    the chances of elemental adaptation triggering.
- *  - strength is currently used in extremely varied ways (including for monsters, handled elsewhere).
- *  - if called with strength 0 (which is the default strength), the only thing this function will do is
- *    put out fires.
- *  - this used to call maybe_melt_player_enchantments, which seems to be vestigial and wrong --
- *    maybe_melt_player_enchantments needs an actual damage value, rather than "strength".
  *
  * @param flavour The beam type.
  * @param strength The strength of the attack.  Used in different ways for different side-effects.

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -946,7 +946,7 @@ void player_reacts()
 
     // Icy shield and armour melt over lava.
     if (grd(you.pos()) == DNGN_LAVA)
-        expose_player_to_element(BEAM_LAVA);
+        maybe_melt_player_enchantments(BEAM_FIRE, 10);
 
     // Handle starvation before subtracting hunger for this turn (including
     // hunger from the berserk duration) and before monsters react, so you

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4737,11 +4737,11 @@ void dec_napalm_player(int delay)
 
     mprf(MSGCH_WARN, "You are covered in liquid flames!");
 
-    expose_player_to_element(BEAM_STICKY_FLAME,
-                             div_rand_round(delay * 4, BASELINE_DELAY));
-
     const int hurted = resist_adjust_damage(&you, BEAM_FIRE,
                                             random2avg(9, 2) + 1);
+
+    you.expose_to_element(BEAM_STICKY_FLAME, 2);
+    maybe_melt_player_enchantments(BEAM_STICKY_FLAME, hurted * delay / BASELINE_DELAY);
 
     ouch(hurted * delay / BASELINE_DELAY, KILLED_BY_BURNING);
 
@@ -7997,7 +7997,8 @@ void temperature_changed(float change)
     if (you.temperature >= TEMP_WARM)
     {
         // Handles condensation shield, ozo's armour, icemail.
-        expose_player_to_element(BEAM_FIRE, 0);
+        // 10 => 100aut reduction in duration.
+        maybe_melt_player_enchantments(BEAM_FIRE, 10);
 
         // Handled separately because normally heat doesn't affect this.
         if (you.form == TRAN_ICE_BEAST || you.form == TRAN_STATUE)

--- a/crawl-ref/source/ranged_attack.cc
+++ b/crawl-ref/source/ranged_attack.cc
@@ -640,7 +640,13 @@ bool ranged_attack::apply_missile_brand()
         calc_elemental_brand_damage(BEAM_FIRE,
                                     defender->is_icy() ? "melt" : "burn",
                                     projectile->name(DESC_THE).c_str());
-        defender->expose_to_element(BEAM_FIRE);
+
+        defender->expose_to_element(BEAM_FIRE, 2);
+        if (defender->is_player())
+        {
+            maybe_melt_player_enchantments(BEAM_FIRE, special_damage);
+        }
+
         attacker->god_conduct(DID_FIRE, 1);
         break;
     case SPMSL_FROST:

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -447,7 +447,7 @@ static int _refrigerate_player(actor* agent, int pow, int avg,
             ouch(hurted, KILLED_BY_BEAM, agent->mid,
                  "by Ozocubu's Refrigeration", true,
                  agent->as_monster()->name(DESC_A).c_str());
-            expose_player_to_element(BEAM_COLD, 5, added_effects);
+            you.expose_to_element(BEAM_COLD, 5, added_effects);
 
             // Note: this used to be 12!... and it was also applied even if
             // the player didn't take damage from the cold, so we're being
@@ -456,6 +456,7 @@ static int _refrigerate_player(actor* agent, int pow, int avg,
         else
         {
             ouch(hurted, KILLED_BY_FREEZING);
+            you.expose_to_element(BEAM_COLD, 5, added_effects);
             you.increase_duration(DUR_NO_POTIONS, 7 + random2(9), 15);
         }
     }
@@ -1632,6 +1633,8 @@ static int _ignite_poison_monsters(coord_def where, int pow, actor *agent)
     if (damage <= 0)
         return 0;
 
+    mon->expose_to_element(BEAM_FIRE, damage);
+
     if (tracer)
         return mons_aligned(mon, agent) ? -1 * damage : damage;
 
@@ -1706,6 +1709,8 @@ static int _ignite_poison_player(coord_def where, int pow, actor *agent)
     ouch(damage, KILLED_BY_BEAM, agent->mid,
          "by burning poison", you.can_see(*agent),
          agent->as_monster()->name(DESC_A, true).c_str());
+    if (damage > 0)
+        agent->expose_to_element(BEAM_FIRE, 2);
 
     mprf(MSGCH_RECOVERY, "You are no longer poisoned.");
     you.duration[DUR_POISONING] = 0;
@@ -1881,6 +1886,8 @@ int discharge_monsters(coord_def where, int pow, actor *agent)
                                     "static discharge");
         ouch(damage, KILLED_BY_BEAM, agent->mid, "by static electricity", true,
              agent->is_player() ? "you" : agent->name(DESC_A).c_str());
+        if (damage > 0)
+            victim->expose_to_element(BEAM_ELECTRICITY, 2);
     }
     else if (victim->res_elec() > 0)
         return 0;
@@ -1892,6 +1899,8 @@ int discharge_monsters(coord_def where, int pow, actor *agent)
         dprf("%s: static discharge damage: %d",
              mons->name(DESC_PLAIN, true).c_str(), damage);
         damage = mons_adjust_flavoured(mons, beam, damage);
+        if (damage > 0)
+            victim->expose_to_element(BEAM_ELECTRICITY, 2);
 
         if (damage)
         {


### PR DESCRIPTION
This started as an attempt to add expose_to_element back into beam.cc so that Qazlal characters properly adapt in response to spells; it spiraled out of control due to consequences for other aspects of exposure to elements.  The PR will have two main effects: (i) cause Qazlal elemental adaptations to trigger (hopefully properly) on all appropriate spells, and (ii) cause cold-blooded players to be slowed properly on all appropriate spells.  Neither of these were working correctly.

This also eliminates the call to melt player enchantments from expose_to_element: it is called from elsewhere and wasn't working properly in any case (it expects damage, not "strength").  However, this call may have been doing some token melting in special cases (token in the sense that it wouldn't have a real impact on duration).

A few other small changes: duration of adaptation no longer scales with strength (which was only doing something in weird special cases anyways).  one of the brands was being checked wrong.  Correctly trigger physical protection on earth spells (and others).