### PR TITLE
Lava orc / Djinni cleanup

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2539,10 +2539,6 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             pow = 3 + you.skill_rdiv(SK_INVOCATIONS, 1, 6);
         else
             pow = 10 + you.skill_rdiv(SK_INVOCATIONS, 1, 3);
-#if TAG_MAJOR_VERSION == 34
-        if (you.species == SP_DJINNI)
-            pow /= 2;
-#endif
         pow = min(50, pow);
         const int healed = pow + roll_dice(2, pow) - 2;
         mpr("You are healed.");
@@ -3403,11 +3399,7 @@ vector<talent> your_talents(bool check_confused, bool include_unusable)
     }
 
     if (player_mutation_level(MUT_TENGU_FLIGHT) && !you.airborne()
-        || you.racial_permanent_flight() && !you.attribute[ATTR_PERM_FLIGHT]
-#if TAG_MAJOR_VERSION == 34
-           && you.species != SP_DJINNI
-#endif
-           )
+        || you.racial_permanent_flight() && !you.attribute[ATTR_PERM_FLIGHT])
     {
         // Tengu can fly, but only from the ground
         // (until level 14, when it becomes permanent until revoked).

--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -49,11 +49,7 @@ level_id actor::shaft_dest(bool known = false) const
  */
 bool actor::ground_level() const
 {
-    return !airborne() && !is_wall_clinging()
-#if TAG_MAJOR_VERSION == 34
-        && mons_species() != MONS_DJINNI
-#endif
-        ;
+    return !airborne() && !is_wall_clinging();
 }
 
 bool actor::stand_on_solid_ground() const

--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -365,10 +365,6 @@ public:
     virtual bool haloed() const;
     // Within an umbra?
     virtual bool umbraed() const;
-#if TAG_MAJOR_VERSION == 34
-    // Being heated by a heat aura?
-    virtual bool heated() const;
-#endif
     // Halo radius.
     virtual int halo_radius() const = 0;
     // Silence radius.
@@ -376,9 +372,6 @@ public:
     // Liquefying radius.
     virtual int liquefying_radius() const = 0;
     virtual int umbra_radius() const = 0;
-#if TAG_MAJOR_VERSION == 34
-    virtual int heat_radius() const = 0;
-#endif
 
     virtual bool petrifying() const = 0;
     virtual bool petrified() const = 0;

--- a/crawl-ref/source/aptitudes.h
+++ b/crawl-ref/source/aptitudes.h
@@ -1332,6 +1332,7 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_OCTOPODE,        SK_EVOCATIONS,      1),
 
 #if TAG_MAJOR_VERSION == 34
+    // Need to keep this as long as the species are still around
     // SP_DJINNI
     APT(SP_DJINNI,          SK_FIGHTING,       -1),
     APT(SP_DJINNI,          SK_SHORT_BLADES,   -2),

--- a/crawl-ref/source/aptitudes.h
+++ b/crawl-ref/source/aptitudes.h
@@ -1332,7 +1332,9 @@ static const species_skill_aptitude species_skill_aptitudes[] =
     APT(SP_OCTOPODE,        SK_EVOCATIONS,      1),
 
 #if TAG_MAJOR_VERSION == 34
-    // Need to keep this as long as the species are still around
+    // It seems that we need to keep this as long as SP_DJINNI/SP_LAVAORC
+    // (which  are needed for loading old Djinni saves) is still around.
+
     // SP_DJINNI
     APT(SP_DJINNI,          SK_FIGHTING,       -1),
     APT(SP_DJINNI,          SK_SHORT_BLADES,   -2),

--- a/crawl-ref/source/areas.cc
+++ b/crawl-ref/source/areas.cc
@@ -40,9 +40,6 @@ enum class areaprop
     QUAD          = (1 << 8),
     DISJUNCTION   = (1 << 9),
     SOUL_AURA     = (1 << 10),
-#if TAG_MAJOR_VERSION == 34
-    HOT           = (1 << 11),
-#endif
 };
 DEF_BITFIELD(areaprops, areaprop);
 
@@ -85,11 +82,7 @@ void areas_actor_moved(const actor* act, const coord_def& oldpos)
     if (act->alive() &&
         (you.entering_level
          || act->halo_radius() > -1 || act->silence_radius() > -1
-         || act->liquefying_radius() > -1 || act->umbra_radius() > -1
-#if TAG_MAJOR_VERSION == 34
-         || act->heat_radius() > -1
-#endif
-         ))
+         || act->liquefying_radius() > -1 || act->umbra_radius() > -1))
     {
         // Not necessarily new, but certainly potentially interesting.
         invalidate_agrid(true);
@@ -142,17 +135,6 @@ static void _actor_areas(actor *a)
             _set_agrid_flag(*ri, areaprop::UMBRA);
         no_areas = false;
     }
