### PR TITLE
Make flight ignore grasping roots

### DIFF
--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -1028,7 +1028,7 @@ void check_grasping_roots(actor* act, bool quiet)
         }
     }
 
-    if (!source || !feat_has_solid_floor(grd(act->pos())))
+    if (!source) 
     {
         if (act->is_player())
         {

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1095,12 +1095,6 @@ static void _entangle_actor(actor* act)
     {
         you.duration[DUR_GRASPING_ROOTS] = 10;
         you.redraw_evasion = true;
-        if (you.duration[DUR_FLIGHT] ||  you.attribute[ATTR_PERM_FLIGHT])
-        {
-            you.duration[DUR_FLIGHT] = 0;
-            you.attribute[ATTR_PERM_FLIGHT] = 0;
-            land_player(true);
-        }
     }
     else
     {
@@ -1129,32 +1123,7 @@ static bool _apply_grasping_roots(monster* mons)
 
         found_hostile = true;
 
-        // Roots can't reach things over deep water or lava
-        if (!feat_has_solid_floor(grd(ai->pos())))
-            continue;
-
-        // Some messages are suppressed for monsters, to reduce message spam.
-        if (ai->airborne())
-        {
-            if (x_chance_in_y(3, 5))
-                continue;
-
-            if (x_chance_in_y(10, 50 - ai->evasion()))
-            {
-                if (ai->is_player())
-                    mpr("Roots rise up to grasp you, but you nimbly evade.");
-                continue;
-            }
-
-            if (you.can_see(**ai))
-            {
-                mprf("Roots rise up from beneath %s and drag %s %sto the ground.",
-                     ai->name(DESC_THE).c_str(),
-                     ai->pronoun(PRONOUN_OBJECTIVE).c_str(),
-                     ai->is_monster() ? "" : "back ");
-            }
-        }
-        else if (ai->is_player() && !you.duration[DUR_GRASPING_ROOTS])
+        if (ai->is_player() && !you.duration[DUR_GRASPING_ROOTS])
         {
             mprf("Roots grasp at your %s, making movement difficult.",
                  you.foot_name(true).c_str());

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5028,11 +5028,6 @@ bool flight_allowed(bool quiet, string *fail_reason)
         msg = "You can't fly while stuck in liquid ground.";
         success = false;
     }
-    else if (you.duration[DUR_GRASPING_ROOTS])
-    {
-        msg = "The grasping roots prevent you from becoming airborne.";
-        success = false;
-    }
 
     if (!success)
     {
@@ -5535,7 +5530,7 @@ player::~player()
 bool player::airborne() const
 {
     // Might otherwise be airborne, but currently stuck to the ground
-    if (you.duration[DUR_GRASPING_ROOTS] || get_form()->forbids_flight())
+    if (get_form()->forbids_flight())
         return false;
 
     if (duration[DUR_FLIGHT]


### PR DESCRIPTION
This removes the odd and spoilery secret tech of flying over deep water
to avoid getting rooted by a shambling mangrove. It also removes the
evasion-based chance to avoid getting rooted while flying as that is
also spoilery. This makes roots much more straightforward.