### PR TITLE
Improve mottled draconians (Lightli)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1826,7 +1826,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_BREATHE_STICKY_FLAME:
     {
         targetter_splash hitfunc(&you);
-        beam.range = 1;
+        beam.range = 3;
         direction_chooser_args args;
         args.mode = TARG_HOSTILE;
         args.hitfunc = &hitfunc;


### PR DESCRIPTION
Let breath sticky flame have perfect accuracy (can be flavoured as you
just spraying napalm everywhere in front of you), and give +1
conjurations aptitude.