-
-#if TAG_MAJOR_VERSION == 34
-    if ((r = a->heat_radius()) >= 0)
-    {
-        _agrid_centres.emplace_back(AREA_HOT, a->pos(), r);
-
-        for (radius_iterator ri(a->pos(), r, C_SQUARE, LOS_NO_TRANS); ri; ++ri)
-            _set_agrid_flag(*ri, areaprop::HOT);
-        no_areas = false;
-    }
-#endif
 }
 
 /**
@@ -234,10 +216,6 @@ static area_centre_type _get_first_area(const coord_def& f)
         return AREA_SANCTUARY;
     if (a & areaprop::SILENCE)
         return AREA_SILENCE;
-#if TAG_MAJOR_VERSION == 34
-    if (a & areaprop::HOT)
-        return AREA_HOT;
-#endif
     if (a & areaprop::HALO)
         return AREA_HALO;
     if (a & areaprop::UMBRA)
@@ -753,42 +731,3 @@ int monster::umbra_radius() const
         return -1;
     }
 }
-
-#if TAG_MAJOR_VERSION == 34
-/////////////
-// Heat aura (lava orcs).
-
-// Player radius
-int player::heat_radius() const
-{
-    if (species != SP_LAVA_ORC)
-        return -1;
-
-    if (!temperature_effect(LORC_HEAT_AURA))
-        return -1;
-
-    return 1; // Surrounds you to radius of 1.
-}
-
-// Stub for monster radius
-int monster::heat_radius() const
-{
-    return -1;
-}
-
-bool heated(const coord_def& p)
-{
-    if (!map_bounds(p))
-        return false;
-
-    if (!_agrid_valid)
-        _update_agrid();
-
-    return _check_agrid_flag(p, areaprop::HOT);
-}
-
-bool actor::heated() const
-{
-    return ::heated(pos());
-}
-#endif

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -433,7 +433,7 @@ static void _wucad_backfire()
         break;
     case 4:
     case 5:
-        drain_mp(5 + random2(20));
+        dec_mp(5 + random2(20));
         break;
     case 6:
         lose_stat(STAT_INT, 1 + random2avg(5, 2));
@@ -443,15 +443,6 @@ static void _wucad_backfire()
 
 static bool _WUCAD_MU_evoke(item_def *item, bool* did_work, bool* unevokable)
 {
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-    {
-        mpr("The staff is unable to affect your essence.");
-        *unevokable = true;
-        return true;
-    }
-
-#endif
     if (you.magic_points == you.max_magic_points)
     {
         mpr("Your reserves of magic are full.");

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3000,12 +3000,6 @@ bool bolt::harmless_to_player() const
     case BEAM_COLD:
         return is_big_cloud() && you.mutation[MUT_FREEZING_CLOUD_IMMUNITY];
 
-#if TAG_MAJOR_VERSION == 34
-    case BEAM_FIRE:
-    case BEAM_STICKY_FLAME:
-        return you.species == SP_DJINNI;
-#endif
-
     case BEAM_VIRULENCE:
         return player_res_poison(false) >= 3;
 
@@ -3566,7 +3560,7 @@ void bolt::affect_player_enchantment(bool resistible)
         if (!amount)
             break;
         mprf(MSGCH_WARN, "You feel your power leaking away.");
-        drain_mp(amount);
+        dec_mp(amount);
         if (agent() && (agent()->type == MONS_EYE_OF_DRAINING
                         || agent()->type == MONS_GHOST_MOTH))
         {

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -906,9 +906,7 @@ bool actor_cloud_immune(const actor &act, const cloud_struct &cloud)
     }
 
     // Qazlalites get immunity to clouds.
-    if (player && have_passive(passive_t::cloud_immunity))
-        return true;
-    return false;
+    return player && have_passive(passive_t::cloud_immunity);
 }
 
 // Returns a numeric resistance value for the actor's resistance to

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -908,16 +908,6 @@ bool actor_cloud_immune(const actor &act, const cloud_struct &cloud)
     // Qazlalites get immunity to clouds.
     if (player && have_passive(passive_t::cloud_immunity))
         return true;
-#if TAG_MAJOR_VERSION == 34
-
-    if (player && you.species == SP_DJINNI
-        && (cloud.type == CLOUD_FIRE
-            || cloud.type == CLOUD_FOREST_FIRE))
-    {
-        return true;
-    }
-#endif
-
     return false;
 }
 

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -276,15 +276,6 @@ static bool _evoke_horn_of_geryon()
 
 static bool _check_crystal_ball()
 {
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-    {
-        mpr("These balls have not yet been approved for use by djinn. "
-            "(OOC: they're supposed to work, but need a redesign.)");
-        return false;
-    }
-#endif
-
     if (you.confused())
     {
         canned_msg(MSG_TOO_CONFUSED);
@@ -1706,11 +1697,7 @@ bool evoke_item(int slot, bool check_range)
             canned_msg(MSG_TOO_HUNGRY);
             return false;
         }
-        else if (you.magic_points >= you.max_magic_points
-#if TAG_MAJOR_VERSION == 34
-                 && (you.species != SP_DJINNI || you.hp == you.hp_max)
-#endif
-                )
+        else if (you.magic_points >= you.max_magic_points)
         {
             canned_msg(MSG_FULL_MAGIC);
             return false;

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -63,6 +63,7 @@
 #include "output.h"
 #include "place.h"
 #include "prompt.h"
+#include "species.h"
 #include "spl-summoning.h"
 #include "stash.h"  // for fedhas_rot_all_corpses
 #include "state.h"
@@ -80,7 +81,6 @@
 #include "unwind.h"
 #include "version.h"
 #include "view.h"
-#include "wiz-you.h"
 #include "xom.h"
 
 #ifdef __ANDROID__
@@ -2105,7 +2105,7 @@ static bool _convert_obsolete_species()
             you.save = 0;
             end(0, false, "Please load the save in an earlier version if you want to keep it as a Lava Orc.\n");
         }
-        wizard_change_species_to(SP_HILL_ORC);
+        change_species_to(SP_HILL_ORC);
         // No need for conservation
         you.innate_mutation[MUT_CONSERVE_SCROLLS] = you.mutation[MUT_CONSERVE_SCROLLS] = 0;
         // This is not an elegant way to deal with lava, but at this point the
@@ -2125,7 +2125,7 @@ static bool _convert_obsolete_species()
             you.save = 0;
             end(0, false, "Please load the save in an earlier version if you want to keep it as a Djinni.\n");
         }
-        wizard_change_species_to(SP_VINE_STALKER);
+        change_species_to(SP_VINE_STALKER);
         you.magic_contamination = 0;
         // Djinni were flying, so give the player some time to land
         fly_player(100);

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2119,7 +2119,7 @@ static bool _convert_obsolete_species()
     if (you.species == SP_DJINNI)
     {
         if (!yes_or_no("This <red>Djinni</red> save game cannot be loaded as-is. If you "
-                       "load it now, your character will be converted to a Vinestalker. Continue?"))
+                       "load it now, your character will be converted to a Vine Stalker. Continue?"))
         {
             you.save->abort(); // don't even rewrite the header
             delete you.save;

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2108,7 +2108,6 @@ static bool _convert_obsolete_species()
         wizard_change_species_to(SP_HILL_ORC);
         // No need for conservation
         you.innate_mutation[MUT_CONSERVE_SCROLLS] = you.mutation[MUT_CONSERVE_SCROLLS] = 0;
-        you.temperature = you.temperature_last = 1;
         // This is not an elegant way to deal with lava, but at this point the
         // level isn't loaded so we can't check the grid features. In
         // addition, even if the player isn't over lava, they might still get
@@ -2130,7 +2129,7 @@ static bool _convert_obsolete_species()
         you.magic_contamination = 0;
         // Djinni were flying, so give the player some time to land
         fly_player(100);
-        // Give them some time to find food.  Creating food isn't safe as the grid doesn't exist yet, and may have water anyways.
+        // Give them some time to find food. Creating food isn't safe as the grid doesn't exist yet, and may have water anyways.
         you.hunger = HUNGER_MAXIMUM;
         return true;
     }

--- a/crawl-ref/source/food.cc
+++ b/crawl-ref/source/food.cc
@@ -53,19 +53,6 @@ void make_hungry(int hunger_amount, bool suppress_msg,
     if (crawl_state.disables[DIS_HUNGER])
         return;
 
-#if TAG_MAJOR_VERSION == 34
-    // Lich/tree form djinn don't get exempted from food costs: infinite
-    // healing from channeling would be just too good.
-    if (you.species == SP_DJINNI)
-    {
-        if (!magic)
-            return;
-
-        contaminate_player(hunger_amount * 4 / 3, true);
-        return;
-    }
-#endif
-
     if (you_foodless())
         return;
 
@@ -133,20 +120,12 @@ void set_hunger(int new_hunger_level, bool suppress_msg)
 
 bool you_foodless(bool can_eat)
 {
-    return you.undead_state() == US_UNDEAD
-#if TAG_MAJOR_VERSION == 34
-        || you.species == SP_DJINNI && !can_eat
-#endif
-        ;
+    return you.undead_state() == US_UNDEAD;
 }
 
 bool you_foodless_normally()
 {
-    return you.undead_state(false) == US_UNDEAD
-#if TAG_MAJOR_VERSION == 34
-        || you.species == SP_DJINNI
-#endif
-        ;
+    return you.undead_state(false) == US_UNDEAD;
 }
 
 bool prompt_eat_item(int slot)
@@ -852,9 +831,7 @@ bool is_preferred_food(const item_def &food)
 
 #if TAG_MAJOR_VERSION == 34
     if (food.is_type(OBJ_POTIONS, POT_PORRIDGE)
-        && item_type_known(food)
-        && you.species != SP_DJINNI
-        )
+        && item_type_known(food))
     {
         return !player_mutation_level(MUT_CARNIVOROUS);
     }

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -946,13 +946,9 @@ static bool _sif_muna_retribution()
     case 6:
     case 7:
     case 8:
-        if (you.magic_points > 0
-#if TAG_MAJOR_VERSION == 34
-                 || you.species == SP_DJINNI
-#endif
-                )
+        if (you.magic_points > 0)
         {
-            drain_mp(100);  // This should zero it.
+            dec_mp(you.magic_points);
             canned_msg(MSG_MAGIC_DRAIN);
         }
         break;

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3467,11 +3467,6 @@ bool is_useless_item(const item_def &item, bool temp)
                 || (is_shield(item) && player_mutation_level(MUT_MISSING_HAND));
 
     case OBJ_SCROLLS:
-#if TAG_MAJOR_VERSION == 34
-        if (you.species == SP_LAVA_ORC && temperature_effect(LORC_NO_SCROLLS))
-            return true;
-#endif
-
         if (temp && silenced(you.pos()))
             return true; // can't use scrolls while silenced
 

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -404,21 +404,6 @@ bool can_wield(const item_def *weapon, bool say_reason,
         else
             return false;
     }
-#if TAG_MAJOR_VERSION == 34
-    else if (you.species == SP_DJINNI
-             && get_weapon_brand(*weapon) == SPWPN_ANTIMAGIC
-             && (item_type_known(*weapon) || !only_known))
-    {
-        if (say_reason)
-        {
-            mpr("As you grasp it, you feel your magic disrupted. Quickly, you stop.");
-            id_brand = true;
-        }
-        else
-            return false;
-    }
-#endif
-
     if (id_brand)
     {
         auto wwpn = const_cast<item_def*>(weapon);
@@ -900,11 +885,7 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
             return false;
         }
 
-        if (you.species == SP_NAGA
-#if TAG_MAJOR_VERSION == 34
-            || you.species == SP_DJINNI
-#endif
-           )
+        if (you.species == SP_NAGA)
         {
             if (verbose)
                 mpr("You have no legs!");

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2686,12 +2686,6 @@ string cannot_read_item_reason(const item_def &item)
     if (you.duration[DUR_NO_SCROLLS])
         return "You cannot read scrolls in your current state!";
 
-#if TAG_MAJOR_VERSION == 34
-    // Prevent hot lava orcs reading scrolls
-    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_NO_SCROLLS))
-        return "You'd burn any scroll you tried to read!";
-#endif
-
     // don't waste the player's time reading known scrolls in situations where
     // they'd be useless
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -354,6 +354,7 @@ static void _reset_game()
     macro_clear_buffers();
     transit_lists_clear();
     you = player();
+    reset_hud();
     StashTrack = StashTracker();
     travel_cache = TravelCache();
     clear_level_target();

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -507,9 +507,6 @@ bool melee_attack::handle_phase_hit()
         // the player is hit, each of them will verify their own required
         // parameters.
         do_passive_freeze();
-#if TAG_MAJOR_VERSION == 34
-        do_passive_heat();
-#endif
         emit_foul_stench();
     }
 
@@ -3102,42 +3099,6 @@ void melee_attack::do_passive_freeze()
         }
     }
 }
-
-#if TAG_MAJOR_VERSION == 34
-void melee_attack::do_passive_heat()
-{
-    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_PASSIVE_HEAT)
-        && attacker->alive()
-        && grid_distance(you.pos(), attacker->as_monster()->pos()) == 1)
-    {
-        bolt beam;
-        beam.flavour = BEAM_FIRE;
-        beam.thrower = KILL_YOU;
-
-        monster* mon = attacker->as_monster();
-
-        const int orig_hurted = random2(5);
-        int hurted = mons_adjust_flavoured(mon, beam, orig_hurted);
-
-        if (!hurted)
-            return;
-
-        simple_monster_message(*mon, " is singed by your heat.");
-
-#ifndef USE_TILE
-        flash_monster_colour(mon, LIGHTRED, 200);
-#endif
-
-        mon->hurt(&you, hurted);
-
-        if (mon->alive())
-        {
-            mon->expose_to_element(BEAM_FIRE, orig_hurted);
-            print_wounds(*mon);
-        }
-    }
-}
-#endif
 
 void melee_attack::mons_do_eyeball_confusion()
 {

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -3689,4 +3689,3 @@ static void _mons_in_cloud(monster& mons)
 
     actor_apply_cloud(&mons);
 }
-

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -73,9 +73,6 @@
 
 static bool _handle_pickup(monster* mons);
 static void _mons_in_cloud(monster& mons);
-#if TAG_MAJOR_VERSION == 34
-static void _heated_area(monster& mons);
-#endif
 static bool _monster_move(monster* mons);
 
 // [dshaligram] Doesn't need to be extern.
@@ -1495,9 +1492,6 @@ static void _pre_monster_move(monster& mons)
         // Update constriction durations
         mons.accum_has_constricted();
 
-#if TAG_MAJOR_VERSION == 34
-        _heated_area(mons);
-#endif
         if (mons.type == MONS_NO_MONSTER)
             return;
     }
@@ -1641,9 +1635,6 @@ void handle_monster_move(monster* mons)
     mons->shield_blocks = 0;
 
     _mons_in_cloud(*mons);
-#if TAG_MAJOR_VERSION == 34
-    _heated_area(*mons);
-#endif
     if (!mons->alive())
         return;
 
@@ -3699,54 +3690,3 @@ static void _mons_in_cloud(monster& mons)
     actor_apply_cloud(&mons);
 }
 
-#if TAG_MAJOR_VERSION == 34
-static void _heated_area(monster& mons)
-{
-    if (!heated(mons.pos()))
-        return;
-
-    if (mons.is_fiery())
-        return;
-
-    // HACK: Currently this prevents even auras not caused by lava orcs...
-    if (you_worship(GOD_BEOGH) && mons.friendly() && mons.god == GOD_BEOGH)
-        return;
-
-    const int base_damage = random2(11);
-
-    // Timescale, like with clouds:
-    const int speed = mons.speed > 0 ? mons.speed : 10;
-    const int timescaled = max(0, base_damage) * 10 / speed;
-
-    // rF protects:
-    const int adjusted_damage = resist_adjust_damage(&mons,
-                                BEAM_FIRE, timescaled);
-    // So does AC:
-    const int final_damage = max(0, adjusted_damage
-                                 - random2(mons.armour_class()));
-
-    if (final_damage > 0)
-    {
-        if (mons.observable())
-        {
-            mprf("%s is %s by your radiant heat.",
-                 mons.name(DESC_THE).c_str(),
-                 (final_damage) > 10 ? "blasted" : "burned");
-        }
-
-        behaviour_event(&mons, ME_DISTURB, 0, mons.pos());
-
-#ifdef DEBUG_DIAGNOSTICS
-        mprf(MSGCH_DIAGNOSTICS, "%s %s %d damage from heat.",
-             mons.name(DESC_THE).c_str(),
-             mons.conj_verb("take").c_str(),
-             final_damage);
-#endif
-
-        mons.hurt(&you, final_damage, BEAM_MISSILE);
-
-        if (mons.alive() && mons.observable())
-            print_wounds(mons);
-    }
-}
-#endif

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2307,10 +2307,6 @@ item_def* monster_die(monster* mons, killer_type killer,
                     }
                 }
 
-#if TAG_MAJOR_VERSION == 34
-                if (you.species == SP_DJINNI)
-                    hp_heal = max(hp_heal, mp_heal * 2), mp_heal = 0;
-#endif
                 if (hp_heal && you.hp < you.hp_max
                     && !you.duration[DUR_DEATHS_DOOR])
                 {

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -418,9 +418,6 @@ public:
     int silence_radius() const override;
     int liquefying_radius() const override;
     int umbra_radius() const override;
-#if TAG_MAJOR_VERSION == 34
-    int heat_radius() const override;
-#endif
     bool petrified() const override;
     bool petrifying() const override;
     bool liquefied_ground() const override;

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1014,18 +1014,6 @@ bool physiology_mutation_conflict(mutation_type mutat)
             return true;
         }
     }
-#if TAG_MAJOR_VERSION == 34
-
-    // Heat doesn't hurt fire, djinn don't care about hunger.
-    if (you.species == SP_DJINNI && (mutat == MUT_HEAT_RESISTANCE
-        || mutat == MUT_HEAT_VULNERABILITY
-        || mutat == MUT_BERSERK
-        || mutat == MUT_FAST_METABOLISM || mutat == MUT_SLOW_METABOLISM
-        || mutat == MUT_CARNIVOROUS || mutat == MUT_HERBIVOROUS))
-    {
-        return true;
-    }
-#endif
 
     // Already immune.
     if (you.species == SP_GARGOYLE && mutat == MUT_POISON_RESISTANCE)

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -542,17 +542,6 @@ static const string _vampire_Ascreen_footer = (
     " to toggle between mutations and properties depending on your blood\n"
     "level.\n");
 
-#if TAG_MAJOR_VERSION == 34
-static const string _lava_orc_Ascreen_footer = (
-#ifndef USE_TILE_LOCAL
-    "Press '<w>!</w>'"
-#else
-    "<w>Right-click</w>"
-#endif
-    " to toggle between mutations and properties depending on your\n"
-    "temperature.\n");
-#endif
-
 static void _display_vampire_attributes()
 {
     ASSERT(you.species == SP_VAMPIRE);
@@ -638,88 +627,6 @@ static void _display_vampire_attributes()
     }
 }
 
-#if TAG_MAJOR_VERSION == 34
-static void _display_temperature()
-{
-    ASSERT(you.species == SP_LAVA_ORC);
-
-    clrscr();
-    cgotoxy(1,1);
-
-    string result;
-
-    string title = "Temperature Effects";
-
-    // center title
-    int offset = 39 - strwidth(title) / 2;
-    if (offset < 0) offset = 0;
-
-    result += string(offset, ' ');
-
-    result += "<white>";
-    result += title;
-    result += "</white>\n\n";
-
-    const int lines = TEMP_MAX + 1; // 15 lines plus one for off-by-one.
-    string column[lines];
-
-    for (int t = 1; t <= TEMP_MAX; t++)  // lines
-    {
-        string text;
-        ostringstream ostr;
-
-        string colourname = temperature_string(t);
-#define F(x) stringize_glyph(dchar_glyph(DCHAR_FRAME_##x))
-        if (t == TEMP_MAX)
-            text = "  " + F(TL) + F(HORIZ) + "MAX" + F(HORIZ) + F(HORIZ) + F(TR);
-        else if (t == TEMP_MIN)
-            text = "  " + F(BL) + F(HORIZ) + F(HORIZ) + "MIN" + F(HORIZ) + F(BR);
-        else if (temperature() < t)
-            text = "  " + F(VERT) + "      " + F(VERT);
-        else if (temperature() == t)
-            text = "  " + F(VERT) + "~~~~~~" + F(VERT);
-        else
-            text = "  " + F(VERT) + "######" + F(VERT);
-        text += "    ";
-#undef F
-
-        ostr << '<' << colourname << '>' << text
-             << "</" << colourname << '>';
-
-        colourname = (temperature() >= t) ? "lightred" : "darkgrey";
-        text = temperature_text(t);
-        ostr << '<' << colourname << '>' << text
-             << "</" << colourname << '>';
-
-       column[t] = ostr.str();
-    }
-
-    for (int y = TEMP_MAX; y >= TEMP_MIN; y--)  // lines
-    {
-        result += column[y];
-        result += "\n";
-    }
-
-    result += "\n";
-
-    result += "You get hot in tense situations, when berserking, or when you enter lava. You \ncool down when your rage ends or when you enter water.";
-    result += "\n";
-    result += "\n";
-
-    result += _lava_orc_Ascreen_footer;
-
-    formatted_scroller temp_menu;
-    temp_menu.add_text(result);
-
-    temp_menu.show();
-    if (temp_menu.getkey() == '!'
-        || temp_menu.getkey() == CK_MOUSE_CMD)
-    {
-        display_mutations();
-    }
-}
-#endif
-
 void display_mutations()
 {
     string mutation_s = describe_mutations(true);
@@ -738,16 +645,6 @@ void display_mutations()
 
         extra += _vampire_Ascreen_footer;
     }
-
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC)
-    {
-        if (!extra.empty())
-            extra += "\n";
-
-        extra += _lava_orc_Ascreen_footer;
-    }
-#endif
 
     if (!extra.empty())
     {
@@ -768,14 +665,6 @@ void display_mutations()
     {
         _display_vampire_attributes();
     }
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC
-        && (mutation_menu.getkey() == '!'
-            || mutation_menu.getkey() == CK_MOUSE_CMD))
-    {
-        _display_temperature();
-    }
-#endif
 }
 
 static int _calc_mutation_amusement_value(mutation_type which_mutation)

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -459,15 +459,12 @@ public:
 };
 
 static colour_bar HP_Bar(LIGHTGREEN, GREEN, RED, DARKGREY);
-static colour_bar EP_Bar(LIGHTMAGENTA, MAGENTA, BLUE, DARKGREY);
 
 #ifdef USE_TILE_LOCAL
 static colour_bar MP_Bar(BLUE, BLUE, LIGHTBLUE, DARKGREY);
 #else
 static colour_bar MP_Bar(LIGHTBLUE, BLUE, MAGENTA, DARKGREY);
 #endif
-
-colour_bar Contam_Bar(DARKGREY, DARKGREY, DARKGREY, DARKGREY);
 
 #ifdef USE_TILE_LOCAL
 static colour_bar Noise_Bar(WHITE, LIGHTGREY, LIGHTGREY, DARKGREY);
@@ -669,11 +666,6 @@ static void _print_stats_gold(int x, int y, colour_t colour)
 
 static void _print_stats_mp(int x, int y)
 {
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        return;
-
-#endif
     // Calculate colour
     short mp_colour = HUD_VALUE_COLOUR;
 
@@ -716,61 +708,9 @@ static void _print_stats_mp(int x, int y)
     MP_Bar.draw(19, y, you.magic_points, you.max_magic_points);
 }
 
-#if TAG_MAJOR_VERSION == 34
-static void _print_stats_contam(int x, int y)
-{
-    if (you.species != SP_DJINNI)
-        return;
-
-    const int max_contam = 8000;
-    int contam = min(you.magic_contamination, max_contam);
-
-    // Calculate colour
-    if (you.magic_contamination > 15000)
-    {
-        Contam_Bar.m_default = RED;
-        Contam_Bar.m_change_pos = Contam_Bar.m_change_neg = RED;
-    }
-    else if (you.magic_contamination > 5000) // harmful
-    {
-        Contam_Bar.m_default = LIGHTRED;
-        Contam_Bar.m_change_pos = Contam_Bar.m_change_neg = RED;
-    }
-    else if (you.magic_contamination > 3333)
-    {
-        Contam_Bar.m_default = YELLOW;
-        Contam_Bar.m_change_pos = Contam_Bar.m_change_neg = BROWN;
-    }
-    else if (you.magic_contamination > 1666)
-    {
-        Contam_Bar.m_default = LIGHTGREY;
-        Contam_Bar.m_change_pos = Contam_Bar.m_change_neg = DARKGREY;
-    }
-    else
-    {
-#ifdef USE_TILE_LOCAL
-        Contam_Bar.m_default = LIGHTGREY;
-#else
-        Contam_Bar.m_default = DARKGREY;
-#endif
-        Contam_Bar.m_change_pos = Contam_Bar.m_change_neg = DARKGREY;
-    }
-
-#ifdef TOUCH_UI
-    if (tiles.is_using_small_layout())
-        Contam_Bar.vdraw(6, 10, contam, max_contam);
-    else
-#endif
-    Contam_Bar.draw(19, y, contam, max_contam);
-}
-#endif
 static void _print_stats_hp(int x, int y)
 {
     int max_max_hp = get_real_hp(true, true);
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        max_max_hp += get_real_mp(true);
-#endif
 
     // Calculate colour
     short hp_colour = HUD_VALUE_COLOUR;
@@ -793,11 +733,6 @@ static void _print_stats_hp(int x, int y)
     // Health: xxx/yyy (zzz)
     CGOTOXY(x, y, GOTO_STAT);
     textcolour(HUD_CAPTION_COLOUR);
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        CPRINTF(player_rotted() ? "EP: " : "Essence: ");
-    else
-#endif
     CPRINTF(player_rotted() ? "HP: " : "Health: ");
     textcolour(hp_colour);
     CPRINTF("%d", you.hp);
@@ -815,19 +750,7 @@ static void _print_stats_hp(int x, int y)
 
 #ifdef USE_TILE_LOCAL
     if (tiles.is_using_small_layout())
-    {
-#if TAG_MAJOR_VERSION == 34
-        if (you.species == SP_DJINNI)
-            EP_Bar.vdraw(2, 10, you.hp, you.hp_max);
-        else
-#endif
         HP_Bar.vdraw(2, 10, you.hp, you.hp_max);
-    }
-    else
-#endif
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        EP_Bar.draw(19, y, you.hp, you.hp_max);
     else
 #endif
         HP_Bar.draw(19, y, you.hp, you.hp_max, you.hp - max(0, poison_survival()));
@@ -1354,10 +1277,7 @@ void print_stats()
         you.redraw_magic_points = false;
         _print_stats_mp(1, 4);
     }
-#if TAG_MAJOR_VERSION == 34
-    _print_stats_contam(1, 4);
-#endif
-    
+
     if (you.redraw_armour_class)
     {
         you.redraw_armour_class = false;
@@ -1371,9 +1291,7 @@ void print_stats()
 
     for (int i = 0; i < NUM_STATS; ++i)
         if (you.redraw_stats[i])
-        {
             _print_stat(static_cast<stat_type>(i), 19, 5 + i);
-        }
     you.redraw_stats.init(false);
 
     if (you.redraw_experience)
@@ -1498,11 +1416,6 @@ void draw_border()
 
     //CGOTOXY(1, 3, GOTO_STAT); CPRINTF("Hp:");
     CGOTOXY(1, mp_pos, GOTO_STAT);
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        CPRINTF("Contam:");
-    else
-#endif
     CGOTOXY(1, ac_pos, GOTO_STAT); CPRINTF("AC:");
     CGOTOXY(1, ev_pos, GOTO_STAT); CPRINTF("EV:");
     CGOTOXY(1, sh_pos, GOTO_STAT); CPRINTF("SH:");

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -451,6 +451,7 @@ public:
     void reset()
     {
         m_old_disp = -1;
+        m_request_redraw_after = 0;
     }
 
  private:
@@ -472,6 +473,12 @@ static colour_bar Noise_Bar(WHITE, LIGHTGREY, LIGHTGREY, DARKGREY);
 static colour_bar Noise_Bar(LIGHTGREY, LIGHTGREY, MAGENTA, DARKGREY);
 #endif
 
+void reset_hud()
+{
+    HP_Bar.reset();
+    MP_Bar.reset();
+    Noise_Bar.reset();
+}
 
 // ----------------------------------------------------------------------
 // Status display

--- a/crawl-ref/source/output.h
+++ b/crawl-ref/source/output.h
@@ -9,6 +9,8 @@
 void update_message_status();
 #endif
 
+void reset_hud();
+
 void update_turn_count();
 
 void print_stats();

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -780,10 +780,6 @@ bool player::can_go_berserk(bool intentional, bool potion, bool quiet,
         msg = "You are too mesmerised to rage.";
     else if (afraid())
         msg = "You are too terrified to rage.";
-#if TAG_MAJOR_VERSION == 34
-    else if (you.species == SP_DJINNI)
-        msg = "Only creatures of flesh and blood can berserk.";
-#endif
     else if (is_lifeless_undead())
         msg = "You cannot raise a blood rage in your lifeless body.";
     else if (stasis())

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -750,15 +750,6 @@ bool player::go_berserk(bool intentional, bool potion)
 
     you.redraw_quiver = true; // Account for no firing.
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC)
-    {
-        mpr("You burn with rage!");
-        // This will get sqrt'd later, so.
-        you.temperature = TEMP_MAX;
-    }
-#endif
-
     if (player_equip_unrand(UNRAND_ZEALOT_SWORD))
         for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
             if (mi->friendly())

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -972,11 +972,6 @@ void player_reacts()
     mprf(MSGCH_DIAGNOSTICS, "stealth: %d", stealth);
 #endif
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC)
-        temperature_check();
-#endif
-
     if (player_mutation_level(MUT_DEMONIC_GUARDIAN))
         check_demonic_guardian();
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5097,12 +5097,6 @@ player::player()
     lives = 0;
     deaths = 0;
 
-#if TAG_MAJOR_VERSION == 34
-    // need to keep this field around for save compat, might as well initialize it
-    temperature = 1; // 1 is min; 15 is max.
-    temperature_last = 1;
-#endif
-
     xray_vision = false;
 
     init_skills();

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -199,11 +199,6 @@ public:
     bool pending_revival;
     int lives;
     int deaths;
-#if TAG_MAJOR_VERSION == 34
-    // Need to keep these fields for save compat reasons.
-    float temperature; // For lava orcs.
-    float temperature_last;
-#endif
 
     FixedVector<uint8_t, NUM_SKILLS> skills; ///< skill level
     FixedVector<training_status, NUM_SKILLS> train; ///< see enum def

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -200,6 +200,7 @@ public:
     int lives;
     int deaths;
 #if TAG_MAJOR_VERSION == 34
+    // Need to keep these fields for save compat reasons.
     float temperature; // For lava orcs.
     float temperature_last;
 #endif
@@ -410,9 +411,6 @@ public:
     bool redraw_title;
     bool redraw_hit_points;
     bool redraw_magic_points;
-#if TAG_MAJOR_VERSION == 34
-    bool redraw_temperature;
-#endif
     FixedVector<bool, NUM_STATS> redraw_stats;
     bool redraw_experience;
     bool redraw_armour_class;
@@ -763,9 +761,6 @@ public:
     int silence_radius() const override;
     int liquefying_radius() const override;
     int umbra_radius() const override;
-#if TAG_MAJOR_VERSION == 34
-    int heat_radius() const override;
-#endif
     bool petrifying() const override;
     bool petrified() const override;
     bool liquefied_ground() const override;
@@ -1140,44 +1135,3 @@ bool need_expiration_warning(coord_def p = you.pos());
 
 bool player_has_orb();
 bool player_on_orb_run();
-
-#if TAG_MAJOR_VERSION == 34
-enum temperature_level
-{
-    TEMP_MIN = 1, // Minimum (and starting) temperature. Not any warmer than bare rock.
-    TEMP_COLD = 3,
-    TEMP_COOL = 5,
-    TEMP_ROOM = 7,
-    TEMP_WARM = 9, // Warmer than most creatures.
-    TEMP_HOT = 11,
-    TEMP_FIRE = 13, // Hot enough to ignite paper around you.
-    TEMP_MAX = 15, // Maximum temperature. As hot as lava!
-};
-
-enum temperature_effect
-{
-    LORC_LAVA_BOOST,
-    LORC_FIRE_BOOST,
-    LORC_STONESKIN,
-    LORC_COLD_VULN,
-    LORC_PASSIVE_HEAT,
-    LORC_HEAT_AURA,
-    LORC_NO_SCROLLS,
-    LORC_FIRE_RES_I,
-    LORC_FIRE_RES_II,
-    LORC_FIRE_RES_III,
-};
-
-int temperature();
-int temperature_last();
-void temperature_check();
-void temperature_increment(float degree);
-void temperature_decrement(float degree);
-void temperature_changed(float change);
-void temperature_decay();
-bool temperature_tier(int which);
-bool temperature_effect(int which);
-int temperature_colour(int temp);
-string temperature_string(int temp);
-string temperature_text(int temp);
-#endif

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1044,7 +1044,6 @@ void recalc_and_scale_hp();
 
 void dec_hp(int hp_loss, bool fatal, const char *aux = nullptr);
 void dec_mp(int mp_loss, bool silent = false);
-void drain_mp(int mp_loss);
 
 void inc_mp(int mp_gain, bool silent = false);
 void inc_hp(int hp_gain);

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -606,10 +606,6 @@ public:
 
     bool can_quaff(string *reason = nullptr) const override
     {
-#if TAG_MAJOR_VERSION == 34
-        if (you.species == SP_DJINNI)
-            return PotionHealWounds::instance().can_quaff(reason);
-#endif
         if (you.magic_points == you.max_magic_points)
         {
             if (reason)
@@ -621,14 +617,6 @@ public:
 
     bool effect(bool=true, int pow = 40, bool=true) const override
     {
-#if TAG_MAJOR_VERSION == 34
-        // Allow repairing rot, disallow going through Death's Door.
-        if (you.species == SP_DJINNI
-            && PotionHealWounds::instance().can_quaff())
-        {
-            return PotionHealWounds::instance().effect(pow);
-        }
-#endif
         inc_mp(POT_MAGIC_MP);
         mpr("Magic courses through your body.");
         return true;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3034,16 +3034,6 @@ bool player_can_join_god(god_type which_god)
     if (which_god == GOD_FEDHAS && you.holiness() & MH_UNDEAD)
         return false;
 
-#if TAG_MAJOR_VERSION == 34
-    // Dithmenos hates fiery species.
-    if (which_god == GOD_DITHMENOS
-        && (you.species == SP_DJINNI
-            || you.species == SP_LAVA_ORC))
-    {
-        return false;
-    }
-#endif
-
     if (which_god == GOD_GOZAG && you.gold < gozag_service_fee())
         return false;
 

--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -140,11 +140,6 @@ static void _update_feat_at(const coord_def &gp)
     if (disjunction_haloed(gp))
         env.map_knowledge(gp).flags |= MAP_DISJUNCT;
 
-#if TAG_MAJOR_VERSION == 34
-    if (heated(gp))
-        env.map_knowledge(gp).flags |= MAP_HOT;
-#endif
-
     if (is_sanctuary(gp))
     {
         if (testbits(env.pgrid(gp), FPROP_SANCTUARY_1))

--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -728,12 +728,9 @@ static const map<species_type, species_def> species_data =
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     8, 8, 8, // 24
     { STAT_STR, STAT_INT, STAT_DEX }, 4,
-    { { MUT_NEGATIVE_ENERGY_RESISTANCE, 3, 1 }, },
-    { "You are immune to all types of fire, even holy and hellish.",
-      "You are vulnerable to cold.",
-      "You need no food.",
-      "You have no legs." },
-    { "fire immunity", "cold vulnerability" },
+    {},
+    {},
+    {},
     {}, // not a starting race
     {}, // not a starting race
 } },

--- a/crawl-ref/source/species.h
+++ b/crawl-ref/source/species.h
@@ -60,3 +60,5 @@ int species_mr_modifier(species_type species);
 void species_stat_init(species_type species);
 void species_stat_gain(species_type species);
 bool species_has_low_str(species_type species);
+
+void change_species_to(species_type sp);

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -350,22 +350,6 @@ int raw_spell_fail(spell_type spell)
     ASSERT_RANGE(spell_level, 0, (int) ARRAYSZ(difficulty_by_level));
     chance += difficulty_by_level[spell_level];
 
-#if TAG_MAJOR_VERSION == 34
-    // Only apply this penalty to Dj because other species lose nutrition
-    // rather than gaining contamination when casting spells.
-    // Also, this penalty gives fairly precise information about contam
-    // level, and only Dj already has such information (on the contam bar).
-    // Other species would have to check their failure rates all the time
-    // when at yellow glow.
-    if (you.species == SP_DJINNI)
-    {
-        int64_t contam = you.magic_contamination;
-        // Just +25 on the edge of yellow glow, +200 in the middle of yellow,
-        // forget casting when in orange.
-        chance += contam * contam * contam / 5000000000LL;
-    }
-#endif
-
     int chance2 = chance;
 
     const int chance_breaks[][2] =
@@ -847,18 +831,7 @@ bool cast_a_spell(bool check_range, spell_type spell)
         count_action(CACT_CAST, spell);
     }
 
-#if TAG_MAJOR_VERSION == 34
-    // Nasty special cases.
-    if (you.species == SP_DJINNI && cast_result == SPRET_SUCCESS
-        && (spell == SPELL_BORGNJORS_REVIVIFICATION
-         || spell == SPELL_SUBLIMATION_OF_BLOOD && you.hp == you.hp_max))
-    {
-        // These spells have replenished essence to full.
-        inc_mp(cost, true);
-    }
-    else // Redraw MP
-#endif
-        flush_mp();
+    flush_mp();
 
     if (!staff_energy && you.undead_state() != US_UNDEAD)
     {

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -508,14 +508,6 @@ static int _spell_enhancement(spell_type spell)
     enhanced += you.archmagi();
     enhanced += player_equip_unrand(UNRAND_MAJIN);
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC && temperature_effect(LORC_LAVA_BOOST)
-        && (typeflags & SPTYP_FIRE) && (typeflags & SPTYP_EARTH))
-    {
-        enhanced++;
-    }
-#endif
-
     // These are used in an exponential way, so we'll limit them a bit. -- bwr
     if (enhanced > 3)
         enhanced = 3;

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -1157,14 +1157,8 @@ void MiscastEffect::_charms(int severity)
                 if (target->is_player())
                 {
                     debuff_player();
-                    if (you.magic_points > 0
-#if TAG_MAJOR_VERSION == 34
-                        || you.species == SP_DJINNI
-#endif
-                        )
-                        {
-                            drain_mp(4 + random2(3));
-                        }
+                    if (you.magic_points > 0)
+                        dec_mp(4 + random2(3));
                 }
                 else if (target->is_monster())
                 {

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1109,25 +1109,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         if (spell == SPELL_LEDAS_LIQUEFACTION)
             return "you can't cast this while perpetually flying.";
     }
-
-    if (you.species == SP_LAVA_ORC)
-    {
-        if (spell == SPELL_OZOCUBUS_ARMOUR)
-            return "your stony body would shatter the ice.";
-
-        if (temp && !temperature_effect(LORC_STONESKIN))
-        {
-            switch (spell)
-            {
-                case SPELL_STATUE_FORM:
-                case SPELL_ICE_FORM:
-                    return "you're too hot.";
-                default:
-                    break;
-            }
-        }
-
-    }
 #endif
 
     switch (spell)

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1100,17 +1100,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
     if (!fake_spell && cannot_use_schools(get_spell_disciplines(spell)))
         return "you cannot use spells of this school.";
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-    {
-        if (spell == SPELL_ICE_FORM  || spell == SPELL_OZOCUBUS_ARMOUR)
-            return "you're too hot.";
-
-        if (spell == SPELL_LEDAS_LIQUEFACTION)
-            return "you can't cast this while perpetually flying.";
-    }
-#endif
-
     switch (spell)
     {
     case SPELL_BLINK:

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -299,10 +299,6 @@ static void _post_init(bool newc)
     you.redraw_armour_class = true;
     you.redraw_evasion      = true;
     you.redraw_experience   = true;
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC)
-        you.redraw_temperature = true;
-#endif
     you.redraw_quiver       = true;
     you.wield_change        = true;
 

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -786,9 +786,6 @@ static void _describe_glow(status_info* inf)
         inf->light_colour = LIGHTGREY;
     else
         inf->light_colour = DARKGREY;
-#if TAG_MAJOR_VERSION == 34
-    if (cont > 1 || you.species != SP_DJINNI)
-#endif
     inf->light_text = "Contam";
 
     /// Mappings from contamination levels to descriptions.

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -203,6 +203,7 @@ enum tag_minor_version
     TAG_MINOR_FOOD_PURGE_RELOADED, // The exciting sequel, removing pizza/jerky.
     TAG_MINOR_ELYVILON_WRATH,      // Make Elyvilon wrath expire with XP gain.
     TAG_MINOR_DESOLATION_GLOBAL,   // Recover from saves where desolation is incorrectly marked as global
+    TAG_MINOR_NO_MORE_LORC,        // Don't save lava orc temperature (or anything else). LO/Dj removal.
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1565,11 +1565,6 @@ static void tag_construct_you(writer &th)
     marshallByte(th, you.deaths);
     marshallByte(th, you.lives);
 
-#if TAG_MAJOR_VERSION == 34
-    marshallFloat(th, you.temperature);
-    marshallFloat(th, you.temperature_last);
-#endif
-
     CANARY;
 
     marshallInt(th, you.dactions.size());
@@ -3274,15 +3269,13 @@ static void tag_read_you(reader &th)
     you.lives = unmarshallByte(th);
 
 #if TAG_MAJOR_VERSION == 34
-    if (th.getMinorVersion() >= TAG_MINOR_LORC_TEMPERATURE)
+    if (th.getMinorVersion() >= TAG_MINOR_LORC_TEMPERATURE &&
+        th.getMinorVersion() < TAG_MINOR_NO_MORE_LORC)
     {
-        you.temperature = unmarshallFloat(th);
-        you.temperature_last = unmarshallFloat(th);
-    }
-    else
-    {
-        you.temperature = 0.0;
-        you.temperature_last = 0.0;
+        // These were once the temperature fields on player for lava orcs.
+        // Still need to unmarshall them from older saves.
+        unmarshallFloat(th); // was you.temperature
+        unmarshallFloat(th); // was you.temperature_last
     }
 #endif
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2795,11 +2795,6 @@ static void tag_read_you(reader &th)
             you.mutation[MUT_POISON_RESISTANCE] =
             you.innate_mutation[MUT_POISON_RESISTANCE] = 0;
         }
-        if (you.species == SP_DJINNI)
-        {
-            you.mutation[MUT_NEGATIVE_ENERGY_RESISTANCE] =
-            you.innate_mutation[MUT_NEGATIVE_ENERGY_RESISTANCE] = 3;
-        }
         if (you.species == SP_FORMICID)
         {
             you.mutation[MUT_ANTENNAE] = you.innate_mutation[MUT_ANTENNAE] = 3;

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -622,10 +622,6 @@ tileidx_t tilep_species_to_base_tile(int sp, int level)
         return TILEP_BASE_FELID;
     case SP_OCTOPODE:
         return TILEP_BASE_OCTOPODE;
-#if TAG_MAJOR_VERSION == 34
-    case SP_DJINNI:
-        return TILEP_BASE_DJINNI;
-#endif
     case SP_FORMICID:
         return TILEP_BASE_FORMICID;
     case SP_VINE_STALKER:
@@ -732,11 +728,6 @@ void tilep_race_default(int sp, int level, dolls_data *doll)
         case SP_FORMICID:
             hair = 0;
             break;
-#if TAG_MAJOR_VERSION == 34
-        case SP_DJINNI:
-            hair = TILEP_HAIR_DJINN2;
-            break;
-#endif
         default:
             // nothing to do
             break;
@@ -1000,15 +991,6 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
         flag[TILEP_PART_LEG]    = TILEP_FLAG_HIDE;
         flag[TILEP_PART_SHADOW] = TILEP_FLAG_HIDE;
     }
-#if TAG_MAJOR_VERSION == 34
-    else if (is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_DJINNI))
-    {
-        flag[TILEP_PART_BOOTS]  = TILEP_FLAG_HIDE;
-        flag[TILEP_PART_LEG]    = TILEP_FLAG_HIDE;
-        flag[TILEP_PART_SHADOW] = TILEP_FLAG_HIDE;
-        flag[TILEP_PART_BODY]   = TILEP_FLAG_CUT_NAGA; // Do they need their own flag?
-    }
-#endif
     else if (doll.parts[TILEP_PART_BASE] >= TILEP_BASE_DRACONIAN_FIRST
              && doll.parts[TILEP_PART_BASE] <= TILEP_BASE_DRACONIAN_LAST)
     {

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -573,10 +573,6 @@ tileidx_t tilep_species_to_base_tile(int sp, int level)
         return TILEP_BASE_HALFLING;
     case SP_HILL_ORC:
         return TILEP_BASE_ORC;
-#if TAG_MAJOR_VERSION == 34
-    case SP_LAVA_ORC:
-        return TILEP_BASE_LAVA_ORC;
-#endif
     case SP_KOBOLD:
         return TILEP_BASE_KOBOLD;
     case SP_MUMMY:
@@ -682,36 +678,6 @@ void tilep_race_default(int sp, int level, dolls_data *doll)
         case SP_HILL_ORC:
             hair = 0;
             break;
-#if TAG_MAJOR_VERSION == 34
-        case SP_LAVA_ORC:
-            // This should respect the player's choice of base tile, if possible.
-            switch (temperature_colour(you.temperature))
-            {
-                case LIGHTRED:
-                    result = TILEP_BASE_LAVA_ORC_HEAT + 5;
-                    break;
-                case RED:
-                    result = TILEP_BASE_LAVA_ORC_HEAT + 4;
-                    break;
-                case YELLOW:
-                    result = TILEP_BASE_LAVA_ORC_HEAT + 3;
-                    break;
-                case WHITE:
-                    result = TILEP_BASE_LAVA_ORC_HEAT + 2;
-                    break;
-                case LIGHTCYAN:
-                    result = TILEP_BASE_LAVA_ORC_HEAT + 1;
-                    break;
-                case LIGHTBLUE:
-                    result = TILEP_BASE_LAVA_ORC_HEAT;
-                    break;
-                default:
-                    result = TILEP_BASE_LAVA_ORC;
-                    break;
-            }
-            hair = 0;
-            break;
-#endif
         case SP_KOBOLD:
             hair = 0;
             break;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1305,11 +1305,6 @@ void TilesFramework::layout_statcol()
 
         m_statcol_bottom = m_region_tab->sy - m_tab_margin;
 
-#if TAG_MAJOR_VERSION == 34
-        // Lava orc temperature bar
-        if (you.species == SP_LAVA_ORC)
-            ++crawl_view.hudsz.y;
-#endif
         m_region_stat->resize(m_region_stat->mx, crawl_view.hudsz.y);
         m_statcol_top += m_region_stat->dy;
 

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -741,34 +741,11 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.hp, you.hp, "hp");
     _update_int(force_full, c.hp_max, you.hp_max, "hp_max");
     int max_max_hp = get_real_hp(true, true);
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_DJINNI)
-        max_max_hp += get_real_mp(true); // compare _print_stats_hp
 
-    _update_int(force_full, c.real_hp_max, max_max_hp, "real_hp_max");
-
-    if (you.species != SP_DJINNI)
-    {
-        _update_int(force_full, c.mp, you.magic_points, "mp");
-        _update_int(force_full, c.mp_max, you.max_magic_points, "mp_max");
-    }
-
-    if (you.species == SP_DJINNI)
-    {
-        // Don't send more information than can be seen from the console HUD.
-        // Compare _print_stats_contam and get_contamination_level
-        int contam = you.magic_contamination;
-        if (contam >= 26000)
-            contam = 26000;
-        else if (contam >= 16000)
-            contam = 16000;
-        _update_int(force_full, c.contam, contam, "contam");
-    }
-#else
     _update_int(force_full, c.real_hp_max, max_max_hp, "real_hp_max");
     _update_int(force_full, c.mp, you.magic_points, "mp");
     _update_int(force_full, c.mp_max, you.max_magic_points, "mp_max");
-#endif
+
     _update_int(force_full, c.poison_survival, max(0, poison_survival()),
                 "poison_survival");
 

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -772,11 +772,6 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.poison_survival, max(0, poison_survival()),
                 "poison_survival");
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.species == SP_LAVA_ORC)
-        _update_int(force_full, c.heat, temperature(), "heat");
-#endif
-
     _update_int(force_full, c.armour_class, you.armour_class(), "ac");
     _update_int(force_full, c.evasion, you.evasion(), "ev");
     _update_int(force_full, c.shield_class, player_displayed_shield_class(),
@@ -1228,11 +1223,6 @@ void TilesFramework::_send_cell(const coord_def &gc,
 
         if (next_pc.travel_trail != current_pc.travel_trail)
             json_write_int("travel_trail", next_pc.travel_trail);
-
-#if TAG_MAJOR_VERSION == 34
-        if (next_pc.heat_aura != current_pc.heat_aura)
-            json_write_int("heat_aura", next_pc.heat_aura);
-#endif
 
         if (_needs_flavour(next_pc) &&
             (next_pc.flv.floor != current_pc.flv.floor

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -51,7 +51,6 @@ struct player_info
     int hp, hp_max, real_hp_max, poison_survival;
     int mp, mp_max;
     int contam;
-    int heat;
     int noise;
     int adjusted_noise;
 

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -720,10 +720,6 @@ static void _handle_magic_contamination()
     if (you.duration[DUR_HASTE])
         added_contamination += 30;
 
-#if TAG_MAJOR_VERSION == 34
-    if (you.duration[DUR_REGENERATION] && you.species == SP_DJINNI)
-        added_contamination += 20;
-#endif
     // The Orb halves dissipation (well a bit more, I had to round it),
     // but won't cause glow on its own -- otherwise it'd spam the player
     // with messages about contamination oscillating near zero.
@@ -775,13 +771,7 @@ static void _magic_contamination_effects()
         beam.explode();
     }
 
-#if TAG_MAJOR_VERSION == 34
-    const mutation_permanence_class mutclass = you.species == SP_DJINNI
-        ? MUTCLASS_TEMPORARY
-        : MUTCLASS_NORMAL;
-#else
     const mutation_permanence_class mutclass = MUTCLASS_NORMAL;
-#endif
 
     // We want to warp the player, not do good stuff!
     mutate(one_chance_in(5) ? RANDOM_MUTATION : RANDOM_BAD_MUTATION,

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -579,22 +579,11 @@ public:
     string get_untransform_message() const override
     {
         // This only handles lava orcs going statue -> stoneskin.
-        if (
-#if TAG_MAJOR_VERSION == 34
-            you.species == SP_LAVA_ORC && temperature_effect(LORC_STONESKIN)
-            ||
-#endif
-            you.species == SP_GARGOYLE)
+        if (you.species == SP_GARGOYLE)
         {
             return "You revert to a slightly less stony form.";
         }
-#if TAG_MAJOR_VERSION == 34
-        if (you.species != SP_LAVA_ORC)
-#endif
-            return "You revert to your normal fleshy form.";
-#if TAG_MAJOR_VERSION == 34
-        return Form::get_untransform_message();
-#endif
+        return "You revert to your normal fleshy form.";
     }
 
     /**
@@ -625,12 +614,7 @@ public:
      */
     string get_untransform_message() const override
     {
-#if TAG_MAJOR_VERSION == 34
-        if (you.species == SP_LAVA_ORC && !temperature_effect(LORC_STONESKIN))
-            return "Your icy form melts away into molten rock.";
-        else
-#endif
-            return "You warm up again.";
+        return "You warm up again.";
     }
 
     /**
@@ -1108,16 +1092,8 @@ bool form_likes_water(transformation form)
 
 bool form_likes_lava(transformation form)
 {
-#if TAG_MAJOR_VERSION == 34
-    // Lava orcs can only swim in non-phys-change forms.
-    // However, ice beast & statue form will melt back to lava, so they're OK
-    return you.species == SP_LAVA_ORC
-           && (!form_changed_physiology(form)
-               || form == transformation::ice_beast
-               || form == transformation::statue);
-#else
+    // No forms currently like lava
     return false;
-#endif
 }
 
 // Used to mark transformations which override species intrinsics.
@@ -1705,15 +1681,6 @@ bool transform(int pow, transformation which_trans, bool involuntary,
         msg = "You cannot become a lich while in Death's Door.";
         success = false;
     }
-#if TAG_MAJOR_VERSION == 34
-    else if (you.species == SP_LAVA_ORC && !temperature_effect(LORC_STONESKIN)
-             && (which_trans == transformation::ice_beast
-                 || which_trans == transformation::statue))
-    {
-        msg =  "Your temperature is too high to benefit from that spell.";
-        success = false;
-    }
-#endif
 
     if (!just_check && previous_trans != transformation::none)
         untransform(true);

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -580,9 +580,7 @@ public:
     {
         // This only handles lava orcs going statue -> stoneskin.
         if (you.species == SP_GARGOYLE)
-        {
             return "You revert to a slightly less stony form.";
-        }
         return "You revert to your normal fleshy form.";
     }
 
@@ -1441,10 +1439,6 @@ static bool _transformation_is_safe(transformation which_trans,
                                     dungeon_feature_type feat,
                                     string *fail_reason)
 {
-#if TAG_MAJOR_VERSION == 34
-    if (which_trans == transformation::ice_beast && you.species == SP_DJINNI)
-        return false; // melting is fatal...
-#endif
     if (!feat_dangerous_for_form(which_trans, feat))
         return true;
 

--- a/crawl-ref/source/viewgeom.cc
+++ b/crawl-ref/source/viewgeom.cc
@@ -361,12 +361,7 @@ void crawl_view_geometry::set_player_at(const coord_def &c, bool centre)
 void crawl_view_geometry::init_geometry()
 {
     termsz = coord_def(get_number_of_cols(), get_number_of_lines());
-    hudsz  = coord_def(HUD_WIDTH,
-                       HUD_HEIGHT
-#if TAG_MAJOR_VERSION == 34
-                                  + ((you.species == SP_LAVA_ORC) ? 1 : 0)
-#endif
-                                  );
+    hudsz  = coord_def(HUD_WIDTH, HUD_HEIGHT);
 
     const _inline_layout lay_inline(termsz, hudsz);
     const _mlist_col_layout lay_mlist(termsz, hudsz);

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -71,26 +71,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
             .css("width", 0);
     }
 
-    function update_bar_contam()
-    {
-        player.contam_max = 16000;
-        update_bar("contam");
-
-        // Calculate level for the colour
-        var contam_level = 0;
-
-        if (player.contam > 25000)
-            contam_level = 4;
-        else if (player.contam > 15000)
-            contam_level = 3;
-        else if (player.contam > 5000)
-            contam_level = 2;
-        else if (player.contam > 0)
-            contam_level = 1;
-
-        $("#stats_contamline").attr("data-contam", contam_level);
-    }
-
     function update_bar_noise()
     {
         player.noise_max = 1000;
@@ -347,8 +327,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
         $("#stats_titleline").text(player.name + " " + player.title);
         $("#stats_wizmode").text(player.wizard ? "*WIZARD*" : "");
 
-        var do_contam = false;
-
         // Setup species
         // TODO: Move to a proper initialisation task
         if ($("#stats").attr("data-species") != player.species)
@@ -358,22 +336,12 @@ function ($, comm, enums, map_knowledge, messages, options) {
             if (player.real_hp_max != player.hp_max)
             {
                 hp_cap = "HP";
-                if (player.species == "Djinni")
-                    hp_cap = "EP";
             }
             else
             {
                 hp_cap = "Health";
-                if (player.species == "Djinni")
-                    hp_cap = "Essence";
             }
             $("#stats_hpline > .stats_caption").text(hp_cap+":");
-        }
-        switch (player.species)
-        {
-            case "Djinni":
-                do_contam = true;
-                break;
         }
 
         var species_god = player.species;
@@ -425,10 +393,7 @@ function ($, comm, enums, map_knowledge, messages, options) {
         percentage_color("hp");
         percentage_color("mp");
         update_bar("hp");
-        if (do_contam)
-            update_bar_contam();
-        else
-            update_bar("mp");
+        update_bar("mp");
 
         update_defense("ac");
         update_defense("ev");

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -91,12 +91,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
         $("#stats_contamline").attr("data-contam", contam_level);
     }
 
-    function update_bar_heat()
-    {
-        player.heat_max = 15; // Value of TEMP_MAX
-        update_bar("heat");
-    }
-
     function update_bar_noise()
     {
         player.noise_max = 1000;
@@ -353,7 +347,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
         $("#stats_titleline").text(player.name + " " + player.title);
         $("#stats_wizmode").text(player.wizard ? "*WIZARD*" : "");
 
-        var do_temperature = false;
         var do_contam = false;
 
         // Setup species
@@ -380,9 +373,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
         {
             case "Djinni":
                 do_contam = true;
-                break;
-            case "Lava Orc":
-                do_temperature = true;
                 break;
         }
 
@@ -439,8 +429,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
             update_bar_contam();
         else
             update_bar("mp");
-        if (do_temperature)
-            update_bar_heat();
 
         update_defense("ac");
         update_defense("ev");
@@ -566,7 +554,6 @@ function ($, comm, enums, map_knowledge, messages, options) {
                 wizard: 0,
                 depth: 0, place: "",
                 contam: 0,
-                heat: 0,
                 noise: 0,
                 adjusted_noise: 0
             });

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -125,31 +125,6 @@ body {
     display: none;
 }
 
-/* Temperature bar, hidden normally */
-#stats_heatline {
-    display:none;
-    visibility:hidden;
-}
-
-/* Visible for Lava Orcs */
-#stats[data-species="Lava Orc"] #stats_heatline {
-    display:block;
-    visibility:visible;
-}
-
-#stats_heat_bar {
-    background-color: #555753; /* darkgray */
-}
-#stats_heat_bar_full {
-    background-color: #a40000; /* red */
-}
-#stats_heat_bar_decrease {
-    background-color: #729fcf; /* lightblue */
-}
-#stats_heat_bar_increase {
-    background-color: #ee4f45; /* lightred */
-}
-
 /* default color when showing "Silenced" */
 #stats_noise_status {
     color: #FF00FF; /* magenta */

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -193,69 +193,6 @@ body {
      width: 45%;
 }
 
