### PR TITLE
Clarify which monster reflects damage (3774)

### DIFF
--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -184,7 +184,13 @@ void mirror_damage_fineff::fire()
 
     if (att == MID_PLAYER)
     {
-        mpr("Your damage is reflected back at you!");
+        const monster* reflector = defender() ?
+                                   defender()->as_monster() : nullptr;
+        if (reflector)
+            mprf("%s reflects your damage back at you!",
+                 reflector->name(DESC_THE).c_str());
+        else
+            mpr("Your damage is reflected back at you!");
         ouch(damage, KILLED_BY_MIRROR_DAMAGE);
     }
     else if (def == MID_PLAYER)


### PR DESCRIPTION
Doesn't cleanly handle the case where the monster is killed while
reflecting damage (since the monster no longer exists to have its name
called), but fixing that apparently may go on to cause more issues with
messaging.