### PR TITLE
Ensure viewwindow is called in the input loop for instantaneous actions

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1511,9 +1511,12 @@ static void _input()
         _do_searing_ray();
 
         world_reacts();
-    } else {
+    }
+    else
+    {
         // Make sure to do a full view update even when the turn isn't over.
-        // This else will be triggered by instantaneous actions, such as Chei's temporal distortion.
+        // This else will be triggered by instantaneous actions, such as
+        // Chei's temporal distortion.
         viewwindow();
     }
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1511,6 +1511,10 @@ static void _input()
         _do_searing_ray();
 
         world_reacts();
+    } else {
+        // Make sure to do a full view update even when the turn isn't over.
+        // This else will be triggered by instantaneous actions, such as Chei's temporal distortion.
+        viewwindow();
     }
 
     update_can_train();


### PR DESCRIPTION
This needs some vetting to make sure there aren't unintended side effects -- I've checked the other cases where you.turn_is_over is false and didn't spot any problems, but it is nonetheless a change in the input loop.

Commit message:
This specifically addresses 10314, where shoals wave/beach tiles weren't being
updated after temporal distortion.  Temporal distortion results in
`you.turn_is_over` being false at this point in the loop, but apparently
`viewwindow` needs to be called at this specific time to get the waves right.
For non-instantaneous actions, `viewwindow` is called as part of
`world_reacts`.