### PR TITLE
Replace some magic numbers with new EQ_ enum values

### DIFF
--- a/crawl-ref/source/dbg-asrt.cc
+++ b/crawl-ref/source/dbg-asrt.cc
@@ -353,7 +353,7 @@ static void _dump_player(FILE *file)
     fprintf(file, "\n");
 
     fprintf(file, "Equipment:\n");
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
     {
         int8_t eq = you.equip[i];
 

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -2119,14 +2119,15 @@ enum equipment_type
     EQ_NONE = -1,
 
     EQ_WEAPON,
+    EQ_FIRST_EQUIP = EQ_WEAPON,
     EQ_CLOAK,
     EQ_HELMET,
     EQ_GLOVES,
     EQ_BOOTS,
     EQ_SHIELD,
     EQ_BODY_ARMOUR,
-    //Everything beyond here is jewellery
-    EQ_LEFT_RING,
+    EQ_FIRST_JEWELLERY,
+    EQ_LEFT_RING = EQ_FIRST_JEWELLERY,
     EQ_RIGHT_RING,
     EQ_AMULET,
     //Octopodes don't have left and right rings. They have eight rings, instead.
@@ -2140,6 +2141,7 @@ enum equipment_type
     EQ_RING_EIGHT,
     // Finger amulet provides an extra ring slot
     EQ_RING_AMULET,
+    EQ_LAST_JEWELLERY = EQ_RING_AMULET,
     NUM_EQUIP,
 
     EQ_MIN_ARMOUR = EQ_CLOAK,

--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -419,7 +419,7 @@ void ash_check_bondage(bool msg)
 
     int cursed[NUM_ET] = {0}, slots[NUM_ET] = {0};
 
-    for (int j = EQ_WEAPON; j < NUM_EQUIP; j++)
+    for (int j = EQ_FIRST_EQUIP; j < NUM_EQUIP; j++)
     {
         const equipment_type i = static_cast<equipment_type>(j);
         eq_type s;

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -157,7 +157,7 @@ bool InvEntry::is_equipped() const
     if (item->link == -1 || item->pos != ITEM_IN_INVENTORY)
         return false;
 
-    for (int i = 0; i < NUM_EQUIP; i++)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
         if (item->link == you.equip[i])
             return true;
 
@@ -1699,7 +1699,7 @@ bool check_warning_inscriptions(const item_def& item,
             }
             else
             {
-                for (int slots = EQ_LEFT_RING; slots < NUM_EQUIP; ++slots)
+                for (int slots = EQ_FIRST_JEWELLERY; slots <= EQ_LAST_JEWELLERY; ++slots)
                 {
                     if (slots == EQ_AMULET)
                         continue;

--- a/crawl-ref/source/item_use.cc
+++ b/crawl-ref/source/item_use.cc
@@ -1534,7 +1534,7 @@ static bool _puton_item(int item_slot, bool prompt_slot)
 {
     item_def& item = you.inv[item_slot];
 
-    for (int eq = EQ_LEFT_RING; eq < NUM_EQUIP; eq++)
+    for (int eq = EQ_FIRST_JEWELLERY; eq <= EQ_LAST_JEWELLERY; eq++)
         if (item_slot == you.equip[eq])
         {
             // "Putting on" an equipped item means taking it off.
@@ -3073,7 +3073,7 @@ void tile_item_use(int idx)
     // Equipped?
     bool equipped = false;
     bool equipped_weapon = false;
-    for (unsigned int i = 0; i < NUM_EQUIP; i++)
+    for (unsigned int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
     {
         if (you.equip[i] == idx)
         {

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -414,7 +414,7 @@ bool dec_inv_item_quantity(int obj, int amount)
 
     if (you.inv[obj].quantity <= amount)
     {
-        for (int i = 0; i < NUM_EQUIP; i++)
+        for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
         {
             if (you.equip[i] == obj)
             {
@@ -2516,7 +2516,7 @@ int get_equip_slot(const item_def *item)
     int worn = -1;
     if (item && in_inventory(*item))
     {
-        for (int i = 0; i < NUM_EQUIP; ++i)
+        for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         {
             if (you.equip[i] == item->link)
             {
@@ -3212,7 +3212,7 @@ equipment_type item_equip_slot(const item_def& item)
     if (!in_inventory(item))
         return EQ_NONE;
 
-    for (int i = 0; i < NUM_EQUIP; i++)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
         if (item.link == you.equip[i])
             return static_cast<equipment_type>(i);
 

--- a/crawl-ref/source/l_item.cc
+++ b/crawl-ref/source/l_item.cc
@@ -187,7 +187,7 @@ static int l_item_do_remove(lua_State *ls)
     }
 
     int eq = get_equip_slot(item);
-    if (eq < 0 || eq >= NUM_EQUIP)
+    if (eq < EQ_FIRST_EQUIP || eq >= NUM_EQUIP)
     {
         mpr("Item is not equipped");
         return 0;
@@ -196,7 +196,7 @@ static int l_item_do_remove(lua_State *ls)
     bool result = false;
     if (eq == EQ_WEAPON)
         result = wield_weapon(true, SLOT_BARE_HANDS);
-    else if (eq >= EQ_LEFT_RING && eq < NUM_EQUIP)
+    else if (eq >= EQ_FIRST_JEWELLERY && eq <= EQ_LAST_JEWELLERY)
         result = remove_ring(item->link);
     else
         result = takeoff_armour(item->link);
@@ -217,7 +217,7 @@ static int l_item_do_drop(lua_State *ls)
         return 0;
 
     int eq = get_equip_slot(item);
-    if (eq >= 0 && eq < NUM_EQUIP)
+    if (eq >= EQ_FIRST_EQUIP && eq < NUM_EQUIP)
     {
         lua_pushboolean(ls, false);
         lua_pushstring(ls, "Can't drop worn items");
@@ -243,7 +243,7 @@ IDEF(equipped)
         lua_pushboolean(ls, false);
 
     int eq = get_equip_slot(item);
-    if (eq < 0 || eq >= NUM_EQUIP)
+    if (eq < EQ_FIRST_EQUIP || eq >= NUM_EQUIP)
         lua_pushboolean(ls, false);
     else
         lua_pushboolean(ls, true);
@@ -1173,7 +1173,7 @@ static int l_item_equipped_at(lua_State *ls)
         eq = equip_name_to_slot(eqname);
     }
 
-    if (eq < 0 || eq >= NUM_EQUIP)
+    if (eq < EQ_FIRST_EQUIP || eq >= NUM_EQUIP)
         return 0;
 
     if (you.equip[eq] != -1)

--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -897,7 +897,7 @@ void melee_attack::check_autoberserk()
 {
     if (attacker->is_player())
     {
-        for (int i = EQ_WEAPON; i < NUM_EQUIP; ++i)
+        for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         {
             const item_def *item = you.slot_item(static_cast<equipment_type>(i));
             if (!item)

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1814,9 +1814,7 @@ const char *equip_slot_to_name(int equip)
     COMPILE_CHECK(ARRAYSZ(s_equip_slot_names) == NUM_EQUIP);
 
     if (equip == EQ_RINGS
-        || equip == EQ_LEFT_RING || equip == EQ_RIGHT_RING
-        || equip >= EQ_RING_ONE && equip <= EQ_RING_EIGHT
-        || equip == EQ_RING_AMULET)
+        || equip >= EQ_FIRST_JEWELLERY && equip <= EQ_LAST_JEWELLERY)
     {
         return "Ring";
     }
@@ -1827,7 +1825,7 @@ const char *equip_slot_to_name(int equip)
         return "Barding";
     }
 
-    if (equip < 0 || equip >= NUM_EQUIP)
+    if (equip < EQ_FIRST_EQUIP || equip >= NUM_EQUIP)
         return "";
 
     return s_equip_slot_names[equip];
@@ -1835,7 +1833,7 @@ const char *equip_slot_to_name(int equip)
 
 int equip_name_to_slot(const char *s)
 {
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         if (!strcasecmp(s_equip_slot_names[i], s))
             return i;
 

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -331,7 +331,7 @@ random_var player::attack_delay(const item_def *projectile, bool rescale) const
 // eq must be in [EQ_WEAPON, EQ_RING_AMULET], or bad things will happen.
 item_def *player::slot_item(equipment_type eq, bool include_melded) const
 {
-    ASSERT_RANGE(eq, EQ_WEAPON, NUM_EQUIP);
+    ASSERT_RANGE(eq, EQ_FIRST_EQUIP, NUM_EQUIP);
 
     const int item = equip[eq];
     if (item == -1 || !include_melded && melded[eq])

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -52,7 +52,7 @@ static void _calc_hp_artefact()
 // Fill an empty equipment slot.
 void equip_item(equipment_type slot, int item_slot, bool msg)
 {
-    ASSERT_RANGE(slot, EQ_NONE + 1, NUM_EQUIP);
+    ASSERT_RANGE(slot, EQ_FIRST_EQUIP, NUM_EQUIP);
     ASSERT(you.equip[slot] == -1);
     ASSERT(!you.melded[slot]);
 
@@ -67,7 +67,7 @@ void equip_item(equipment_type slot, int item_slot, bool msg)
 // Clear an equipment slot (possibly melded).
 bool unequip_item(equipment_type slot, bool msg)
 {
-    ASSERT_RANGE(slot, EQ_NONE + 1, NUM_EQUIP);
+    ASSERT_RANGE(slot, EQ_FIRST_EQUIP, NUM_EQUIP);
     ASSERT(!you.melded[slot] || you.equip[slot] != -1);
 
     const int item_slot = you.equip[slot];
@@ -91,7 +91,7 @@ bool unequip_item(equipment_type slot, bool msg)
 // you should call all unequip effects after all melding is done)
 bool meld_slot(equipment_type slot, bool msg)
 {
-    ASSERT_RANGE(slot, EQ_NONE + 1, NUM_EQUIP);
+    ASSERT_RANGE(slot, EQ_FIRST_EQUIP, NUM_EQUIP);
     ASSERT(!you.melded[slot] || you.equip[slot] != -1);
 
     if (you.equip[slot] != -1 && !you.melded[slot])
@@ -106,7 +106,7 @@ bool meld_slot(equipment_type slot, bool msg)
 // you should call all equip effects after all unmelding is done)
 bool unmeld_slot(equipment_type slot, bool msg)
 {
-    ASSERT_RANGE(slot, EQ_NONE + 1, NUM_EQUIP);
+    ASSERT_RANGE(slot, EQ_FIRST_EQUIP, NUM_EQUIP);
     ASSERT(!you.melded[slot] || you.equip[slot] != -1);
 
     if (you.equip[slot] != -1 && you.melded[slot])
@@ -164,7 +164,7 @@ void equip_effect(equipment_type slot, int item_slot, bool unmeld, bool msg)
         _equip_weapon_effect(item, msg, unmeld);
     else if (slot >= EQ_CLOAK && slot <= EQ_BODY_ARMOUR)
         _equip_armour_effect(item, unmeld, slot);
-    else if (slot >= EQ_LEFT_RING && slot < NUM_EQUIP)
+    else if (slot >= EQ_FIRST_JEWELLERY && slot <= EQ_LAST_JEWELLERY)
         _equip_jewellery_effect(item, unmeld, slot);
 }
 
@@ -182,7 +182,7 @@ void unequip_effect(equipment_type slot, int item_slot, bool meld, bool msg)
         _unequip_weapon_effect(item, msg, meld);
     else if (slot >= EQ_CLOAK && slot <= EQ_BODY_ARMOUR)
         _unequip_armour_effect(item, meld, slot);
-    else if (slot >= EQ_LEFT_RING && slot < NUM_EQUIP)
+    else if (slot >= EQ_FIRST_JEWELLERY && slot <= EQ_LAST_JEWELLERY)
         _unequip_jewellery_effect(item, msg, meld, slot);
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -891,7 +891,7 @@ int player::wearing(equipment_type slot, int sub_type, bool calc_unid) const
 
     case EQ_RINGS:
     case EQ_RINGS_PLUS:
-        for (int slots = EQ_LEFT_RING; slots < NUM_EQUIP; slots++)
+        for (int slots = EQ_FIRST_JEWELLERY; slots <= EQ_LAST_JEWELLERY; slots++)
         {
             if (slots == EQ_AMULET)
                 continue;
@@ -912,7 +912,7 @@ int player::wearing(equipment_type slot, int sub_type, bool calc_unid) const
         break;
 
     default:
-        if (! (slot > EQ_NONE && slot < NUM_EQUIP))
+        if (! (slot >= EQ_FIRST_EQUIP && slot < NUM_EQUIP))
             die("invalid slot");
         if ((item = slot_item(slot))
             && item->sub_type == sub_type
@@ -1010,7 +1010,7 @@ bool player_equip_unrand(int unrand_index)
         break;
 
     case EQ_RINGS:
-        for (int slots = EQ_LEFT_RING; slots < NUM_EQUIP; ++slots)
+        for (int slots = EQ_FIRST_JEWELLERY; slots <= EQ_LAST_JEWELLERY; ++slots)
         {
             if (slots == EQ_AMULET)
                 continue;
@@ -3771,7 +3771,7 @@ int player::scan_artefacts(artefact_prop_type which_property,
 {
     int retval = 0;
 
-    for (int i = EQ_WEAPON; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
     {
         if (melded[i] || equip[i] == -1)
             continue;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3081,7 +3081,7 @@ static void _god_welcome_handle_gear()
         ash_detect_portals(true);
 
     // Give a reminder to remove any disallowed equipment.
-    for (int i = EQ_WEAPON; i < NUM_EQUIP; i++)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
     {
         const item_def* item = you.slot_item(static_cast<equipment_type>(i));
         if (item && god_hates_item(*item))

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1361,10 +1361,10 @@ static void tag_construct_you(writer &th)
     CANARY;
 
     // how many you.equip?
-    marshallByte(th, NUM_EQUIP);
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    marshallByte(th, NUM_EQUIP - EQ_FIRST_EQUIP);
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         marshallByte(th, you.equip[i]);
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         marshallBoolean(th, you.melded[i]);
 
     ASSERT_RANGE(you.magic_points, 0, you.max_magic_points + 1);
@@ -2313,7 +2313,7 @@ static void tag_read_you(reader &th)
     // How many you.equip?
     count = unmarshallByte(th);
     ASSERT(count <= NUM_EQUIP);
-    for (int i = 0; i < count; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < count; ++i)
     {
         you.equip[i] = unmarshallByte(th);
         ASSERT_RANGE(you.equip[i], -1, ENDOFPACK);
@@ -3478,7 +3478,7 @@ static void tag_read_you_items(reader &th)
 #endif
 
     // Initialize cache of equipped unrand functions
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
     {
         const item_def *item = you.slot_item(static_cast<equipment_type>(i));
 

--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -730,7 +730,7 @@ void InventoryRegion::update()
             _fill_item_info(desc, get_item_info(you.inv[i]));
             desc.idx = i;
 
-            for (int eq = 0; eq < NUM_EQUIP; ++eq)
+            for (int eq = EQ_FIRST_EQUIP; eq < NUM_EQUIP; ++eq)
             {
                 if (you.equip[eq] == i)
                 {

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -860,7 +860,7 @@ void TilesFramework::_send_player(bool force_full)
     json_close_object(true);
 
     json_open_object("equip");
-    for (unsigned int i = 0; i < NUM_EQUIP; ++i)
+    for (unsigned int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
     {
         const int8_t equip = !you.melded[i] ? you.equip[i] : -1;
         _update_int(force_full, c.equip[i], equip, to_string(i));

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1218,7 +1218,7 @@ _init_equipment_removal(transformation_type form)
     if (form == TRAN_LICH && you.weapon() && is_holy_item(*you.weapon()))
         result.insert(EQ_WEAPON);
 
-    for (int i = EQ_WEAPON + 1; i < NUM_EQUIP; ++i)
+    for (int i = EQ_MIN_ARMOUR; i < NUM_EQUIP; ++i)
     {
         const equipment_type eq = static_cast<equipment_type>(i);
         const item_def *pitem = you.slot_item(eq, true);

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -942,7 +942,7 @@ static void _debug_acquirement_stats(FILE *ostat)
     };
 
     bool naked = true;
-    for (int i = 0; i < NUM_EQUIP; i++)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; i++)
     {
         int eqslot = e_order[i];
 

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -203,7 +203,7 @@ void wizard_change_species_to(species_type sp)
 
     // FIXME: this checks only for valid slots, not for suitability of the
     // item in question. This is enough to make assertions happy, though.
-    for (int i = 0; i < NUM_EQUIP; ++i)
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         if (you_can_wear(static_cast<equipment_type>(i)) == MB_FALSE
             && you.equip[i] != -1)
         {


### PR DESCRIPTION
Added enum values:

- `EQ_FIRST_EQUIP = EQ_WEAPON`
- `EQ_FIRST_JEWELLERY = EQ_LEFT_RING`
- `EQ_LAST_JEWELLERY = EQ_RING_AMULET`

Used these enum values to clarify the intent of various instances of iterating subsets of the available equip slots.

I'm not pushing this directly because it involved a number of fiddly little changes that (a) would be easy to get wrong, and (b) are hard to find places to test, so I think it could benefit from someone looking over it before merging in.