### PR TITLE
Add a noise meter to the HUD

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -234,9 +234,15 @@ Place
   branch. The starting branch is called Dungeon, so that the place information
   will read "Dungeon:1" for a new character.
 
-Gold
-  Displays the number of gold pieces you have found. Gold is found scattered
-  around the dungeon, and is primarily used to buy items from shops.
+Noise
+  This is a colored bar indicating the loudness of noise that you heard on your
+  last turn. The color provides a rough guide to how far away the noise it
+  indicates might be audible.  If the bar is gray, the sound is less likely to
+  be audible outside of your line of sight (at least in an open area); if it is
+  yellow, the sound is likely to be audible outside of your line of sight, and
+  if it is red the sound will be audible at a substantial distance.  If the bar
+  turns magenta, you have made one of the loudest noises in the dungeon.  Terrain
+  may affect how noise spreads beyond this indicator.
 
 Time
   This indicates the amount of time that has passed since entering the dungeon,

--- a/crawl-ref/source/duration-data.h
+++ b/crawl-ref/source/duration-data.h
@@ -583,7 +583,7 @@ static const duration_def duration_data[] =
         {{"", trog_remove_trogs_hand},
           {"You feel the effects of Trog's Hand fading.", 1}}, 6},
     { DUR_GOZAG_GOLD_AURA, 0, "", "gold aura", "", "", D_NO_FLAGS,
-        {{ "", []() { you.props[GOZAG_GOLD_AURA_KEY] = 0; }}}},
+        {{ "", []() { you.props[GOZAG_GOLD_AURA_KEY] = 0; you.redraw_title = true;}}}},
     { DUR_COLLAPSE, 0, "", "", "collapse", "", D_NO_FLAGS },
     { DUR_BRAINLESS, 0, "", "", "brainless", "", D_NO_FLAGS },
     { DUR_CLUMSY, 0, "", "", "clumsy", "", D_NO_FLAGS },

--- a/crawl-ref/source/duration-data.h
+++ b/crawl-ref/source/duration-data.h
@@ -273,7 +273,7 @@ static const duration_def duration_data[] =
       {{ "", []() { invalidate_agrid(true); }},
         { "Quad Damage is wearing off."}}, 3 }, // per client.qc
     { DUR_SILENCE,
-      MAGENTA, "Sil",
+      0, "",
       "silence", "",
       "You radiate silence.", D_DISPELLABLE | D_EXPIRES,
       {{ "Your hearing returns.", []() { invalidate_agrid(true); }}}, 5 },

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1520,6 +1520,7 @@ static void _input()
     _update_place_info();
 
     crawl_state.clear_god_acting();
+
 }
 
 static bool _can_take_stairs(dungeon_feature_type ftype, bool down,
@@ -2566,6 +2567,13 @@ void world_reacts()
             save_game(false);
         }
     }
+    // End of a turn.
+    //
+    // `los_noise_last_turn` is the value for display -- it needs to persist
+    // for any calls to print_stats during the next turn. Meanwhile, reset
+    // the loudest noise tracking for the next world_reacts cycle.
+    you.los_noise_last_turn = you.los_noise_level;
+    you.los_noise_level = 0;
 }
 
 static command_type _get_next_cmd()

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -409,6 +409,7 @@ static void _gold_pile(item_def &corpse, monster_type corpse_class)
     const int chance = you.props[GOZAG_GOLD_AURA_KEY].get_int();
     if (!x_chance_in_y(chance, chance + 9))
         ++you.props[GOZAG_GOLD_AURA_KEY].get_int();
+    you.redraw_title = true;
 }
 
 static void _create_monster_hide(const item_def &corpse, bool silent)

--- a/crawl-ref/source/nearby-danger.cc
+++ b/crawl-ref/source/nearby-danger.cc
@@ -429,6 +429,8 @@ void revive()
     you.attribute[ATTR_INVIS_UNCANCELLABLE] = 0;
     you.attribute[ATTR_FLIGHT_UNCANCELLABLE] = 0;
     you.attribute[ATTR_XP_DRAIN] = 0;
+    you.los_noise_level = 0;
+    you.los_noise_last_turn = 0; // silence in death
     if (you.duration[DUR_SCRYING])
         you.xray_vision = false;
 

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -419,11 +419,14 @@ public:
         textbackground(BLACK);
     }
 
