### PR TITLE
Terminal rendering option fixes (for PR #377)

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -134,8 +134,8 @@ The contents of this text are:
 5-b     DOS and Windows.
                 dos_use_background_intensity
 5-c     Unix.
-                no_dark_brand, blink_brightens_background,
-                bold_brightens_foreground, best_effort_brighten_background,
+                blink_brightens_background, bold_brightens_foreground,
+                best_effort_brighten_background,
                 best_effort_brighten_foreground, background_colour,
                 foreground_colour, use_fake_cursor
 
@@ -2508,15 +2508,6 @@ dos_use_background_intensity = false
 
 5-c     Unix.
 -------------
-no_dark_brand = true
-        Assume that dark grey will end up rendered identically to black.
-        I.e., bright black rendering is assumed to be broken for the terminal.
-
-        For a value of false to take effect, appropriate rendering assumptions
-        must also be enabled. See the blink_brightens_background,
-        bold_brightens_foreground, and allow_extended_colours options for more
-        details.
-
 blink_brightens_background = false
         For 8-colour mode, assume that a blink text attribute will end up
         brightening the background colour.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -136,8 +136,8 @@ The contents of this text are:
 5-c     Unix.
                 blink_brightens_background, bold_brightens_foreground,
                 best_effort_brighten_background,
-                best_effort_brighten_foreground, background_colour,
-                foreground_colour, use_fake_cursor
+                best_effort_brighten_foreground, allow_extended_colours,
+                background_colour, foreground_colour, use_fake_cursor
 
 6-  Lua.
 6-a     Including lua files.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -134,7 +134,10 @@ The contents of this text are:
 5-b     DOS and Windows.
                 dos_use_background_intensity
 5-c     Unix.
-                background_colour, use_fake_cursor
+                no_dark_brand, blink_brightens_background,
+                bold_brightens_foreground, best_effort_brighten_background,
+                best_effort_brighten_foreground, background_colour,
+                foreground_colour, use_fake_cursor
 
 6-  Lua.
 6-a     Including lua files.
@@ -2509,37 +2512,49 @@ no_dark_brand = true
         Assume that dark grey will end up rendered identically to black.
         I.e., bright black rendering is assumed to be broken for the terminal.
 
+        For a value of false to take effect, appropriate rendering assumptions
+        must also be enabled. See the blink_brightens_background,
+        bold_brightens_foreground, and allow_extended_colours options for more
+        details.
+
 blink_brightens_background = false
-        Assume that a blink text attribute will end up brightening the
-        background colour.
+        For 8-colour mode, assume that a blink text attribute will end up
+        brightening the background colour.
 
         If enabled on a terminal where this assumption does not hold, this will
-        result in invisible glyphs for normal/bright color combos of the same
+        result in invisible glyphs for normal/bright colour combos of the same
         base colour.
+
+        This option is ignored when running in 16-colour mode via
+        allow_extended_colours.
 
 bold_brightens_foreground = false
-        Assume that a bold text attribute will end up brightening the foreground
-        colour.
+        For 8-colour mode, assume that a bold text attribute will end up
+        brightening the foreground colour.
 
-        If enabled on a terminal where this assumption does not hold, this will
-        result in invisible glyphs for bright/normal color combos of the same
-        base colour.
+        See blink_brightens_background for more information.
 
 best_effort_brighten_background = true
         If set to true, try to brighten a background colour using blink even if
         it is not assumed to be successful.
 
-        This option only affects colors which are safe to brighten. If the
+        This option only affects colours which are safe to brighten. If the
         blink_brightens_background option is set to true, this option is
         effectively ignored.
+
+        This option is ignored when running in 16-colour mode via
+        allow_extended_colours.
 
 best_effort_brighten_foreground = true
         If set to true, try to brighten a foreground colour using bold even if
         it is not assumed to be successful.
 
-        This option only affects colors which are safe to brighten. If the
+        This option only affects colours which are safe to brighten. If the
         bold_brightens_foreground option is set to true, this option is
         effectively ignored.
+
+        This option is ignored when running in 16-colour mode via
+        allow_extended_colours.
 
 allow_extended_colours = false
         Allow an *attempt* to use more than the eight basic terminal colours
@@ -2549,28 +2564,36 @@ allow_extended_colours = false
         the terminal, use the terminal's extended colour palette directly for
         internal colours.
 
-        If both of these conditions are not met, crawl will fall back to
-        rendering bright colors using character attributes.
+        An appropriate TERM environment variable must be set for this option to
+        function as expected for capable terminals. For example:
+          * XTerm: xterm-256color
+          * gnome-terminal: vte-256color
+          * PuTTY: putty-256color
+            (set in 'Connection->Data->Terminal-type string')
+
+        If these conditions are not met, crawl will fall back to 8-colour mode
+        and use character attributes to render bright colours.
 
 background_colour = black
         Sets the default background colour by name (defaults to BLACK).
         This may be useful if you're using a terminal with a background
-        colour other than black (such as an xterm) and don't want to change
-        the terminal's palette just for crawl.
+        colour other than black and wish to retain the colour scheme for crawl.
 
         Internally, black is mapped to the the passed background colour and
         vice-versa.
 
         This option requires extended support by the terminal library as well
-        as the terminal itself. Additionally, bright default colors are not
-        available unless extended color support is present and enabled. If
-        support is not present, either outright or for the selected colour,
-        this option will have an effective value of black.
+        as the terminal itself. Additionally, bright default colours are not
+        available unless extended colour support is present and explicitly
+        enabled via allow_extended_colours. If support is not present, either
+        outright or for the selected colour, this option will have an effective
+        value of black.
 
-        The allow_extended_colors option may help with with enabling bright
-        background colors. Beware of buggy or misleading terminfo files.
+        See the allow_extended_colours option for more information on enabling
+        use of bright default colours. Beware of buggy or misleading terminfo
+        files.
 
-foreground_color = lightgrey
+foreground_colour = lightgrey
         Sets the default foreground colour by name (defaults to LIGHTGREY).
 
         Internally, lightgrey is mapped to the passed foreground colour and

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -155,10 +155,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(auto_butcher), false),
         new BoolGameOption(SIMPLE_NAME(easy_eat_chunks), false),
         new BoolGameOption(SIMPLE_NAME(auto_eat_chunks), true),
