### PR TITLE
Load saves where desolation is incorrectly global

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -356,7 +356,6 @@ static void _reset_game()
     StashTrack = StashTracker();
     travel_cache = TravelCache();
     clear_level_target();
-    you.clear_place_info();
     overview_clear();
     clear_message_window();
     note_list.clear();

--- a/crawl-ref/source/place-info.cc
+++ b/crawl-ref/source/place-info.cc
@@ -128,5 +128,9 @@ void player::clear_place_info()
 {
     global_info = PlaceInfo();
     for (branch_iterator it; it; ++it)
+    {
         branch_info[it->id] = PlaceInfo();
+        branch_info[it->id].branch = it->id;
+        branch_info[it->id].assert_validity();
+    }
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5383,11 +5383,7 @@ player::player()
     constricting = 0;
 
     // Protected fields:
-    for (branch_iterator it; it; ++it)
-    {
-        branch_info[it->id].branch = it->id;
-        branch_info[it->id].assert_validity();
-    }
+    clear_place_info();
 }
 
 void player::init_skills()

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -203,6 +203,7 @@ enum tag_minor_version
     TAG_MINOR_SLIME_WALL_CLEAR,    // Turn existing Slime:$ walls clear, so they'll be removed on TRJ death.
     TAG_MINOR_FOOD_PURGE_RELOADED, // The exciting sequel, removing pizza/jerky.
     TAG_MINOR_ELYVILON_WRATH,      // Make Elyvilon wrath expire with XP gain.
+    TAG_MINOR_DESOLATION_GLOBAL,   // Recover from saves where desolation is incorrectly marked as global
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -3923,13 +3923,12 @@ static void tag_read_you_dungeon(reader &th)
         {
             // This is to fix some crashing saves that didn't import
             // correctly, where the desolation slot occasionally gets marked
-            // as global on conversion from pre-0.19 to post-0.19a. Is setting
-            // the place info for branch `i` really a good idea? There's
-            // actually no guarantee that the save order will match the
-            // current branch order; this is really more of a best guess.
-            // HOWEVER, in all the instances I have, this works, and the place
-            // order hasn't changed since the iterator was introduced. (advil)
-            place_info.branch = static_cast<branch_type>(i);
+            // as global on conversion from pre-0.19 to post-0.19a.   This
+            // assumes that the order in `logical_branch_order` (branch.cc)
+            // hasn't changed since the save version (which is moderately safe).
+            const branch_type branch_to_fix = you.get_all_place_info()[i].branch;
+            ASSERT(branch_to_fix == BRANCH_DESOLATION);
+            place_info.branch = branch_to_fix;
         } else {
             // These should all be branch-specific, not global
             ASSERT(!place_info.is_global());


### PR DESCRIPTION
Some games transferred from pre-0.19 to post-0.19a will then save with
desolation's place info incorrectly numbered as the global place slot,
triggering an assertion failure on load.  This patch loads these files
without crashing; it limits the time-frame of this fix with a new minor
tag.  No one who has tried has been able to duplicate the save file
corruption, though we have several saves that result from it, so the
root cause may return or still be present.

Fixes some saves found attached to 10696 and 10788.