### PR TITLE
Don't display extra message for known scroll of acquirement

### DIFF
--- a/crawl-ref/source/item_use.cc
+++ b/crawl-ref/source/item_use.cc
@@ -2746,7 +2746,10 @@ void read_scroll(item_def& scroll)
         break;
 
     case SCR_ACQUIREMENT:
-        mpr("This is a scroll of acquirement!");
+        if (!alreadyknown)
+        {
+            mpr("This is a scroll of acquirement!");
+        }
         // included in default force_more_message
         // Identify it early in case the player checks the '\' screen.
         set_ident_type(scroll, true);


### PR DESCRIPTION
It's weird to see exciting "This is a scroll of acquirement!" when you already know what you are reading.

Read which item? (? for menu, Esc to quit)
As you read the scroll of acquirement, it crumbles to dust.
This is a scroll of acquirement!
[a] Weapon [b] Armour        [c] Jewellery [d] Book [e] Staff  
[f] Wand   [g] Miscellaneous [h] Food      [i] Gold [j] Ammunition