+    // NOTE: this doesn't behave exactly as you might expect on console, because BLACK
+    // prints as dark blue.
     void blank(int ox, int oy, int max_val)
     {
         colour_t old_change_col = m_change_neg;
         colour_t old_change_pos = m_change_pos;
         colour_t old_empty = m_empty;
+        m_old_disp = 0;
 
         m_change_neg = BLACK;
         m_change_pos = BLACK;
@@ -505,7 +508,7 @@ colour_bar Temp_Bar(RED, LIGHTRED, LIGHTBLUE, DARKGREY);
 #ifdef USE_TILE_LOCAL
 static colour_bar Noise_Bar(WHITE, LIGHTGREY, LIGHTGREY, DARKGREY);
 #else
-static colour_bar Noise_Bar(LIGHTGREY, LIGHTGREY, MAGENTA, BLACK);
+static colour_bar Noise_Bar(LIGHTGREY, LIGHTGREY, MAGENTA, DARKGREY);
 #endif
 
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7543,6 +7543,7 @@ void player::set_gold(int amount)
                 else if (old_gold >= cost && gold < cost)
                     power.display(false, "You no longer have enough gold to %s.");
             }
+            you.redraw_title = true;
         }
     }
 }

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -733,7 +733,7 @@ public:
     bool cancellable_flight() const;
     bool permanent_flight() const;
     bool racial_permanent_flight() const;
-    int adjusted_noise_perception() const;
+    int get_noise_perception(bool adjusted = true) const;
 
     bool paralysed() const override;
     bool cannot_move() const override;

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -409,6 +409,10 @@ public:
 
     int old_hunger;            // used for hunger delta-meter (see output.cc)
 
+    // the loudest noise level the player has experienced in los this turn
+    int los_noise_level;
+    int los_noise_last_turn;
+
     // Set when the character is going to a new level, to guard against levgen
     // failures
     dungeon_feature_type transit_stair;
@@ -729,6 +733,7 @@ public:
     bool cancellable_flight() const;
     bool permanent_flight() const;
     bool racial_permanent_flight() const;
