### PR TITLE
Noisebar tweaks

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -465,6 +465,11 @@ public:
         textbackground(BLACK);
     }
 
+    void reset()
+    {
+        m_old_disp = -1;
+    }
+
  private:
     int m_old_disp;
     int m_request_redraw_after; // force a redraw at this turn count
@@ -655,6 +660,7 @@ static void _print_stats_noise(int x, int y)
         // This needs to be one extra wide in case silence happens
         // immediately after super-loud (magenta) noise
         CPRINTF("Silenced  ");
+        Noise_Bar.reset(); // so it doesn't display a change bar after silence ends
     }
     else
     {

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -655,8 +655,8 @@ static void _print_stats_noise(int x, int y)
         // This needs to be one extra wide in case silence happens
         // immediately after super-loud (magenta) noise
         CPRINTF("Silenced  ");
-    } 
-    else 
+    }
+    else
     {
         if (level == 1000)
         {

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -628,7 +628,7 @@ static void _print_stats_noise(int x, int y)
         noisecolour = LIGHTMAGENTA;
 
     int bar_position;
-    if (you.wizard)
+    if (you.wizard && !silence)
     {
         Noise_Bar.horiz_bar_width = 6;
         bar_position = 10;
@@ -639,7 +639,7 @@ static void _print_stats_noise(int x, int y)
         // very complicated.
         CGOTOXY(x + bar_position - 3, y, GOTO_STAT);
         textcolour(noisecolour);
-        CPRINTF("%2d", you.get_noise_perception(false));
+        CPRINTF("%2d ", you.get_noise_perception(false));
     }
     else
     {
@@ -652,11 +652,11 @@ static void _print_stats_noise(int x, int y)
         CGOTOXY(x + bar_position, y, GOTO_STAT);
         textcolour(LIGHTMAGENTA);
 
-        // These need to be one extra wide in case silence happens
+        // This needs to be one extra wide in case silence happens
         // immediately after super-loud (magenta) noise
-        CPRINTF("%-*s", Noise_Bar.horiz_bar_width + 1, "(Sil)");
-    }
-    else
+        CPRINTF("Silenced  ");
+    } 
+    else 
     {
         if (level == 1000)
         {

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -796,7 +796,8 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.experience_level, you.experience_level, "xl");
     _update_int(force_full, c.exp_progress, (int8_t) get_exp_progress(), "progress");
     _update_int(force_full, c.gold, you.gold, "gold");
-    _update_int(force_full, c.noise, you.get_noise_perception(false), "noise");
+    _update_int(force_full, c.noise, 
+                (you.wizard ? you.get_noise_perception(false) : -1), "noise");
     _update_int(force_full, c.adjusted_noise, you.get_noise_perception(true), "adjusted_noise");
 
     if (you.running == 0) // Don't update during running/resting

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -796,7 +796,7 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.experience_level, you.experience_level, "xl");
     _update_int(force_full, c.exp_progress, (int8_t) get_exp_progress(), "progress");
     _update_int(force_full, c.gold, you.gold, "gold");
-    _update_int(force_full, c.noise, 
+    _update_int(force_full, c.noise,
                 (you.wizard ? you.get_noise_perception(false) : -1), "noise");
     _update_int(force_full, c.adjusted_noise, you.get_noise_perception(true), "adjusted_noise");
 

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -113,35 +113,31 @@ function ($, comm, enums, map_knowledge, messages, options) {
 
         // The adjusted_noise value has already been rescaled in
         // player.cc:get_adjusted_noise. It ranges from 0 to 1000.
-        var noise_color = "", adjusted_level = 0;
-        if (level <= 333)
-        {
-            noise_color = "#D3D3D3"; // lightgray
-        }
-        else if (level <= 666)
-        {
-            noise_color = "#FFD700"; // gold
-        }
-        else if (level < 1000)
-        {
-            noise_color = "#FF0000"; // red
-        } else {
-            $("#stats_noise_status").text(level);
-            noise_color = "#FF00FF"; // magenta
-        }
+        var adjusted_level = 0, noise_cat = "";
 
-        if (player.has_status("silence"))
+        // colors are set in `style.css` via the selector `data-level`.
+        if (level <= 333)
+            noise_cat = "quiet";
+        else if (level <= 666)
+            noise_cat = "loud";
+        else if (level < 1000)
+            noise_cat = "veryloud";
+        else
+            noise_cat = "superloud";
+
+        var silenced = player.has_status("silence")
+        if (silenced)
         {
             level = 0;
             old_value = 0;
-            $("#stats_noise_bar").css("background-color", "#000000");
-            // I couldn't get this to work just directly putting the text in #stats_noise_bar
-            $("#stats_noise_status").text("(Sil)");
+            noise_cat = "blank";
+            // I couldn't get this to work just directly putting the text in #stats_noise_bar,
+            // because clearing the text later will adjust the span width.
+            $("#stats_noise_status").text("Silenced");
         } else {
-            $("#stats_noise_bar").css("background-color", "#2F2F2F");
             $("#stats_noise_status").text("");
-            $("#stats_noise_status").css("width", 0);
         }
+        $("#stats_noise").attr("data-level", noise_cat);
 
         player.old_noise = level;
 
@@ -153,33 +149,18 @@ function ($, comm, enums, map_knowledge, messages, options) {
             change_bar = 10000 - full_bar;
         }
 
-        if (player.wizard) // the exact value is too hard to interpret to show outside of wizmode, because noise propagation is very complicated.
+        if (player.wizard && !silenced)
         {
-            $("#stats_noise").text(player.noise);
-            $("#stats_noise").css("color", noise_color);
-            if (level == 1000)
-            {
-                // go to 11
-                $("#stats_noise_container").css("width", "95%");
-                $("#stats_noise_bar").css("width", "46.312%"); // This comes from solving -15 - .85 * 40 = -5 - .95 * x
-            } else {
-                $("#stats_noise_container").css("width", "85%");
-                $("#stats_noise_bar").css("width", "40%");
-            }
-        } else {
-            $("#stats_noise").text("");
-            if (level == 1000)
-            {
-                // go to 11
-                $("#stats_noise_container").css("width", "95%");
-                $("#stats_noise_bar").css("width", "60.632%"); // This comes from solving -15 - .85 * 56 = -5 - .95 * x
-            } else {
-                $("#stats_noise_container").css("width", "85%");
-                $("#stats_noise_bar").css("width", "56%");
-            }
+            // the exact value is too hard to interpret to show outside of
+            // wizmode, because noise propagation is very complicated.
+            $("#stats_noise").attr("data-shownum", true);
+            $("#stats_noise_num").text(player.noise);
         }
-
-        $("#stats_noise_bar_full").css("background-color", noise_color);
+        else
+        {
+            $("#stats_noise").attr("data-shownum", null);
+            $("#stats_noise_num").text("");
+        }
 
         $("#stats_noise_bar_full").css("width", (full_bar / 100) + "%");
         if (adjusted_level < old_value)

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -44,8 +44,11 @@ body {
 #stats_titleline, #stats_species_god {
     color: #fce94f; /* yellow */
 }
-#stats_piety, #stats_gozag_gold {
+#stats_piety {
     color: #fce94f; /* yellow */
+}
+#stats_gozag_gold{
+    color: #babdb6; /* lightgray */
 }
 #stats_piety.penance {
     color: #a40000; /* red */
@@ -147,20 +150,72 @@ body {
     background-color: #ee4f45; /* lightred */
 }
 
-#stats_noise_bar {
-    background-color: #000000; /* dark slate gray */
-}
+/* default color when showing "Silenced" */
 #stats_noise_status {
     color: #FF00FF; /* magenta */
 }
