### PR TITLE
Reflavor High Elves into Fen Elves. 

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -1529,7 +1529,7 @@ Trolls
 
   They can rip creatures apart with their claws, and regenerate very quickly
   from even the most terrible wounds. They learn slowly indeed - as slowly as
-  High Elves - and need a great amount of food to survive.
+  Fen Elves - and need a great amount of food to survive.
 
 Minotaurs
   The Minotaurs are yet another species of hybrids - Human bodies with bovine
@@ -1707,22 +1707,26 @@ Due to their fey natures, all Elves are good at using magic in general and
 elemental magic in particular, while their affinity for other types of magic
 varies among the different sub-species.
 
-High Elves
-  This is a tall and powerful Elven species who advance in levels slowly,
-  requiring half again as much experience as Humans. They have good intelligence
-  and dexterity, but suffer in strength. Compared with Humans, they have fewer
-  HP but more magic. Among all races, they are best with blades and bows. They
-  are not very good with necromancy or with earth or poison magic, but are
-  highly skilled with most other forms of magic, especially Air and Charms.
+Fen Elves
+  A tall and hardened Elven species who rarely venture out of their overgrown
+  swamps. They advance in levels slowly, requiring half again as much experience
+  as Humans. They are intelligent and dexterous, but not as strong as other
+  species. Compared with Humans, they have less health but more magic.
+  
+  Among all species, they are unsurpassed with blades and bows. They are
+  averse to necromancy, fire and ice magic, and magical devices. Fen Elves
+  are self-sufficient survivors who improve their personal capabilities through
+  magical charms and transform the battlefield through hexes and 
+  elemental magic. 
 
 Deep Elves
-  This is an Elven species who long ago fled the overworld to live in darkness
-  underground. There, they developed their mental powers, evolving a natural
-  gift for all forms of magic (including necromancy and earth magic), and
-  adapted physically to their new environment, becoming shorter and weaker than
-  High Elves and losing all colouration. They are poor at hand-to-hand combat,
-  but excellent at fighting from a distance. They advance in levels at the same
-  speed as High Elves.
+   They are descendants of magic-obsessed Fen Elves who long ago fled the
+   swamps to live in darkness underground. There, they developed their mental
+   powers, evolving a natural gift for all forms of magic (including necromancy,
+   fire, and ice magic), and adapted physically to their new environment,
+   becoming shorter and weaker than Fen Elves and losing all colouration.
+   They are poor at hand-to-hand combat, but excellent at fighting from a
+   distance. They advance in levels at the same speed as Fen Elves.
 
 The Undead
 ========================================

--- a/crawl-ref/source/aptitudes.h
+++ b/crawl-ref/source/aptitudes.h
@@ -51,6 +51,7 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_HUMAN,           SK_INVOCATIONS,     1),
     APT(SP_HUMAN,           SK_EVOCATIONS,      0),
 
+#if TAG_MAJOR_VERSION == 34
     // SP_HIGH_ELF
     APT(SP_HIGH_ELF,        SK_FIGHTING,        0),
     APT(SP_HIGH_ELF,        SK_SHORT_BLADES,    2),
@@ -66,13 +67,9 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_HIGH_ELF,        SK_ARMOUR,         -1),
     APT(SP_HIGH_ELF,        SK_DODGING,         1),
     APT(SP_HIGH_ELF,        SK_STEALTH,         2),
-#if TAG_MAJOR_VERSION == 34
     APT(SP_HIGH_ELF,        SK_STABBING,      UNUSABLE_SKILL),
-#endif
     APT(SP_HIGH_ELF,        SK_SHIELDS,        -1),
-#if TAG_MAJOR_VERSION == 34
     APT(SP_HIGH_ELF,        SK_TRAPS,         UNUSABLE_SKILL),
-#endif
     APT(SP_HIGH_ELF,        SK_UNARMED_COMBAT, -2),
     APT(SP_HIGH_ELF,        SK_SPELLCASTING,    1),
     APT(SP_HIGH_ELF,        SK_CONJURATIONS,    1),
