### PR TITLE
Barbs affect more movement methods. More restrictions on hopping.

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1791,24 +1791,21 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_SHAFT_SELF:
         fail_check();
-        if (you.can_do_shaft_ability(false))
+        if (you.can_do_shaft_ability(false)
+            && check_move_barbed("dig")
+            && yesno("Are you sure you want to shaft yourself?", true, 'n'))
         {
-            if (yesno("Are you sure you want to shaft yourself?", true, 'n'))
-                start_delay<ShaftSelfDelay>(1);
-            else
-                return SPRET_ABORT;
+            start_delay<ShaftSelfDelay>(1);
         }
         else
             return SPRET_ABORT;
         break;
 
     case ABIL_HOP:
-        if (you.duration[DUR_NO_HOP])
-        {
-            mpr("Your legs are too worn out to hop.");
+        if (you.can_do_hop_ability(false) && check_move_barbed("hop"))
+            return frog_hop(fail);
+        else
             return SPRET_ABORT;
-        }
-        return frog_hop(fail);
 
 #if TAG_MAJOR_VERSION == 34
     case ABIL_DELAYED_FIREBALL:
@@ -2912,6 +2909,8 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
         if (_abort_if_stationary())
             return SPRET_ABORT;
+        if (!check_move_barbed("power leap"))
+            return SPRET_ABORT;
 
         fail_check();
 
@@ -3033,6 +3032,8 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_USKAYAW_LINE_PASS:
         if (_abort_if_stationary())
+            return SPRET_ABORT;
+        if (!check_move_barbed("line pass"))
             return SPRET_ABORT;
         fail_check();
         if (!uskayaw_line_pass())

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -6261,6 +6261,8 @@ bool ru_power_leap()
 
     move_player_to_grid(beam.target, false);
 
+    handle_player_barbed_move();
+
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
 
@@ -6643,6 +6645,7 @@ bool uskayaw_line_pass()
         line_pass.fire();
         you.stop_being_constricted(false);
         move_player_to_grid(beam.target, false);
+        handle_player_barbed_move();
     }
 
     crawl_state.cancel_cmd_again();

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -2675,24 +2675,6 @@ static int _check_adjacent(dungeon_feature_type feat, coord_def& delta)
     return num;
 }
 
