### PR TITLE
allow monsters to ignore AC if player is incap

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5956,6 +5956,9 @@ int player::base_ac(int scale) const
 
 int player::armour_class(bool /*calc_unid*/) const
 {
+    if (you.incapacitated())
+       return 0;
+ 
     const int scale = 100;
     int AC = base_ac(scale);
 


### PR DESCRIPTION
...acitated. If the player is asleep or paralyzed, there's no reason for a monster to swing wildly at the player's armor, they can simply attack the player's face meat, or other gaps in the armour.

This may help correct AC being significantly more reliable than the other two defenses. Incapacitation will be more universally dangerous. This will hopefully result in fewer laments of "I forgot that (dream sheep, grinder, etc) are actually dangerous when you play a mage", because incap players won't sometimes happen to shrug off attacks during incapacitation and forget to take incap seriously when they play a squishy character.

One way to walk back the intensity of this change would be to allow defense bonuses (such as AC/EV rings, god bonuses, scale mutations, spells, or even the player's size category) to apply during incapacitation, under the justification that they naturally protect the character from harm regardless of the character's current state of consciousness - there's no "gap" to exploit and slice into. So only "base" ev/ac/sh would be set to 0 during incap.