### PR TITLE
Add support for a spell library

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -159,6 +159,12 @@ bool MemoriseDelay::try_interrupt()
     return true;
 }
 
+bool LibraryDelay::try_interrupt()
+{
+  mpr("Your copying is interrupted.");
+  return true;
+}
+
 bool MultidropDelay::try_interrupt()
 {
     // No work lost
@@ -408,6 +414,16 @@ bool already_learning_spell(int spell)
     return false;
 }
 
+bool already_copying_spell()
+{
+    for (const auto delay : you.delay_queue)
+    {
+        if (dynamic_cast<LibraryDelay*>(delay.get()))
+            return true;
+    }
+    return false;
+}
+
 static command_type _get_running_command()
 {
     if (Options.travel_key_stop && kbhit()
@@ -510,6 +526,12 @@ void MemoriseDelay::start()
         simple_god_message(message.c_str());
     }
     mprf(MSGCH_MULTITURN_ACTION, "You start memorising the spell.");
+}
+
+void LibraryDelay::start()
+{
+    mprf(MSGCH_MULTITURN_ACTION, "You start copying %s to your library.",
+         spell_title(spell));
 }
 
 void PasswallDelay::start()
@@ -899,6 +921,12 @@ void MemoriseDelay::finish()
     mpr("You finish memorising.");
     add_spell_to_memory(spell);
     vehumet_accept_gift(spell);
+}
+
+void LibraryDelay::finish()
+{
+  mpr("You finish copying.");
+  add_spell_to_library(spell);
 }
 
 void PasswallDelay::finish()

--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -379,6 +379,31 @@ public:
     }
 };
 
