### PR TITLE
colemak keyboard binding fixed

### DIFF
--- a/crawl-ref/settings/colemak_command_keys.txt
+++ b/crawl-ref/settings/colemak_command_keys.txt
@@ -54,15 +54,6 @@ bindkey = [L] CMD_MAP_JUMP_UP_RIGHT
 bindkey = [B] CMD_MAP_JUMP_DOWN_LEFT
 bindkey = [K] CMD_MAP_JUMP_DOWN_RIGHT
 
-bindkey = [^H] CMD_OPEN_DOOR_LEFT
-bindkey = [^N] CMD_OPEN_DOOR_DOWN
-bindkey = [^E] CMD_OPEN_DOOR_UP
-bindkey = [^I] CMD_OPEN_DOOR_RIGHT
-bindkey = [^J] CMD_OPEN_DOOR_UP_LEFT
-bindkey = [^L] CMD_OPEN_DOOR_UP_RIGHT
-bindkey = [^B] CMD_OPEN_DOOR_DOWN_LEFT
-bindkey = [^K] CMD_OPEN_DOOR_DOWN_RIGHT
-
 # replace (e) with (u)
 bindkey = [u] CMD_EAT
 bindkey = [u] CMD_TARGET_EXCLUDE


### PR DESCRIPTION
As far as I understood this commands for doors are obsolete now, so I removed it to stop crawl complaining about it every time.