### PR TITLE
Simplify base UC damage for forms

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -128,7 +128,7 @@ deplete magical power.
 Blade Hands spell
 
 Causes long, scythe-shaped blades to grow from the caster's hands, increasing
-melee damage to a degree depending on strength and dexterity.
+melee damage significantly.
 
 While transformed, any equipped weapons are melded. The caster also becomes
 unable to evoke wands, and casting spells becomes somewhat more difficult.
@@ -495,8 +495,8 @@ Dragon Form spell
     desc = desc .. "."
 
     return desc
-}} The caster's melee damage will be substantially increased to a degree
-depending on strength, and they become much more robust but less evasive.
+}} The caster will find this form offers incredible melee damage and greatly
+increased robustness (though reduced evasiveness).
 
 While transformed, any equipped weapons and armour are melded.
 %%%%
@@ -1298,9 +1298,9 @@ the target may have.
 Statue Form spell
 
 Transforms the caster into a slow but extremely robust stone statue. The
-caster's unarmed damage will be increased to a degree depending on strength,
-and all melee attacks will be substantially more powerful. The caster's stone
-body is insulated from electricity and gains resistance to poison, rotting and
+caster's unarmed damage will be increased a moderate degree, and all melee
+attacks will be substantially more powerful. The caster's stone body is
+insulated from electricity and gains resistance to poison, rotting and
 negative energy.
 
 While transformed, any equipped body armour, gloves and boots are melded.

--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -505,7 +505,7 @@ slightly reduced, and you are unable to evoke wands.
 Blade status
 
 Long, scythe-shaped blades have grown from your hands, increasing your melee
-damage to a degree depending on strength and dexterity.
+damage to a significant degree.
 
 Any equipped weapons are melded. Your success rate with spells is somewhat
 reduced, and you are unable to evoke wands.
@@ -513,9 +513,8 @@ reduced, and you are unable to evoke wands.
 Statue status
 
 You have been transformed into a slow but extremely robust stone statue.
-Your unarmed damage is increased to a degree depending on strength, and in
-addition all of your melee attacks are substantially more powerful. Your stone
-body is insulated from electricity and gains resistance to poison, rotting and
+Your unarmed damage is increased to a moderate degree. Your stone body is
+is insulated from electricity and gains resistance to poison, rotting and
 negative energy.
 
 Any equipped body armour, gloves and boots are melded.
@@ -559,8 +558,8 @@ Dragon status
     desc = desc .. "."
 
     return desc
-}} Your melee damage is substantially increased to a degree depending on
-strength, and you are much more robust but less evasive.
+}} Your melee damage is increased incredibly, and you are much more robust
+(though less evasive).
 
 Any equipped weapons and armour are melded.
 %%%%

--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -78,7 +78,7 @@ static const form_entry formdata[] =
     "",
     EQF_HANDS, MR_NO_FLAGS,
     FormDuration(10, PS_SINGLE, 100), 0, 0, SIZE_CHARACTER, 10,
-    0, 0, 0, true, 20, 12, -1,
+    0, 0, 0, true, 20, 12, 22,
     SPWPN_NORMAL, RED, "", { "hit", "slash", "slice", "shred" },
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, true,
     "", 0, "scythe-like blade", "", "", ""
@@ -88,7 +88,7 @@ static const form_entry formdata[] =
     "a stone statue.",
     EQF_STATUE, MR_RES_ELEC | MR_RES_NEG | MR_RES_PETRIFY,
     DEFAULT_DURATION, 0, 0, SIZE_CHARACTER, 13,
-    20, 12, 0, true, 0, 9, -1,
+    20, 12, 0, true, 0, 9, 12,
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_FORBID, FC_FORBID, false, true,
     "", 0, "", "", "place yourself before", "stone"
@@ -109,7 +109,7 @@ static const form_entry formdata[] =
     "a fearsome dragon!",
     EQF_PHYSICAL, MR_RES_POISON,
     DEFAULT_DURATION, 10, 0, SIZE_GIANT, 15,
-    16, 0, 0, true, 0, 10, -1,
+    16, 0, 0, true, 0, 10, 32,
     SPWPN_NORMAL, GREEN, "Teeth and claws", { "hit", "claw", "bite", "maul" },
     FC_ENABLE, FC_FORBID, FC_ENABLE, true, false,
     "roar", 6, "foreclaw", "", "bow your head before", "flesh"

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -489,14 +489,6 @@ public:
     static const FormBlade &instance() { static FormBlade inst; return inst; }
 
     /**
-     * Find the player's base unarmed damage in this form.
-     */
-    int get_base_unarmed_damage() const override
-    {
-        return 8 + div_rand_round(you.strength() + you.dex(), 3);
-    }
-
-    /**
      * % screen description
      */
     string get_long_name() const override
@@ -558,14 +550,6 @@ private:
     DISALLOW_COPY_AND_ASSIGN(FormStatue);
 public:
     static const FormStatue &instance() { static FormStatue inst; return inst; }
-
-    /**
-     * Find the player's base unarmed damage in this form.
-     */
-    int get_base_unarmed_damage() const override
-    {
-        return 6 + div_rand_round(you.strength(), 3);
-    }
 
     /**
      * Get a message for transforming into this form.
@@ -688,15 +672,6 @@ public:
         if (species_is_draconian(you.species))
             return 1000;
         return Form::get_ac_bonus();
-    }
-
-    /**
-     * Find the player's base unarmed damage in this form.
-     */
-    int get_base_unarmed_damage() const override
-    {
-        // You also get another 6 damage from claws.
-        return 12 + div_rand_round(you.strength() * 2, 3);
     }
 
     /**


### PR DESCRIPTION
Blade hands, statue form and dragon form all had base unarmed damage
that scaled with strength (and dexterity, for blade hands). Remove this
scaling and replace it with flat damage.

Naive damage comparison, using the average stats of winning transmuters
at various XLs:
* XL10 (17str, 20dex)
* XL15 (22str, 24dex)
* XL20 (25str, 25dex)
* XL27 (28str, 28dex)

Blade Hands (10% more at XL10, 20% less at XL27):
* XL10: Old: 20, New: 22
* XL15: Old: 23, New: 22
* XL20: Old: 25, New: 22
* XL27: Old: 27, New: 22

Statue Form (same at XL10, 20% less at XL27):
* XL10: Old: 12, New: 12
* XL15: Old: 13, New: 12
* XL20: Old: 14, New: 12
* XL27: Old: 15, New: 12

Dragon Form (40% more at XL10, same at XL27):
* XL10: Old: 23, New: 32
* XL15: Old: 27, New: 32
* XL20: Old: 29, New: 32
* XL27: Old: 31, New: 32