### PR TITLE
Put a symlink to init.txt in a sensible place for Mac OS X users

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -76,6 +76,9 @@
 #include <shlobj.h>
 #elif defined (__APPLE__)
 extern char **NXArgv;
+#ifndef DATA_DIR_PATH
+#include <unistd.h>
+#endif
 #elif defined (__linux__)
 #include <unistd.h>
 #endif
@@ -1555,7 +1558,31 @@ void read_init_file(bool runscript)
     }
 
     // Load init.txt.
-    const string init_file_name(find_crawlrc());
+    const string crawl_rc = find_crawlrc();
+    const string init_file_name(crawl_rc);
+
+    /**
+     Mac OS X apps almost always put their user-modifiable configuration files
+     in the Application Support directory.  On Mac OS X when DATA_DIR_PATH is
+     not defined, place a symbolic link to the init.txt file in crawl_dir
+     (probably "~/Library/Application Support/Dungeon Crawl Stone Soup") where
+     the user is likely to go looking for it.
+     */
+#if defined(TARGET_OS_MACOSX) && !defined(DATA_DIR_PATH)
+    char *cwd = getcwd(NULL, 0);
+    if (cwd)
+    {
+        const string absolute_crawl_rc = is_absolute_path(crawl_rc) ? crawl_rc : catpath(cwd, crawl_rc);
+        char *resolved = realpath(absolute_crawl_rc.c_str(), NULL);
+        if (resolved)
+        {
+            const string crawl_dir_init = catpath(SysEnv.crawl_dir.c_str(), "init.txt");
+            symlink(resolved, crawl_dir_init.c_str());
+            free(resolved);
+        }
+        free(cwd);
+    }
+#endif
 
     FileLineInput f(init_file_name.c_str());
 


### PR DESCRIPTION
Mac OS X users will never expect to find init.txt inside the .app
bundle.  The standard place for such files on Mac OS X is in
~/Library/Application Support/<app name>, so on startup we should
put a symbolic link to whatever init.txt file we're going to use
in ~/Library/Application Support/Dungeon Crawl Stone Soup (or
wherever we're putting morgue and saves anyway).

Note that symlink will not overwrite an existing file.
