### PR TITLE
Let claws/hooves work through gloves/boots.

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1301,7 +1301,6 @@ int attack::calc_base_unarmed_damage()
 
     int damage = get_form()->get_base_unarmed_damage();
 
-    // Claw damage only applies for bare hands.
     if (you.has_usable_claws())
         damage += you.has_claws() * 2;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6948,7 +6948,7 @@ int player::has_claws(bool allow_tran) const
 
 bool player::has_usable_claws(bool allow_tran) const
 {
-    return !slot_item(EQ_GLOVES) && has_claws(allow_tran);
+    return has_claws(allow_tran);
 }
 
 int player::has_talons(bool allow_tran) const
@@ -6962,7 +6962,7 @@ int player::has_talons(bool allow_tran) const
 
 bool player::has_usable_talons(bool allow_tran) const
 {
-    return !slot_item(EQ_BOOTS) && has_talons(allow_tran);
+    return has_talons(allow_tran);
 }
 
 int player::has_hooves(bool allow_tran) const
@@ -6976,9 +6976,7 @@ int player::has_hooves(bool allow_tran) const
 
 bool player::has_usable_hooves(bool allow_tran) const
 {
-    return has_hooves(allow_tran)
-           && (!slot_item(EQ_BOOTS)
-               || wearing(EQ_BOOTS, ARM_CENTAUR_BARDING, true));
+    return has_hooves(allow_tran);
 }
 
 int player::has_fangs(bool allow_tran) const


### PR DESCRIPTION
It's a bit simulationist to have this restriction and is very difficult
to communicate to the player. There's not really any other circumstance
you wouldn't want to fill an equipment slot.

Gloves can be considered the finger(claw)-less/ Wolverine-compatible
variety, and I don't think boots would prevent kicking from working
anyway.