### PR TITLE
Several is_useless_item() fixes

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3561,7 +3561,8 @@ bool is_useless_item(const item_def &item, bool temp)
                        || temp && you.hunger_state < HS_SATIATED);
 
         case POT_FLIGHT:
-            return you.permanent_flight();
+            return you.permanent_flight()
+                   || you.racial_permanent_flight();
 
 #if TAG_MAJOR_VERSION == 34
         case POT_PORRIDGE:
@@ -3652,6 +3653,7 @@ bool is_useless_item(const item_def &item, bool temp)
 
         case RING_FLIGHT:
             return you.permanent_flight()
+                   || you.racial_permanent_flight()
                    || player_mutation_level(MUT_NO_ARTIFICE);
 
         case RING_STEALTH:

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3496,7 +3496,7 @@ bool is_useless_item(const item_def &item, bool temp)
         case SCR_RECHARGING:
             return player_mutation_level(MUT_NO_ARTIFICE) > 0;
         case SCR_FOG:
-            return env.level_state & LSTATE_STILL_WINDS;
+            return temp && (env.level_state & LSTATE_STILL_WINDS);
         default:
             return false;
         }
@@ -3518,7 +3518,7 @@ bool is_useless_item(const item_def &item, bool temp)
             return player_mutation_level(MUT_NO_LOVE);
 
         if (item.sub_type == WAND_CLOUDS)
-            return env.level_state & LSTATE_STILL_WINDS;
+            return temp && (env.level_state & LSTATE_STILL_WINDS);
 
         return false;
 


### PR DESCRIPTION
1. `is_useless_item()` checks for potion and ring of flight did not check for innate racial permaflight ability, only whether you were permaflying at the moment. (Hence, toggling permaflight on and off would change the perceived uselessness of these items.) Added missing `racial_permanent_flight()` check to these two cases.
2. `is_useless_item()` checks for scroll of fog and wand of clouds considered Still Winds to be a permanent condition rather than a temporary one. Added missing `temp` check to these two cases.