### PR TITLE
Reduce sleep damage bonus

### DIFF
--- a/crawl-ref/source/melee_attack.cc
+++ b/crawl-ref/source/melee_attack.cc
@@ -3634,7 +3634,7 @@ int melee_attack::apply_damage_modifiers(int damage, int damage_max)
                      || (attk_flavour == AF_SHADOWSTAB
                          &&!defender->can_see(*attacker))))
     {
-        damage = damage * 5 / 2;
+        damage = damage * 2;
         dprf(DIAG_COMBAT, "Stab damage vs %s: %d",
              defender->name(DESC_PLAIN).c_str(),
              damage);


### PR DESCRIPTION
This PR is just in case dream sheep become a problem. It seems that they've stabilized after the monspell changes and the sleep resistance duration got improved. Probably can be closed in a couple weeks if it's still unneeded.