-#stats[data-species="Djinni"] #stats_hp_bar_full {
-    background-color: #ba2cde;
-}
-#stats[data-species="Djinni"] #stats_hp_bar_decrease {
-    background-color: #2d0bba;
-}
-#stats[data-species="Djinni"] #stats_hp_bar_increase {
-    background-color: #6c19e4;
-}
-
-/* Djinni contam bar */
-#stats_contamline {
-    display:none;
-    visibility:hidden;
-}
-
-#stats[data-species="Djinni"] #stats_contamline {
-    display:block;
-    visibility:visible;
-}
-/* Hide MP bar */
-#stats[data-species="Djinni"] #stats_mpline {
-    display:none;
-    visibility:hidden;
-}
-
-#stats_contam_bar {
-    background-color: #555753; /* darkgray */
-}
-
-#stats_contam_bar_full {
-    background-color: #343434;
-}
-
-#stats_contam_bar_decrease,
-#stats_contam_bar_increase {
-    background-color: #232323;
-}
-
-#stats_contamline[data-contam="2"] #stats_contam_bar_full {
-    background-color: yellow;
-}
-
-#stats_contamline[data-contam="2"] #stats_contam_bar_decrease,
-#stats_contamline[data-contam="2"] #stats_contam_bar_increase {
-    background-color: saddlebrown;
-}
-
-#stats_contamline[data-contam="3"] #stats_contam_bar_full {
-    background-color: red;
-}
-
-#stats_contamline[data-contam="3"] #stats_contam_bar_decrease,
-#stats_contamline[data-contam="3"] #stats_contam_bar_increase {
-    background-color: darkred;
-}
-
-#stats_contamline[data-contam="4"] #stats_contam_bar_full,
-#stats_contamline[data-contam="4"] #stats_contam_bar_decrease,
-#stats_contamline[data-contam="4"] #stats_contam_bar_increase {
-    background-color: darkred;
-}
-
 #message_pane {
     width: 100%;
 }

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -62,14 +62,6 @@
      --></span>
         <span class="stats_caption">Contam:</span>
       </div>
