### PR TITLE
WebTiles. Show unvisited areas on minimap. Fix #389.

### DIFF
--- a/crawl-ref/source/webserver/game_data/static/minimap.js
+++ b/crawl-ref/source/webserver/game_data/static/minimap.js
@@ -162,6 +162,25 @@ function ($, map_knowledge, dungeon_renderer, view_data,
     function update(x, y, cell)
     {
         cell = cell || map_knowledge.get(x, y);
+
+        if (cell.mf && cell.mf != enums.MF_WALL && cell.mf != enums.MF_MAP_WALL)
+        {
+            for (var i = -1; i <= 1; i++)
+            {
+                for (var j = -1; j <= 1; j++)
+                {
+                    if (i != 0 || j != 0)
+                    {
+                        var c = map_knowledge.get(x + i, y + j);
+                        if (!c.mf)
+                        {
+                            set(x + i, y + j, minimap_colours[enums.MF_MAP_WALL]);
+                        }
+                    }
+                }
+            }
+        }
+
         if (x == player.pos.x && y == player.pos.y)
             set(x, y, minimap_colours[enums.MF_PLAYER]);
         else


### PR DESCRIPTION
Used MF_MAP_WALL color instead MF_MAP_FLOOR (more contrast).

Original minimap:
![image](https://cloud.githubusercontent.com/assets/13585370/20175895/2e7ec26e-a756-11e6-9795-7fdacf3a1dfb.png)
MF_MAP_FLOOR color:
![image](https://cloud.githubusercontent.com/assets/13585370/20175903/43f91518-a756-11e6-8c50-63f8fe89e5e5.png)
MF_MAP_WALL color:
![image](https://cloud.githubusercontent.com/assets/13585370/20175880/15a3e5a8-a756-11e6-98b5-f871d5729bc5.png)