-#stats_noise_bar_full {
-    background-color: #00D300; /* lightgray */
+
+/* default bar background color */
+#stats_noise_bar {
+    background-color: #2F2F2F; /* dark slate gray */
 }
+
+/* default bar change color */
 #stats_noise_bar_decrease {
     background-color: #555753; /* darkgray */
 }
-#stats_noise_bar_increase {
-    background-color: #555753; /* darkgray */
+
+/* clear the bar entirely */
+#stats_noise[data-level="blank"] #stats_noise_bar,
+#stats_noise[data-level="blank"] #stats_noise_bar_full {
+    background-color: #000000; /* black */
+}
+
+/* noise number is printed here in wizmode */
+#stats_noise_num {
+    color: #D3D3D3; /* default gray */
+    width: 0;
+}
+#stats_noise[data-shownum] #stats_noise_num {
+    width: 2em;
+}
+
+/* use attribute selectors to adjust the bar and number (wizmode) color depending on `data-level`. */
+#stats_noise[data-level="quiet"] #stats_noise_bar_full {
+    background-color: #D3D3D3; /* lightgray */
+}
+#stats_noise[data-level="quiet"] #stats_noise_num {
+    color: #D3D3D3;
+}
+#stats_noise[data-level="loud"] #stats_noise_bar_full {
+    background-color: #FFD700; /* gold */
+}
+#stats_noise[data-level="loud"] #stats_noise_num {
+    color: #FFD700;
+}
+#stats_noise[data-level="veryloud"] #stats_noise_bar_full {
+    background-color: #FF0000; /* red */
+}
+#stats_noise[data-level="veryloud"] #stats_noise_num {
+    color: #FF0000;
+}
+#stats_noise[data-level="superloud"]  #stats_noise_bar_full {
+    background-color: #FF00FF; /* magenta */
+}
+#stats_noise[data-level="superloud"] #stats_noise_num {
+    color: #FF00FF;
+}
+
+/* make the bar go to eleven on superloud sounds. */
+#stats_noise_bar { width: 82%; }
+#stats_noise[data-level="superloud"] #stats_noise_bar {
+    width: 100%;
+}
+
+/* shrink the bar to the right in wizmode (if `data-shownum` is set). */
+#stats_noise_inter { width: 61%; }
+#stats_noise[data-shownum] #stats_noise_inter {
+     width: 45%;
 }
 
 #stats[data-species="Djinni"] #stats_hp_bar_full {

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -82,14 +82,16 @@
             <span id="stats_xl" />
             <span class="stats_caption">Next:</span>
             <span id="stats_progress" />%</div>
