### PR TITLE
Tutorial text fix

### DIFF
--- a/crawl-ref/source/dat/descript/tutorial.txt
+++ b/crawl-ref/source/dat/descript/tutorial.txt
@@ -538,7 +538,7 @@ tutorial4 undead
 # TODO: This is more like hints mode stuff. Not sure if there's any harm though,
 #       and the mouse interface hint is good.
 Unlike most monsters, zombies and skeletons do not regenerate health.
-<localtiles> Incidentally, you can also cast spells by pressing
+<localtiles> You can also attempt to re-cast the last spell you cast by pressing
 <input>Ctrl+leftclick</input> on the monster.</localtiles>
 %%%%
 tutorial4 spell_success

--- a/crawl-ref/source/dat/descript/tutorial.txt
+++ b/crawl-ref/source/dat/descript/tutorial.txt
@@ -538,7 +538,7 @@ tutorial4 undead
 # TODO: This is more like hints mode stuff. Not sure if there's any harm though,
 #       and the mouse interface hint is good.
 Unlike most monsters, zombies and skeletons do not regenerate health.
-<localtiles> You can also attempt to re-cast the last spell you cast by pressing
+<localtiles> You can also attempt to re-cast the last spell you used by pressing
 <input>Ctrl+leftclick</input> on the monster.</localtiles>
 %%%%
 tutorial4 spell_success


### PR DESCRIPTION
The current tutorial text states "Incidentally, you can also cast spells by pressing
Ctrl+leftclick on the monster." This may be a little unclear, since ctrl+clicking won't prompt for which spell to use, but rather cast the spell last used. We may want to update this text.