@@ -89,6 +86,7 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_HIGH_ELF,        SK_POISON_MAGIC,   -2),
     APT(SP_HIGH_ELF,        SK_INVOCATIONS,     1),
     APT(SP_HIGH_ELF,        SK_EVOCATIONS,      0),
+#endif
 
     // SP_DEEP_ELF
     APT(SP_DEEP_ELF,        SK_FIGHTING,       -2),
@@ -1484,6 +1482,45 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_VINE_STALKER,    SK_POISON_MAGIC,    0),
     APT(SP_VINE_STALKER,    SK_INVOCATIONS,     0),
     APT(SP_VINE_STALKER,    SK_EVOCATIONS,     -1),
+
+    // SP_FEN_ELF
+    APT(SP_FEN_ELF,        SK_FIGHTING,        0),
+    APT(SP_FEN_ELF,        SK_SHORT_BLADES,    2),
+    APT(SP_FEN_ELF,        SK_LONG_BLADES,     2),
+    APT(SP_FEN_ELF,        SK_AXES,           -2),
+    APT(SP_FEN_ELF,        SK_MACES_FLAILS,   -2),
+    APT(SP_FEN_ELF,        SK_POLEARMS,       -2),
+    APT(SP_FEN_ELF,        SK_STAVES,          0),
+    APT(SP_FEN_ELF,        SK_SLINGS,         -2),
+    APT(SP_FEN_ELF,        SK_BOWS,            3),
+    APT(SP_FEN_ELF,        SK_CROSSBOWS,       0),
+    APT(SP_FEN_ELF,        SK_THROWING,        0),
+    APT(SP_FEN_ELF,        SK_ARMOUR,         -1),
+    APT(SP_FEN_ELF,        SK_DODGING,         1),
+    APT(SP_FEN_ELF,        SK_STEALTH,         2),
+#if TAG_MAJOR_VERSION == 34
+    APT(SP_FEN_ELF,        SK_STABBING,      UNUSABLE_SKILL),
+#endif
+    APT(SP_FEN_ELF,        SK_SHIELDS,        -1),
+#if TAG_MAJOR_VERSION == 34
+    APT(SP_FEN_ELF,        SK_TRAPS,         UNUSABLE_SKILL),
+#endif
+    APT(SP_FEN_ELF,        SK_UNARMED_COMBAT, -2),
+    APT(SP_FEN_ELF,        SK_SPELLCASTING,    1),
+    APT(SP_FEN_ELF,        SK_CONJURATIONS,   -1),
+    APT(SP_FEN_ELF,        SK_HEXES,           1),
+    APT(SP_FEN_ELF,        SK_CHARMS,          2),
+    APT(SP_FEN_ELF,        SK_SUMMONINGS,     -1),
+    APT(SP_FEN_ELF,        SK_NECROMANCY,     -2),
+    APT(SP_FEN_ELF,        SK_TRANSLOCATIONS,  1),
+    APT(SP_FEN_ELF,        SK_TRANSMUTATIONS,  1),
+    APT(SP_FEN_ELF,        SK_FIRE_MAGIC,     -2),
+    APT(SP_FEN_ELF,        SK_ICE_MAGIC,      -2),
+    APT(SP_FEN_ELF,        SK_AIR_MAGIC,       2),
+    APT(SP_FEN_ELF,        SK_EARTH_MAGIC,     2),
+    APT(SP_FEN_ELF,        SK_POISON_MAGIC,    0),
+    APT(SP_FEN_ELF,        SK_INVOCATIONS,     1),
+    APT(SP_FEN_ELF,        SK_EVOCATIONS,     -2),
 };
 
 #endif

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -103,14 +103,14 @@ function species_mock(e)
     e.kmons("1 = insubstantial wisp")
   elseif you.race() == "Halfling" then
     e.kmons("1 = hobgoblin ; mundane hunting sling")