-      <div id="stats_heatline">
-        <span id="stats_heat_bar" class="bar" style="float:right; width:55%; height:1em;"><!-- Whitespace...
-       --><span id="stats_heat_bar_full" /><!--
-       --><span id="stats_heat_bar_decrease" /><!--
-       --><span id="stats_heat_bar_increase" /><!--
-     --></span>
-        <span class="stats_caption">Temperature:</span>
-      </div>
       <div>
         <div id="stats_leftcolumn" style="float:left;width:45%;">
           <div><span class="stats_caption">AC:</span>

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -54,14 +54,6 @@
         <span class="stats_caption">Magic:</span>
         <span id="stats_mp" /><span id="stats_mp_separator">/</span><span id="stats_mp_max" />
       </div>
-      <div id="stats_contamline">
-        <span id="stats_contam_bar" class="bar" style="float:right; width:55%; height:1em;"><!-- Whitespace...
-       --><span id="stats_contam_bar_full" /><!--
-       --><span id="stats_contam_bar_decrease" /><!--
-       --><span id="stats_contam_bar_increase" /><!--
-     --></span>
-        <span class="stats_caption">Contam:</span>
-      </div>
       <div>
         <div id="stats_leftcolumn" style="float:left;width:45%;">
           <div><span class="stats_caption">AC:</span>

