### PR TITLE
Remove unique names from two wizlab milestones.

### DIFF
--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -1553,7 +1553,7 @@ COLOUR:     wWv#4 = silver
 :           set_feature_name("crystal_wall", "wall of white crystal")
 
 epilogue{{
-            wizlab_milestone(_G, "The Chambers of " .. wizname .. " the Cloud Mage")
+            wizlab_milestone(_G, "The Chambers of the Cloud Mage")
 }}
 #           Map is ugly because border_fill_type doesn't allow for (yet)
 #           recolouring.
@@ -1702,7 +1702,7 @@ SUBST:      7 = 4, 8 = 5, df = 6, eg = 3
 :           set_feature_name("stone_wall", "black wall")
 :           set_feature_name("rock_wall", "carved rock wall")
 epilogue{{
-            wizlab_milestone(_G, "The Hall of " .. wizname .. " the Hellbinder")
+            wizlab_milestone(_G, "The Hall of the Hellbinder")
 }}
 MAP
 cccccccccccccccccccccccccccccccccccccccccccccc


### PR DESCRIPTION
```< Sequell> Command: !wizrank => !lm * br.enter=wizlab s=regexp_replace(milestone, "entered ((the_hall_of_|the_chambers_of_)([_a-z]+(?=the_)))?(.*)\.", "\2\4") milestone!~~ering?ya|cekugob|mortuary|a_wizard|upun's_lair|cloud_mage's_chambers title:"WizLab ranking ($*)" $* / lg:br=wizlab o=%```

The above will still be needed for historical games, of course, but it should simplify matters going forward.