### PR TITLE
Allow armored quarterstaff users of all races (fighter)

### DIFF
--- a/crawl-ref/source/ng-restr.cc
+++ b/crawl-ref/source/ng-restr.cc
@@ -101,12 +101,6 @@ char_choice_restriction weapon_restriction(weapon_type wpn,
         return CC_RESTRICTED;
     }
 
-    if (wpn == WPN_QUARTERSTAFF && ng.job != JOB_GLADIATOR
-        && !(ng.job == JOB_FIGHTER && ng.species == SP_FORMICID))
-    {
-        return CC_BANNED;
-    }
-
     // Javelins are always good, tomahawks not so much.
     if (wpn == WPN_THROWN)
     {


### PR DESCRIPTION
If a player wants to start with a quarterstaff and armor (plus a shield they can't wield), let them. They may be planning to transition into an enhancer staff later in their career, or perhaps they just want to lean on the awesome early game power of a quarterstaff while they train up shields and other skills.

A quarterstaff start is a great start, and for some races, an extraneous shield is preferable to being sent down the Gladiator-style light armor route.

(also, this simplifies the special case for formicid, so that a player who chooses DdFi today has the opportunity to notice the otherwise "hidden" quarterstaff option that works so well for a Formicid)