### PR TITLE
Prevent Makefile from blowing away the prefix and chroot_prefix

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -370,9 +370,6 @@ MCHMOD_LOGS := 664
 INSTALL_UGRP := games:games
 endif
 
-chroot_prefix :=
-prefix        :=
-
 ifeq ($(patsubst %/local,%,$(patsubst %/,%,$(prefix))),/usr)
 FHS := yes
 endif


### PR DESCRIPTION
The Makefile was initializing prefix and chroot_prefix to empty
strings, but never actually wrote anything "useful" to these
variables.  The builder is meant to be able to specify prefix
(per the examples in the Typical parameters notes at the top
of the Makefile).  chroot_prefix is also probably meant to be
specified similarly, though it seems to be an undocumented
option.

Fixes #412 