-  elseif you.race() == "High Elf" then
-    e.kmons("1 = giant orange brain")
   elseif you.race() == "Hill Orc" then
     e.kmons("1 = goblin ; mundane hand axe . mundane ring mail")
   elseif you.race() == "Human" then
     e.kmons("1 = killer klown")
   elseif you.race() == "Felid" then
     e.kmons("1 = sphinx zombie")
+  elseif you.race() == "Fen Elf" then
+    e.kmons("1 = slime creature")
   elseif you.race() == "Formicid" then
     e.kmons("1 = soldier ant")
   elseif you.race() == "Gargoyle" then

--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -111,14 +111,16 @@ Donald
 %%%%
 Dowan
 
-A beautiful but vain elf with an aptitude for magic and little else. His skills
-are the perfect complement of his twin sister Duvessa's fighting prowess.
+A beautiful but vain deep elf with an aptitude for magic and little else. His
+skills are the perfect complement of his twin sister Duvessa's fighting prowess.
+In search of more powerful spells, he journeys to the surface with his sister.
 %%%%
 Duvessa
 
-A plain-looking elven fighter who is technically brilliant in many forms of
+A plain-looking deep elven fighter who is technically brilliant in many forms of
 combat, but over-confident because of it. She is complemented by the magical
-skills of her twin brother, Dowan.
+skills of her twin brother, Dowan. She journeys to the surface to challenge
+its greatest champions.
 %%%%
 Edmund
 
@@ -152,9 +154,10 @@ honour.
 %%%%
 Fannar
 
-A cold-hearted elven sorcerer, draped in robes of high office. He whispers
-grimly to himself as he stalks the dungeon, trailing ice crystals through the
-air behind him.
+A cold-hearted fen elven sorcerer, draped in grand and intricate robes. His
+obsession with ice magic led him to reject his heritage and seek out his deep
+cousins beneath the surface. He whispers grimly to himself as he stalks
+the dungeon, trailing ice crystals through the air behind him.
 %%%%
 Frances
 

--- a/crawl-ref/source/dat/descript/species.txt
+++ b/crawl-ref/source/dat/descript/species.txt
@@ -38,6 +38,11 @@ Felid
 Felids are many-lived cats possessing sentience. They are incapable of advanced
 item manipulation or the use of armour or weapons.
 %%%%
+Fen Elf
+
+Hardened swamp-dwellers, Fen Elves are adept with blades, bows, and many 
++schools of magic, and have high attributes.
+%%%%
 Ghoul
 
 Ghouls are undead creatures, damned to rot eternally. They have sharp claws,
@@ -52,11 +57,6 @@ Halfling
 
 Small but hardy, Halflings excel with slings. They have an increased resistance
 to mutagenic effects.
-%%%%
-High Elf
-
-High Elves are adept with blades and with many schools of magic, and have high
-attributes.
 %%%%
 Hill Orc
 

