### PR TITLE
auto_butcher

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -811,6 +811,10 @@ void game_options::reset_options()
     cloud_status           = !is_tiles();
     darken_beyond_range    = true;
 
+    // MGD
+    auto_butcher           = false;
+    // MGD
+
     user_note_prefix       = "";
     note_all_skill_levels  = false;
     note_skill_max         = true;
@@ -2688,6 +2692,10 @@ void game_options::read_option_line(const string &str, bool runscript)
         else if (field == "auto")
             confirm_butcher = CONFIRM_AUTO;
     }
+    // MGD
+    else BOOL_OPTION(auto_butcher);
+    // MGD
+
     else BOOL_OPTION(easy_eat_chunks);
     else BOOL_OPTION(auto_eat_chunks);
     else if (key == "lua_file" && runscript)

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2869,6 +2869,10 @@ bool item_needs_autopickup(const item_def &item, bool ignore_force)
     if (in_inventory(item))
         return false;
 
+    // MGD mark corpses for pickup if auto_butcher is on
+    if( Options.auto_butcher && item.base_type == OBJ_CORPSES && !is_inedible(item) && !is_bad_food(item) )
+        return true;    
+
     if (item_is_stationary(item))
         return false;
 
@@ -3123,6 +3127,11 @@ static void _do_autopickup()
 
         if (item_needs_autopickup(mitm[o]))
         {
+            //MGD auto_butcher edible corpses
+            item_def& mi = mitm[o];
+            if( Options.auto_butcher && mi.base_type == OBJ_CORPSES && !is_inedible(mi) && !is_bad_food(mi) )
+                butchery(&mi);
+                            
             // Do this before it's picked up, otherwise the picked up
             // item will be in inventory and _interesting_explore_pickup()
             // will always return false.

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -216,6 +216,11 @@ public:
     bool        auto_eat_chunks; // allow eating chunks while resting or travelling
     skill_focus_mode skill_focus; // is the focus skills available
 
+    // MGD
+    bool        auto_butcher; // automatically butchers corpses while travelling
+    // MGD
+
+
     bool        note_all_skill_levels;  // take note for all skill levels (1-27)
     bool        note_skill_max;   // take note when skills reach new max
     string      user_note_prefix; // Prefix for user notes


### PR DESCRIPTION
Simple idea to make food less of a hassle, without changing gameplay much at all -- the auto_butcher option.  If enabled, the player automatically butchers all good edible corpses while travelling.  Great for spellcasters, who need to stave off hunger.  Sucks to have to remember to find and butcher corpses; now the game does it for you automatically!

Works best with `confirm_butcher = never` so it won't even ask you.

Would be even nicer if `explore_auto_rest = true` would fetch food (and items?) first, before resting.