### PR TITLE
Allow travel trails to be cleared while in the level map.

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1893,21 +1893,6 @@ static void _do_rest()
     _start_running(RDIR_REST, RMODE_REST_DURATION);
 }
 
-static void _do_clear_map()
-{
-    if (Options.show_travel_trail && env.travel_trail.size())
-    {
-        mpr("Clearing travel trail.");
-        clear_travel_trail();
-    }
-    else
-    {
-        mpr("Clearing level map.");
-        clear_map();
-        crawl_view.set_player_at(you.pos());
-    }
-}
-
 static void _do_display_map()
 {
     if (Hints.hints_events[HINT_MAP_VIEW])
@@ -2073,7 +2058,7 @@ void process_command(command_type cmd)
     case CMD_TOGGLE_TRAVEL_SPEED:        _toggle_travel_speed(); break;
 
         // Map commands.
-    case CMD_CLEAR_MAP:       _do_clear_map();   break;
+    case CMD_CLEAR_MAP:       clear_map_or_travel_trail(); break;
     case CMD_DISPLAY_OVERMAP: display_overview(); break;
     case CMD_DISPLAY_MAP:     _do_display_map(); break;
 

--- a/crawl-ref/source/map_knowledge.cc
+++ b/crawl-ref/source/map_knowledge.cc
@@ -14,6 +14,7 @@
  #include "tilepick.h"
  #include "tileview.h"
 #endif
+#include "travel.h"
 #include "view.h"
 
 void set_terrain_mapped(const coord_def gc)
@@ -65,6 +66,21 @@ void clear_map(bool clear_items, bool clear_mons)
 #ifdef USE_TILE
         tile_reset_fg(p);
 #endif
+    }
+}
+
+void clear_map_or_travel_trail()
+{
+    if (Options.show_travel_trail && env.travel_trail.size())
+    {
+        mpr("Clearing travel trail.");
+        clear_travel_trail();
+    }
+    else
+    {
+        mpr("Clearing level map.");
+        clear_map();
+        crawl_view.set_player_at(you.pos());
     }
 }
 

--- a/crawl-ref/source/map_knowledge.h
+++ b/crawl-ref/source/map_knowledge.h
@@ -322,7 +322,27 @@ int count_detected_mons();
 
 void update_cloud_knowledge();
 
+/**
+ * @brief Clear non-terrain knowledge from the map.
+ *
+ * Cloud knowledge is always cleared. Item and monster knowledge clears depend
+ * on @p clear_items and @p clear_mons, respectively.
+ *
+ * @param clear_items
+ *  Clear item knowledge?
+ * @param clear_mons
+ *  Clear monster knowledge?
+ */
 void clear_map(bool clear_items = true, bool clear_mons = true);
+
+/**
+ * @brief If a travel trail exists, clear it; otherwise clear the map.
+ *
+ * When clearing the map, all non-terrain knowledge is wiped.
+ *
+ * @see clear_map() and clear_travel_trail()
+ */
+void clear_map_or_travel_trail();
 
 map_feature get_cell_map_feature(const map_cell& cell);
 

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -874,7 +874,7 @@ bool show_map(level_pos &lpos,
                 break;
 
             case CMD_MAP_CLEAR_MAP:
-                clear_map();
+                clear_map_or_travel_trail();
                 break;
 
             case CMD_MAP_FORGET:


### PR DESCRIPTION
For consistency and convenience, adjust the level map to handle CMD_CLEAR_MAP in the same manner as the main screen.

Related commit: 6207113de71659a0cbe17c8978a4c5037fd4aa84

#### Notes / concerns:
- There's now a call to ```crawl_view.set_player_at(you.pos())``` after clearing the map in the level map view.  I didn't notice this having an impact during testing.
- Is map_knowledge the best home for the relocated _do_clear_map() function?
- I added some documentation to clear_map() while dealing with clear_map_or_travel_trail(), mainly for context.  Although I believe it's accurate, it could use a once-over.
