### PR TITLE
commenting convention: don't comment out code

### DIFF
--- a/crawl-ref/docs/develop/coding_conventions.txt
+++ b/crawl-ref/docs/develop/coding_conventions.txt
@@ -328,6 +328,9 @@ leave a free line between them.
 E) Commenting
 -------------
 
+Comments should not be used to archive old code. If something is no longer
+needed, do not comment it out, simply remove it.
+
 If you feel that a method is complicated enough to be difficult to understand,
 or has restrictions or effects that might not be obvious, add explanatory
 comments before it. You may sign your comments if you wish to.

--- a/crawl-ref/docs/develop/coding_conventions.txt
+++ b/crawl-ref/docs/develop/coding_conventions.txt
@@ -328,9 +328,6 @@ leave a free line between them.
 E) Commenting
 -------------
 
-Comments should not be used to archive old code. If something is no longer
-needed, do not comment it out, simply remove it.
-
 If you feel that a method is complicated enough to be difficult to understand,
 or has restrictions or effects that might not be obvious, add explanatory
 comments before it. You may sign your comments if you wish to.
@@ -369,6 +366,9 @@ the issue.
 
   // FIXME: implement this for tiles
   void update_monster_pane() {}
+
+Comments should not be used to archive old code. If something is no longer
+needed, do not comment it out, simply remove it.
 
 F) Macro Usage
 --------------------


### PR DESCRIPTION
PleasingFungus said something to this effect in IRC, and it seems a useful "rule" to have defined in the coding conventions.