### PR TITLE
Allow swimming in deep water

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -3260,6 +3260,7 @@ static void _move_player(coord_def move)
                                                                : "walk";
 
     monster* targ_monst = monster_at(targ);
+
     if (fedhas_passthrough(targ_monst) && !you.is_stationary())
     {
         // Moving on a plant takes 1.5 x normal move delay. We
@@ -3355,6 +3356,14 @@ static void _move_player(coord_def move)
         }
         else if (!try_to_swap) // attack!
         {
+            // Non-swimmers cannot attack while in deep water
+            if (grd(you.pos()) == DNGN_DEEP_WATER
+                && !you.can_swim())
+            {
+                mpr("You cannot attack while swimming in deep water!");
+                return;
+            }
+
             // Don't allow the player to freely locate invisible monsters
             // with confirmation prompts.
             if (!you.can_see(*targ_monst)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -639,6 +639,13 @@ bool can_cast_spells(bool quiet)
         return false;
     }
 
+    if (grd(you.pos()) == DNGN_DEEP_WATER
+        && !you.can_swim())
+    {
+        mpr("You cannot cast spells while swimming in deep water!");
+        return false;
+    }
+
     return true;
 }
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -879,8 +879,7 @@ bool feat_destroys_items(dungeon_feature_type feat)
  */
 bool feat_eliminates_items(dungeon_feature_type feat)
 {
-    return feat_destroys_items(feat)
-           || feat == DNGN_DEEP_WATER && !species_likes_water(you.species);
+    return feat_destroys_items(feat);
 }
 
 static coord_def _dgn_find_nearest_square(
@@ -1576,6 +1575,7 @@ bool slide_feature_over(const coord_def &src, coord_def preferred_dest,
  */
 void fall_into_a_pool(dungeon_feature_type terrain)
 {
+    ASSERT(terrain == DNGN_LAVA || terrain == DNGN_DEEP_WATER);
     if (terrain == DNGN_DEEP_WATER)
     {
         if (you.can_water_walk() || form_likes_water())
@@ -1588,10 +1588,7 @@ void fall_into_a_pool(dungeon_feature_type terrain)
         }
     }
 
-    mprf("You fall into the %s!",
-         (terrain == DNGN_LAVA)       ? "lava" :
-         (terrain == DNGN_DEEP_WATER) ? "water"
-                                      : "programming rift");
+    mprf("You fall into the %s!", terrain == DNGN_LAVA ? "lava" : "water");
     // included in default force_more_message
 
     clear_messages();
@@ -1602,17 +1599,6 @@ void fall_into_a_pool(dungeon_feature_type terrain)
         else
             mpr("The lava burns you to a cinder!");
         ouch(INSTANT_DEATH, KILLED_BY_LAVA);
-    }
-    else if (terrain == DNGN_DEEP_WATER)
-    {
-        mpr("You sink like a stone!");
-
-        if (you.is_nonliving() || you.undead_state())
-            mpr("You fall apart...");
-        else
-            mpr("You drown...");
-
-        ouch(INSTANT_DEATH, KILLED_BY_WATER);
     }
 }
 


### PR DESCRIPTION
All species can now move through deep water with a 2.5x penalty. The
penalty for moving through shallow water is also fixed at 1.5x rather
than the previous random multiplier of 1.3x - 2.0x.

When swimming in deep water, non-native swimmers cannot attack -- it's
not indended for deep water swimming to be part of tactical combat.

Crawl has historically had big problems with players possibly getting
stuck due to deep water -- see lots of island vaults needing to plant
escape hatches and the like to prevent people trapping themselves.

There are also issues with monster gear near deep water -- if you want
to grab a monster's items / corpse you generally just have to step back
once before landing the killing blow so they die over land rather than
deep water.