### PR TITLE
Scale powered by death duration with mutation level.

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2472,6 +2472,7 @@ int augmentation_amount()
 
 void reset_powered_by_death_duration()
 {
-    const int pbd_dur = random_range(2, 5);
+    const int level = player_mutation_level(MUT_POWERED_BY_DEATH);
+    const int pbd_dur = random_range(2 * level, 5 * level);
     you.set_duration(DUR_POWERED_BY_DEATH, pbd_dur);
 }


### PR DESCRIPTION
The rework is a bit too weak -- it's nearly impossible to get more than
a few stacks of pbd unless you're killing trash (in which case pbd is
irrelevant). This change should pull its power closer to the old level
at high mut levels, while keeping it significantly weaker at levels 1 &
2.
