### PR TITLE
Hack to make unidentified wands respect auto-pickup settings

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -955,7 +955,12 @@ static bool _id_floor_item(item_def &item)
     {
         if (!get_ident_type(item))
         {
+            // If the player doesn't want unknown wands picked up, assume
+            // they won't want this wand after it is identified.
+            bool should_pickup = item_needs_autopickup(item);
             set_ident_type(item, true);
+            if (!should_pickup)
+                you.force_autopickup[item.base_type][item.sub_type] = -1;
             return true;
         }
     }


### PR DESCRIPTION
So the wand-identification PR I just sent has an issue where if you have unknown wands set to not be auto-picked-up, they'll get scooped up anyway if you step on them because they stop being unknown and start being a new type. This fixes that by marking the revealed type as undesired as well (since if you're ignoring all unknown wands, you probably don't want the second wand of random effects either).