### PR TITLE
Rework WJC martial attacks

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -863,7 +863,7 @@ Serpent's Lash ability
 
 Allows you to move at supernatural speeds for a short distance, causing the
 next two movement actions taken to be instant. Martial attacks performed under
-the effect of Serpent's Lash are more effective.
+the effect of Serpent's Lash deal increased damage.
 %%%%
 Heaven On Earth ability
 

--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -315,17 +315,18 @@ below. They will also be taught to move at unfathomable speeds for short
 distances, and become able to summon a storm of golden clouds to increase their
 precision and damage for as long as they keep using martial attacks.
 
-  .......       ...<lightred>@</lightred>... (*) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to
+  .......       ....... (*) <lightred>Lunge</lightred>: Move directly towards an enemy to strike.
+  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O.. 
+  .......       .......
+
+  .......       ...<lightred>@</lightred>... (**) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to
   ...<lightred>@</lightred>O..  -->  ....O.. an enemy to deal a weak, dizzying strike.
   .......       .......
 
-  ..x....       ..x.... (**) <lightred>Wall Jump</lightred>: Move into a wall to jump away from 
-  ..x<lightred>@</lightred>O..  -->  ..x.O<lightred>@</lightred>. it in exchange for some piety, distracting and
-  ..x....       ..x.... dealing some damage to nearby foes.
+  ..x....       ..x.... (***) <lightred>Wall Jump</lightred>: Move into a wall to jump away. It  
+  ..x<lightred>@</lightred>O..  -->  ..x.O<lightred>@</lightred>. isn't faster than walking, but will distract and deal 
+  ..x....       ..x.... damage to nearby enemies.
 
-  .......       ....... (***) <lightred>Lunge</lightred>: Move directly towards an enemy to strike.
-  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O.. 
-  .......       .......
 %%%%
 Kikubaaqudgha powers
 

--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -316,15 +316,15 @@ distances, and become able to summon a storm of golden clouds to increase their
 precision and damage for as long as they keep using martial attacks.
 
   .......       ...<lightred>@</lightred>... (*) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to
-  ...<lightred>@</lightred>O..  -->  ....O.. an enemy to strike them and attempt to cause slowing.
+  ...<lightred>@</lightred>O..  -->  ....O.. an enemy to deal a weak, dizzying strike.
   .......       .......
 
-  ..x....       ..x.... (**) <lightred>Wall Jump</lightred>: Move into a wall to vault towards
-  ..x<lightred>@</lightred>O..  -->  ..x.O<lightred>@</lightred>. enemies, striking all enemies adjacent to the landing
-  ..x....       ..x.... spot. May distract any witnessing foes.
+  ..x....       ..x.... (**) <lightred>Wall Jump</lightred>: Move into a wall to jump away from 
+  ..x<lightred>@</lightred>O..  -->  ..x.O<lightred>@</lightred>. it in exchange for some piety, distracting and
+  ..x....       ..x.... dealing some damage to nearby foes.
 
-  .......       ....... (***) <lightred>Lunge</lightred>: Move directly towards an enemy to deal
-  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O.. extra damage, and even more if they are distracted.
+  .......       ....... (***) <lightred>Lunge</lightred>: Move directly towards an enemy to strike.
+  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O.. 
   .......       .......
 %%%%
 Kikubaaqudgha powers

--- a/crawl-ref/source/enchant-type.h
+++ b/crawl-ref/source/enchant-type.h
@@ -174,6 +174,7 @@ enum enchant_type
     ENCH_STILL_WINDS,
     ENCH_RING_OF_THUNDER,
     ENCH_DISTRACTED_ACROBATICS,
+    ENCH_DIZZY, // slow move speed only, other actions unaffected
     // Update enchant_names[] in mon-ench.cc when adding or removing
     // enchantments.
     NUM_ENCHANTMENTS

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -342,15 +342,6 @@ void melee_attack::apply_black_mark_effects()
     }
 }
 
