### PR TITLE
Filter distant duplicates in stash search (Siegurt)

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -457,6 +457,7 @@ vector<stash_search_result> Stash::matches_search(
         {
             stash_search_result res;
             res.match = s;
+            res.primary_sort = item.name(DESC_QUALNAME);
             res.item = item;
             results.push_back(res);
         }
@@ -469,6 +470,7 @@ vector<stash_search_result> Stash::matches_search(
         {
             stash_search_result res;
             res.match = fdesc;
+            res.primary_sort = fdesc;
             results.push_back(res);
         }
     }
@@ -700,6 +702,7 @@ vector<stash_search_result> ShopInfo::matches_search(
     {
         stash_search_result res;
         res.match = shoptitle;
+        res.primary_sort = shoptitle;
         res.shop = this;
         res.pos.pos = shop.pos;
         results.push_back(res);
@@ -719,6 +722,7 @@ vector<stash_search_result> ShopInfo::matches_search(
         {
             stash_search_result res;
             res.match = sname;
+            res.primary_sort = item.name(DESC_QUALNAME);
             res.item = item;
             res.pos.pos = shop.pos;
             results.push_back(res);
@@ -1262,9 +1266,14 @@ static bool _compare_by_distance(const stash_search_result& lhs,
 static bool _compare_by_name(const stash_search_result& lhs,
                              const stash_search_result& rhs)
 {
-    if (lhs.match != rhs.match)
+    if (lhs.primary_sort != rhs.primary_sort)
     {
-        // Sort by name
+        // Sort first by DESC_QUALNAME for items
+        return lhs.primary_sort < rhs.primary_sort;
+    }
+    else if (lhs.match != rhs.match)
+    {
+        // Then sort by full stash description (which is DESC_A plus other stuff)
         return lhs.match < rhs.match;
     }
     else if (lhs.player_distance != rhs.player_distance)
@@ -1292,6 +1301,7 @@ static vector<stash_search_result> _inventory_search(const base_pattern &search)
         {
             stash_search_result res;
             res.match = s;
+            res.primary_sort = s; // don't use DESC_QUALNAME for inventory items
             res.item = item;
             // Needs to not be equal to ITEM_IN_INVENTORY so the describe
             // menu doesn't think it can manipulate the item.
@@ -1303,6 +1313,65 @@ static vector<stash_search_result> _inventory_search(const base_pattern &search)
     }
 
     return results;
+}
+
+static bool _is_potentially_boring(stash_search_result res)
+{
+    return res.item.defined() && !res.in_inventory && !res.shop
+           && (res.item.base_type == OBJ_WEAPONS
+               || res.item.base_type == OBJ_ARMOUR
+               || res.item.base_type == OBJ_MISSILES)
+           && (item_type_known(res.item) || !item_is_branded(res.item));
+}
+
+static bool _is_duplicate_for_search(stash_search_result l, stash_search_result r, bool ignore_missile_stacks=true)
+{
+    if (ignore_missile_stacks &&
+        l.item.base_type == OBJ_MISSILES
+        && r.item.base_type == OBJ_MISSILES
+        && l.item.sub_type == r.item.sub_type
+        && l.item.brand == r.item.brand)
+    {
+        // special handling for missiles -- ignore stacking for deduplication
+        return true;
+    }
+    // Otherwise just use the search result description.
+    // TODO: better handling for items in shops (ideally, ignore price)
+    return l.match == r.match;
+}
+
+/*
+ * Eliminate boring duplicates from stash search results. Uses `match`
+ * to determine whether something is a duplicate.
+ *
+ * Populates the `duplicates` field of the search results as a side effect.
+ *
+ * @param in  the search result to filter.
+ * @return a vector sorted by `match`.
+ */
+static vector<stash_search_result> _stash_filter_duplicates(vector<stash_search_result> &in)
+{
+    vector<stash_search_result> out;
+    out.clear();
+    out.reserve(in.size());
+    // TODO: any problems doing this in place?
+    // Everything gets resorted before display.
+    stable_sort(in.begin(), in.end(), _compare_by_name);
+
+    for (const stash_search_result &res : in)
+    {
+        if (out.size() && _is_potentially_boring(res) && _is_duplicate_for_search(out.back(), res))
+        {
+            // don't push_back the duplicate
+            out.back().duplicates++;
+        }
+        else
+        {
+            out.push_back(res);
+            out.back().duplicates = 0;
+        }
+    }
+    return out;
 }
 
 void StashTracker::search_stashes()
@@ -1396,27 +1465,45 @@ void StashTracker::search_stashes()
         return;
     }
 
-    if (results.size() > SEARCH_SPAM_THRESHOLD)
+    // The spam threshold works a lot better if we use the deduplicated size.
+    vector<stash_search_result> dedup_results = _stash_filter_duplicates(results);
+
+    if (dedup_results.size() > SEARCH_SPAM_THRESHOLD)
     {
         mprf(MSGCH_PLAIN, "Too many matches; use a more specific search.");
         return;
     }
 
     bool sort_by_dist = true;
-    bool filter_useless = false;
+    bool filter_useless = true;
     bool default_execute = true;
     while (true)
     {
+        bool again;
         // Note that sort_by_dist and filter_useless can be modified by the
         // following call if requested by the user. Also, "results" will be
         // sorted by the call as appropriate:
-        const bool again = display_search_results(results,
-                                                  sort_by_dist,
-                                                  filter_useless,
-                                                  default_execute,
-                                                  search,
-                                                  csearch == "."
-                                                  || csearch == "..");
+        if (filter_useless)
+        {
+            // use the deduplicated results if we are filtering useless items
+            again = display_search_results(dedup_results,
+                                                      sort_by_dist,
+                                                      filter_useless,
+                                                      default_execute,
+                                                      search,
+                                                      csearch == "."
+                                                      || csearch == "..");
+        }
+        else
+        {
+            again = display_search_results(results,
+                                                      sort_by_dist,
+                                                      filter_useless,
+                                                      default_execute,
+                                                      search,
+                                                      csearch == "."
+                                                      || csearch == "..");
+        }
         if (!again)
             break;
     }
@@ -1484,15 +1571,24 @@ void StashSearchMenu::draw_title()
 #ifdef USE_TILE_WEB
         webtiles_set_title(fs);
 #endif
-
-        draw_title_suffix(formatted_string::parse_string(make_stringf(
-                 "<lightgrey>"
-                 ": <w>%s</w> [toggle: <w>!</w>],"
-                 " by <w>%s</w> [<w>/</w>],"
-                 " <w>%s</w> useless [<w>=</w>]"
-                 "</lightgrey>",
-                 menu_action == ACT_EXECUTE ? "travel" : "view  ",
-                 sort_style, filtered)), false);
+        if (title->quantity == 0 && filtered)
+        {
+            // TODO: it might be better to just force filtered=false in the
+            // display loop if only useless items are found.
+            draw_title_suffix(formatted_string::parse_string(
+                "<lightgrey>"
+                ": only useless items found; press <w>=</w> to show."
+                "</lightgrey>"), false);
+        } else {
+            draw_title_suffix(formatted_string::parse_string(make_stringf(
+                "<lightgrey>"
+                ": <w>%s</w> [toggle: <w>!</w>],"
+                " by <w>%s</w> [<w>/</w>],"
+                " <w>%s</w> useless & duplicates [<w>=</w>]"
+                "</lightgrey>",
+                menu_action == ACT_EXECUTE ? "travel" : "view  ",
+                sort_style, filtered)), false);
+        }
     }
 }
 
@@ -1512,10 +1608,10 @@ bool StashSearchMenu::process_key(int key)
     return Menu::process_key(key);
 }
 
-static void _stash_filter_useless(const vector<stash_search_result> &in,
-                                  vector<stash_search_result> &out)
+static vector<stash_search_result> _stash_filter_useless(const vector<stash_search_result> &in)
 {
     // Creates search results vector with useless items filtered
+    vector<stash_search_result> out;
     out.clear();
     out.reserve(in.size());
     for (const stash_search_result &res : in)
@@ -1523,6 +1619,7 @@ static void _stash_filter_useless(const vector<stash_search_result> &in,
         if (!res.item.defined() || !is_useless_item(res.item, false))
             out.push_back(res);
     }
+    return out;
 }
 
 // Returns true to request redisplay if display method was toggled
@@ -1542,7 +1639,7 @@ bool StashTracker::display_search_results(
 
     if (filter_useless)
     {
-        _stash_filter_useless(results_in, results_filtered);
+        results_filtered = _stash_filter_useless(results_in);
         results = &results_filtered;
     }
     else
@@ -1584,6 +1681,11 @@ bool StashTracker::display_search_results(
         }
 
         matchtitle << res.match;
+        if (res.duplicates > 0)
+        {
+            matchtitle << " (" << res.duplicates
+                << " further duplicate" << (res.duplicates == 1 ? "" : "s") << ")";
+        }
 
         MenuEntry *me = new MenuEntry(matchtitle.str(), MEL_ITEM, 1,
                                       res.in_inventory ? 0

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -123,6 +123,9 @@ struct stash_search_result
     // the first matching item in the stash or the name of the shop.
     string match;
 
+    // A string to use for a primary sort, if different from just `match`.
+    string primary_sort;
+
     // Item that was matched.
     item_def item;
 
@@ -132,26 +135,12 @@ struct stash_search_result
     // Whether the found items are in the player's inventory.
     bool in_inventory;
 
-    stash_search_result() : pos(), player_distance(0), match(), item(),
-                            shop(nullptr), in_inventory(false)
-    {
-    }
+    // Are there duplicates? This is updated after the initial search.
+    int duplicates;
 
-    stash_search_result(const stash_search_result &o)
-        : pos(o.pos), player_distance(o.player_distance), match(o.match),
-          item(o.item), shop(o.shop), in_inventory(o.in_inventory)
+    stash_search_result() : pos(), player_distance(0), match(), primary_sort(), item(),
+                            shop(nullptr), in_inventory(false), duplicates(0)
     {
-    }
-
-    stash_search_result &operator = (const stash_search_result &o)
-    {
-        pos = o.pos;
-        player_distance = o.player_distance;
-        match = o.match;
-        item = o.item;
-        shop = o.shop;
-        in_inventory = o.in_inventory;
-        return *this;
     }
 
     bool operator < (const stash_search_result &ssr) const


### PR DESCRIPTION
This is a basic implementation of an idea from Siegurt [on tavern](https://crawl.develz.org/tavern/viewtopic.php?f=8&t=23274&p=309432#p309432) to show only the
closest copies of items when searching stashes. It does this only for floor items that aren't missiles. This implementation always does the filtering -- at present, there is no way to disable it.

I'm not sure if this is the ideal way to do it, and this version is probably missing some stuff, so feedback is welcome.

Here are some screenshots to give a sense for what this looks like, taken from an actual player save (XL23) I had around for debugging something else (though I had at some point done &|).  

edit: see below for updated screenshots