+    int adjusted_noise_perception() const;
 
     bool paralysed() const override;
     bool cannot_move() const override;

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -1130,6 +1130,23 @@ void noise_grid::apply_noise_effects(const coord_def &pos,
         _actor_apply_noise(&you, noise.noise_source,
                            noise_intensity_millis, noise,
                            noise_travel_distance);
+
+        // The next bit stores noise heard at the player's position for
+        // display in the HUD.  A more interesting (and much more complicated)
+        // way of doing this might be to sample from the noise grid at
+        // selected distances from the player. Dealing with terrain is a bit
+        // nightmarish for this alternative, though, so I'm going to keep it
+        // simple.
+        if (you.asleep()) // noise may awaken the player but this should be
+                          // dealt with in `_actor_apply_noise`. We want only
+                          // noises after awakening (or the awakening noise)
+                          // to be shown.
+        {
+            you.los_noise_level = 0;
+        } else {
+            you.los_noise_level = max(you.los_noise_level,
+                                      div_rand_round(noise_intensity_millis, 1000));
+        }
         ++affected_actor_count;
     }
 

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -1127,6 +1127,11 @@ void noise_grid::apply_noise_effects(const coord_def &pos,
 {
     if (you.pos() == pos)
     {
+        // The bizarre arrangement of those code into two functions that each
+        // check whether the actor is the player, but work at different types,
+        // probably ought to be refactored. I put the noise updating code here
+        // because the type is correct here.
+
         _actor_apply_noise(&you, noise.noise_source,
                            noise_intensity_millis, noise,
                            noise_travel_distance);
@@ -1144,8 +1149,7 @@ void noise_grid::apply_noise_effects(const coord_def &pos,
         {
             you.los_noise_level = 0;
         } else {
-            you.los_noise_level = max(you.los_noise_level,
-                                      div_rand_round(noise_intensity_millis, 1000));
+            you.los_noise_level = max(you.los_noise_level, noise_intensity_millis);
         }
         ++affected_actor_count;
     }

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -1132,7 +1132,7 @@ void noise_grid::apply_noise_effects(const coord_def &pos,
                            noise_travel_distance);
 
         // The next bit stores noise heard at the player's position for
-        // display in the HUD.  A more interesting (and much more complicated)
+        // display in the HUD. A more interesting (and much more complicated)
         // way of doing this might be to sample from the noise grid at
         // selected distances from the player. Dealing with terrain is a bit
         // nightmarish for this alternative, though, so I'm going to keep it

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -427,8 +427,6 @@ bool fill_status_info(int status, status_info* inf)
     case STATUS_SILENCE:
         if (silenced(you.pos()) && !you.duration[DUR_SILENCE])
         {
-            inf->light_colour = LIGHTRED;
-            inf->light_text   = "Sil";
             inf->short_text   = "silenced";
             inf->long_text    = "You are silenced.";
         }

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -796,6 +796,7 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.experience_level, you.experience_level, "xl");
     _update_int(force_full, c.exp_progress, (int8_t) get_exp_progress(), "progress");
     _update_int(force_full, c.gold, you.gold, "gold");
+    _update_int(force_full, c.noise, you.adjusted_noise_perception(), "noise");
 
     if (you.running == 0) // Don't update during running/resting
     {

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -796,7 +796,8 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.experience_level, you.experience_level, "xl");
     _update_int(force_full, c.exp_progress, (int8_t) get_exp_progress(), "progress");
     _update_int(force_full, c.gold, you.gold, "gold");
-    _update_int(force_full, c.noise, you.adjusted_noise_perception(), "noise");
+    _update_int(force_full, c.noise, you.get_noise_perception(false), "noise");
+    _update_int(force_full, c.adjusted_noise, you.get_noise_perception(true), "adjusted_noise");
 
     if (you.running == 0) // Don't update during running/resting
     {

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -51,6 +51,7 @@ struct player_info
     int mp, mp_max;
     int contam;
     int heat;
+    int noise;
 
     int armour_class;
     int evasion;

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -52,6 +52,7 @@ struct player_info
     int contam;
     int heat;
     int noise;
+    int adjusted_noise;
 
     int armour_class;
     int evasion;

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -163,7 +163,7 @@ function ($, comm, enums, map_knowledge, messages, options) {
             $("#stats_noise").css("color", noise_color);
         }
 
-        $("#stats_noise_bar_full").css("background-color", noise_color); 
+        $("#stats_noise_bar_full").css("background-color", noise_color);
 
         $("#stats_noise_bar_full").css("width", (full_bar / 100) + "%");
         if (adjusted_level < old_value)
@@ -347,7 +347,7 @@ function ($, comm, enums, map_knowledge, messages, options) {
             $("#stats_" + name).addClass("colour_" + colour);
     }
 
-    var simple_stats = ["hp", "hp_max", "mp", "mp_max", "xl", "progress", "gold"];
+    var simple_stats = ["hp", "hp_max", "mp", "mp_max", "xl", "progress"];
     /**
      * Update the stats pane area based on the player's current properties.
      */
@@ -410,14 +410,25 @@ function ($, comm, enums, map_knowledge, messages, options) {
         }
         else
             $("#stats_piety").text("");
+
+        if (player.god == "Gozag")
+        {
+            $("#stats_gozag_gold_label").text(" Gold: ");
+            $("#stats_gozag_gold_label").css("padding-left", "0.5em");
+            $("#stats_gozag_gold").text(player.gold);
+        } else {
+            $("#stats_gozag_gold_label").text("");
+            $("#stats_gozag_gold").text("");
+            $("#stats_gozag_gold_label").css("padding-left", "0");
+        }
+        $("#stats_gozag_gold").toggleClass("boosted_stat", player.has_status("gold aura"));
+
         $("#stats_species_god").text(species_god);
         $("#stats_piety").toggleClass("penance", !!player.penance);
         $("#stats_piety").toggleClass("monk", player.god == "");
 
         for (var i = 0; i < simple_stats.length; ++i)
             $("#stats_" + simple_stats[i]).text(player[simple_stats[i]]);
-
-        $("#stats_gold").toggleClass("boosted_stat", player.has_status("gold aura"));
 
         if (player.real_hp_max != player.hp_max)
             $("#stats_real_hp_max").text("(" + player.real_hp_max + ")");

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -147,6 +147,22 @@ body {
     background-color: #ee4f45; /* lightred */
 }
 
+#stats_noise_bar {
+    background-color: #000000; /* dark slate gray */
+}
+#stats_noise_status {
+    color: #FF00FF; /* magenta */
+}
+#stats_noise_bar_full {
+    background-color: #00D300; /* lightgray */
+}
+#stats_noise_bar_decrease {
+    background-color: #555753; /* darkgray */
+}
+#stats_noise_bar_increase {
+    background-color: #555753; /* darkgray */
+}
+
 #stats[data-species="Djinni"] #stats_hp_bar_full {
     background-color: #ba2cde;
 }

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -44,7 +44,7 @@ body {
 #stats_titleline, #stats_species_god {
     color: #fce94f; /* yellow */
 }
