### PR TITLE
Don't let haste + finesse bring the player below 0.2 attack delay.

### DIFF
--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -320,7 +320,8 @@ random_var player::attack_delay(const item_def *projectile, bool rescale) const
         // longer so when Haste speeds it up, only Finesse will apply.
         if (you.duration[DUR_HASTE] && rescale)
             attk_delay = rv::max(random_var(haste_mul(2)), div_rand_round(haste_mul(attk_delay), 2));
-        attk_delay = rv::max(random_var(2), div_rand_round(attk_delay, 2));
+        else
+            attk_delay = rv::max(random_var(2), div_rand_round(attk_delay, 2));
     }
 
     // see comment on player.cc:player_speed

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -319,7 +319,7 @@ random_var player::attack_delay(const item_def *projectile, bool rescale) const
         // Finesse shouldn't stack with Haste, so we make this attack take
         // longer so when Haste speeds it up, only Finesse will apply.
         if (you.duration[DUR_HASTE] && rescale)
-            attk_delay = haste_mul(attk_delay);
+            attk_delay = rv::max(random_var(haste_mul(2)), div_rand_round(haste_mul(attk_delay), 2));
         attk_delay = rv::max(random_var(2), div_rand_round(attk_delay, 2));
     }
 


### PR DESCRIPTION
They're not intended to stack, but in the rare case where the player was
running into the limit at 0.2 attack delay (e.g. with a finessed
quickblade), adding haste on top could let them go down to 0.1.