-          <div id="stats_noise_container" style="float:left;width:85%;">
-            <span id="stats_noise_bar" class="bar" style="float:right;width:56%;height:1em;"><!-- Whitespace...
-           --><span id="stats_noise_bar_full" /><!--
-           --><span id="stats_noise_bar_decrease" /><!--
-         --></span>
+          <div id="stats_noise" style="float:left;width:95%;">
+            <div id="stats_noise_inter" style="float:right;height:1em;"><!--
+           --><span id="stats_noise_bar" class="bar" style="float:left;height:1em;"><!-- Whitespace...
+             --><span id="stats_noise_bar_full" /><!--
+             --><span id="stats_noise_bar_decrease" /><!--
+           --></span><!--
+         --></div>
            <span id="stats_noise_status" style="float:right;width:0%;"></span>
             <span class="stats_caption">Noise:</span>
-            <span id="stats_noise"></span>
+            <span id="stats_noise_num"></span>
           </div>
         </div>
         <div id="stats_rightcolumn" style="float:right;width:55%;">


### PR DESCRIPTION
Refactors noise bar webtiles code to use custom attribute selectors.

Also:
- Change silencing to show as "Silenced" instead of "(Sil)"  (all interfaces)
- Prevent a leak of exact noise information outside of wizmode (webtiles)
- Changes Gozag money to be lightgray instead of gold based on feedback in IRC (missed this in the commit message but this is in  31f7f79).