+class LibraryDelay : public Delay
+{
+    void start() override;
+
+    void tick() override
+    {
+        mprf(MSGCH_MULTITURN_ACTION, "You continue copying.");
+    }
+
+    void finish() override;
+public:
+    spell_type spell;
+
+    LibraryDelay(int dur, spell_type sp) :
+                 Delay(dur), spell{sp}
+    {}
+
+    bool try_interrupt() override;
+
+    const char* name() const override
+    {
+        return "library";
+    }
+};
+
 class ButcherDelay : public Delay
 {
     item_def& corpse;
@@ -786,6 +811,7 @@ bool is_being_butchered(const item_def &item, bool just_first = true);
 bool is_vampire_feeding();
 bool player_stair_delay();
 bool already_learning_spell(int spell = -1);
+bool already_copying_spell();
 
 void clear_macro_process_key_delay();
 

--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -556,7 +556,7 @@ void list_spellset(const spellset &spells, const monster_info *mon_owner,
 {
     const bool can_memorise = source_item
                               && source_item->base_type == OBJ_BOOKS
-                              && in_inventory(*source_item);
+                              && item_accessible(*source_item);
 
     formatted_string &description = initial_desc;
     describe_spellset(spells, source_item, description, mon_owner);
@@ -565,7 +565,7 @@ void list_spellset(const spellset &spells, const monster_info *mon_owner,
 
     description.cprintf("Select a spell to read its description");
     if (can_memorise)
-        description.cprintf(" or to to memorise it");
+        description.cprintf(" or to memorise it");
     description.cprintf(".\n");
 
     spell_scroller ssc(spells, mon_owner, source_item);
@@ -603,7 +603,8 @@ bool spell_scroller::process_key(int keyin)
     const spell_type chosen_spell = flat_spells[spell_index];
     describe_spell(chosen_spell, mon_owner, source_item);
 
-    if (already_learning_spell()) // player began (M)emorizing
+    // Has the player began (M)emorizing or (C)opying?
+    if (already_learning_spell() || already_copying_spell())
         return false; // time to leave the menu
 
     draw_menu();

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2706,10 +2706,11 @@ static bool _get_spell_description(const spell_type spell,
     if (!quote.empty())
         description += "\n" + quote;
 
-    if (item && item->base_type == OBJ_BOOKS && in_inventory(*item)
+    if (item && item->base_type == OBJ_BOOKS && item_accessible(*item)
         && !you.has_spell(spell) && you_can_memorise(spell))
     {
         description += "\n(M)emorise this spell.\n";
+        description += "(C)opy this spell to your library.\n";
         return true;
     }
 
@@ -2756,13 +2757,21 @@ void describe_spell(spell_type spelled, const monster_info *mon_owner,
     if ((ch = getchm()) == 0)
         ch = getchm();
 
-    if (can_mem && toupper(ch) == 'M')
+    if (!can_mem) return;
+
+    ch = toupper(ch);
+
+    redraw_screen();
+    if (ch == 'M')
     {
-        redraw_screen();
         if (!learn_spell(spelled) || !you.turn_is_over)
             more();
-        redraw_screen();
     }
+    else if (ch == 'C')
+    {
+        copy_spell_to_library(spelled);
+    }
+    redraw_screen();
 }
 
 static string _describe_draconian(const monster_info& mi)

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -4241,7 +4241,7 @@ enum species_type
     SP_VIABLE   = 102,
 };
 
-enum spell_type
+enum spell_type : int
 {
     SPELL_NO_SPELL,
     SPELL_TELEPORT_SELF,

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -898,6 +898,11 @@ bool in_inventory(const item_def &i)
     return i.pos == ITEM_IN_INVENTORY;
 }
 
+bool item_accessible(const item_def &i)
+{
+    return in_inventory(i) || i.pos == you.pos();
+}
+
 const char *item_class_name(int type, bool terse)
 {
     if (terse)

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -227,6 +227,7 @@ vector<SelItem> prompt_invent_items(
 void display_inventory();
 
 bool in_inventory(const item_def &i);
+bool item_accessible(const item_def &i);
 void identify_inventory();
 
 const char *item_class_name(int type, bool terse = false);

--- a/crawl-ref/source/l_you.cc
+++ b/crawl-ref/source/l_you.cc
@@ -294,8 +294,7 @@ static int l_you_mem_spells(lua_State *ls)
     char buf[2];
     buf[1] = 0;
 
-    vector<int> books;
-    vector<spell_type> mem_spells = get_mem_spell_list(books);
+    vector<spell_type> mem_spells = get_mem_spell_list();
 
     for (size_t i = 0; i < mem_spells.size(); ++i)
     {

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -11,6 +11,7 @@
 #include <list>
 #include <memory>
 #include <vector>
+#include <unordered_set>
 
 #include "actor.h"
 #include "beam.h"
@@ -157,6 +158,7 @@ public:
 
     FixedVector<spell_type, MAX_KNOWN_SPELLS> spells;
     set<spell_type> old_vehumet_gifts, vehumet_gifts;
+    unordered_set<spell_type, hash<int>> library_spells;
 
     uint8_t spell_no;
     game_chapter chapter;

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -406,6 +406,12 @@ static bool _get_mem_list(spell_list &mem_spells,
       available_spells.insert(gift);
     }
 
+    // Handle spells stored in library
+    for (auto lib_spell : you.library_spells)
+    {
+      available_spells.insert(lib_spell);
+    }
+
     if (book_errors)
         more();
 
@@ -414,13 +420,13 @@ static bool _get_mem_list(spell_list &mem_spells,
         if (!just_check)
         {
             if (num_unknown > 1)
-                mprf(MSGCH_PROMPT, "You must pick up those books before reading them.");
+                mprf(MSGCH_PROMPT, "You must read or pickup those books before memorising spells.");
             else if (num_unknown == 1)
-                mprf(MSGCH_PROMPT, "You must pick up this book before reading it.");
+                mprf(MSGCH_PROMPT, "You must read or pickup that book before memorising spells");
             else if (book_errors)
                 mprf(MSGCH_PROMPT, "None of the spellbooks you are carrying contain any spells.");
             else
-                mprf(MSGCH_PROMPT, "You aren't carrying or standing over any spellbooks.");
+                mprf(MSGCH_PROMPT, "You aren't carrying or standing over any spellbooks and your library is empty.");
         }
         return false;
     }
@@ -892,4 +898,19 @@ void destroy_spellbook(const item_def &book)
     int maxlevel = 0;
     for (spell_type stype : spells_in_book(book))
         maxlevel = max(maxlevel, spell_difficulty(stype));
+}
+
+void copy_spell_to_library(spell_type spell, bool silent)
+{
+    auto iter = you.library_spells.find(spell);
+
+    if (iter == you.library_spells.end())
+    {
+        start_delay<LibraryDelay>(spell_difficulty(spell), spell);
+        you.turn_is_over = true;
+    }
+    else if (!silent)
+    {
+        mprf(MSGCH_PLAIN, "%s is already in your library!", spell_title(spell));
+    }
 }

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -13,7 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iomanip>
-#include <set>
+#include <unordered_set>
 
 #include "artefact.h"
 #include "colour.h"
@@ -339,11 +339,11 @@ bool player_can_memorise(const item_def &book)
     return false;
 }
 
-typedef vector<spell_type>   spell_list;
-typedef map<spell_type, int> spells_to_books;
+typedef vector<spell_type>                     spell_list;
+typedef unordered_set<spell_type, hash<int>>   spell_set;
 
-static void _index_book(item_def& book, spells_to_books &book_hash,
-                        bool &book_errors)
+static void _get_book_spells(item_def& book, spell_set &spells,
+                             bool &book_errors)
 {
     mark_had_book(book);
     set_ident_flags(book, ISFLAG_KNOW_TYPE);
@@ -353,10 +353,7 @@ static void _index_book(item_def& book, spells_to_books &book_hash,
     for (spell_type spell : spells_in_book(book))
     {
         num_spells++;
-
-        auto it = book_hash.find(spell);
-        if (it == book_hash.end())
-            book_hash[spell] = book.sub_type;
+        spells.insert(spell);
     }
 
     if (num_spells == 0)
@@ -368,15 +365,13 @@ static void _index_book(item_def& book, spells_to_books &book_hash,
 }
 
 static bool _get_mem_list(spell_list &mem_spells,
-                          spells_to_books &book_hash,
                           unsigned int &num_misc,
                           bool just_check = false,
                           spell_type current_spell = SPELL_NO_SPELL)
 {
-    bool          book_errors    = false;
-    unsigned int  num_on_ground  = 0;
-    unsigned int  num_books      = 0;
-    unsigned int  num_unknown    = 0;
+    bool          book_errors      = false;
+    unsigned int  num_unknown      = 0;
+    spell_set     available_spells;
 
     // Collect the list of all spells in all available spellbooks.
     for (auto &book : you.inv)
@@ -384,8 +379,7 @@ static bool _get_mem_list(spell_list &mem_spells,
         if (!book.defined() || !item_is_spellbook(book))
             continue;
 
-        num_books++;
-        _index_book(book, book_hash, book_errors);
+        _get_book_spells(book, available_spells, book_errors);
     }
 
     // We also check the ground
@@ -403,24 +397,19 @@ static bool _get_mem_list(spell_list &mem_spells,
             continue;
         }
 
-        num_books++;
-        num_on_ground++;
-        _index_book(book, book_hash, book_errors);
+        _get_book_spells(book, available_spells, book_errors);
     }
 
     // Handle Vehumet gifts
-    auto gift_iterator = you.vehumet_gifts.begin();
-    if (gift_iterator != you.vehumet_gifts.end())
+    for (auto gift : you.vehumet_gifts)
     {
-        num_books++;
-        while (gift_iterator != you.vehumet_gifts.end())
-            book_hash[*gift_iterator++] = NUM_BOOKS;
+      available_spells.insert(gift);
     }
 
     if (book_errors)
         more();
 
-    if (num_books == 0)
+    if (available_spells.empty())
     {
         if (!just_check)
         {
@@ -428,15 +417,11 @@ static bool _get_mem_list(spell_list &mem_spells,
                 mprf(MSGCH_PROMPT, "You must pick up those books before reading them.");
             else if (num_unknown == 1)
                 mprf(MSGCH_PROMPT, "You must pick up this book before reading it.");
+            else if (book_errors)
+                mprf(MSGCH_PROMPT, "None of the spellbooks you are carrying contain any spells.");
             else
                 mprf(MSGCH_PROMPT, "You aren't carrying or standing over any spellbooks.");
         }
-        return false;
-    }
-    else if (book_hash.empty())
-    {
-        if (!just_check)
-            mprf(MSGCH_PROMPT, "None of the spellbooks you are carrying contain any spells.");
         return false;
     }
 
@@ -448,10 +433,8 @@ static bool _get_mem_list(spell_list &mem_spells,
     unsigned int num_memable    = 0;
     bool         form           = false;
 
-    for (const auto &entry : book_hash)
+    for (const spell_type spell : available_spells)
     {
-        const spell_type spell = entry.first;
-
         if (spell == current_spell || you.has_spell(spell))
             num_known++;
         else if (!you_can_memorise(spell))
@@ -530,10 +513,9 @@ static bool _get_mem_list(spell_list &mem_spells,
 bool has_spells_to_memorise(bool silent, spell_type current_spell)
 {
     spell_list      mem_spells;
-    spells_to_books book_hash;
     unsigned int    num_misc;
 
-    return _get_mem_list(mem_spells, book_hash, num_misc, silent,
+    return _get_mem_list(mem_spells, num_misc, silent,
                          (spell_type) current_spell);
 }
 
@@ -570,30 +552,20 @@ static bool _sort_mem_spells(spell_type a, spell_type b)
     return strcasecmp(spell_title(a), spell_title(b)) < 0;
 }
 
-vector<spell_type> get_mem_spell_list(vector<int> &books)
+vector<spell_type> get_mem_spell_list()
 {
-    vector<spell_type> spells;
-
     spell_list      mem_spells;
-    spells_to_books book_hash;
     unsigned int    num_misc;
 
-    if (!_get_mem_list(mem_spells, book_hash, num_misc))
-        return spells;
+    if (!_get_mem_list(mem_spells, num_misc))
+        return spell_list();
 
     sort(mem_spells.begin(), mem_spells.end(), _sort_mem_spells);
 
-    for (spell_type spell : mem_spells)
-    {
-        spells.push_back(spell);
-        books.push_back(*map_find(book_hash, spell));
-    }
-
-    return spells;
+    return mem_spells;
 }
 
 static spell_type _choose_mem_spell(spell_list &spells,
-                                    spells_to_books &book_hash,
                                     unsigned int num_misc)
 {
     sort(spells.begin(), spells.end(), _sort_mem_spells);
@@ -770,14 +742,13 @@ bool learn_spell()
         return false;
 
     spell_list      mem_spells;
-    spells_to_books book_hash;
 
     unsigned int num_misc;
 
-    if (!_get_mem_list(mem_spells, book_hash, num_misc))
+    if (!_get_mem_list(mem_spells, num_misc))
         return false;
 
-    spell_type specspell = _choose_mem_spell(mem_spells, book_hash, num_misc);
+    spell_type specspell = _choose_mem_spell(mem_spells, num_misc);
 
     if (specspell == SPELL_NO_SPELL)
     {

--- a/crawl-ref/source/spl-book.h
+++ b/crawl-ref/source/spl-book.h
@@ -46,4 +46,6 @@ bool has_spells_to_memorise(bool silent = true,
 vector<spell_type> get_mem_spell_list();
 
 void destroy_spellbook(const item_def &book);
+
+void copy_spell_to_library(spell_type spell, bool silent = false);
 #endif

--- a/crawl-ref/source/spl-book.h
+++ b/crawl-ref/source/spl-book.h
@@ -43,7 +43,7 @@ vector<spell_type> spells_in_book(const item_def &book);
 bool you_can_memorise(spell_type spell) PURE;
 bool has_spells_to_memorise(bool silent = true,
                             spell_type current_spell = SPELL_NO_SPELL);
-vector<spell_type> get_mem_spell_list(vector<int> &books);
+vector<spell_type> get_mem_spell_list();
 
 void destroy_spellbook(const item_def &book);
 #endif

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -404,6 +404,11 @@ bool del_spell_from_memory(spell_type spell)
         return del_spell_from_memory_by_slot(i);
 }
 
+void add_spell_to_library(spell_type spell)
+{
+    you.library_spells.insert(spell);
+}
+
 int spell_hunger(spell_type which_spell, bool rod)
 {
     if (player_energy())

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -62,6 +62,8 @@ bool add_spell_to_memory(spell_type spell);
 bool del_spell_from_memory_by_slot(int slot);
 bool del_spell_from_memory(spell_type spell);
 
+void add_spell_to_library(spell_type spell);
+
 int spell_hunger(spell_type which_spell, bool rod = false);
 int spell_mana(spell_type which_spell);
 int spell_difficulty(spell_type which_spell);

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -187,6 +187,7 @@ enum tag_minor_version
     TAG_MINOR_GHOST_NOSINV,        // don't marshall ghost_demon sinv
     TAG_MINOR_NO_DRACO_TYPE,       // don't marshall mon-info draco_type
     TAG_MINOR_DEMONIC_SPELLS,      // merge demonic spells into magical spells
+    TAG_MINOR_SPELL_LIBRARY,
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1421,6 +1421,10 @@ static void tag_construct_you(writer &th)
     for (auto spell : you.vehumet_gifts)
         marshallShort(th, spell);
 
+    marshallUByte(th, you.library_spells.size());
+    for (auto spell : you.library_spells)
+        marshallShort(th, spell);
+
     CANARY;
 
     // how many skills?
@@ -2518,6 +2522,16 @@ static void tag_read_you(reader &th)
                 you.vehumet_gifts.insert(unmarshallSpellType(th));
 #if TAG_MAJOR_VERSION == 34
         }
+    }
+#endif
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_SPELL_LIBRARY)
+    {
+#endif
+        count = unmarshallUByte(th);
+        for (int i = 0; i < count; ++i)
+            you.library_spells.insert(unmarshallSpellType(th));
+#if TAG_MAJOR_VERSION == 34
     }
 #endif
     EAT_CANARY;

--- a/crawl-ref/source/tilereg-mem.cc
+++ b/crawl-ref/source/tilereg-mem.cc
@@ -128,8 +128,7 @@ void MemoriseRegion::update()
 
     const unsigned int max_spells = mx * my;
 
-    vector<int>  books;
-    vector<spell_type> spells = get_mem_spell_list(books);
+    vector<spell_type> spells = get_mem_spell_list();
     for (unsigned int i = 0; m_items.size() < max_spells && i < spells.size();
          ++i)
     {
@@ -138,7 +137,6 @@ void MemoriseRegion::update()
         InventoryTile desc;
         desc.tile     = tileidx_spell(spell);
         desc.idx      = (int) spell;
-        desc.special  = books[i];
         desc.quantity = spell_difficulty(spell);
 
         if (!can_learn_spell(true)


### PR DESCRIPTION
The spell library allows you to (C)opy spells to your library from the read book screen, and to later (M)emorize those spells without the original source book present. The idea is to reduce tedium in spellbook inventory management. An action to add an entire book to your library still needs to be added to avoid the current need to individually copy each spell from the book.

Currently spells take the same amount of time to copy as to memorize. My justification for this was to avoid people instantly copying spellbooks from the ground in an unsafe situation and then making their getaway without needing to have some space in their inventory to pick up the spellbook and get to a safe place to copy. That said the current copying time may be excessive, so perhaps it could be 1/2 the memorization time?

The first commit is just general cleanup in case this feature is poorly received, so hopefully the cleanup can still be merged in.