-static bool _cancel_barbed_move()
-{
-    if (you.duration[DUR_BARBS] && !you.props.exists(BARBS_MOVE_KEY))
-    {
-        string prompt = "The barbs in your skin will harm you if you move."
-                        " Continue?";
-        if (!yesno(prompt.c_str(), false, 'n'))
-        {
-            canned_msg(MSG_OK);
-            return true;
-        }
-
-        you.props[BARBS_MOVE_KEY] = true;
-    }
-
-    return false;
-}
-
 static bool _cancel_confused_move(bool stationary)
 {
     dungeon_feature_type dangerous = DNGN_FLOOR;
@@ -3169,7 +3151,7 @@ static void _move_player(coord_def move)
         if (_cancel_confused_move(false))
             return;
 
-        if (_cancel_barbed_move())
+        if (!check_move_barbed())
             return;
 
         if (!one_chance_in(3))
@@ -3373,7 +3355,7 @@ static void _move_player(coord_def move)
 
         // If confused, we've already been prompted (in case of stumbling into
         // a monster and attacking instead).
-        if (!you.confused() && _cancel_barbed_move())
+        if (!you.confused() && !check_move_barbed())
             return;
 
         if (!you.attempt_escape()) // false means constricted and did not escape
@@ -3437,17 +3419,7 @@ static void _move_player(coord_def move)
         if (swap)
             targ_monst->apply_location_effects(targ);
 
-        if (you.duration[DUR_BARBS])
-        {
-            mprf(MSGCH_WARN, "The barbed spikes dig painfully into your body "
-                             "as you move.");
-            ouch(roll_dice(2, you.attribute[ATTR_BARBS_POW]), KILLED_BY_BARBS);
-            bleed_onto_floor(you.pos(), MONS_PLAYER, 2, false);
-
-            // Sometimes decrease duration even when we move.
-            if (one_chance_in(3))
-                extract_manticore_spikes("The barbed spikes snap loose.");
-        }
+        handle_player_barbed_move();
 
         if (you_are_delayed() && current_delay()->is_run())
             env.travel_trail.push_back(you.pos());

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -54,6 +54,7 @@
 #include "nearby-danger.h"
 #include "notes.h"
 #include "output.h"
+#include "player-reacts.h"
 #include "player-stats.h"
 #include "potion.h"
 #include "prompt.h"
@@ -297,7 +298,26 @@ bool check_moveto(const coord_def& p, const string &move_verb, const string &msg
     return check_moveto_terrain(p, move_verb, msg)
            && check_moveto_cloud(p, move_verb)
            && check_moveto_trap(p, move_verb)
-           && check_moveto_exclusion(p, move_verb);
+           && check_moveto_exclusion(p, move_verb)
+           && check_move_barbed(move_verb);
+}
+
+bool check_move_barbed(const string &move_verb)
+{
+    if (you.duration[DUR_BARBS] && !you.props.exists(BARBS_MOVE_KEY))
+    {
+        string prompt = make_stringf("The barbs in your skin will harm you"
+                                     " if you %s. Continue?",
+                                     move_verb.c_str());
+        if (!yesno(prompt.c_str(), false, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return false;
+        }
+
+        you.props[BARBS_MOVE_KEY] = true;
+    }
+    return true;
 }
 
 // Returns true if this is a valid swap for this monster. If true, then
@@ -4314,6 +4334,21 @@ bool confuse_player(int amount, bool quiet, bool force)
     return true;
 }
 
+void handle_player_barbed_move(const string &move_verb)
+{
+    if (you.duration[DUR_BARBS])
+    {
+        mprf(MSGCH_WARN, "The barbed spikes dig painfully into your body "
+                         "as you %s.", move_verb.c_str());
+        ouch(roll_dice(2, you.attribute[ATTR_BARBS_POW]), KILLED_BY_BARBS);
+        bleed_onto_floor(you.pos(), MONS_PLAYER, 2, false);
+
+        // Sometimes decrease duration as a result of moving.
+        if (one_chance_in(3))
+            extract_manticore_spikes("The barbed spikes snap loose.");
+    }
+}
+
 void paralyse_player(string source, int amount)
 {
     if (!amount)
@@ -7389,6 +7424,42 @@ vector<PlaceInfo> player::get_all_place_info(bool visited_only,
     }
 
     return list;
+}
+
+bool player::can_do_hop_ability(bool quiet) const
+{
+    if (attribute[ATTR_HELD])
+    {
+        if (!quiet)
+            mprf("You can't hop while %s.", held_status());
+        return false;
+    }
+    else if (you.liquefied_ground())
+    {
+        if (!quiet)
+            mpr("You can't hop while stuck in liquid ground.");
+        return false;
+    }
+    else if (you.duration[DUR_GRASPING_ROOTS])
+    {
+        if (!quiet)
+            mpr("The grasping roots prevent you from hopping.");
+        return false;
+    }
+    else if (you.duration[DUR_EXHAUSTED])
+    {
+        if (!quiet)
+            mpr("You're too exhausted to hop.");
+        return false;
+    }
+    else if (you.duration[DUR_NO_HOP])
+    {
+        if (!quiet)
+            mpr("Your legs are too worn out to hop.");
+        return false;
+    }
+
+    return true;
 }
 
 // Used for falling into traps and other bad effects, but is a slightly

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -794,6 +794,8 @@ public:
     int  skill(skill_type skill, int scale =1,
                bool real = false, bool drained = true) const override;
 
+    bool can_do_hop_ability(bool quiet = false) const;
+
     bool do_shaft() override;
 
     bool can_do_shaft_ability(bool quiet = false) const;
@@ -892,6 +894,8 @@ bool check_moveto_exclusion(const coord_def& p,
                             bool *prompted = nullptr);
 bool check_moveto_trap(const coord_def& p, const string &move_verb = "step",
         bool *prompted = nullptr);
+
+bool check_move_barbed(const string &move_verb = "move");
 
 bool swap_check(monster* mons, coord_def &loc, bool quiet = false);
 
@@ -1066,6 +1070,8 @@ void print_potion_heal_message();
 void contaminate_player(int change, bool controlled = false, bool msg = true);
 
 bool confuse_player(int amount, bool quiet = false, bool force = false);
+
+void handle_player_barbed_move(const string &move_verb = "move");
 
 bool poison_player(int amount, string source, string source_aux = "",
                    bool force = false);

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -350,6 +350,7 @@ spret_type frog_hop(bool fail)
     if (!cell_is_solid(you.pos())) // should be safe.....
         place_cloud(CLOUD_DUST, you.pos(), 2 + random2(3), &you);
     move_player_to_grid(target, false);
+    handle_player_barbed_move("hop");
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
     mpr("Boing!");


### PR DESCRIPTION
The following movement actions now warn the player if barbed, and trigger pain if
followed through:
- Formicid Shaft Self ability
- Barachian Hop ability (issue [10889](https://crawl.develz.org/mantis/view.php?id=10889))
- Ru Power Leap ability
- Uskayaw Line Pass ability

Other god movement abilities (Shadow Step, Bend Space) are more
explicitly "Blink-like" and so still do not trigger barbs.

Additionally, some more restrictions on Hop to make it behave less like cBlink:
- Can't hop if exhausted
- Can't hop if stuck in liquefied ground
- Can't hop if stuck in grasping roots
- Can't hop if netted