### PR TITLE
reduce intensity of conjure flame verb

### DIFF
--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -90,7 +90,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         // Reinforce the cloud - but not too much.
         // It must be a fire cloud from a previous test.
         if (you.see_cell(where))
-            mpr("The fire roars with new energy!");
+            mpr("The fire blazes with new energy!");
         const int extra_dur = 2 + min(random2(pow) / 2, 20);
         cloud->decay += extra_dur * 5;
         cloud->source = agent->mid;
@@ -106,7 +106,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         if (you.see_cell(where))
         {
             if (agent->is_player())
-                mpr("The fire roars!");
+                mpr("The fire ignites!");
             else
                 mpr("A cloud of flames roars to life!");
         }


### PR DESCRIPTION
"Roar" in Crawl is usually a loud noise, typically one issued by a beast or a Trog-worshipper.

Conjure flame, however, is quite a quiet spell and cautious (but inexperienced) players might avoid casting it for fear of a loud "roaring" noise if they fail to check the full spell details in the z ? ! menu. The description of the sound could stand to be toned down a little.

Perhaps "The fire ignites dangerously||menacingly!" would retain some of the original phrase's feeling of power and violence, at the risk of throwing around unnecessary adverbs!

Uncertain whether "The fire roars!" was being called by other sources than Conjure Flame, sources which perhaps **are** loud enough to earn a "roar".