### PR TITLE
Tweak Artificer starting stats.

### DIFF
--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -56,7 +56,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ARTIFICER, {
     "Ar", "Artificer",
-    3, 4, 5,
+    4, 3, 5,
     { SP_DEEP_DWARF, SP_HALFLING, SP_KOBOLD, SP_SPRIGGAN, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
     { "short sword", "leather armour", "wand of flame charges:15",


### PR DESCRIPTION
It's (much) more common to build artificers as heavy-armour meleedudes
than spellcasters, so tweak artificer stats from 3,4,5 to 4,3,5.

To be honest, I could also see 5,2,5, or 6,2,4, but those seem more controversial. I'll happily update the patch if either of those are preferred though.