### PR TITLE
Fix display on excommunication

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1286,7 +1286,24 @@ static void _redraw_title()
     CGOTOXY(1, 2, GOTO_STAT);
     string species = species_name(you.species);
     NOWRAP_EOL_CPRINTF("%s", species.c_str());
-    if (!you_worship(GOD_NO_GOD))
+    if (you_worship(GOD_NO_GOD))
+    {
+        if (you.char_class == JOB_MONK && you.species != SP_DEMIGOD
+             && !had_gods())
+        {
+            string godpiety = "**....";
+            textcolour(DARKGREY);
+            if ((unsigned int)(strwidth(species) + strwidth(godpiety) + 1) <= WIDTH)
+                NOWRAP_EOL_CPRINTF(" %s", godpiety.c_str());
+            clear_to_end_of_line();
+        }
+        else
+        {
+            // Still need to clear in case the player was excommunicated
+            clear_to_end_of_line();
+        }
+    }
+    else
     {
         string god = " of ";
         god += you_worship(GOD_JIYVA) ? god_name_jiyva(true)
@@ -1311,16 +1328,6 @@ static void _redraw_title()
             _print_stats_gold(textwidth + 2, 2, _god_status_colour(god_colour(you.religion)));
         }
     }
-    else if (you.char_class == JOB_MONK && you.species != SP_DEMIGOD
-             && !had_gods())
-    {
-        string godpiety = "**....";
-        textcolour(DARKGREY);
-        if ((unsigned int)(strwidth(species) + strwidth(godpiety) + 1) <= WIDTH)
-            NOWRAP_EOL_CPRINTF(" %s", godpiety.c_str());
-        clear_to_end_of_line();
-    }
-
 
     textcolour(LIGHTGREY);
 }

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -482,6 +482,7 @@ void wizard_set_gold()
         you.gold = default_gold;
     else
         you.gold = atoi(buf);
+    you.redraw_title = true; // for Gozag worshippers
 }
 
 void wizard_set_piety()


### PR DESCRIPTION
There was an implicit else case that I had missed in case the player
worships GOD_NO_GOD.  This restructures the if to be nested, which I
think is much clearer in this case.

This also catches a gold change case (in wizmode) that the PR missed.