### PR TITLE
Make Clarity resist sleep

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -192,7 +192,7 @@ bool actor::can_sleep(bool holi_only) const
         return false;
 
     if (!holi_only)
-        return !(berserk() || asleep());
+        return !(berserk() || clarity() || asleep());
 
     return true;
 }


### PR DESCRIPTION
Affects Aizul, satyrs, dream sheep, sleeping needles, hibernation, one
Hell miscast effect, and Dithmenos wrath.

With the removal of "Clarity, the only way for players to gain Clarity
is via Ashenzari (where the buff wouldn't hurt), a mutation (rare!), or
the autumn katana (very rare!), so this seems fine to do.