### PR TITLE
Allow (un)wielding items while berserk

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -494,17 +494,6 @@ bool wield_weapon(bool auto_wield, int slot, bool show_weff_messages,
         return true;
     }
 
-    // Switching weapons while berserk is usually a waste of time.
-    if (you.berserk())
-    {
-        string prompt = "Really switch weapons while berserk?";
-        if (!yesno(prompt.c_str(), false, 'n'))
-        {
-            canned_msg(MSG_OK);
-            return false;
-        }
-    }
-
     // Reset the warning counter.
     you.received_weapon_warning = false;
 
@@ -559,11 +548,11 @@ bool wield_weapon(bool auto_wield, int slot, bool show_weff_messages,
 
     item_def& new_wpn(you.inv[item_slot]);
 
-    // Switching to a launcher while berserk is almost certainly a mistake.
-    // They've already gone through the first prompt but just to make sure...
+    // Switching to a launcher while berserk is likely a mistake.
     if (you.berserk() && is_range_weapon(new_wpn))
     {
-        string prompt = "You can't shoot while berserk! Are you sure about this?";
+        string prompt = "You can't shoot while berserk! Really wield " +
+                        new_wpn.name(DESC_INVENTORY) + "?";
         if (!yesno(prompt.c_str(), false, 'n'))
         {
             canned_msg(MSG_OK);

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -313,12 +313,6 @@ bool can_wield(const item_def *weapon, bool say_reason,
                bool ignore_temporary_disability, bool unwield, bool only_known)
 {
 #define SAY(x) {if (say_reason) { x; }}
-    if (!ignore_temporary_disability && you.berserk())
-    {
-        SAY(canned_msg(MSG_TOO_BERSERK));
-        return false;
-    }
-
     if (you.melded[EQ_WEAPON] && unwield)
     {
         SAY(mpr("Your weapon is melded into your body!"));

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -494,6 +494,17 @@ bool wield_weapon(bool auto_wield, int slot, bool show_weff_messages,
         return true;
     }
 
+    // Switching weapons while berserk is usually a waste of time.
+    if (you.berserk())
+    {
+        string prompt = "Really switch weapons while berserk?";
+        if (!yesno(prompt.c_str(), false, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return false;
+        }
+    }
+
     // Reset the warning counter.
     you.received_weapon_warning = false;
 
@@ -547,6 +558,18 @@ bool wield_weapon(bool auto_wield, int slot, bool show_weff_messages,
     }
 
     item_def& new_wpn(you.inv[item_slot]);
+
+    // Switching to a launcher while berserk is almost certainly a mistake.
+    // They've already gone through the first prompt but just to make sure...
+    if (you.berserk() && is_range_weapon(new_wpn))
+    {
+        string prompt = "You can't shoot while berserk! Are you sure about this?";
+        if (!yesno(prompt.c_str(), false, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return false;
+        }
+    }
 
     // Ensure wieldable
     if (!can_wield(&new_wpn, true))

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2124,10 +2124,6 @@ void monster::swap_weapons(maybe_bool maybe_msg)
 {
     const bool msg = tobool(maybe_msg, observable());
 
-    // Don't let them swap weapons if berserk. ("You are too berserk!")
-    if (berserk())
-        return;
-
     item_def *weap = mslot_item(MSLOT_WEAPON);
     item_def *alt  = mslot_item(MSLOT_ALT_WEAPON);
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1362,13 +1362,6 @@ bool unwield_item(bool showMsgs)
     if (!you.weapon())
         return false;
 
-    if (you.berserk())
-    {
-        if (showMsgs)
-            canned_msg(MSG_TOO_BERSERK);
-        return false;
-    }
-
     item_def& item = *you.weapon();
 
     const bool is_weapon = get_item_slot(item) == EQ_WEAPON;


### PR DESCRIPTION
"You are too angry to draw your sword" is a ridiculous state to be in. Warnings surrounding intentional berserk stay in place as swapping to a proper weapon is a waste of precious berserk turns.

Also enables the same for ranged weapon-having monsters who get unintentionally berserked, in the interest of player-monster symmetry. Given that launchers are used by almost nothing in the places where moths of wrath spawn, I don't think this is a huge balance change.