### PR TITLE
FIX for bug#0010518

### DIFF
--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -857,7 +857,7 @@ static bool _grab_follower_at(const coord_def &pos, bool can_follow)
         return false;
 
     monster* fol = monster_at(pos);
-    if (!fol || !fol->alive())
+    if (!fol || !fol->alive() || fol->incapacitated())
         return false;
 
     // only H's ancestors can follow into portals & similar.


### PR DESCRIPTION
Added a check to see if monster was incapacitated just as you started to ascend or descend stairs.
Testing done in wizmode with allies and monsters.

1. Monsters don't follow if incapacitated. 
2. Follow when they are not incapacitated.
3. They're still present when I go back.