### PR TITLE
Fix Desolation portal description

### DIFF
--- a/crawl-ref/source/feature-data.h
+++ b/crawl-ref/source/feature-data.h
@@ -376,7 +376,7 @@ PORTAL_ENTRANCE(DNGN_ENTER_BAILEY, "flagged portal", "enter_bailey", LIGHTRED),
 PORTAL_ENTRANCE(DNGN_ENTER_ICE_CAVE, "frozen archway", "enter_ice_cave", WHITE),
 PORTAL_ENTRANCE(DNGN_ENTER_VOLCANO, "dark tunnel", "enter_volcano", RED),
 PORTAL_ENTRANCE(DNGN_ENTER_WIZLAB, "magical portal", "enter_wizlab", ETC_SHIMMER_BLUE),
-PORTAL_ENTRANCE(DNGN_ENTER_DESOLATION, "ruined silver gateway", "enter_desolation", WHITE),
+PORTAL_ENTRANCE(DNGN_ENTER_DESOLATION, "ruined gateway", "enter_desolation", WHITE),
 #if TAG_MAJOR_VERSION == 34
 PORTAL_EXIT(DNGN_EXIT_PORTAL_VAULT, "gate leading back out of this place", "exit_portal_vault", ETC_SHIMMER_BLUE),
 #endif


### PR DESCRIPTION
Turns out I forgot to edit the entry in feature-data.h, so it wasn't
showing the portal description at all!