### PR TITLE
Remove some unused dlua

### DIFF
--- a/crawl-ref/source/l_you.cc
+++ b/crawl-ref/source/l_you.cc
@@ -804,38 +804,6 @@ LUAFN(you_in_branch)
     PLUARET(boolean, in_branch);
 }
 
-LUAFN(_you_shopping_list_has)
-{
-    const char *thing = luaL_checkstring(ls, 1);
-    MAPMARKER(ls, 2, mark);
-
-    level_pos pos(level_id::current(), mark->pos);
-    bool has = shopping_list.is_on_list(thing, &pos);
-    PLUARET(boolean, has);
-}
-
-LUAFN(_you_shopping_list_add)
-{
-    const char *thing = luaL_checkstring(ls, 1);
-    const char *verb  = luaL_checkstring(ls, 2);
-    const int  cost   = luaL_checkint(ls, 3);
-    MAPMARKER(ls, 4, mark);
-
-    level_pos pos(level_id::current(), mark->pos);
-    bool added = shopping_list.add_thing(thing, verb, cost, &pos);
-    PLUARET(boolean, added);
-}
-
-LUAFN(_you_shopping_list_del)
-{
-    const char *thing = luaL_checkstring(ls, 1);
-    MAPMARKER(ls, 2, mark);
-
-    level_pos pos(level_id::current(), mark->pos);
-    bool deleted = shopping_list.del_thing(thing, &pos);
-    PLUARET(boolean, deleted);
-}
-
 LUAFN(_you_at_branch_bottom)
 {
     PLUARET(boolean, at_branch_bottom());
@@ -890,9 +858,6 @@ static const struct luaL_reg you_dlib[] =
 { "dock_piety",         you_dock_piety },
 { "lose_piety",         you_lose_piety },
 { "in_branch",          you_in_branch },
-{ "shopping_list_has",  _you_shopping_list_has },
-{ "shopping_list_add",  _you_shopping_list_add },
-{ "shopping_list_del",  _you_shopping_list_del },
 { "stop_running",       you_stop_running },
 { "at_branch_bottom",   _you_at_branch_bottom },
 { "gain_exp",           you_gain_exp },


### PR DESCRIPTION
These had been out of commission since the removal of ziggurat entry fees
(which were accompanied by adding inaccessible ziggurats to shopping list)
in 07949ec7b9c0b9583012be218f9b887257a10cd9 .