### PR TITLE
Buff !cancellation (Yermak)

### DIFF
--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -454,7 +454,7 @@ public:
         debuff_player();
         mpr("You feel magically purged.");
         const int old_contam_level = get_contamination_level();
-        contaminate_player(-1 * (1000 + random2(4000)));
+        contaminate_player(-1 * (3000 + random2(2000)));
         if (old_contam_level && old_contam_level == get_contamination_level())
             mpr("You feel slightly less contaminated with magical energies.");
         return true;


### PR DESCRIPTION
Instead of removing 1000-5000 contamination, remove 3000-5000.

For reference, yellow contam is 3333 and (light)red is 5000.