--- a/crawl-ref/source/wiz-dump.cc
+++ b/crawl-ref/source/wiz-dump.cc
@@ -474,8 +474,20 @@ bool chardump_parser::_check_char(const vector<string> &tokens)
                 race = tokens[k-3].substr(1) + " " + tokens[k-2];
             string role = tokens[k-1].substr(0, tokens[k-1].length() - 1);
 
-            wizard_change_species_to(find_species_from_string(race));
-            wizard_change_job_to(find_job_from_string(role));
+            const species_type sp = find_species_from_string(race);
+            if (sp == SP_UNKNOWN)
+            {
+                mprf("Unknown species: %s", race.c_str());
+                return false;
+            }
+            const job_type job = find_job_from_string(role);
+            if (job == JOB_UNKNOWN)
+            {
+                mprf("Unknown job: %s", role.c_str());
+                return false;
+            }
+            change_species_to(sp);
+            wizard_change_job_to(job);
             return true;
         }
     }

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -28,6 +28,7 @@
 #include "prompt.h"
 #include "religion.h"
 #include "skills.h"
+#include "species.h"
 #include "spl-book.h"
 #include "spl-util.h"
 #include "state.h"
@@ -40,13 +41,6 @@
 #include "xom.h"
 
 #ifdef WIZARD
