### PR TITLE
Remove contamination from Haste.

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3330,7 +3330,6 @@ void bolt::affect_player_enchantment(bool resistible)
     case BEAM_HASTE:
         haste_player(40 + random2(ench_power));
         did_god_conduct(DID_HASTY, 10, blame_player);
-        contaminate_player(750 + random2(500), blame_player);
         obvious_effect = true;
         nasty = false;
         nice  = true;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4631,7 +4631,6 @@ bool haste_player(int turns, bool rageext)
     else if (!rageext)
     {
         mpr("You feel as though your hastened speed will last longer.");
-        contaminate_player(750 + random2(500), true); // always deliberate
     }
 
     you.increase_duration(DUR_HASTE, turns, threshold);

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -714,21 +714,18 @@ static void _handle_magic_contamination()
     // every turn instead of every 20 turns, so everything has been multiplied
     // by 50 and scaled to you.time_taken.
 
+    //Increase contamination each turn while invisible
     if (you.duration[DUR_INVIS])
         added_contamination += 30;
-
-    if (you.duration[DUR_HASTE])
-        added_contamination += 30;
+    //If not invisible, normal dissipation
+    else
+        added_contamination -= 25;
 
     // The Orb halves dissipation (well a bit more, I had to round it),
     // but won't cause glow on its own -- otherwise it'd spam the player
     // with messages about contamination oscillating near zero.
     if (you.magic_contamination && player_has_orb())
         added_contamination += 13;
-
-    // Normal dissipation
-    if (!you.duration[DUR_INVIS] && !you.duration[DUR_HASTE])
-        added_contamination -= 25;
 
     // Scaling to turn length
     added_contamination = div_rand_round(added_contamination * you.time_taken,


### PR DESCRIPTION
Removes the contamination from gaining and extending the Haste effect, as
well as the per-turn contamination gain (and prevention of contamination
dissipation) while Haste is ongoing.

While Haste was a spell (and to a lesser degree, as a wand), it made sense
to limit the amount of times Haste was allowed to be used per tactical
encounter, as it could effectively be used as many times as desired
throughout the game.  However, now that the only source of Haste are
potions and unreliable god effects where the player cannot necessarily
guarantee they will receive Haste (Potion Petition, calling a potion shop,
decks of escape, Xom), tactical limitation no longer seems necessary.