### PR TITLE
Identify wands when the player steps on them.

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -934,29 +934,39 @@ void item_check()
     }
 }
 
-/// If the given item is an unknown book, ID it; return whether we did.
-static bool _id_floor_book(item_def &book)
+// Identify the object the player stepped on.
+// Books and manuals are fully identified.
+// Wands are only type-identified.
+static bool _id_floor_item(item_def &item)
 {
-    if (book.base_type != OBJ_BOOKS)
-        return false;
+    if (item.base_type == OBJ_BOOKS)
+    {
+        if (fully_identified(item) && item.sub_type != BOOK_MANUAL)
+            return false;
 
-    if (fully_identified(book) && book.sub_type != BOOK_MANUAL)
-        return false;
-
-    // fix autopickup for previously-unknown books (hack)
-    if (item_needs_autopickup(book))
-        book.props["needs_autopickup"] = true;
-    set_ident_flags(book, ISFLAG_IDENT_MASK);
-    mark_had_book(book);
-    return true;
+        // fix autopickup for previously-unknown books (hack)
+        if (item_needs_autopickup(item))
+            item.props["needs_autopickup"] = true;
+        set_ident_flags(item, ISFLAG_IDENT_MASK);
+        mark_had_book(item);
+        return true;
+    }
+    else if (item.base_type == OBJ_WANDS)
+    {
+        if (!get_ident_type(item))
+        {
+            set_ident_type(item, true);
+            return true;
+        }
+    }
+    return false;
 }
 
-/// Auto-ID whatever spellbooks and manuals the player stands on.
-void id_floor_books()
+/// Auto-ID whatever stuff the player stands on.
+void id_floor_items()
 {
     for (stack_iterator si(you.pos()); si; ++si)
-        if (si->base_type == OBJ_BOOKS)
-            _id_floor_book(*si);
+        _id_floor_item(*si);
 }
 
 void pickup_menu(int item_link)
@@ -2231,7 +2241,7 @@ bool move_item_to_grid(int *const obj, const coord_def& p, bool silent)
         maybe_identify_base_type(item);
     }
 
-    if (p == you.pos() && _id_floor_book(item))
+    if (p == you.pos() && _id_floor_item(item))
         mprf("You see here %s.", item.name(DESC_A).c_str());
 
     return true;

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -74,7 +74,7 @@ void lose_item_stack(const coord_def& where);
 
 void item_check();
 void request_autopickup(bool do_pickup = true);
-void id_floor_books();
+void id_floor_items();
 
 bool player_on_single_stack();
 void pickup_menu(int item_link);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -488,7 +488,7 @@ void moveto_location_effects(dungeon_feature_type old_feat,
             you.props.erase(TEMP_WATERWALK_KEY);
     }
 
-    id_floor_books();
+    id_floor_items();
 
     // Traps go off.
     // (But not when losing flight - i.e., moving into the same tile)


### PR DESCRIPTION
Wands can be trivially type-identified by picking them up, and it's rather annoying when encountering a wand with a full inventory to figure out the safest item to drop, pick up the wand, then immediately discard it and pick up the item again because it's a trash wand (e.g. random effects or flame outside early-game). Spellbooks are in the same boat and identify just by standing over them; this extends that behavior to wands. 