### PR TITLE
Forbid *Corrode on CPA artefacts

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -546,7 +546,7 @@ static bool _artp_can_go_on_item(artefact_prop_type prop, const item_def &item,
             return !item.is_type(OBJ_ARMOUR, ARM_NAGA_BARDING);
             // naga already have rPois & sInv!
         case ARTP_CORRODE:
-            return !extant_props[ARTP_RCORR];
+            return !extant_props[ARTP_RCORR] && !item.is_type(OBJ_ARMOUR, ARM_CRYSTAL_PLATE_ARMOUR);
         case ARTP_RCORR:
             return item_class == OBJ_ARMOUR && !extant_props[ARTP_CORRODE];
         case ARTP_REGENERATION:


### PR DESCRIPTION
Much like dwarven items, crystal plate mail is exceptionally resistant to corrosion, after all.