-// This is useful for terms where dark grey does
-// not have standout modes (since it's black on black).
-// This option will use light-grey instead in these cases.
-        new BoolGameOption(SIMPLE_NAME(no_dark_brand), true),
         new BoolGameOption(SIMPLE_NAME(blink_brightens_background), false),
         new BoolGameOption(SIMPLE_NAME(bold_brightens_foreground), false),
         new BoolGameOption(SIMPLE_NAME(best_effort_brighten_background), true),
@@ -229,7 +225,6 @@ const vector<GameOption*> game_options::build_options_list()
                              CHATTR_HILITE | (YELLOW << 8)),
         new CursesGameOption(SIMPLE_NAME(feature_item_brand), CHATTR_REVERSE),
         new CursesGameOption(SIMPLE_NAME(trap_item_brand), CHATTR_REVERSE),
-        // no_dark_brand applies here as well.
         new CursesGameOption(SIMPLE_NAME(heap_brand), CHATTR_REVERSE),
         new IntGameOption(SIMPLE_NAME(note_hp_percent), 5, 0, 100),
         new IntGameOption(SIMPLE_NAME(hp_warning), 30, 0, 100),

--- a/crawl-ref/source/l_option.cc
+++ b/crawl-ref/source/l_option.cc
@@ -49,7 +49,6 @@ static option_handler handlers[] =
     { "easy_unequip",  &Options.easy_unequip, option_hboolean },
     { "note_skill_max",       &Options.note_skill_max, option_hboolean },
     { "clear_messages",  &Options.clear_messages, option_hboolean },
-    { "no_dark_brand",   &Options.no_dark_brand, option_hboolean },
     { "blink_brightens_background", &Options.blink_brightens_background,
                                    option_hboolean },
     { "bold_brightens_foreground", &Options.bold_brightens_foreground,

--- a/crawl-ref/source/libunix.cc
+++ b/crawl-ref/source/libunix.cc
@@ -1115,27 +1115,6 @@ static short curs_get_fg_color_non_identical(short fg, short bg)
         }
     }
 
-    // Special case: bright black, due to the history of broken terminals.
-    if (Options.no_dark_brand)
-    {
-        const short curses_black = translate_colour(BLACK);
-        const short curses_darkgrey = translate_colour(DARKGREY);
-        short * colours_to_change[] =
-        {
-            &fg_to_compare,
-            &bg_to_compare,
-            &fg_default_to_compare,
-            &bg_default_to_compare
-        };
-
-        // Convert any darkgreys to black.
-        for (size_t i = 0; i < ARRAYSZ(colours_to_change); i++)
-        {
-            if (*(colours_to_change[i]) == curses_darkgrey)
-                *(colours_to_change[i]) = curses_black;
-        }
-    }
-
     // Got the adjusted colors -- resolve any conflict.
     if (fg_to_compare == bg_to_compare)
     {

--- a/crawl-ref/source/libunix.cc
+++ b/crawl-ref/source/libunix.cc
@@ -1161,7 +1161,6 @@ static short curs_get_fg_color_non_identical(short fg, short bg)
                 }
                 else
                     failsafe_col = COLOR_WHITE;
-                failsafe_col = COLOR_BLUE;
                 break;
             case COLOR_WHITE:
                 if (fg_default_to_compare == COLOR_WHITE
@@ -1171,7 +1170,6 @@ static short curs_get_fg_color_non_identical(short fg, short bg)
                 }
                 else
                     failsafe_col = COLOR_BLACK;
-                failsafe_col = COLOR_BLUE;
                 break;
             default:
                 failsafe_col = COLOR_BLACK;

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -242,7 +242,6 @@ public:
     bool        small_more;       // Show one-char more prompts.
     unsigned    friend_brand;     // Attribute for branding friendly monsters
     unsigned    neutral_brand;    // Attribute for branding neutral monsters
-    bool        no_dark_brand;    // Assume dark grey is displayed as black.
     bool        blink_brightens_background; // Assume blink will brighten bg.
     bool        bold_brightens_foreground; // Assume bold will brighten fg.
     bool        best_effort_brighten_background; // Allow bg brighten attempts.


### PR DESCRIPTION
Includes:
- A fix for a failsafe colour problem (amalloy)
- Fixes and tweaks for the options guide
- Removal of the no_dark_brand option (|amethyst)