### PR TITLE
Be consistent about Gr +AC mutation effect on `A`, too

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -399,7 +399,7 @@ string describe_mutations(bool center_title)
               + (you.species == SP_GREY_DRACONIAN ? "very " : "") + "hard";
 
         result += _annotate_form_based(
-                    make_stringf("Your %s (AC +%d).",
+                    make_stringf("Your %s. (AC +%d)",
                        you.species == SP_NAGA ? "serpentine skin is tough" :
                        you.species == SP_GARGOYLE ? "stone body is resilient" :
                                                     scale_clause.c_str(),


### PR DESCRIPTION
The display of most such mutations was addressed in
  7a8084aeb01337ba140cbf3eea07ba489de9968f
but this one lives in a different file and was overlooked.