### PR TITLE
Simplify demonic guardian spawning/despawning

### DIFF
--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -2380,7 +2380,7 @@ int mon_enchant::calc_duration(const monster* mons,
         cturn = 1000 / _mod_speed(50, mons->speed);
         break;
     case ENCH_LIFE_TIMER:
-        cturn = 10 * (4 + random2(4)) / _mod_speed(10, mons->speed);
+        cturn = 20 * (4 + random2(4)) / _mod_speed(10, mons->speed);
         break;
     case ENCH_INNER_FLAME:
         return random_range(25, 35) * 10;

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2320,27 +2320,8 @@ static bool _balance_demonic_guardian()
     monster_iterator mons;
 
     // tension is unfavorably high, perhaps another guardian should spawn
-    if (tension*3/4 > mutlevel*6 + random2(mutlevel*mutlevel*2))
+    if (tension*3/4 > mutlevel*mutlevel*3 + random2(mutlevel*mutlevel*2))
         return false;
-
-    for (int i = 0; mons && i <= 20/mutlevel; ++mons)
-    {
-        mons_val = get_monster_tension(**mons, GOD_NO_GOD);
-        const mon_attitude_type att = mons_attitude(**mons);
-
-        if (testbits(mons->flags, MF_DEMONIC_GUARDIAN)
-            && total < random2(mutlevel * 5)
-            && att == ATT_FRIENDLY
-            && !one_chance_in(3)
-            && !mons->has_ench(ENCH_LIFE_TIMER))
-        {
-            mprf("%s %s!", mons->name(DESC_THE).c_str(),
-                           summoned_poof_msg(*mons).c_str());
-            monster_die(*mons, KILL_NONE, NON_MONSTER);
-        }
-        else
-            total += mons_val;
-    }
 
     return true;
 }


### PR DESCRIPTION
Don't despawn demonic guardian based on tension, instead make them
behave more like normal summons. This changes the life timer enchantment
from a 'guaranteed minimum' duration to 'summon length' duration --
double it in recompense.

Finally, lower the tension requirements to spawn a guardian at level 1 &
2.