### PR TITLE
Only set an ugly thing band colour for fully-ugly bands (#8343).

### DIFF
--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -885,11 +885,11 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
     band_type band = BAND_NO_BAND;
     band_monsters[0] = mg.cls;
 
-    // The (very) ugly thing band colour.
-    static colour_t ugly_colour = COLOUR_UNDEF;
-
     if (create_band)
     {
+        // Is this a band comprised solely of ugly things?
+        bool band_is_ugly = band_monsters[0] == MONS_UGLY_THING
+            || band_monsters[0] == MONS_VERY_UGLY_THING;
 #ifdef DEBUG_MON_CREATION
         mprf(MSGCH_DIAGNOSTICS, "Choose band members...");
 #endif
@@ -901,22 +901,19 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
             if (band_monsters[i] == NUM_MONSTERS)
                 die("Unhandled band type %d", band);
 
-            // Get the (very) ugly thing band colour, so that all (very)
-            // ugly things in a band will start with it.
-            if ((band_monsters[i] == MONS_UGLY_THING
-                || band_monsters[i] == MONS_VERY_UGLY_THING)
-                    && ugly_colour == COLOUR_UNDEF)
+            if (band_is_ugly
+                && !(band_monsters[i] == MONS_UGLY_THING
+                    || band_monsters[i] == MONS_VERY_UGLY_THING))
             {
-                ugly_colour = ugly_thing_colour_offset(mg.colour) == -1
-                            ? ugly_thing_random_colour()
-                            : mg.colour;
+                // The whole band isn't ugly.
+                band_is_ugly = false;
             }
         }
-    }
 
-    // Set the (very) ugly thing band colour.
-    if (ugly_colour != COLOUR_UNDEF)
-        mg.colour = ugly_colour;
+        // Set the (very) ugly thing band colour.
+        if (band_is_ugly && ugly_thing_colour_offset(mg.colour) == -1)
+            mg.colour = ugly_thing_random_colour();
+    }
 
     // Returns 2 if the monster is placed near player-occupied stairs.
     int pval = _is_near_stairs(mg.pos);
@@ -1036,10 +1033,6 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
         // Sanity check that the specified position is valid.
         return 0;
     }
-
-    // Reset the (very) ugly thing band colour.
-    if (ugly_colour != COLOUR_UNDEF)
-        ugly_colour = COLOUR_UNDEF;
 
     monster* mon = _place_monster_aux(mg, 0, place, force_pos, dont_place);
 

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -887,9 +887,6 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
 
     if (create_band)
     {
-        // Is this a band comprised solely of ugly things?
-        bool band_is_ugly = band_monsters[0] == MONS_UGLY_THING
-            || band_monsters[0] == MONS_VERY_UGLY_THING;
 #ifdef DEBUG_MON_CREATION
         mprf(MSGCH_DIAGNOSTICS, "Choose band members...");
 #endif
@@ -900,19 +897,10 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
             band_monsters[i] = _band_member(band, i, place, allow_ood);
             if (band_monsters[i] == NUM_MONSTERS)
                 die("Unhandled band type %d", band);
-
-            if (band_is_ugly
-                && !(band_monsters[i] == MONS_UGLY_THING
-                    || band_monsters[i] == MONS_VERY_UGLY_THING))
-            {
-                // The whole band isn't ugly.
-                band_is_ugly = false;
-            }
         }
 
         // Set the (very) ugly thing band colour.
-        if (band_is_ugly && ugly_thing_colour_offset(mg.colour) == -1)
-            mg.colour = ugly_thing_random_colour();
+        ugly_thing_apply_uniform_band_colour(mg, band_monsters, band_size);
     }
 
     // Returns 2 if the monster is placed near player-occupied stairs.

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3017,6 +3017,27 @@ int ugly_thing_colour_offset(colour_t colour)
     return -1;
 }
 
+void ugly_thing_apply_uniform_band_colour(mgen_data &mg,
+    const monster_type *band_monsters, size_t num_monsters_in_band)
+{
+    bool band_is_ugly = true;
+
+    // Verify that the whole band is ugly.
+    for (size_t i = 0; i < num_monsters_in_band; i++)
+    {
+        if (!(band_monsters[i] == MONS_UGLY_THING
+            || band_monsters[i] == MONS_VERY_UGLY_THING))
+        {
+            band_is_ugly = false;
+            break;
+        }
+    }
+
+    // Apply a uniform colour to a fully-ugly band.
+    if (band_is_ugly && ugly_thing_colour_offset(mg.colour) == -1)
+        mg.colour = ugly_thing_random_colour();
+}
+
 static const char *drac_colour_names[] =
 {
     "black", "", "yellow", "green", "purple", "red", "white", "grey", "pale"

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -11,6 +11,7 @@
 #include "player.h"
 
 struct bolt;
+struct mgen_data;
 
 struct mon_attack_def
 {
@@ -433,6 +434,23 @@ colour_t ugly_thing_random_colour();
 int str_to_ugly_thing_colour(const string &s);
 colour_t random_monster_colour();
 int ugly_thing_colour_offset(colour_t colour);
+
+/**
+ * @brief
+ *  Apply uniform colour when generating a band containing only ugly things.
+ *
+ * If the passed band does not contain only ugly things, @p mg is not modified.
+ *
+ * @param mg
+ *  The generation data to adjust.
+ * @param band_monsters
+ *  The array of monsters types comprising the band.
+ * @param num_monsters_in_band
+ *  The number of elements in @p band_monsters.
+ */
+void ugly_thing_apply_uniform_band_colour(mgen_data &mg,
+    const monster_type *band_monsters, size_t num_monsters_in_band);
+
 string  draconian_colour_name(monster_type mon_type);
 monster_type draconian_colour_by_name(const string &colour);
 string  demonspawn_base_name(monster_type mon_type);


### PR DESCRIPTION
This is a two-part fix:

 1. Only apply a uniform ugly thing colour to a band if the band contains *only* ugly things.

 2. Don't let a failed ugly thing band placement influence the colour of the next call to place_monster().

See [mantis #8343](https://crawl.develz.org/mantis/view.php?id=8343) for more information.