### PR TITLE
Have ash id stacks when standing on them (10580)

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -275,7 +275,10 @@ void Stash::update()
 
         // Now, grab all items on that square and fill our vector
         for (stack_iterator si(pos, true); si; ++si)
+        {
+            god_id_item(*si);
             add_item(*si);
+        }
 
         verified = true;
     }


### PR DESCRIPTION
Previously, `god_id_item` was called only from a distance, and then only on the
top item of the stack, so items not at the top of the stack would not be id'd
when you move onto their square.  This fix ids the whole stack when you stand
on it if appropriate.  This may overcall `god_id_item` but I haven't spotted
any detrimental effects.  Addresses 10580, 10919.