### PR TITLE
Fix a few typos in docs and source

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -1673,7 +1673,7 @@ Formicids
   and magical sides. Their abilities have been used to tunnel immense underground
   communities and structures, many of which are tens of thousands of years old.
 
-  Perhaps unfortunately, their strong ties to to earth have left them completely
+  Perhaps unfortunately, their strong ties to earth have left them completely
   impervious to being teleported or hasted; Formicids are tied to the earth with
   a complete sense of stasis. While this is a seemingly bad property for a
   dungeon adventurer, stasis has the beneficial effect of preventing many types

--- a/crawl-ref/docs/develop/levels/triggerables.txt
+++ b/crawl-ref/docs/develop/levels/triggerables.txt
@@ -492,7 +492,7 @@ F.     Master and slaves
 ========================
 
 Multiple Triggerables can be combined together in a master/slave setup. There
-are multiple methods of doing this. The simplest is to to provide a
+are multiple methods of doing this. The simplest is to provide a
 "master_name" parameter to the main marker, and then provide "slave_to" at all
 of the individual slave markers, setting the same value for each.
 

--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -5101,7 +5101,7 @@ _Menkaure_rare_
 
 @The_monster@'s ankle releases a plume of dust as @subjective@ confides, "I'm not really a mummy, you know."
 
-VISUAL:@The_monster@ forgets how to to speak, silenced by the ages.
+VISUAL:@The_monster@ forgets how to speak, silenced by the ages.
 
 VISUAL:@The_monster@ gestures ominously @at_foe@.
 

--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -614,7 +614,7 @@ void list_spellset(const spellset &spells, const monster_info *mon_owner,
 
     description.cprintf("Select a spell to read its description");
     if (can_memorise)
-        description.cprintf(" or to to memorise it");
+        description.cprintf(" or to memorise it");
     description.cprintf(".\n");
 
     spell_scroller ssc(spells, mon_owner, source_item);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -3453,7 +3453,7 @@ void hints_inscription_info(string prompt)
     {
         text << "\n"
          "Inscriptions are a powerful concept of Dungeon Crawl.\n"
-         "You can inscribe items to to comment on them \n"
+         "You can inscribe items to comment on them \n"
          "or to set rules for item interaction. If you are new to Crawl, \n"
          "you can safely ignore this feature.";
 


### PR DESCRIPTION
Duplicated "to", for example:
"Select a spell to read its description or *to to* memorise it"