### PR TITLE
cause Amulet of Faith to interact with Gozag

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1591,7 +1591,6 @@ bool needs_handle_warning(const item_def &item, operation_types oper,
     if (oper == OPER_REMOVE
         && item.is_type(OBJ_JEWELLERY, AMU_FAITH)
         && !(you_worship(GOD_RU) && you.piety >= piety_breakpoint(5))
-        && !you_worship(GOD_GOZAG)
         && !you_worship(GOD_NO_GOD)
         && !you_worship(GOD_XOM))
     {

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -406,6 +406,10 @@ static void _gold_pile(item_def &corpse, monster_type corpse_class)
     if (crawl_state.game_is_sprint())
         corpse.quantity *= SPRINT_MULTIPLIER;
 
+    // players with AMU_FAITH get a bit more gold (but not gold aura!)
+    if (you.faith())
+        corpse.quantity *= div_rand_round(piety, 4);
+
     const int chance = you.props[GOZAG_GOLD_AURA_KEY].get_int();
     if (!x_chance_in_y(chance, chance + 9))
         ++you.props[GOZAG_GOLD_AURA_KEY].get_int();

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1199,7 +1199,7 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
                                " has no use for such trinkets.");
         }
         else if (you_worship(GOD_GOZAG))
-            simple_god_message(" cares for nothing but gold!");
+            simple_god_message(" grants you a favorable conversion rate!");
         else
         {
             mprf(MSGCH_GOD, "You feel a %ssurge of divine interest.",

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1070,9 +1070,18 @@ static void _remove_amulet_of_faith(item_def &item)
                  you.props[RU_SACRIFICE_DELAY_KEY].get_int());
         }
     }
+    else if (you_worship(GOD_GOZAG))
+    {
+#ifdef DEBUG_DIAGNOSTICS
+            const int shop_price = you.props[gozag_price_for_shop].get_int();
+#endif
+        // Gozag shops get more expensive by 200, as if you called one.
+        you.attribute[ATTR_GOZAG_SHOPS]++;
+        you.attribute[ATTR_GOZAG_SHOPS_CURRENT]++;
+        simple_god_message(" raises the fee for funding new merchants.");
+        dprf("prev price %d, new price %d", shop_price,
     else if (!you_worship(GOD_NO_GOD)
-             && !you_worship(GOD_XOM)
-             && !you_worship(GOD_GOZAG))
+             && !you_worship(GOD_XOM))
     {
         simple_god_message(" seems less interested in you.");
 


### PR DESCRIPTION
Gozag isn't just a beautiful and witty shopkeeper, Gozag is also a god!
That's why a background spent meditating in a monastery waives the fee,
and that's why a player of great faith could stand to be blessed by Gozag.

Wearing =faith increases Gozag's corpse-to-gold conversion rate by 25%.
Removing =faith increases the price of summoning merchants by 200.