### PR TITLE
Update the description of the staff of summoning

### DIFF
--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -90,7 +90,6 @@ function ch_stash_search_annotate_item(it)
       ["fire"] = "rF+",
       ["poison"] = "rPois",
       ["power"] = "MP+",
-      ["summoning"] = "Ward",
       ["wizardry"] = "Wiz"
     }
     if props[it.subtype()] then


### PR DESCRIPTION
Warding was removed in 0.18, but the description of the staff of summoning still mentions the "{Ward}" stash search prefix.