### PR TITLE
Remove special case for tiles tool tip for cards (fixes #391)

### DIFF
--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -429,12 +429,6 @@ bool InventoryRegion::update_tip_text(string& tip)
                 }
                 break;
             case OBJ_MISCELLANY:
-                if (item.sub_type >= MISC_FIRST_DECK
-                    && item.sub_type <= MISC_LAST_DECK)
-                {
-                    _handle_wield_tip(tmp, cmd);
-                    break;
-                }
                 tmp += "Evoke (V)";
                 cmd.push_back(CMD_EVOKE);
                 break;


### PR DESCRIPTION
Cards are now evoked like normal miscellany type objects, so
there shouldn't be a special case to say left clicking cards
will "wield" them.