### PR TITLE
Fix for pain bond and aux attacks (10472)

### DIFF
--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -558,7 +558,7 @@ int max_mons_charge(monster_type m);
 
 void init_mutant_beast(monster &mon, short HD, vector<int> beast_facets,
                        set<int> avoid_facets);
-void radiate_pain_bond(const monster& mon, int damage);
+void radiate_pain_bond(const monster& mon, int damage, const monster* original_target);
 void throw_monster_bits(const monster& mon);
 void set_ancestor_spells(monster &ancestor, bool notify = false);
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4487,6 +4487,14 @@ int monster::hurt(const actor *agent, int amount, beam_type flavour,
 
         // Allow the victim to exhibit passive damage behaviour (e.g.
         // the Royal Jelly).
+        if (has_ench(ENCH_PAIN_BOND) && flavour != BEAM_SHARED_PAIN)
+        {
+            // this is passive damage behaviour in a sense, but unlike everything else there, can do damage.
+            // radiate_pain_bond may do additional damage in a complex recursive fashion, by looping back to the original trigger.
+            int hp_before_pain_bond = hit_points;
+            radiate_pain_bond(*this, amount, this);
+            amount += hp_before_pain_bond - hit_points; // is this right? it seems like react_to_damage should want the updated amount.
+        }
         react_to_damage(agent, amount, flavour);
 
         // Don't mirror Yredelemnul's effects (in particular don't mirror
@@ -5993,9 +6001,6 @@ bool monster::evoke_jewellery_effect(jewellery_type jtype)
 void monster::react_to_damage(const actor *oppressor, int damage,
                                beam_type flavour)
 {
-    if (has_ench(ENCH_PAIN_BOND))
-        radiate_pain_bond(*this, damage);
-
     // Don't discharge on small amounts of damage (this helps avoid
     // continuously shocking when poisoned or sticky flamed)
     // XXX: this might not be necessary anymore?


### PR DESCRIPTION
The basic problem was that radiate_pain_bond was called recursively from
monster::hurt (which radiate_pain_bond calls), and could loop.  When the
loop reached the original target, if the embedded call to hurt killed
the monster, it was guaranteed to clean up at that point, ignoring the
`clean` argument to the original call.  In a number of cases that relied
on a <1hp monster not being cleaned up, this led to odd messages or
crashes.

This commit fixes the problem by refactoring the recursion into a single
function (radiate_pain_bond) that tracks the original target.  It defers
cleanup for that target to the outer call of monster::hurt, and so will
respect the cleanup_dead argument for that function.  As a side effect,
pain bond damage is calculated slightly more correctly for passive
damage effects.  I've tested this as carefully as I can and am fairly
confident that it prevents the DEAD_MONSTER messages as well as the
crash from constriction, but there were a lot of hard-to-replicate
special cases that I haven't tested directly.