### PR TITLE
 add some non-"of" randarmors

### DIFF
--- a/crawl-ref/source/dat/database/rand_arm.txt
+++ b/crawl-ref/source/dat/database/rand_arm.txt
@@ -1017,4 +1017,16 @@ Sufferslight
 
 Echobright
 
+Unforgotten
+
+Alossiod Vex
+
+Thin
+
+Pallidus Mort
+
+Xob
+
+Altus Ipson Amico
+
 %%%%

--- a/crawl-ref/source/dat/database/rand_arm.txt
+++ b/crawl-ref/source/dat/database/rand_arm.txt
@@ -999,4 +999,22 @@ Hero's Friend
 
 Trusted Companion
 
+Believe the Magic
+
+Put Me On
+
+Dragonsphere
+
+Earthly Heaven
+
+Damnable Contraption
+
+Elixir Crab
+
+Viciousness Negated
+
+Sufferslight
+
+Echobright
+
 %%%%

--- a/crawl-ref/source/dat/database/randname.txt
+++ b/crawl-ref/source/dat/database/randname.txt
@@ -213,7 +213,7 @@ of @_game_name_@
 w:15
 of @_other_armour_name_@
 
-w:1
+w:5
 "@_plain_armour_name_@"
 
 # weapon specific keywords (see rand_arm.txt)


### PR DESCRIPTION
Almost all randarmor is appended with "of Foo", here are some additional options so that @_plain_armour_name_@ can have a little higher weight.