### PR TITLE
Make CrawlHashMap inherit from std::map

### DIFF
--- a/crawl-ref/source/enum.h
+++ b/crawl-ref/source/enum.h
@@ -3869,7 +3869,7 @@ enum mutation_type
     MUT_NON_MUTATION,
 };
 
-enum object_class_type                 // mitm[].base_type
+enum object_class_type : uint8_t           // mitm[].base_type
 {
     OBJ_WEAPONS,
     OBJ_MISSILES,

--- a/crawl-ref/source/externs.h
+++ b/crawl-ref/source/externs.h
@@ -504,7 +504,7 @@ typedef uint32_t iflags_t;
 
 struct item_def
 {
-    object_class_type base_type:8; ///< basic class (eg OBJ_WEAPON)
+    object_class_type base_type; ///< basic class (eg OBJ_WEAPON)
     uint8_t        sub_type;       ///< type within that class (eg WPN_DAGGER)
 #pragma pack(push,2)
     union

--- a/crawl-ref/source/store.h
+++ b/crawl-ref/source/store.h
@@ -265,7 +265,7 @@ public:
     const CrawlStoreValue& get_value(const char *key) const
     { return get_value(string(key)); }
     const CrawlStoreValue& operator[] (const string &key) const
-    { return get_value(string(key)); }
+    { return get_value(key); }
     const CrawlStoreValue& operator[] (const char *key) const
     { return get_value(string(key)); }
 

--- a/crawl-ref/source/store.h
+++ b/crawl-ref/source/store.h
@@ -247,34 +247,16 @@ protected:
 // make it homogeneous (which causes dynamic type checking) you have
 // to give a type to the hash table constructor; once it's been
 // created its type (or lack of type) is immutable.
-class CrawlHashTable
+class CrawlHashTable : public map<string, CrawlStoreValue>
 {
 public:
-    CrawlHashTable();
-    CrawlHashTable(const CrawlHashTable& other);
-
-    ~CrawlHashTable();
-
-    typedef map<string, CrawlStoreValue>  hash_map_type;
-    typedef hash_map_type::iterator       iterator;
-    typedef hash_map_type::const_iterator const_iterator;
-
-protected:
-    // NOTE: Not using auto_ptr because making hash_map an auto_ptr
-    // causes compile weirdness in externs.h
-    hash_map_type *hash_map;
-
-    void init_hash_map();
-
     friend class CrawlStoreValue;
-
-public:
-    CrawlHashTable &operator = (const CrawlHashTable &other);
 
     void write(writer &) const;
     void read(reader &);
 
     bool exists(const string &key) const;
+
     void assert_validity() const;
 
     // NOTE: If the const versions of get_value() or [] are given a
@@ -283,7 +265,7 @@ public:
     const CrawlStoreValue& get_value(const char *key) const
     { return get_value(string(key)); }
     const CrawlStoreValue& operator[] (const string &key) const
-    { return get_value(key); }
+    { return get_value(string(key)); }
     const CrawlStoreValue& operator[] (const char *key) const
     { return get_value(string(key)); }
 
@@ -297,24 +279,9 @@ public:
     CrawlStoreValue& get_value(const string &key);
     CrawlStoreValue& get_value(const char *key)
     { return get_value(string(key)); }
-    CrawlStoreValue& operator[] (const string &key)
-    { return get_value(key); }
+    using map::operator[];
     CrawlStoreValue& operator[] (const char *key)
     { return get_value(string(key)); }
-
-    // std::map style interface
-    unsigned int size() const;
-    bool      empty() const;
-
-    void      erase(const string& key);
-    void      erase(const char *key) { erase(string(key)); }
-    void      clear();
-
-    const_iterator begin() const;
-    const_iterator end() const;
-
-    iterator  begin();
-    iterator  end();
 };
 
 // A CrawlVector is the vector version of CrawlHashTable, except that


### PR DESCRIPTION
Compiles without warnings and seems to work fine (I can save/load games, tweak artefact props, etc). 

But it would be a pretty big deal if there were a mistake in this commit, so I'd like it reviewed by someone before I merge it.