### PR TITLE
Color the text when an object is identified by a scroll of identify.

### DIFF
--- a/crawl-ref/source/item_use.cc
+++ b/crawl-ref/source/item_use.cc
@@ -2235,7 +2235,7 @@ static bool _identify(bool alreadyknown, const string &pre_msg)
     set_ident_flags(item, ISFLAG_IDENT_MASK);
 
     // Output identified item.
-    mprf_nocap("%s", item.name(DESC_INVENTORY_EQUIP).c_str());
+    mprf_nocap("%s", get_menu_colour_prefix_tags(item, DESC_INVENTORY_EQUIP).c_str());
     if (in_inventory(item))
     {
         if (item.link == you.equip[EQ_WEAPON])


### PR DESCRIPTION
Previously, the text shown when an object was identified was always grey. Now, for example, the text identifying a scroll of random uselessness will be dark gray, and when following Chei a potion of haste will be shown in red. 