### PR TITLE
Bug #10638: Halazid Warlock description typo

### DIFF
--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -1280,7 +1280,7 @@ die in battle than leave anything to an intruder.
 halazid warlock
 
 An ancient undead sorcerer. The halazid warlocks were exhumed and enslaved by
-the living divines Sheza and Sargol, forced to labour night night and day to
+the living divines Sheza and Sargol, forced to labour night and day to
 anchor the Twins to the world. The warlocks were not freed by their passing;
 even now, they work to resurrect their fallen masters.
 %%%%


### PR DESCRIPTION
Mantis Bug 10638  https://crawl.develz.org/mantis/view.php?id=10638

Repeated word in Halazid Warlock description ("night night")

Fixed to remove extraneous repeated night.