### PR TITLE
Tightened the 0 bonus/penalty range for STR.

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1199,10 +1199,10 @@ int attack::player_stat_modify_damage(int damage)
 {
     int dammod = 39;
 
-    if (you.strength() > 11)
-        dammod += (random2(you.strength() - 11) * 2);
-    else if (you.strength() < 9)
-        dammod -= (random2(9 - you.strength()) * 3);
+    if (you.strength() > 10)
+        dammod += (random2(you.strength() - 10) * 2);
+    else if (you.strength() < 10)
+        dammod -= (random2(10 - you.strength()) * 3);
 
     damage *= dammod;
     damage /= 39;


### PR DESCRIPTION
STR = 9,10,11 would not pass either if statement, providing no appreciable benefit to damage scaling for going from 9 to 11 strength. This was a classic inclusive/exclusive range if statement bug.