### PR TITLE
Fix DEAD_MONSTER message prompt on wall jump

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1773,6 +1773,9 @@ void wu_jian_wall_jump_effects(const coord_def& old_pos)
 
     for (auto target : targets)
     {
+        if (!target->alive())
+            continue;
+
          if (you.attribute[ATTR_HEAVEN_ON_EARTH] > 0)
              you.attribute[ATTR_HEAVEN_ON_EARTH] += 2;
 


### PR DESCRIPTION
Wall jump attacks had an aliveness check on the attack part, but didn't have one when displaying the initial "attack from above" text.