### PR TITLE
Prevent elemental adaptation at max resists

### DIFF
--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -1032,17 +1032,23 @@ void qazlal_element_adapt(beam_type flavour, int strength)
         case BEAM_LAVA:
         case BEAM_STICKY_FLAME:
         case BEAM_STEAM:
+            if (you.res_fire() >= 3)
+                return;
             what = BEAM_FIRE;
             dur = DUR_QAZLAL_FIRE_RES;
             descript = "fire";
             break;
         case BEAM_COLD:
         case BEAM_ICE:
+            if (you.res_cold() >= 3)
+                return;
             what = BEAM_COLD;
             dur = DUR_QAZLAL_COLD_RES;
             descript = "cold";
             break;
         case BEAM_ELECTRICITY:
+            if (you.res_elec() >= 2) // max is 2 for this way of accessing it
+                return;
             what = BEAM_ELECTRICITY;
             dur = DUR_QAZLAL_ELEC_RES;
             descript = "electricity";

--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -1026,29 +1026,31 @@ void qazlal_element_adapt(beam_type flavour, int strength)
     beam_type what = BEAM_NONE;
     duration_type dur = NUM_DURATIONS;
     string descript = "";
+    bool max_resists = false;
+
     switch (flavour)
     {
         case BEAM_FIRE:
         case BEAM_LAVA:
         case BEAM_STICKY_FLAME:
         case BEAM_STEAM:
-            if (you.res_fire() >= 3)
-                return;
+            if (you.res_fire() >= 3 && !you.duration[DUR_QAZLAL_FIRE_RES])
+                max_resists = true;
             what = BEAM_FIRE;
             dur = DUR_QAZLAL_FIRE_RES;
             descript = "fire";
             break;
         case BEAM_COLD:
         case BEAM_ICE:
-            if (you.res_cold() >= 3)
-                return;
+            if (you.res_cold() >= 3 && !you.duration[DUR_QAZLAL_COLD_RES])
+                max_resists = true;
             what = BEAM_COLD;
             dur = DUR_QAZLAL_COLD_RES;
             descript = "cold";
             break;
         case BEAM_ELECTRICITY:
-            if (you.res_elec() >= 2) // max is 2 for this way of accessing it
-                return;
+            if (you.res_elec() >= 2 && !you.duration[DUR_QAZLAL_ELEC_RES]) // max is 2 for this way of accessing it
+                max_resists = true;
             what = BEAM_ELECTRICITY;
             dur = DUR_QAZLAL_ELEC_RES;
             descript = "electricity";
@@ -1089,8 +1091,13 @@ void qazlal_element_adapt(beam_type flavour, int strength)
         you.redraw_armour_class = true;
     }
 
-    mprf(MSGCH_GOD, "You feel %sprotected from %s.",
-         you.duration[dur] > 0 ? "more " : "", descript.c_str());
+    if (max_resists)
+    {
+        mprf(MSGCH_GOD, "You feel momentarily protected from %s.", descript.c_str());
+        return;
+    } else
+        mprf(MSGCH_GOD, "You feel %sprotected from %s.",
+            you.duration[dur] > 0 ? "more " : "", descript.c_str());
 
     // was scaled by 10 * strength. But the strength parameter is used so inconsistently that
     // it seems like a constant would be better, based on the typical value of 2.


### PR DESCRIPTION
Before, the resistance would apparently trigger and show the rF+ status
indicator, but have no effect -- despite the misleading status
indicator.  With this patch it will silently fail if the player is at
max resists for the relevant element at the time of exposure.  This
could be a very slight buff in that AC can always trigger, and it is now
more likely to be continuously on when receiving hybrid damage (e.g.
brands) when at max resists.  However, AC is the weakest of the resists
at the point in the game where this is typically relevant.

This doesn't do anything with equipment, so you could still get the
status indicator on at max resists by letting it trigger and then
putting on the relevant ring.