### PR TITLE
Lua: Expose shopping list as `items.shopping_list()`

### DIFF
--- a/crawl-ref/source/l_item.cc
+++ b/crawl-ref/source/l_item.cc
@@ -28,6 +28,7 @@
 #include "output.h"
 #include "player.h"
 #include "prompt.h"
+#include "shopping.h"
 #include "skills.h"
 #include "spl-book.h"
 #include "spl-summoning.h"
@@ -1257,6 +1258,28 @@ static int l_item_shop_inventory(lua_State *ls)
     return 1;
 }
 
+static int l_item_shopping_list(lua_State *ls)
+{
+    if (shopping_list.empty())
+        return 0;
+
+    lua_newtable(ls);
+
+    const vector<shoplist_entry> items = shopping_list.entries();
+    int index = 0;
+    for (const auto &item : items)
+    {
+        lua_newtable(ls);
+        lua_pushstring(ls, item.first.c_str());
+        lua_rawseti(ls, -2, 1);
+        lua_pushnumber(ls, item.second);
+        lua_rawseti(ls, -2, 2);
+        lua_rawseti(ls, -2, ++index);
+    }
+
+    return 1;
+}
+
 struct ItemAccessor
 {
     const char *attribute;
@@ -1355,6 +1378,7 @@ static const struct luaL_reg item_lib[] =
     { "inslot",            l_item_inslot },
     { "get_items_at",      l_item_get_items_at },
     { "shop_inventory",    l_item_shop_inventory },
+    { "shopping_list",     l_item_shopping_list },
     { nullptr, nullptr },
 };
 

--- a/crawl-ref/source/l_item.cc
+++ b/crawl-ref/source/l_item.cc
@@ -1252,6 +1252,8 @@ static int l_item_shop_inventory(lua_State *ls)
         lua_rawseti(ls, -2, 1);
         lua_pushnumber(ls, item_price(item, *shop));
         lua_rawseti(ls, -2, 2);
+        lua_pushboolean(ls, shopping_list.is_on_list(item));
+        lua_rawseti(ls, -2, 3);
         lua_rawseti(ls, -2, ++index);
     }
 

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2278,6 +2278,21 @@ void ShoppingList::remove_dead_shops()
     refresh();
 }
 
+vector<shoplist_entry> ShoppingList::entries()
+{
+    ASSERT(list);
+
+    vector<shoplist_entry> list_entries;
+    for (const CrawlHashTable &entry : *list)
+    {
+        list_entries.push_back(
+            make_pair(name_thing(entry), thing_cost(entry))
+        );
+    }
+
+    return list_entries;
+}
+
 int ShoppingList::size() const
 {
     ASSERT(list);

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -43,6 +43,7 @@ void list_shop_types();
 struct level_pos;
 class  Menu;
 
+typedef pair<string, int> shoplist_entry;
 class ShoppingList
 {
 public:
@@ -76,6 +77,8 @@ public:
 
     bool empty() const { return !list || list->empty(); };
     int size() const;
+
+    vector<shoplist_entry> entries();
 
     static bool items_are_same(const item_def& item_a,
                                const item_def& item_b);


### PR DESCRIPTION
Rather similar to `items.shop_inventory()` for exposing a shop's stock as lua table, all in all.
(Except it works everywhere, not just when on the same tile as a shop.)
Said shop table gets a third return value per item as well, indicating whether the item in question
has been added to the shopping list.