### PR TITLE
Exclude "MacOSX.sdk" from the SDK search for Mac OS X builds

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -432,7 +432,7 @@ endif
 
 # Find the oldest SDK available, in attempt to make this build as
 # backward-compatible as we possibly can.
-SDK_VER := $(shell ls $(DEVELOPER_PATH)/SDKs | sort -n | head -1 | perl -pe 's/^MacOSX//g;s/.sdk$$//g')
+SDK_VER := $(shell ls $(DEVELOPER_PATH)/SDKs | grep -v "MacOSX.sdk" | sort -n | head -1 | perl -pe 's/^MacOSX//g;s/.sdk$$//g')
 
 ifeq ($(SDK_VER),10.4u)
 SDK_VER := 10.4


### PR DESCRIPTION
In Sierra with Xcode 8 installed an SDK "MacOSX.sdk" with no version
number appears in the list of installed SDKs and this causes the
SDK version to come out empty.  We should exclude this special case
from the list of SDKs to consider so we find only the versioned
SDKs.  This change gets crawl building again on Mac OS X using, e.g.
"make APPLE_GCC=y NO_PKGCONFIG=y CONTRIB_SDL=y TILES=y".