### PR TITLE
Render useless items in dark grey in Known Items menu

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -33,11 +33,12 @@ known-menu
 Pressing an item type's letter key selects that item.
 
 <h>Selecting item types</h>
-Items types displayed in grey use the default autopickup options set in your
-configuration file. Selecting a type of item overrides those options
+Item types displayed in grey use the default autopickup options set in your
+configuration file. (Items that are useless to your character are displayed
+in <darkgrey>dark grey</darkgrey>.) Selecting a type of item overrides those options
 (indicated by <w>white</w> text), and toggles the item between the states:
  <w>+</w>  Items of this type will be picked up automatically.
- <w>-</w>  Items of this type will will not be picked up automatically.
+ <w>-</w>  Items of this type will not be picked up automatically.
 Autopickup can also be toggled for all unknown items of a given category.
 
 <h>Category shortcuts</h>

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2427,6 +2427,8 @@ public:
     {
         if (selected_qty >= 1)
             return WHITE;
+        else if (is_useless_item(*item))
+            return DARKGREY;
         else
             return MENU_ITEM_STOCK_COLOUR;
 


### PR DESCRIPTION
In the "Known Items" menu, render useless items in dark grey instead of the default light grey used for other non-overridden items. Useful when configuring manual autopickup overrides for a randomly chosen character as it reminds me to e.g., not enable javelin pickup if I'm playing a kobold.