### PR TITLE
Mennas weapon upgrade

### DIFF
--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -695,7 +695,6 @@ static void _give_weapon(monster* mon, int level, bool melee_only = false,
             { { SPWPN_FLAMING, 1 } },
         } },
         { MONS_DAEVA,                   DAEVA_WSPEC },
-        { MONS_MENNAS,                  DAEVA_WSPEC },
         { MONS_PROFANE_SERVITOR,
             { { { WPN_DEMON_WHIP,       1 },
                 { WPN_WHIP,             3 }, },
@@ -1085,9 +1084,17 @@ static void _give_weapon(monster* mon, int level, bool melee_only = false,
 
     case MONS_ANGEL:
     case MONS_DAEVA:
-    case MONS_MENNAS:
     case MONS_PROFANE_SERVITOR:
         set_equip_desc(item, ISFLAG_GLOWING); // will never come up...
+        break;
+
+    case MONS_MENNAS:
+        item.base_type = OBJ_WEAPONS;
+        item.sub_type = random_choose(WPN_TRISHULA,
+                                      WPN_SACRED_SCOURGE,
+                                      WPN_EUDEMON_BLADE);
+        set_item_ego_type(item, OBJ_WEAPONS, SPWPN_HOLY_WRATH);
+        level = binomial(5, 50);
         break;
 
     case MONS_DONALD:


### PR DESCRIPTION
Always give mennas a holy base weapon type, which makes him the only monster who can possibly spawn with a trishula in-game.