### PR TITLE
Display reflection chance for warlock's mirror

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "adjust.h"
+#include "art-enum.h"
 #include "artefact.h"
 #include "branch.h"
 #include "butcher.h"
@@ -1095,6 +1096,13 @@ static string _describe_weapon(const item_def &item, bool verbose)
         {
             description += "\n";
             description += rand_desc;
+        }
+        
+        if (is_unrandom_artefact(item)
+            && item.unrand_idx == UNRAND_WARLOCK_MIRROR)
+        {
+            int reflect_chance = 100 * player_shield_class() / (player_shield_class() + 40);
+            description += "\n\nThe shield has " + to_string(reflect_chance) + "% chance to reflect enchantments.";
         }
 
         // XXX: Can't happen, right?


### PR DESCRIPTION
Monster spells description displays chance for player to be banished, confused etc so player can make a decision about using MR items.
Warlock's mirror is functionally the same, player can make decision about using amulet of reflection.