### PR TITLE
Reduce circular_temple_12 weight.

### DIFF
--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -900,7 +900,7 @@ ENDMAP
 
 ##########################################################################
 # Circular temples
-#   Total weight: 90 = 40+10+10+10+5+5+5+5
+#   Total weight: 60 = 10+10+10+10+5+5+5+5
 #   The classical shape, so highest weight.
 #   Several versions, to accommodate differing numbers of gods.
 #   Stones walls, so grey colour. (The versions with a pool change colour.)
@@ -908,7 +908,7 @@ ENDMAP
 # 12 gods
 NAME:   circular_temple_12
 PLACE:  Temple
-WEIGHT: 40
+WEIGHT: 10
 TAGS:   no_rotate
 ORIENT: encompass
 MAP


### PR DESCRIPTION
Previously this temple placed in 12.5% of games, compared to 3.5% for
the next most common. It's good to have variable weight temple maps, but
with the current number of maps (70), you still get such a rarity
distribution without a single map dominating the top placement chance.

Fuller placement % analysis here:
https://docs.google.com/spreadsheets/d/1n48f-wt36iYd-ige6bcvD5JZEYofcj-oaunE7QCBp9s