-static void _swap_equip(equipment_type a, equipment_type b)
-{
-    swap(you.equip[a], you.equip[b]);
-    bool tmp = you.melded[a];
-    you.melded.set(a, you.melded[b]);
-    you.melded.set(b, tmp);
-}
 
 job_type find_job_from_string(const string &job)
 {
@@ -132,106 +126,6 @@ static xom_event_type _find_xom_event_from_string(const string &event_name)
     return x;
 }
 
-void wizard_change_species_to(species_type sp)
-{
-    // Means find_species_from_string couldn't interpret right.
-    if (sp == SP_UNKNOWN)
-    {
-        mpr("That species isn't available.");
-        return;
-    }
-
-    // Re-scale skill-points.
-    for (skill_type sk = SK_FIRST_SKILL; sk < NUM_SKILLS; ++sk)
-    {
-        you.skill_points[sk] *= species_apt_factor(sk, sp)
-                                / species_apt_factor(sk);
-    }
-
-    species_type old_sp = you.species;
-    you.species = sp;
-    you.chr_species_name = species_name(sp);
-
-    // Change permanent mutations, but preserve non-permanent ones.
-    uint8_t prev_muts[NUM_MUTATIONS];
-    for (int i = 0; i < NUM_MUTATIONS; ++i)
-    {
-        if (you.innate_mutation[i] > 0)
-        {
-            if (you.innate_mutation[i] > you.mutation[i])
-                you.mutation[i] = 0;
-            else
-                you.mutation[i] -= you.innate_mutation[i];
-
-            you.innate_mutation[i] = 0;
-        }
-        prev_muts[i] = you.mutation[i];
-    }
-    give_basic_mutations(sp);
-    for (int i = 2; i <= you.experience_level; ++i)
-        give_level_mutations(sp, i);
-    for (int i = 0; i < NUM_MUTATIONS; ++i)
-    {
-        if (prev_muts[i] > you.innate_mutation[i])
-            you.innate_mutation[i] = 0;
-        else
-            you.innate_mutation[i] -= prev_muts[i];
-    }
-
-    if (sp == SP_DEMONSPAWN)
-    {
-        roll_demonspawn_mutations();
-        for (int i = 0; i < int(you.demonic_traits.size()); ++i)
-        {
-            mutation_type m = you.demonic_traits[i].mutation;
-
-            if (you.demonic_traits[i].level_gained > you.experience_level)
-                continue;
-
-            ++you.mutation[m];
-            ++you.innate_mutation[m];
-        }
-    }
-
-    update_vision_range(); // for Ba, and for DS with Nightstalker
-
-    if ((old_sp == SP_OCTOPODE) != (sp == SP_OCTOPODE))
-    {
-        _swap_equip(EQ_LEFT_RING, EQ_RING_ONE);
-        _swap_equip(EQ_RIGHT_RING, EQ_RING_TWO);
-        // All species allow exactly one amulet. When (and knowing you guys,
-        // that's "when" not "if") ettins go in, you'll need handle the Macabre
-        // Finger Necklace on neck 2 here.
-    }
-
-    // FIXME: this checks only for valid slots, not for suitability of the
-    // item in question. This is enough to make assertions happy, though.
-    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
-        if (you_can_wear(static_cast<equipment_type>(i)) == MB_FALSE
-            && you.equip[i] != -1)
-        {
-            mprf("%s fall%s away.",
-                 you.inv[you.equip[i]].name(DESC_YOUR).c_str(),
-                 you.inv[you.equip[i]].quantity > 1 ? "" : "s");
-            // Unwear items without the usual processing.
-            you.equip[i] = -1;
-            you.melded.set(i, false);
-        }
-
-    // Sanitize skills.
-    fixup_skills();
-
-    calc_hp();
-    calc_mp();
-
-    // The player symbol depends on species.
-    update_player_symbol();
-#ifdef USE_TILE
-    init_player_doll();
-#endif
-    redraw_screen();
-}
-
 void wizard_change_job_to(job_type job)
 {
     you.char_class = job;
@@ -251,9 +145,16 @@ void wizard_change_species()
         return;
     }
 