-#stats_piety {
+#stats_piety, #stats_gozag_gold {
     color: #fce94f; /* yellow */
 }
 #stats_piety.penance {

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -97,6 +97,16 @@
           <div><span class="stats_caption" id="stats_time_caption"></span>
             <span id="stats_time" /></div>
         </div>
+        <div id="stats_noise_container">
+        <span id="stats_noise_bar" class="bar" style="float:right; width:55%; height:1em;"><!-- Whitespace...
+       --><span id="stats_noise_bar_full" /><!--
+       --><span id="stats_noise_bar_decrease" /><!--
+       --><span id="stats_noise_bar_increase" /><!--
+       --><span id="stats_noise_status" /><!--
+     --></span>
+        <span class="stats_caption">Noise:</span>
+        <span id="stats_noise"></span>
+      </div>
         <div><span class="stats_caption" id="stats_weapon_letter"></span>
           <span id="stats_weapon" /></div>
         <div id="stats_quiver_line"><span class="stats_caption" id="stats_quiver_letter"></span>

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -83,7 +83,7 @@
             <span class="stats_caption">Next:</span>
             <span id="stats_progress" />%</div>
           <div id="stats_noise_container" style="float:left;width:85%;">
-            <span id="stats_noise_bar" class="bar" style="float:right;width:40%;height:1em;"><!-- Whitespace...
+            <span id="stats_noise_bar" class="bar" style="float:right;width:56%;height:1em;"><!-- Whitespace...
            --><span id="stats_noise_bar_full" /><!--
            --><span id="stats_noise_bar_decrease" /><!--
          --></span>

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -32,7 +32,7 @@
       <div id="stats_titleline" />
       <div>
         <span id="stats_species_god" />
-        <span id="stats_piety" />
+        <span id="stats_piety" /><span id="stats_gozag_gold_label" class="stats_caption" /><span id="stats_gozag_gold" />
       </div>
       <div id="stats_hpline">
         <span id="stats_hp_bar" class="bar" style="float:right; width:55%; height:1em;"><!-- Whitespace...
@@ -82,8 +82,6 @@
             <span id="stats_xl" />
             <span class="stats_caption">Next:</span>
             <span id="stats_progress" />%</div>
-          <div><span class="stats_caption">Gold:</span>
-            <span id="stats_gold" /></div>
           <div id="stats_noise_container" style="float:left;width:85%;">
             <span id="stats_noise_bar" class="bar" style="float:right;width:40%;height:1em;"><!-- Whitespace...
            --><span id="stats_noise_bar_full" /><!--

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -84,6 +84,15 @@
             <span id="stats_progress" />%</div>
           <div><span class="stats_caption">Gold:</span>
             <span id="stats_gold" /></div>
+          <div id="stats_noise_container" style="float:left;width:85%;">
+            <span id="stats_noise_bar" class="bar" style="float:right;width:40%;height:1em;"><!-- Whitespace...
+           --><span id="stats_noise_bar_full" /><!--
+           --><span id="stats_noise_bar_decrease" /><!--
+         --></span>
+           <span id="stats_noise_status" style="float:right;width:0%;"></span>
+            <span class="stats_caption">Noise:</span>
+            <span id="stats_noise"></span>
+          </div>
         </div>
         <div id="stats_rightcolumn" style="float:right;width:55%;">
           <div><span class="stats_caption">Str:</span>