--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -4184,7 +4184,9 @@ enum skill_focus_mode
 enum species_type
 {
     SP_HUMAN,
+#if TAG_MAJOR_VERSION == 34
     SP_HIGH_ELF,
+#endif
     SP_DEEP_ELF,
 #if TAG_MAJOR_VERSION == 34
     SP_SLUDGE_ELF,
@@ -4228,6 +4230,7 @@ enum species_type
     SP_GARGOYLE,
     SP_FORMICID,
     SP_VINE_STALKER,
+    SP_FEN_ELF,
     NUM_SPECIES,
 
     SP_UNKNOWN  = 100,

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -36,7 +36,7 @@ static const map<job_type, job_def> job_data =
 { JOB_AIR_ELEMENTALIST, {
     "AE", "Air Elementalist",
     0, 7, 5,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_TENGU, SP_BASE_DRACONIAN, SP_NAGA,
+    { SP_FEN_ELF, SP_DEEP_ELF, SP_TENGU, SP_BASE_DRACONIAN, SP_NAGA,
       SP_VINE_STALKER, },
     { "robe", "book of Air" },
     WCHOICE_NONE,
@@ -47,7 +47,7 @@ static const map<job_type, job_def> job_data =
 { JOB_ARCANE_MARKSMAN, {
     "AM", "Arcane Marksman",
     3, 5, 4,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_KOBOLD, SP_SPRIGGAN, SP_TROLL, SP_CENTAUR, },
+    { SP_FEN_ELF, SP_DEEP_ELF, SP_KOBOLD, SP_SPRIGGAN, SP_TROLL, SP_CENTAUR, },
     { "robe", "book of Debilitation" },
     WCHOICE_RANGED,
     { { SK_FIGHTING, 1 }, { SK_DODGING, 2 }, { SK_SPELLCASTING, 1 },
@@ -69,8 +69,8 @@ static const map<job_type, job_def> job_data =
 { JOB_ASSASSIN, {
     "As", "Assassin",
     3, 3, 6,
-    { SP_TROLL, SP_HALFLING, SP_SPRIGGAN, SP_DEMONSPAWN, SP_VAMPIRE,
-      SP_VINE_STALKER, },
+    { SP_FEN_ELF, SP_TROLL, SP_HALFLING, SP_SPRIGGAN, SP_DEMONSPAWN, 
+      SP_VAMPIRE, SP_VINE_STALKER, },
     { "dagger plus:2", "blowgun", "robe", "cloak", "needle ego:poisoned q:8",
       "needle ego:curare q:2" },
     WCHOICE_NONE,
@@ -102,8 +102,7 @@ static const map<job_type, job_def> job_data =
 { JOB_CONJURER, {
     "Cj", "Conjurer",
     0, 7, 5,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_NAGA, SP_TENGU, SP_BASE_DRACONIAN,
-      SP_DEMIGOD, },
+    { SP_DEEP_ELF, SP_NAGA, SP_TENGU, SP_BASE_DRACONIAN, SP_DEMIGOD, },
     { "robe", "book of Conjurations" },
     WCHOICE_NONE,
     { { SK_CONJURATIONS, 4 }, { SK_SPELLCASTING, 2 }, { SK_DODGING, 2 },
@@ -113,8 +112,8 @@ static const map<job_type, job_def> job_data =
 { JOB_EARTH_ELEMENTALIST, {
     "EE", "Earth Elementalist",
     0, 7, 5,
-    { SP_DEEP_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_GARGOYLE, SP_DEMIGOD,
-      SP_GHOUL, SP_OCTOPODE, },
+    { SP_FEN_ELF, SP_DEEP_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_GARGOYLE, 
+      SP_DEMIGOD, SP_GHOUL, SP_OCTOPODE, },
     { "book of Geomancy", "stone q:20", "robe", },
     WCHOICE_NONE,
     { { SK_TRANSMUTATIONS, 1 }, { SK_EARTH_MAGIC, 3 }, { SK_SPELLCASTING, 2 },
@@ -124,7 +123,8 @@ static const map<job_type, job_def> job_data =
 { JOB_ENCHANTER, {
     "En", "Enchanter",
     0, 7, 5,
-    { SP_DEEP_ELF, SP_FELID, SP_KOBOLD, SP_SPRIGGAN, SP_NAGA, SP_VAMPIRE, },
+    { SP_FEN_ELF, SP_DEEP_ELF, SP_FELID, SP_KOBOLD, SP_SPRIGGAN, 
+      SP_NAGA, SP_VAMPIRE, },
     { "dagger plus:1", "robe plus:1", "book of Maledictions" },
     WCHOICE_NONE,
     { { SK_WEAPON, 1 }, { SK_HEXES, 3 }, { SK_SPELLCASTING, 2 },
@@ -145,8 +145,7 @@ static const map<job_type, job_def> job_data =
 { JOB_FIRE_ELEMENTALIST, {
     "FE", "Fire Elementalist",
     0, 7, 5,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_HILL_ORC, SP_NAGA, SP_TENGU, SP_DEMIGOD,
-      SP_GARGOYLE, },
+    { SP_DEEP_ELF, SP_HILL_ORC, SP_NAGA, SP_TENGU, SP_DEMIGOD, SP_GARGOYLE, },
     { "robe", "book of Flames" },
     WCHOICE_NONE,
     { { SK_CONJURATIONS, 1 }, { SK_FIRE_MAGIC, 3 }, { SK_SPELLCASTING, 2 },
@@ -167,7 +166,7 @@ static const map<job_type, job_def> job_data =
 { JOB_HUNTER, {
     "Hu", "Hunter",
     4, 3, 5,
-    { SP_HIGH_ELF, SP_HILL_ORC, SP_HALFLING, SP_KOBOLD, SP_OGRE, SP_TROLL,
+    { SP_FEN_ELF, SP_HILL_ORC, SP_HALFLING, SP_KOBOLD, SP_OGRE, SP_TROLL,
       SP_CENTAUR, },
     { "short sword", "leather armour" },
     WCHOICE_RANGED,
@@ -178,7 +177,7 @@ static const map<job_type, job_def> job_data =
 { JOB_ICE_ELEMENTALIST, {
     "IE", "Ice Elementalist",
     0, 7, 5,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_MERFOLK, SP_NAGA, SP_BASE_DRACONIAN,
+    { SP_DEEP_ELF, SP_MERFOLK, SP_NAGA, SP_BASE_DRACONIAN,
       SP_DEMIGOD, SP_GARGOYLE, },
     { "robe", "book of Frost" },
     WCHOICE_NONE,
@@ -211,7 +210,7 @@ static const map<job_type, job_def> job_data =
 { JOB_SKALD, {
     "Sk", "Skald",
     4, 4, 4,
-    { SP_HIGH_ELF, SP_HALFLING, SP_CENTAUR, SP_MERFOLK, SP_BASE_DRACONIAN,
+    { SP_FEN_ELF, SP_HALFLING, SP_CENTAUR, SP_MERFOLK, SP_BASE_DRACONIAN,
       SP_VAMPIRE, },
     { "leather armour", "book of Battle" },
     WCHOICE_PLAIN,
@@ -265,7 +264,7 @@ static const map<job_type, job_def> job_data =
 { JOB_WARPER, {
     "Wr", "Warper",
     3, 5, 4,
-    { SP_HALFLING, SP_HIGH_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_CENTAUR,
+    { SP_HALFLING, SP_FEN_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_CENTAUR,
       SP_BASE_DRACONIAN, },
     { "leather armour", "book of Spatial Translocations", "scroll of blinking",
       "tomahawk ego:dispersal q:5" },
@@ -278,7 +277,7 @@ static const map<job_type, job_def> job_data =
 { JOB_WIZARD, {
     "Wz", "Wizard",
     -1, 10, 3,
-    { SP_HIGH_ELF, SP_DEEP_ELF, SP_NAGA, SP_BASE_DRACONIAN, SP_OCTOPODE,
+    { SP_FEN_ELF, SP_DEEP_ELF, SP_NAGA, SP_BASE_DRACONIAN, SP_OCTOPODE,
       SP_HUMAN, SP_MUMMY, },
     { "robe", "hat", "book of Minor Magic" },
     WCHOICE_NONE,

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -149,7 +149,7 @@ static void _print_character_info(const newgame_def& ng)
 
 void choose_tutorial_character(newgame_def& ng_choice)
 {
-    ng_choice.species = SP_HIGH_ELF;
+    ng_choice.species = SP_FEN_ELF;
     ng_choice.job = JOB_FIGHTER;
     ng_choice.weapon = WPN_FLAIL;
 }
@@ -160,7 +160,7 @@ void choose_tutorial_character(newgame_def& ng_choice)
 static const species_type species_order[] =
 {
     // comparatively human-like looks
-    SP_HUMAN,          SP_HIGH_ELF,
+    SP_HUMAN,          SP_FEN_ELF,
     SP_DEEP_ELF,       SP_DEEP_DWARF,
     SP_HILL_ORC,
     // small species

--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -343,6 +343,24 @@ static const map<species_type, species_def> species_data =
     { SK_UNARMED_COMBAT },
 } },
 
+{ SP_FEN_ELF, {
+    "Fn",
+    "Fen Elf", "Elven", "Elf",
+    SPF_ELVEN,
+    -1, -1, 1,
+    15, 4,
+    MONS_ELF,
+    HT_LAND, US_ALIVE, SIZE_MEDIUM,
+    7, 11, 10, // 28
+    { STAT_INT, STAT_DEX }, 3,
+    {},
+    {},
+    {},
+    { JOB_HUNTER, JOB_ASSASSIN, JOB_SKALD, JOB_ARCANE_MARKSMAN, JOB_WIZARD,
+      JOB_ENCHANTER, JOB_AIR_ELEMENTALIST, JOB_EARTH_ELEMENTALIST, },
+    { SK_SHORT_BLADES, SK_LONG_BLADES, SK_STAVES, SK_UNARMED_COMBAT, SK_BOWS },
+} },
+
 { SP_FORMICID, {
     "Fo",
     "Formicid", nullptr, "Ant",
@@ -423,24 +441,6 @@ static const map<species_type, species_def> species_data =
     { JOB_FIGHTER, JOB_HUNTER, JOB_ASSASSIN, JOB_BERSERKER, JOB_ENCHANTER,
       JOB_AIR_ELEMENTALIST },
     { SK_SHORT_BLADES, SK_LONG_BLADES, SK_SLINGS },
-} },
-
-{ SP_HIGH_ELF, {
-    "HE",
-    "High Elf", "Elven", "Elf",
-    SPF_ELVEN,
-    -1, -1, 1,
-    15, 4,
-    MONS_ELF,
-    HT_LAND, US_ALIVE, SIZE_MEDIUM,
-    7, 11, 10, // 28
-    { STAT_INT, STAT_DEX }, 3,
-    {},
-    {},
-    {},
-    { JOB_HUNTER, JOB_SKALD, JOB_WIZARD, JOB_CONJURER, JOB_FIRE_ELEMENTALIST,
-      JOB_ICE_ELEMENTALIST, JOB_AIR_ELEMENTALIST },
-    { SK_SHORT_BLADES, SK_LONG_BLADES, SK_STAVES, SK_BOWS },
 } },
 
 { SP_HILL_ORC, {
@@ -771,6 +771,24 @@ static const map<species_type, species_def> species_data =
     { "fire immunity", "cold vulnerability" },
     {}, // not a starting race
     {}, // not a starting race
+} },
+
+{ SP_HIGH_ELF, {
+    "HE",
+    "High Elf", "Elven", "Elf",
+    SPF_ELVEN,
+    -1, -1, 1,
+    15, 4,
+    MONS_ELF,
+    HT_LAND, US_ALIVE, SIZE_MEDIUM,
+    7, 11, 10, // 28
+    { STAT_INT, STAT_DEX }, 3,
+    {},
+    {},
+    {},
+    { JOB_HUNTER, JOB_SKALD, JOB_WIZARD, JOB_CONJURER, JOB_FIRE_ELEMENTALIST,
+      JOB_ICE_ELEMENTALIST, JOB_AIR_ELEMENTALIST },
+    { SK_SHORT_BLADES, SK_LONG_BLADES, SK_STAVES, SK_BOWS },
 } },
 #endif
 // Ideally this wouldn't be necessary...

--- a/crawl-ref/source/test/stress/qw.rc
+++ b/crawl-ref/source/test/stress/qw.rc
@@ -1373,7 +1373,7 @@ end
 function intrinsic_dodgy()
   local sp = you.race()
   return (sp == "Deep Elf" or sp:find("Draconian") or sp == "Felid"
-          or sp == "Halfling" or sp == "High Elf" or sp == "Kobold"
+          or sp == "Halfling" or sp == "Fen Elf" or sp == "Kobold"
           or sp == "Merfolk" or sp == "Ogre" or sp == "Octopode"
           or sp == "Spriggan" or sp == "Troll")
 end
@@ -1416,7 +1416,7 @@ function weapon_choice()
   sp = you.race()
   if sp == "Felid" or sp == "Troll" or sp == "Ghoul" then
     return "Unarmed Combat"
-  elseif sp == "Halfling" or sp == "High Elf" then
+  elseif sp == "Halfling" or sp == "Fen Elf" then
     return "Long Blades"
   elseif sp == "Ogre" or sp == "Kobold" then
     return "Maces & Flails"

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -572,10 +572,11 @@ tileidx_t tilep_species_to_base_tile(int sp, int level)
     {
     case SP_HUMAN:
         return TILEP_BASE_HUMAN;
-    case SP_HIGH_ELF:
 #if TAG_MAJOR_VERSION == 34
+    case SP_HIGH_ELF:
     case SP_SLUDGE_ELF:
 #endif
+    case SP_FEN_ELF:
         return TILEP_BASE_ELF;
     case SP_DEEP_ELF:
         return TILEP_BASE_DEEP_ELF;

--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -124,6 +124,7 @@ sub aptitude_table
     my $seen_draconian_length;
     for my $sp (sort_species(@SPECIES))
     {
+        next if $sp eq 'High Elf';
         next if $sp eq 'Sludge Elf';
         next if $sp eq 'Djinni';
         next if $sp eq 'Lava Orc';


### PR DESCRIPTION
High Elves have a few problems.

1. They are a highly generic Tolkien race with no representation in the game (except, vaguely, Dowan and Duvessa, who anyway were referred to as "elven" instead of "high elven"). 
2. Their aptitudes and gameplay threaten to overlap onto other, more uniquely differentiated species (Human, Merfolk, Tengu). Attempts to give them minor adjustments to their aptitudes, while staying with the original boundaries, infringe onto other species. They are in a tight spot, design-wise. Their strongest points are their high attributes, incredible bows aptitude, good swordfighting, and good (but limited) spellcasting.

This PR addresses the first problem by tapping into the legacy of Sludge Elves. SE were removed three years ago, joining Elf and Grey Elf as elves who were insufficiently differentiated from other races. In their case, Merfolk did better everything SE could do. Further, "Elves, but evil and unscrupulous" is a flavor niche occupied by Deep Elves. These parts of SE should be discarded. 

High Elves thus are converted into Fen Elves (Fn). The idea of "primitive swamp-dwelling elves" is rarely found in other media, and resonates well with a Crawlian interpretation on fantasy tropes. Deep Elves (and Fannar) have been slightly reflavored as the descendants of Fen Elves which became magic-obsessed and ventured into the Dungeon seeking greater arcane knowledge. 

The second problem is addressed by somewhat ambitiously adjusting Fen Elf aptitudes. High Elf combat aptitudes remain intact: Fn are exceptional at bladework and are the best archers in the game along with Centaurs. Instead, Fn have had their magical aptitudes altered. They are poor at Conjurations and very poor at Fire and Ice Magic, but strong with Hexes, Charms, Earth, and Air Magic. This gives them a territory all their own, distinct from Merfolk (good with Charms, Transmutations, and Ice Magic) and Tengu (exceptional at Conjurations, Air Magic, and Summoning). Contrasted against Tengu, who supplement their melee combat aggressively and offensively with blasting conjurations and allies, Fen Elves support their combat skills through improving themselves, debilitating their enemies, and altering and controlling the battlefield. Fen Elves are also the only race in the game to have good aptitudes with both Earth and Air Magic. 

Fn are poor at Evocations, tied with Ogres and Mummies as the second worst race in the game using magical devices after Trolls. This makes them the only race in the game with high Intelligence to be exceptionally poor at Evocations, and encourages Fn characters to focus on spellcasting to diversify from melee combat. 

These aptitude changes not only help differentiate High Elves/Fen Elves and give them a distinct niche, but also strengthen the Fen Elf flavor by tying what they do with who they are. 