-    species_type sp = find_species_from_string(specs);
+    const species_type sp = find_species_from_string(specs);
 
-    wizard_change_species_to(sp);
+    // Means find_species_from_string couldn't interpret `specs`.
+    if (sp == SP_UNKNOWN)
+    {
+        mpr("That species isn't available.");
+        return;
+    }
+
+    change_species_to(sp);
 }
 
 // Casts a specific spell by number or name.

--- a/crawl-ref/source/wiz-you.h
+++ b/crawl-ref/source/wiz-you.h
@@ -38,7 +38,6 @@ void wizard_god_mollify();
 void wizard_transform();
 void wizard_join_religion();
 species_type find_species_from_string(const string &species_str);
-void wizard_change_species_to(species_type sp);
 job_type find_job_from_string(const string &job_str);
 void wizard_change_job_to(job_type job);
 void wizard_xom_acts();


### PR DESCRIPTION
Lava orcs and Djinni haven't been startable species in years, but their code lingers -- and there is a lot of it.  (|amethyst calculated that this PR removes 1378 net lines of code.)  This PR:

- on load, converts Lava Orcs to Hill Orcs, and Djinni to Vine Stalkers (both after a special full "yes" confirmation).  They both get to fly for a little while, and Djinni get some extra nutrition, but that's it.
- eliminates most code involved in both species.  What's left is the bare minimum to support save compatibility.

Hopefully this won't break anything else, but it's a pretty big change so it's entirely possible I missed something.  It doesn't mess with anything in `rltiles` because I wasn't quite sure what could be changed safely.

Here are some save games (generated in the last point in history to support starting a character for each of these species) for anyone who wants to test the conversions:

[lavaorc-djinn-saves.zip](https://github.com/crawl/crawl/files/807371/lavaorc-djinn-saves.zip)

(Because one of the LO saves has its stats maxed via &A, you get a slightly weird order of the training screen vs the load confirmation, but this is harmless as far as I can tell.)

Credit to |amethyst for the basic idea this PR implements.