### PR TITLE
Fix issue 10940 introduced by #423

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1031,7 +1031,6 @@ bool wear_armour(int item)
     }
 
     item_def &invitem = you.inv[item];
-    const equipment_type slot = get_armour_slot(invitem);
     // First, let's check for any conditions that would make it impossible to
     // equip the given item
     if (!invitem.defined())
@@ -1071,6 +1070,7 @@ bool wear_armour(int item)
     }
 
     bool swapping = false;
+    const equipment_type slot = get_armour_slot(invitem);
     if ((slot == EQ_CLOAK
            || slot == EQ_HELMET
            || slot == EQ_GLOVES


### PR DESCRIPTION
In `wear_armour`, don't call get_armour_slot until we know it's an armour item.

Fixes crash issue 10940 introduced by #423.