### PR TITLE
Don't create Qaz clouds over firewood

### DIFF
--- a/crawl-ref/source/godpassive.cc
+++ b/crawl-ref/source/godpassive.cc
@@ -977,6 +977,11 @@ void qazlal_storm_clouds()
         if (cell_is_solid(*ri) || cloud_at(*ri))
             continue;
 
+        // Don't create clouds over firewood
+        const monster * mon = monster_at(*ri);
+        if (mon != nullptr && mons_is_firewood(*mon))
+            continue;
+
         // No clouds in corridors.
         for (adjacent_iterator ai(*ri); ai; ++ai)
             if (!cell_is_solid(*ai))


### PR DESCRIPTION
The messages generated by burning/freezing flora made resting in certain
places (especially lair) quite noisy/tedious.

Hopefully doesn't prevent any cool tech?