### PR TITLE
Consistent table header style for chardump notes section

### DIFF
--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -546,7 +546,7 @@ static void _sdump_notes(dump_params &par)
         return;
 
     text += "Notes\nTurn   | Place    | Note\n";
-    text += "--------------------------------------------------------------\n";
+    text += "-------+----------+-------------------------------------------\n";
     for (const Note &note : note_list)
     {
         if (note.hidden())


### PR DESCRIPTION
Action count and skill tables use this style for their headers already,
as did the optional `turns_by_place` and `kills_by_place`.