-// For WJC, does the defender count as being distracted?
-bool melee_attack::defender_wjc_distracted() const
-{
-    ASSERT(defender->is_monster());
-    return defender->as_monster()->has_ench(ENCH_DISTRACTED_ACROBATICS)
-            || defender->as_monster()->foe != MHITYOU
-               && !mons_is_batty(*defender->as_monster());
-}
-
 /* An attack has been determined to have hit something
  *
  * Handles to-hit effects for both attackers and defenders,
@@ -462,18 +453,6 @@ bool melee_attack::handle_phase_hit()
 
     // Check for weapon brand & inflict that damage too
     apply_damage_brand();
-
-    // Fireworks when hitting distracted enemies.
-    // XXX: this seems massively overcomplicated.
-    if (!defender->alive()
-        && defender->as_monster()->can_bleed()
-        && wu_jian_attack == WU_JIAN_ATTACK_LUNGE
-        && defender_wjc_distracted())
-    {
-        blood_spray(defender->pos(), defender->as_monster()->type,
-                    damage_done / 5);
-        defender->as_monster()->flags |= MF_EXPLODE_KILL;
-    }
 
     if (check_unrand_effects())
         return false;
@@ -3363,19 +3342,11 @@ int melee_attack::cleave_damage_mod(int dam)
 int melee_attack::martial_damage_mod(int dam)
 {
     if (wu_jian_has_momentum(wu_jian_attack))
-        dam = div_rand_round(dam * 15, 10);
+        dam = div_rand_round(dam * 20, 10);
 
-    if (wu_jian_attack == WU_JIAN_ATTACK_LUNGE)
-    {
-        if (defender_wjc_distracted())
-        {
-            mprf("%s is caught off-guard!",
-                 defender->as_monster()->name(DESC_THE).c_str());
-            dam = div_rand_round(dam * 16, 10);
-        }
-        else
-            dam = div_rand_round(dam * 13, 10);
-    }
+    if (wu_jian_attack == WU_JIAN_ATTACK_WHIRLWIND
+        || wu_jian_attack == WU_JIAN_ATTACK_WALL_JUMP)
+        dam = div_rand_round(dam * 75, 100);
 
     return dam;
 }

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -143,7 +143,6 @@ private:
     void player_warn_miss();
     void player_weapon_upsets_god();
     void _defender_die();
-    bool defender_wjc_distracted() const;
 
     // Added in, were previously static methods of fight.cc
     bool _extra_aux_attack(unarmed_attack_type atk);

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1458,6 +1458,7 @@ void monster::apply_enchantment(const mon_enchant &me)
     case ENCH_CORROSION:
     case ENCH_GOLD_LUST:
     case ENCH_DISTRACTED_ACROBATICS:
+    case ENCH_DIZZY:
     case ENCH_RESISTANCE:
     case ENCH_HEXED:
     case ENCH_BRILLIANCE_AURA:

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -471,6 +471,13 @@ void monster::remove_enchantment_effect(const mon_enchant &me, bool quiet)
         }
         break;
 
+    case ENCH_DIZZY:
+        if (!quiet)
+        {
+             simple_monster_message(*this, " is no longer dizzy.");
+        }
+        break;
+
     case ENCH_SILENCE:
         invalidate_agrid();
         if (!quiet && !silenced(pos()))
@@ -2161,7 +2168,7 @@ static const char *enchant_names[] =
 #endif
     "aura_of_brilliance", "empowered_spells", "gozag_incite", "pain_bond",
     "idealised", "bound_soul", "infestation",
-    "stilling the winds", "thunder_ringed", "distracted by acrobatics",
+    "stilling the winds", "thunder_ringed", "distracted by acrobatics","dizzy",
     "buggy",
 };
 
@@ -2318,6 +2325,7 @@ int mon_enchant::calc_duration(const monster* mons,
         cturn = 300 / _mod_speed(25, mons->speed);
         break;
     case ENCH_SLOW:
+    case ENCH_DIZZY:
     case ENCH_CORROSION:
         cturn = 250 / (1 + modded_speed(mons, 10));
         break;

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -115,6 +115,7 @@ static map<enchant_type, monster_info_flags> trivial_ench_mb_mappings = {
     { ENCH_STILL_WINDS,     MB_STILL_WINDS },
     { ENCH_SLOWLY_DYING,    MB_SLOWLY_DYING },
     { ENCH_DISTRACTED_ACROBATICS,     MB_DISTRACTED },
+    { ENCH_DIZZY,            MB_SLOWED },
 };
 
 static monster_info_flags ench_to_mb(const monster& mons, enchant_type ench)
@@ -122,6 +123,7 @@ static monster_info_flags ench_to_mb(const monster& mons, enchant_type ench)
     // Suppress silly-looking combinations, even if they're
     // internally valid.
     if (mons.paralysed() && (ench == ENCH_SLOW || ench == ENCH_HASTE
+                      || ench == ENCH_DIZZY
                       || ench == ENCH_SWIFT
                       || ench == ENCH_PETRIFIED
                       || ench == ENCH_PETRIFYING))

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5700,6 +5700,9 @@ int monster::action_energy(energy_use_type et) const
     if (has_ench(ENCH_SWIFT))
         move_cost -= 3;
 
+    if (has_ench(ENCH_DIZZY))
+        move_cost += 5;
+
     if (wearing_ego(EQ_ALL_ARMOUR, SPARM_PONDEROUSNESS))
         move_cost += 1;
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -340,7 +340,7 @@ const vector<god_power> god_powers[NUM_GODS] =
            "no longer perform lunging strikes" },
       { 2, "attack monsters by moving around them",
            "no longer perform spinning attacks" },
-      { 3, "spend piety to perform an aerial attack, by moving against a wall",
+      { 3, "perform a distracting aerial attack by moving against a wall",
            "no longer perform airborne attacks" },
       { 4, ABIL_WU_JIAN_SERPENTS_LASH, "briefly move at supernatural speeds" },
       { 5, ABIL_WU_JIAN_HEAVEN_ON_EARTH, "summon a storm of heavenly clouds to empower your attacks" },

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -336,12 +336,12 @@ const vector<god_power> god_powers[NUM_GODS] =
     },
 
     // Wu Jian
-    { { 1, "attack monsters by moving around them",
-           "no longer perform spinning attacks" },
-      { 2, "perform distracting airborne attacks by moving against a solid obstacle",
-           "no longer perform airborne attacks" },
-      { 3, "strike by moving towards foes, devastating them if distracted",
+    { { 1, "strike by moving towards foes",
            "no longer perform lunging strikes" },
+      { 2, "attack monsters by moving around them",
+           "no longer perform spinning attacks" },
+      { 3, "spend piety to perform an aerial attack, by moving against a wall",
+           "no longer perform airborne attacks" },
       { 4, ABIL_WU_JIAN_SERPENTS_LASH, "briefly move at supernatural speeds" },
       { 5, ABIL_WU_JIAN_HEAVEN_ON_EARTH, "summon a storm of heavenly clouds to empower your attacks" },
     },

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -1288,7 +1288,7 @@ void monster::timeout_enchantments(int levels)
         case ENCH_BLACK_MARK: case ENCH_SAP_MAGIC: case ENCH_NEUTRAL_BRIBED:
         case ENCH_FRIENDLY_BRIBED: case ENCH_CORROSION: case ENCH_GOLD_LUST:
         case ENCH_RESISTANCE: case ENCH_HEXED: case ENCH_IDEALISED:
-        case ENCH_BOUND_SOUL: case ENCH_DISTRACTED_ACROBATICS:
+        case ENCH_BOUND_SOUL: case ENCH_DISTRACTED_ACROBATICS: case ENCH_DIZZY:
         case ENCH_STILL_WINDS: case ENCH_RING_OF_THUNDER:
             lose_ench_levels(entry.second, levels);
             break;


### PR DESCRIPTION
This revision of WJC is a result of a conversation between me and Lasty,
in which we managed to converge into a set of changes that have
potential to solve the issues with both the current and past
implementations of the god. It stems from the agreement that WJC is not
to be a combo god, or to dictate a specific flowchart of abilities to be
used one after the other, but a set of mobility (and mobility control)
tools that allow the player to be at the ideal position to take enemies
out safely, even in the open.

Fundamental changes:
* Lunge now deals 100% weapon damage and has no extra effects. This
makes sense in context of a reduction in damage to wall jump and
whirlwind, so lunge is now the only martial attack that can match
tabbing in terms of damage. This leaves Lunge a niche for dealing with
polearms, ranged monsters, blinkers, etcetera while not superseding tab
or allowing degenerate behaviour like swapping with minions to be
optimal.
* Whirlwind and wall jump now deal 75% normal damage. This makes them
desirable to use against groups but not against a single target, unless the
player is also interested in the mobility itself.
* Whirlwind now causes Dizzy instead of Slow. Dizzy causes monsters to
walk slowly, but does not affect other actions. This is in line with the
goal of making all of the god's tools be based on positioning, not
combat modifiers.
* ~Wall Jump can again be used anywhere, but now comes at a cost of 1
piety per jump. This cost is represented in three places: In the ^^
window, in the power description when obtained, and reflected in a
message after every wall jump. This alleviates the interface problem of
wall jump being available sometimes but not others, and prevents is use
as a level traversal tool. Due to its reduced damage, it will
necessarily be used as a mobility skill first.~
EDIT: As per the second commit, wall jump has been reworked again. Take a look at that commit for info: a730685b0bc7ae3ced4b87fe43e65d15085929df
* Serpent's Lash does not increase the chance to cause status effects.
Instead, its effect on martial strike damage has increased. This pushes
it further into an offense tool, and particularly rewards lunge,
allowing the player to be explosive when necessary.

These changes reduce the power level of the god severely, but also
define its role more clearly and move it away from the mass damage field
occupied by Uskayaw. I believe that the strength of wall jump is still
enough to offset the lost power, but in case a buff is necessary, we
also discussed the possibility of the god passively trading a fraction
of your AC for damage bonus, in order to both punish high mitigation
builds and increase offense across all builds, in a step towards the
melee glass cannon idea (This is not part of the PR)