### PR TITLE
Don't mislabel DUR_LOWERED_MR status as MR- in HUD

### DIFF
--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -286,7 +286,7 @@ You are surrounded by a ring of flame clouds, increasing the power of your fire
 magic and giving protection from fire but also making you much more susceptible
 to cold.
 %%%%
-MR- status
+MR/2 status
 
 You are more vulnerable to hostile enchantments.
 %%%%

--- a/crawl-ref/source/duration-data.h
+++ b/crawl-ref/source/duration-data.h
@@ -207,7 +207,7 @@ static const duration_def duration_data[] =
       "liquid flames", "",
       "You are covered in liquid flames.", D_NO_FLAGS},
     { DUR_LOWERED_MR,
-      RED, "MR-",
+      RED, "MR/2",
       "vulnerable", "lowered mr",
       "", D_DISPELLABLE,
       {{ "You feel less vulnerable to hostile enchantments." }}},


### PR DESCRIPTION
There's MR+ which increases MR by one pip,
there's MR++ which increases MR by two pips,
there's an MR- mutation lowering MR by one pip,
there's an MR-- mutation lowering MR by two pips,
and there's the MR- status light which … halves your MR.

No reason not to just tell players what is happening here, I think.