@@ -97,21 +106,12 @@
           <div><span class="stats_caption" id="stats_time_caption"></span>
             <span id="stats_time" /></div>
         </div>
-        <div id="stats_noise_container">
-        <span id="stats_noise_bar" class="bar" style="float:right; width:55%; height:1em;"><!-- Whitespace...
-       --><span id="stats_noise_bar_full" /><!--
-       --><span id="stats_noise_bar_decrease" /><!--
-       --><span id="stats_noise_bar_increase" /><!--
-       --><span id="stats_noise_status" /><!--
-     --></span>
-        <span class="stats_caption">Noise:</span>
-        <span id="stats_noise"></span>
-      </div>
-        <div><span class="stats_caption" id="stats_weapon_letter"></span>
+        </div>
+        <div style="float:left;width:100%;"><span class="stats_caption" id="stats_weapon_letter"></span>
           <span id="stats_weapon" /></div>
-        <div id="stats_quiver_line"><span class="stats_caption" id="stats_quiver_letter"></span>
+        <div id="stats_quiver_line" style="float:left;width:100%;"><span class="stats_caption" id="stats_quiver_letter"></span>
           <span id="stats_quiver" /></div>
-        <div id="stats_status_lights" />
+        <div id="stats_status_lights" style="float:left;width:100%;" />
       </div>
     </div>
     <div id="minimap_block">


### PR DESCRIPTION
Noise is one of the more complicated systems in dcss, yet it's barely
represented in the UI.  This is partly because there's just so much
information to represent.  This commit attempts to partially solve this
problem by providing a very simple UI element that summarizes noise
heard by the player during the last turn in the form of a meter.  This
meter peaks at the loudest noise audible at the player's position during
that turn, and will switch between several different colors (details
vary slightly for different interfaces), described below.  I chose to
use sound that has propagated to the player, so more distant events will
be attenuated by distance and dungeon features -- the idea is to give a
measure as to how likely things are to move towards the player's
position.

While experienced players may have internalized a lot of this, most of
this information is not at all apparent to less experienced players, and
I think this UI element is potentially extremely useful (as opposed to
clutter).

1. lightgray: the noise level at the player's position is within a range
that makes it unlikely to propagate outside the player's los (though
this can happen depending on terrain).  Or more simply: this noise is
probably basically ok.  Most low-medium melee damage is in this
category, as are most low-damage spells.

2. yellow: the noise heard at the player's position is likely to
propagate outside the player's los, up to twice the los radius.  Or more
simply: this noise is bad.  Shouting, distant fireballs, high damage
melee attacks, high damage spells (e.g. many bolt spells), door creaks
are in this category.  longbows and bigger crossbows are on the border
of this category.

3. red: the noise is like to be heard at a substantial distance, on an
open level more than 2x the los radius.  Or more simply: this noise is
very bad.  This category includes howler monkeys, lightning bolt, nearby
fireballs, qazlal at pieties above ****.  (Though thunder clouds may
randomly produce red noise at nearly any piety.)

4. lightmagenta: these sounds are off the meter, the loudest sounds you
can make.  Includes: shatter, gong, ood collision, orb apport/pickup

Potential issues/complications:

* The above categories could be tweaked or added to.  How they use
the meter could also be tweaked.  (Loudness maps linearly onto the
meter so about half of it is occupied by red.)
* This implementation uses a heuristic for branch noise adjustment
that is kind of hacky.  A better (but much more complicated) solution
might be to sample noise at various distances directly from the noise
grid.  Right now I just use a constant addition or subtraction to model
the effects of branch noise; in e.g. shoals or crypt this will push
some of the category boundaries for colors around.
* An alternative approach would be to not use attenuated noise at all,
but find the loudest noise (before propagation) in the player's los.
* This implementation doesn't save the noise state, so it isn't displayed
after loading.
* In wizmode there is also a numeric version of the meter displayed,
but I decided this is too uninterpretable to be useful to players.
(But, the heuristic for normal noise branches is: in a completely open
area a sound of loudness l will propagate approximately l/.85 spaces.)
* exposing this to the player may reveal some cases where it is not
entirely intuitive that no sound is made.  For example, berserking is
silent (but unstealthy) except when opening doors.