### PR TITLE
Mummy unconfuse

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -313,7 +313,7 @@ static const ability_def Ability_List[] =
     { ABIL_STOP_SINGING, "Stop Singing",
       0, 0, 0, 0, {}, abflag::NONE },
     { ABIL_MUMMY_RESTORATION, "Self-Restoration",
-      1, 0, 0, 0, {}, abflag::PERMANENT_MP },
+      1, 0, 0, 0, {}, abflag::PERMANENT_MP | abflag::CONF_OK },
 
     { ABIL_DIG, "Dig", 0, 0, 0, 0, {}, abflag::INSTANT },
     { ABIL_SHAFT_SELF, "Shaft Self", 0, 0, 250, 0, {}, abflag::DELAY },
@@ -1303,7 +1303,8 @@ static bool _check_ability_possible(const ability_def& abil,
         if (you.strength(false) == you.max_strength()
             && you.intel(false) == you.max_intel()
             && you.dex(false) == you.max_dex()
-            && !player_rotted())
+            && !player_rotted()
+            && !you.confused())
         {
             if (!quiet)
                 mpr("You don't need to restore your attributes or health!");
@@ -1653,6 +1654,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         fail_check();
         mpr("You infuse your body with magical energy.");
         bool did_restore = restore_stat(STAT_ALL, 0, false);
+        
+        // Now cures confusion too!
+        if (you.confused()) {
+            you.duration[DUR_CONF] = 0;
+            did_restore = true; 
+        }
 
         const int oldhpmax = you.hp_max;
         unrot_hp(9999);

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -529,7 +529,7 @@ BOOL:     elec
 NAME:     heavy crossbow "Sniper"
 OBJ:      OBJ_WEAPONS/WPN_TRIPLE_CROSSBOW
 TYPE:     heavy crossbow
-PLUS:     +15
+PLUS:     +10
 COLOUR:   ETC_DARK
 TILE:     urand_sniper
 TILE_EQ:  sniper

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -238,8 +238,12 @@ int attack::calc_to_hit(bool random)
     if (attacker->confused())
         mhit -= 5;
 
-    if (using_weapon() && is_unrandom_artefact(*weapon, UNRAND_WOE))
+    if (using_weapon()
+        && (is_unrandom_artefact(*weapon, UNRAND_WOE)
+            || is_unrandom_artefact(*weapon, UNRAND_SNIPER)))
+    {
         return AUTOMATIC_HIT;
+    }
 
     // If no defender, we're calculating to-hit for debug-display
     // purposes, so don't drop down to defender code below

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -91,8 +91,9 @@ Stops singing your Song of Slaying.
 %%%%
 Self-Restoration ability
 
-Restores your strength, dexterity and intelligence and heals any rotted health,
-at the permanent cost of one magic point.
+Restores your strength, dexterity, intelligence, heals any rotted health, and
+cures confusion at the permanent cost of one magic point. Can be used while
+confused.
 %%%%
 Device Recharging ability
 


### PR DESCRIPTION
This branch implements a change to Mummies' Self-restoration ability.  It is now usable while confused and cures confusion.  Damn tarantellas.