### PR TITLE
Make monster_die take a monster& instead of a monster*

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -709,7 +709,7 @@ void actor::handle_constriction()
         if (defender->is_monster()
             && defender->as_monster()->hit_points < 1)
         {
-            monster_die(defender->as_monster(), this);
+            monster_die(*defender->as_monster(), this);
         }
     }
 }

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -737,17 +737,17 @@ namespace arena
                 // We have no members left, so to prevent the round
                 // from ending attempt to displace whatever is in
                 // our position.
-                monster* other = monster_at(pos);
+                monster& other = *monster_at(pos);
 
-                if (to_respawn[other->mindex()] == -1)
+                if (to_respawn[other.mindex()] == -1)
                 {
                     // The other monster isn't a respawner itself, so
                     // just get rid of it.
                     mprf(MSGCH_DIAGNOSTICS,
                          "Dismissing non-respawner %s to make room for "
                          "respawner whose side has 0 active members.",
-                         other->name(DESC_PLAIN, true).c_str());
-                    monster_die(*other, KILL_DISMISSED, NON_MONSTER);
+                         other.name(DESC_PLAIN, true).c_str());
+                    monster_die(other, KILL_DISMISSED, NON_MONSTER);
                 }
                 else
                 {
@@ -755,8 +755,8 @@ namespace arena
                     mprf(MSGCH_DIAGNOSTICS,
                          "Teleporting respawner %s to make room for "
                          "other respawner whose side has 0 active members.",
-                         other->name(DESC_PLAIN, true).c_str());
-                    monster_teleport(other, true);
+                         other.name(DESC_PLAIN, true).c_str());
+                    monster_teleport(&other, true);
                 }
 
                 mon = dgn_place_monster(spec, pos, false, true);

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -747,7 +747,7 @@ namespace arena
                          "Dismissing non-respawner %s to make room for "
                          "respawner whose side has 0 active members.",
                          other->name(DESC_PLAIN, true).c_str());
-                    monster_die(other, KILL_DISMISSED, NON_MONSTER);
+                    monster_die(*other, KILL_DISMISSED, NON_MONSTER);
                 }
                 else
                 {

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -124,7 +124,7 @@ bool attack::handle_phase_killed()
 {
     monster* mon = defender->as_monster();
     if (!invalid_monster(mon))
-        monster_die(mon, attacker);
+        monster_die(*mon, attacker);
 
     return true;
 }

--- a/crawl-ref/source/attitude-change.cc
+++ b/crawl-ref/source/attitude-change.cc
@@ -141,7 +141,7 @@ void make_god_gifts_disappear()
             && mons_is_god_gift(**mi, god))
         {
             // The monster disappears.
-            monster_die(*mi, KILL_DISMISSED, NON_MONSTER);
+            monster_die(**mi, KILL_DISMISSED, NON_MONSTER);
         }
     }
 }

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4268,7 +4268,7 @@ static void _glaciate_freeze(monster* mon, killer_type englaciator,
     simple_monster_message(*mon, " is frozen into a solid block of ice!");
 
     // If the monster leaves a corpse when it dies, destroy the corpse.
-    item_def* corpse = monster_die(mon, englaciator, kindex);
+    item_def* corpse = monster_die(*mon, englaciator, kindex);
     if (corpse)
         destroy_item(corpse->index());
 
@@ -4855,7 +4855,7 @@ void bolt::affect_monster(monster* mon)
         {
             if (mon->attitude == ATT_FRIENDLY)
                 mon->attitude = ATT_HOSTILE;
-            monster_die(mon, KILL_MON, kindex);
+            monster_die(*mon, KILL_MON, kindex);
         }
         else
         {
@@ -4865,7 +4865,7 @@ void bolt::affect_monster(monster* mon)
                 ref_killer = KILL_YOU_MISSILE;
                 kindex = YOU_FAULTLESS;
             }
-            monster_die(mon, ref_killer, kindex);
+            monster_die(*mon, ref_killer, kindex);
         }
     }
 

--- a/crawl-ref/source/dactions.cc
+++ b/crawl-ref/source/dactions.cc
@@ -184,7 +184,7 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
             if (mon->type == MONS_ZOMBIE)
             {
                 simple_monster_message(*mon, " crumbles into dust!");
-                monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+                monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
                 break;
             }
         case DACT_ALLY_UNHOLY_EVIL:
@@ -209,7 +209,7 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
 
         case DACT_ALLY_HEPLIAKLQANA:
             simple_monster_message(*mon, " returns to the mists of memory.");
-            monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+            monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
             break;
 
         case DACT_UPGRADE_ANCESTOR:
@@ -220,7 +220,7 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
         case DACT_OLD_ENSLAVED_SOULS_POOF:
             simple_monster_message(*mon, " is freed.");
             // The monster disappears.
-            monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+            monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
             break;
 
         case DACT_SLIME_NEW_ATTEMPT:

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1749,7 +1749,7 @@ void direction_chooser::handle_wizard_command(command_type key_command,
         break;
 
     case CMD_TARGET_WIZARD_KILL_MONSTER:
-        monster_die(m, KILL_YOU, NON_MONSTER);
+        monster_die(*m, KILL_YOU, NON_MONSTER);
         break;
 
     default:

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -4201,7 +4201,7 @@ static int _dgn_item_corpse(const item_spec &ispec, const coord_def where)
         corpse = place_monster_corpse(*mon, true, true);
         // Dismiss the monster we used to place the corpse.
         mon->flags |= MF_HARD_RESET;
-        monster_die(mon, KILL_DISMISSED, NON_MONSTER, false, true);
+        monster_die(*mon, KILL_DISMISSED, NON_MONSTER, false, true);
     }
 
     if (ispec.props.exists(CORPSE_NEVER_DECAYS))

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1225,7 +1225,7 @@ static void _place_player(dungeon_feature_type stair_taken,
 
         dprf("%s under player and can't be moved anywhere; killing",
              mon->name(DESC_PLAIN).c_str());
-        monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+        monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
         // XXX: do we need special handling for uniques...?
     }
 }

--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -375,7 +375,7 @@ static void _do_merge_masses(monster* initial_mass, monster* merge_to)
     behaviour_event(merge_to, ME_EVAL);
 
     // Have to 'kill' the slime doing the merging.
-    monster_die(initial_mass, KILL_DISMISSED, NON_MONSTER, true);
+    monster_die(*initial_mass, KILL_DISMISSED, NON_MONSTER, true);
 }
 
 void starcursed_merge_fineff::fire()

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1180,7 +1180,7 @@ bool zin_recite_to_single_monster(const coord_def& where)
                 {
                     simple_monster_message(*mon,
                         " melts away into a sizzling puddle of chaotic flesh.");
-                    monster_die(mon, KILL_YOU, NON_MONSTER);
+                    monster_die(*mon, KILL_YOU, NON_MONSTER);
                 }
             }
         }
@@ -1252,7 +1252,7 @@ static void _zin_saltify(monster* mon)
     simple_monster_message(*mon, " is turned into a pillar of salt by the wrath of Zin!");
 
     // If the monster leaves a corpse when it dies, destroy the corpse.
-    item_def* corpse = monster_die(mon, KILL_YOU, NON_MONSTER);
+    item_def* corpse = monster_die(*mon, KILL_YOU, NON_MONSTER);
     if (corpse)
         destroy_item(corpse->index());
 
@@ -2506,7 +2506,7 @@ int fedhas_fungal_bloom()
 
                 const coord_def pos = target->pos();
                 const int colour = target->colour;
-                const item_def* corpse = monster_die(target, KILL_MISC,
+                const item_def* corpse = monster_die(*target, KILL_MISC,
                                                      NON_MONSTER, true);
 
                 // If a corpse didn't drop, create a toadstool.
@@ -6751,7 +6751,7 @@ spret_type uskayaw_grand_finale(bool fail)
         throw_monster_bits(*mons); // have some fun while we're at it
     }
 
-    monster_die(mons, KILL_YOU, NON_MONSTER, false);
+    monster_die(*mons, KILL_YOU, NON_MONSTER, false);
 
     if (!mons->alive())
         move_player_to_grid(beam.target, false);

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -186,7 +186,7 @@ LUAFN(debug_cull_monsters)
             continue;
 
         mi->flags |= MF_HARD_RESET;
-        monster_die(*mi, KILL_DISMISSED, NON_MONSTER);
+        monster_die(**mi, KILL_DISMISSED, NON_MONSTER);
     }
 
     return 0;
@@ -201,7 +201,7 @@ LUAFN(debug_dismiss_adjacent)
         if (mon)
         {
             mon->flags |= MF_HARD_RESET;
-            monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+            monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
         }
     }
 
@@ -215,7 +215,7 @@ LUAFN(debug_dismiss_monsters)
         if (mi)
         {
             mi->flags |= MF_HARD_RESET;
-            monster_die(*mi, KILL_DISMISSED, NON_MONSTER);
+            monster_die(**mi, KILL_DISMISSED, NON_MONSTER);
         }
     }
 

--- a/crawl-ref/source/l-mons.cc
+++ b/crawl-ref/source/l-mons.cc
@@ -217,7 +217,7 @@ static int l_mons_do_dismiss(lua_State *ls)
     if (mons->alive())
     {
         mons->flags |= MF_HARD_RESET;
-        monster_die(mons, KILL_DISMISSED, NON_MONSTER);
+        monster_die(*mons, KILL_DISMISSED, NON_MONSTER);
     }
     return 0;
 }

--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -403,7 +403,7 @@ static bool _do_merge_crawlies(monster* crawlie, monster* merge_to)
         mprf("%s suddenly disappears!", crawlie->name(DESC_A).c_str());
 
     // Now kill the other monster.
-    monster_die(crawlie, KILL_DISMISSED, NON_MONSTER, true);
+    monster_die(*crawlie, KILL_DISMISSED, NON_MONSTER, true);
 
     return true;
 }
@@ -459,7 +459,7 @@ static void _do_merge_slimes(monster* initial_slime, monster* merge_to)
         mpr("A slime creature suddenly disappears!");
 
     // Have to 'kill' the slime doing the merging.
-    monster_die(initial_slime, KILL_DISMISSED, NON_MONSTER, true);
+    monster_die(*initial_slime, KILL_DISMISSED, NON_MONSTER, true);
 }
 
 // Slime creatures can split but not merge under these conditions.
@@ -913,7 +913,7 @@ bool lost_soul_revive(monster* mons, killer_type killer)
             }
         }
 
-        monster_die(*mi, KILL_MISC, -1, true);
+        monster_die(**mi, KILL_MISC, -1, true);
 
         return true;
     }

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1430,7 +1430,7 @@ static void _pre_monster_move(monster& mons)
         if (awakener && !awakener->can_see(mons))
         {
             simple_monster_message(mons, " falls limply to the ground.");
-            monster_die(&mons, KILL_RESET, NON_MONSTER);
+            monster_die(mons, KILL_RESET, NON_MONSTER);
             return;
         }
     }
@@ -1440,7 +1440,7 @@ static void _pre_monster_move(monster& mons)
     if (mons.type == MONS_BALL_LIGHTNING && mons.summoner == MID_PLAYER
         && !cell_see_cell(you.pos(), mons.pos(), LOS_SOLID))
     {
-        monster_die(&mons, KILL_RESET, NON_MONSTER);
+        monster_die(mons, KILL_RESET, NON_MONSTER);
         return;
     }
 
@@ -1978,7 +1978,7 @@ void handle_monster_move(monster* mons)
             if (outward)
                 outward->props["inwards"].get_int() = mons->mid;
 
-            monster_die(targ, KILL_MISC, NON_MONSTER, true);
+            monster_die(*targ, KILL_MISC, NON_MONSTER, true);
             targ = nullptr;
         }
 
@@ -2300,7 +2300,7 @@ static void _post_monster_move(monster* mons)
     }
 
     if (mons->type != MONS_NO_MONSTER && mons->hit_points < 1)
-        monster_die(mons, KILL_MISC, NON_MONSTER);
+        monster_die(*mons, KILL_MISC, NON_MONSTER);
 }
 
 priority_queue<pair<monster *, int>,

--- a/crawl-ref/source/mon-behv.cc
+++ b/crawl-ref/source/mon-behv.cc
@@ -1462,7 +1462,7 @@ void make_mons_leave_level(monster* mon)
         // Pacified monsters leaving the level take their stuff with
         // them.
         mon->flags |= MF_HARD_RESET;
-        monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+        monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
     }
 }
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -3580,7 +3580,7 @@ static bool _prepare_ghostly_sacrifice(monster &caster, bolt &beam)
         mprf("%s animating energy erupts into ghostly fire!",
              apostrophise(victim->name(DESC_THE)).c_str());
     }
-    monster_die(victim, &caster, true);
+    monster_die(*victim, &caster, true);
     return true;
 }
 

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1808,7 +1808,7 @@ static void _fire_kill_conducts(monster &mons, killer_type killer,
         did_kill_conduct(DID_KILL_FIERY, mons);
 }
 
-item_def* monster_die(monster* mons, const actor *killer, bool silent,
+item_def* monster_die(monster& mons, const actor *killer, bool silent,
                       bool wizard, bool fake)
 {
     killer_type ktype = KILL_YOU;
@@ -1881,64 +1881,63 @@ static void _special_corpse_messaging(monster &mons)
  * @param fake   The death of the mount of a mounted monster (spriggan rider).
  * @returns a pointer to the created corpse, possibly null
  */
-item_def* monster_die(monster* mons, killer_type killer,
+item_def* monster_die(monster& mons, killer_type killer,
                       int killer_index, bool silent, bool wizard, bool fake)
 {
-    if (invalid_monster(mons))
-        return nullptr;
+    ASSERT(!invalid_monster(&mons));
 
-    const bool was_visible = you.can_see(*mons);
+    const bool was_visible = you.can_see(mons);
 
     // If a monster was banished to the Abyss and then killed there,
     // then its death wasn't a banishment.
     if (player_in_branch(BRANCH_ABYSS))
-        mons->flags &= ~MF_BANISHED;
+        mons.flags &= ~MF_BANISHED;
 
-    const bool spectralised = testbits(mons->flags, MF_SPECTRALISED);
+    const bool spectralised = testbits(mons.flags, MF_SPECTRALISED);
 
     if (!silent && !fake
-        && _monster_avoided_death(mons, killer, killer_index))
+        && _monster_avoided_death(&mons, killer, killer_index))
     {
-        mons->flags &= ~MF_EXPLODE_KILL;
+        mons.flags &= ~MF_EXPLODE_KILL;
 
         // revived by a lost soul?
-        if (!spectralised && testbits(mons->flags, MF_SPECTRALISED))
-            return place_monster_corpse(*mons, silent);
+        if (!spectralised && testbits(mons.flags, MF_SPECTRALISED))
+            return place_monster_corpse(mons, silent);
         return nullptr;
     }
 
     // If the monster was calling the tide, let go now.
-    mons->del_ench(ENCH_TIDE);
+    mons.del_ench(ENCH_TIDE);
 
     // Same for silencers.
-    mons->del_ench(ENCH_SILENCE);
+    mons.del_ench(ENCH_SILENCE);
 
     // ... and liquefiers.
-    mons->del_ench(ENCH_LIQUEFYING);
+    mons.del_ench(ENCH_LIQUEFYING);
 
     // ... and wind-stillers.
-    mons->del_ench(ENCH_STILL_WINDS, true);
+    mons.del_ench(ENCH_STILL_WINDS, true);
 
     // and webbed monsters
-    monster_web_cleanup(*mons, true);
+    monster_web_cleanup(mons, true);
 
     // Clean up any blood from the flayed effect
-    if (mons->has_ench(ENCH_FLAYED))
-        heal_flayed_effect(mons, true, true);
+    if (mons.has_ench(ENCH_FLAYED))
+        heal_flayed_effect(&mons, true, true);
 
-    crawl_state.inc_mon_acting(mons);
+    crawl_state.inc_mon_acting(&mons);
 
     ASSERT(!(YOU_KILL(killer) && crawl_state.game_is_arena()));
 
-    if (mons->props.exists(MONSTER_DIES_LUA_KEY))
+    if (mons.props.exists(MONSTER_DIES_LUA_KEY))
     {
         lua_stack_cleaner clean(dlua);
 
-        dlua_chunk &chunk = mons->props[MONSTER_DIES_LUA_KEY];
+        dlua_chunk &chunk = mons.props[MONSTER_DIES_LUA_KEY];
 
         if (!chunk.load(dlua))
         {
-            push_monster(dlua, mons);
+            push_monster(dlua, &mons);
             clua_pushcxxstring(dlua, _killer_type_name(killer));
             dlua.callfn(nullptr, 2, 0);
         }
@@ -1946,54 +1945,54 @@ item_def* monster_die(monster* mons, killer_type killer,
         {
             mprf(MSGCH_ERROR,
                  "Lua death function for monster '%s' didn't load: %s",
-                 mons->full_name(DESC_PLAIN).c_str(),
+                 mons.full_name(DESC_PLAIN).c_str(),
                  dlua.error.c_str());
         }
     }
 
-    mons_clear_trapping_net(mons);
-    mons->stop_constricting_all(false);
-    mons->stop_being_constricted();
+    mons_clear_trapping_net(&mons);
+    mons.stop_constricting_all(false);
+    mons.stop_being_constricted();
 
-    you.remove_beholder(*mons);
-    you.remove_fearmonger(mons);
+    you.remove_beholder(mons);
+    you.remove_fearmonger(&mons);
     // Uniques leave notes and milestones, so this information is already leaked.
-    remove_unique_annotation(mons);
+    remove_unique_annotation(&mons);
 
     // Clear auto exclusion now the monster is killed - if we know about it.
-    if (you.see_cell(mons->pos()) || wizard || mons_is_unique(mons->type))
-        remove_auto_exclude(mons);
+    if (you.see_cell(mons.pos()) || wizard || mons_is_unique(mons.type))
+        remove_auto_exclude(&mons);
 
           int  duration      = 0;
-    const bool summoned      = mons->is_summoned(&duration);
-    const int monster_killed = mons->mindex();
-    const bool hard_reset    = testbits(mons->flags, MF_HARD_RESET);
+    const bool summoned      = mons.is_summoned(&duration);
+    const int monster_killed = mons.mindex();
+    const bool hard_reset    = testbits(mons.flags, MF_HARD_RESET);
     const bool timeout       = killer == KILL_TIMEOUT;
-    const bool fake_abjure   = mons->has_ench(ENCH_FAKE_ABJURATION);
-    const bool gives_player_xp = mons_gives_xp(*mons, you);
+    const bool fake_abjure   = mons.has_ench(ENCH_FAKE_ABJURATION);
+    const bool gives_player_xp = mons_gives_xp(mons, you);
     bool drop_items          = !hard_reset;
-    const bool submerged     = mons->submerged();
+    const bool submerged     = mons.submerged();
     bool in_transit          = false;
     const bool was_banished  = (killer == KILL_BANISHED);
     const bool mons_reset    = (killer == KILL_RESET
                                 || killer == KILL_DISMISSED);
     const bool leaves_corpse = !summoned && !fake_abjure && !timeout
                                && !mons_reset
-                               && !mons_is_tentacle_segment(mons->type);
+                               && !mons_is_tentacle_segment(mons.type);
     // Award experience for suicide if the suicide was caused by the
     // player.
     if (MON_KILL(killer) && monster_killed == killer_index)
     {
-        if (mons->confused_by_you())
+        if (mons.confused_by_you())
         {
             ASSERT(!crawl_state.game_is_arena());
             killer = KILL_YOU_CONF;
         }
     }
-    else if (MON_KILL(killer) && mons->has_ench(ENCH_CHARM))
+    else if (MON_KILL(killer) && mons.has_ench(ENCH_CHARM))
     {
         bool arena = crawl_state.game_is_arena();
-        mon_enchant ench = mons->get_ench(ENCH_CHARM);
+        mon_enchant ench = mons.get_ench(ENCH_CHARM);
         if (ench.who == KC_YOU || (!arena && ench.who == KC_FRIENDLY))
         {
             ASSERT(!arena);
@@ -2019,7 +2018,7 @@ item_def* monster_die(monster* mons, killer_type killer,
         killer = (killer == KILL_MON_MISSILE) ? KILL_YOU_MISSILE : KILL_YOU;
 
     // Take notes and mark milestones.
-    record_monster_defeat(mons, killer);
+    record_monster_defeat(&mons, killer);
 
     // Various sources of berserk extension on kills.
     if (killer == KILL_YOU && you.berserk())
@@ -2056,64 +2055,64 @@ item_def* monster_die(monster* mons, killer_type killer,
 
     bool did_death_message = false;
 
-    if (mons->type == MONS_BALLISTOMYCETE_SPORE
-        || mons->type == MONS_BALL_LIGHTNING
-        || mons->type == MONS_LURKING_HORROR
-        || (mons->type == MONS_FULMINANT_PRISM && mons->prism_charge > 0)
-        || mons->type == MONS_BENNU
-        || mons->has_ench(ENCH_INNER_FLAME))
+    if (mons.type == MONS_BALLISTOMYCETE_SPORE
+        || mons.type == MONS_BALL_LIGHTNING
+        || mons.type == MONS_LURKING_HORROR
+        || (mons.type == MONS_FULMINANT_PRISM && mons.prism_charge > 0)
+        || mons.type == MONS_BENNU
+        || mons.has_ench(ENCH_INNER_FLAME))
     {
         did_death_message =
-            _explode_monster(mons, killer, killer_index, pet_kill, wizard);
+            _explode_monster(&mons, killer, killer_index, pet_kill, wizard);
     }
-    else if (mons->type == MONS_FULMINANT_PRISM && mons->prism_charge == 0)
+    else if (mons.type == MONS_FULMINANT_PRISM && mons.prism_charge == 0)
     {
         if (!silent && !hard_reset && !was_banished)
         {
-            simple_monster_message(*mons, " detonates feebly.",
+            simple_monster_message(mons, " detonates feebly.",
                                    MSGCH_MONSTER_DAMAGE, MDAM_DEAD);
             silent = true;
         }
     }
-    else if (mons->type == MONS_FIRE_VORTEX
-             || mons->type == MONS_SPATIAL_VORTEX
-             || mons->type == MONS_TWISTER)
+    else if (mons.type == MONS_FIRE_VORTEX
+             || mons.type == MONS_SPATIAL_VORTEX
+             || mons.type == MONS_TWISTER)
     {
         if (!silent && !mons_reset && !was_banished)
         {
-            simple_monster_message(*mons, " dissipates!",
+            simple_monster_message(mons, " dissipates!",
                                    MSGCH_MONSTER_DAMAGE, MDAM_DEAD);
             silent = true;
         }
 
-        if (mons->type == MONS_FIRE_VORTEX && !wizard && !mons_reset
-            && !submerged && !was_banished && !cell_is_solid(mons->pos()))
+        if (mons.type == MONS_FIRE_VORTEX && !wizard && !mons_reset
+            && !submerged && !was_banished && !cell_is_solid(mons.pos()))
         {
-            place_cloud(CLOUD_FIRE, mons->pos(), 2 + random2(4), mons);
+            place_cloud(CLOUD_FIRE, mons.pos(), 2 + random2(4), &mons);
         }
 
         if (killer == KILL_RESET)
             killer = KILL_DISMISSED;
     }
-    else if (mons->type == MONS_SIMULACRUM)
+    else if (mons.type == MONS_SIMULACRUM)
     {
         if (!silent && !mons_reset && !was_banished)
         {
-            simple_monster_message(*mons, " vapourises!",
+            simple_monster_message(mons, " vapourises!",
                                    MSGCH_MONSTER_DAMAGE, MDAM_DEAD);
             silent = true;
         }
 
         if (!wizard && !mons_reset && !submerged && !was_banished
-            && !cell_is_solid(mons->pos()))
+            && !cell_is_solid(mons.pos()))
         {
-            place_cloud(CLOUD_COLD, mons->pos(), 2 + random2(4), mons);
+            place_cloud(CLOUD_COLD, mons.pos(), 2 + random2(4), &mons);
         }
 
         if (killer == KILL_RESET)
             killer = KILL_DISMISSED;
     }
-    else if (mons->type == MONS_DANCING_WEAPON)
+    else if (mons.type == MONS_DANCING_WEAPON)
     {
         if (!hard_reset)
         {
@@ -2121,10 +2120,10 @@ item_def* monster_die(monster* mons, killer_type killer,
                 killer = KILL_DISMISSED;
         }
 
-        int w_idx = mons->inv[MSLOT_WEAPON];
+        int w_idx = mons.inv[MSLOT_WEAPON];
         ASSERT(w_idx != NON_ITEM);
 
-        // XXX: This can probably become mons->is_summoned(): there's no
+        // XXX: This can probably become mons.is_summoned(): there's no
         // feasible way for a dancing weapon to "drop" it's weapon and somehow
         // gain a summoned one, or vice versa.
         bool summoned_it = mitm[w_idx].flags & ISFLAG_SUMMONED;
@@ -2134,9 +2133,9 @@ item_def* monster_die(monster* mons, killer_type killer,
             // Under Gozag, permanent dancing weapons get turned to gold.
             if (!summoned_it
                 && (!have_passive(passive_t::goldify_corpses)
-                    || mons->has_ench(ENCH_ABJ)))
+                    || mons.has_ench(ENCH_ABJ)))
             {
-                simple_monster_message(*mons, " falls from the air.",
+                simple_monster_message(mons, " falls from the air.",
                                        MSGCH_MONSTER_DAMAGE, MDAM_DEAD);
                 silent = true;
             }
@@ -2145,7 +2144,7 @@ item_def* monster_die(monster* mons, killer_type killer,
         }
 
         if (was_banished && !summoned_it && !hard_reset
-            && mons->has_ench(ENCH_ABJ))
+            && mons.has_ench(ENCH_ABJ))
         {
             if (is_unrandom_artefact(mitm[w_idx]))
                 set_unique_item_status(mitm[w_idx], UNIQ_LOST_IN_ABYSS);
@@ -2153,14 +2152,14 @@ item_def* monster_die(monster* mons, killer_type killer,
             destroy_item(w_idx);
         }
     }
-    else if (mons->type == MONS_ELDRITCH_TENTACLE)
+    else if (mons.type == MONS_ELDRITCH_TENTACLE)
     {
-        if (!silent && !mons_reset && !mons->has_ench(ENCH_SEVERED)
+        if (!silent && !mons_reset && !mons.has_ench(ENCH_SEVERED)
             && !was_banished)
         {
-            if (you.can_see(*mons))
+            if (you.can_see(mons))
             {
-                mprf(MSGCH_MONSTER_DAMAGE, MDAM_DEAD, silenced(mons->pos()) ?
+                mprf(MSGCH_MONSTER_DAMAGE, MDAM_DEAD, silenced(mons.pos()) ?
                     "The tentacle is hauled back through the portal!" :
                     "With a roar, the tentacle is hauled back through the portal!");
             }
@@ -2170,49 +2169,49 @@ item_def* monster_die(monster* mons, killer_type killer,
         if (killer == KILL_RESET)
             killer = KILL_DISMISSED;
     }
-    else if (mons->type == MONS_BATTLESPHERE)
+    else if (mons.type == MONS_BATTLESPHERE)
     {
         if (!wizard && !mons_reset && !was_banished
-            && !cell_is_solid(mons->pos()))
+            && !cell_is_solid(mons.pos()))
         {
-            place_cloud(CLOUD_MAGIC_TRAIL, mons->pos(), 3 + random2(3), mons);
+            place_cloud(CLOUD_MAGIC_TRAIL, mons.pos(), 3 + random2(3), &mons);
         }
-        end_battlesphere(mons, true);
+        end_battlesphere(&mons, true);
     }
-    else if (mons->type == MONS_BRIAR_PATCH)
+    else if (mons.type == MONS_BRIAR_PATCH)
     {
         if (timeout && !silent)
-            simple_monster_message(*mons, " crumbles away.");
+            simple_monster_message(mons, " crumbles away.");
     }
-    else if (mons->type == MONS_SPECTRAL_WEAPON)
+    else if (mons.type == MONS_SPECTRAL_WEAPON)
     {
-        end_spectral_weapon(mons, true, killer == KILL_RESET);
+        end_spectral_weapon(&mons, true, killer == KILL_RESET);
         silent = true;
     }
-    else if (mons->type == MONS_DROWNED_SOUL)
+    else if (mons.type == MONS_DROWNED_SOUL)
     {
         // Suppress death message if 'killed' by touching something
-        if (mons->hit_points == -1000)
+        if (mons.hit_points == -1000)
             silent = true;
     }
-    else if (mons->type == MONS_SPRIGGAN_DRUID && !silent && !was_banished
+    else if (mons.type == MONS_SPRIGGAN_DRUID && !silent && !was_banished
              && !wizard && !mons_reset)
     {
-        _druid_final_boon(mons);
+        _druid_final_boon(&mons);
     }
-    else if (mons->type == MONS_ELEMENTAL_WELLSPRING
-             && mons->mindex() == killer_index)
+    else if (mons.type == MONS_ELEMENTAL_WELLSPRING
+             && mons.mindex() == killer_index)
     {
         if (!silent)
-            simple_monster_message(*mons, " exhausts itself and dries up.");
+            simple_monster_message(mons, " exhausts itself and dries up.");
         silent = true;
     }
 
     const bool death_message = !silent && !did_death_message
-                               && you.can_see(*mons);
-    const bool exploded {mons->flags & MF_EXPLODE_KILL};
+                               && you.can_see(mons);
+    const bool exploded {mons.flags & MF_EXPLODE_KILL};
     bool anon = (killer_index == ANON_FRIENDLY_MONSTER);
-    const mon_holy_type targ_holy = mons->holiness();
+    const mon_holy_type targ_holy = mons.holiness();
 
     // Adjust song of slaying bonus. Kills by relevant avatars are adjusted by
     // now to KILL_YOU and are counted.
@@ -2237,7 +2236,7 @@ item_def* monster_die(monster* mons, killer_type killer,
                     && (anon || !invalid_monster_index(killer_index)))
                 {
                     mprf(MSGCH_MONSTER_DAMAGE, MDAM_DEAD, "%s is %s!",
-                         mons->name(DESC_THE).c_str(),
+                         mons.name(DESC_THE).c_str(),
                          exploded                        ? "blown up" :
                          wounded_damaged(targ_holy)      ? "destroyed"
                                                          : "killed");
@@ -2248,15 +2247,15 @@ item_def* monster_die(monster* mons, killer_type killer,
                          exploded                        ? "blow up" :
                          wounded_damaged(targ_holy)      ? "destroy"
                                                          : "kill",
-                         mons->name(DESC_THE).c_str());
+                         mons.name(DESC_THE).c_str());
                 }
                 // If this monster would otherwise give xp but didn't because
                 // it grants no reward or was neutral, give a message.
                 if (!gives_player_xp
-                    && mons_class_gives_xp(mons->type)
+                    && mons_class_gives_xp(mons.type)
                     && !summoned
                     && !fake_abjure
-                    && !mons->friendly())
+                    && !mons.friendly())
                 {
                     mpr("That felt strangely unrewarding.");
                 }
@@ -2266,7 +2265,7 @@ item_def* monster_die(monster* mons, killer_type killer,
             if (gives_player_xp)
                 _hints_inspect_kill();
 
-            _fire_kill_conducts(*mons, killer, killer_index, gives_player_xp);
+            _fire_kill_conducts(mons, killer, killer_index, gives_player_xp);
 
             // Divine health and mana restoration doesn't happen when
             // killing born-friendly monsters.
@@ -2274,8 +2273,8 @@ item_def* monster_die(monster* mons, killer_type killer,
                 && (have_passive(passive_t::restore_hp)
                     || have_passive(passive_t::mp_on_kill)
                     || have_passive(passive_t::restore_hp_mp_vs_evil)
-                       && mons->evil())
-                && !mons_is_object(mons->type)
+                       && mons.evil())
+                && !mons_is_object(mons.type)
                 && !player_under_penance()
                 && (you_worship(GOD_PAKELLAS)
                     || random2(you.piety) >= piety_breakpoint(0)))
@@ -2284,13 +2283,13 @@ item_def* monster_die(monster* mons, killer_type killer,
 
                 if (have_passive(passive_t::restore_hp))
                 {
-                    hp_heal = mons->get_experience_level()
-                        + random2(mons->get_experience_level());
+                    hp_heal = mons.get_experience_level()
+                        + random2(mons.get_experience_level());
                 }
                 if (have_passive(passive_t::restore_hp_mp_vs_evil))
                 {
-                    hp_heal = random2(1 + 2 * mons->get_experience_level());
-                    mp_heal = random2(2 + mons->get_experience_level() / 3);
+                    hp_heal = random2(1 + 2 * mons.get_experience_level());
+                    mp_heal = random2(2 + mons.get_experience_level() / 3);
                 }
 
                 if (have_passive(passive_t::mp_on_kill))
@@ -2298,11 +2297,11 @@ item_def* monster_die(monster* mons, killer_type killer,
                     switch (you.religion)
                     {
                     case GOD_PAKELLAS:
-                        mp_heal = random2(2 + mons->get_experience_level() / 6);
+                        mp_heal = random2(2 + mons.get_experience_level() / 6);
                         break;
                     case GOD_VEHUMET:
                     default:
-                        mp_heal = 1 + random2(mons->get_experience_level() / 2);
+                        mp_heal = 1 + random2(mons.get_experience_level() / 2);
                         break;
                     }
                 }
@@ -2365,8 +2364,8 @@ item_def* monster_die(monster* mons, killer_type killer,
 
             // Randomly bless a follower.
             if (gives_player_xp
-                && !mons_is_object(mons->type)
-                && _god_will_bless_follower(mons))
+                && !mons_is_object(mons.type)
+                && _god_will_bless_follower(&mons))
             {
                 bless_follower();
             }
@@ -2382,28 +2381,28 @@ item_def* monster_die(monster* mons, killer_type killer,
                     exploded                   ? " is blown up!" :
                     wounded_damaged(targ_holy) ? " is destroyed!"
                                                : " dies!";
-                simple_monster_message(*mons, msg, MSGCH_MONSTER_DAMAGE,
+                simple_monster_message(mons, msg, MSGCH_MONSTER_DAMAGE,
                                        MDAM_DEAD);
             }
 
             if (crawl_state.game_is_arena())
                 break;
 
-            _fire_kill_conducts(*mons, killer, killer_index, gives_player_xp);
+            _fire_kill_conducts(mons, killer, killer_index, gives_player_xp);
 
             // Kill conducts do not assess piety loss for friends
             // killed by other monsters.
-            if (mons->friendly())
+            if (mons.friendly())
             {
-                const bool sentient = mons_class_intel(mons->type) >= I_HUMAN;
+                const bool sentient = mons_class_intel(mons.type) >= I_HUMAN;
                 // plant HD aren't very meaningful. (fedhas hack)
-                const int severity = mons->holiness() & MH_PLANT ?
+                const int severity = mons.holiness() & MH_PLANT ?
                                      1 :
-                                     1 + (mons->get_experience_level() / 4);
+                                     1 + (mons.get_experience_level() / 4);
 
                 did_god_conduct(sentient ? DID_SOULED_FRIEND_DIED
                                          : DID_FRIEND_DIED,
-                                severity, true, mons);
+                                severity, true, &mons);
             }
 
             // Trying to prevent summoning abuse here, so we're trying to
@@ -2421,7 +2420,7 @@ item_def* monster_die(monster* mons, killer_type killer,
                 killer_mon = &menv[killer_index];
 
             if (!invalid_monster_index(killer_index)
-                && _god_will_bless_follower(mons))
+                && _god_will_bless_follower(&mons))
             {
                 // Randomly bless the follower who killed.
                 bless_follower(killer_mon);
@@ -2437,28 +2436,28 @@ item_def* monster_die(monster* mons, killer_type killer,
                 if (fake_abjure)
                 {
                     // Sticks to Snakes
-                    if (mons_genus(mons->type) == MONS_SNAKE)
-                        simple_monster_message(*mons, " withers and dies!");
+                    if (mons_genus(mons.type) == MONS_SNAKE)
+                        simple_monster_message(mons, " withers and dies!");
                     // ratskin cloak
-                    else if (mons_genus(mons->type) == MONS_RAT)
+                    else if (mons_genus(mons.type) == MONS_RAT)
                     {
-                        simple_monster_message(*mons, " returns to the shadows"
+                        simple_monster_message(mons, " returns to the shadows"
                                                       " of the Dungeon!");
                     }
                     // Death Channel
-                    else if (mons->type == MONS_SPECTRAL_THING)
-                        simple_monster_message(*mons, " fades into mist!");
+                    else if (mons.type == MONS_SPECTRAL_THING)
+                        simple_monster_message(mons, " fades into mist!");
                     // Animate Skeleton/Animate Dead/Infestation
-                    else if (mons->type == MONS_ZOMBIE
-                             || mons->type == MONS_SKELETON
-                             || mons->type == MONS_DEATH_SCARAB)
+                    else if (mons.type == MONS_ZOMBIE
+                             || mons.type == MONS_SKELETON
+                             || mons.type == MONS_DEATH_SCARAB)
                     {
-                        simple_monster_message(*mons, " crumbles into dust!");
+                        simple_monster_message(mons, " crumbles into dust!");
                     }
                     else
                     {
-                        string msg = " " + summoned_poof_msg(mons) + "!";
-                        simple_monster_message(*mons, msg.c_str());
+                        string msg = " " + summoned_poof_msg(&mons) + "!";
+                        simple_monster_message(mons, msg.c_str());
                     }
                 }
                 else
@@ -2467,7 +2466,7 @@ item_def* monster_die(monster* mons, killer_type killer,
                         exploded                     ? " is blown up!" :
                         wounded_damaged(targ_holy)   ? " is destroyed!"
                                                      : " dies!";
-                    simple_monster_message(*mons, msg, MSGCH_MONSTER_DAMAGE,
+                    simple_monster_message(mons, msg, MSGCH_MONSTER_DAMAGE,
                                            MDAM_DEAD);
                 }
             }
@@ -2481,30 +2480,30 @@ item_def* monster_die(monster* mons, killer_type killer,
 
             // KILL_RESET monsters no longer lose their whole inventory, only
             // items they were generated with.
-            if (mons->pacified() || !mons->needs_abyss_transit())
+            if (mons.pacified() || !mons.needs_abyss_transit())
             {
                 // A banished monster that doesn't go on the transit list
                 // loses all items.
-                if (!mons->is_summoned())
+                if (!mons.is_summoned())
                     drop_items = false;
                 break;
             }
 
             // Monster goes to the Abyss.
-            mons->flags |= MF_BANISHED;
+            mons.flags |= MF_BANISHED;
             {
-                unwind_var<int> dt(mons->damage_total, 0);
-                unwind_var<int> df(mons->damage_friendly, 0);
-                mons->set_transit(level_id(BRANCH_ABYSS));
+                unwind_var<int> dt(mons.damage_total, 0);
+                unwind_var<int> df(mons.damage_friendly, 0);
+                mons.set_transit(level_id(BRANCH_ABYSS));
             }
-            set_unique_annotation(mons, BRANCH_ABYSS);
+            set_unique_annotation(&mons, BRANCH_ABYSS);
             in_transit = true;
             drop_items = false;
-            mons->firing_pos.reset();
+            mons.firing_pos.reset();
             // Make monster stop patrolling and/or travelling.
-            mons->patrol_point.reset();
-            mons->travel_path.clear();
-            mons->travel_target = MTRAV_NONE;
+            mons.patrol_point.reset();
+            mons.travel_path.clear();
+            mons.travel_target = MTRAV_NONE;
             break;
 
         case KILL_RESET:
@@ -2521,164 +2520,164 @@ item_def* monster_die(monster* mons, killer_type killer,
     }
 
     // Make sure Boris has a foe to address.
-    if (mons->foe == MHITNOT)
+    if (mons.foe == MHITNOT)
     {
-        if (!mons->wont_attack() && !crawl_state.game_is_arena())
-            mons->foe = MHITYOU;
+        if (!mons.wont_attack() && !crawl_state.game_is_arena())
+            mons.foe = MHITYOU;
         else if (!invalid_monster_index(killer_index))
-            mons->foe = killer_index;
+            mons.foe = killer_index;
     }
 
     // Make sure that the monster looks dead.
-    if (mons->alive() && (!summoned || duration > 0))
+    if (mons.alive() && (!summoned || duration > 0))
     {
         dprf("Granting xp for non-damage kill.");
         if (YOU_KILL(killer))
-            mons->damage_friendly += mons->hit_points * 2;
+            mons.damage_friendly += mons.hit_points * 2;
         else if (pet_kill)
-            mons->damage_friendly += mons->hit_points;
-        mons->damage_total += mons->hit_points;
+            mons.damage_friendly += mons.hit_points;
+        mons.damage_total += mons.hit_points;
 
         if (!in_transit) // banishment only
-            mons->hit_points = -1;
+            mons.hit_points = -1;
     }
 
-    if (!silent && !wizard && you.see_cell(mons->pos()))
+    if (!silent && !wizard && you.see_cell(mons.pos()))
     {
         // Make sure that the monster looks dead.
-        if (mons->alive() && !in_transit && (!summoned || duration > 0))
-            mons->hit_points = -1;
+        if (mons.alive() && !in_transit && (!summoned || duration > 0))
+            mons.hit_points = -1;
         // Hack: with cleanup_dead=false, a tentacle [segment] of a dead
         // [malign] kraken has no valid head reference.
-        if (!mons_is_tentacle_or_tentacle_segment(mons->type))
+        if (!mons_is_tentacle_or_tentacle_segment(mons.type))
         {
             // Make sure Natasha gets her say even if she got polymorphed.
             const monster_type orig =
-                mons_is_mons_class(mons, MONS_NATASHA) ? MONS_NATASHA
-                                                       : mons->type;
-            unwind_var<monster_type> mt(mons->type, orig);
-            mons_speaks(mons);
+                mons_is_mons_class(&mons, MONS_NATASHA) ? MONS_NATASHA
+                                                       : mons.type;
+            unwind_var<monster_type> mt(mons.type, orig);
+            mons_speaks(&mons);
         }
     }
 
     // None of these effects should trigger on illusory copies.
-    if (!mons->is_illusion())
+    if (!mons.is_illusion())
     {
-        if (mons->type == MONS_BORIS && !in_transit && !mons->pacified())
+        if (mons.type == MONS_BORIS && !in_transit && !mons.pacified())
         {
             // XXX: Actual blood curse effect for Boris? - bwr
 
             // Now that Boris is dead, he's a valid target for monster
             // creation again. - bwr
-            you.unique_creatures.set(mons->type, false);
+            you.unique_creatures.set(mons.type, false);
             // And his vault can be placed again.
             you.uniq_map_names.erase("uniq_boris");
         }
-        if (mons->type == MONS_JORY && !in_transit)
-            blood_spray(mons->pos(), MONS_JORY, 50);
-        else if (mons_is_mons_class(mons, MONS_KIRKE)
+        if (mons.type == MONS_JORY && !in_transit)
+            blood_spray(mons.pos(), MONS_JORY, 50);
+        else if (mons_is_mons_class(&mons, MONS_KIRKE)
                  && !in_transit
-                 && !testbits(mons->flags, MF_WAS_NEUTRAL))
+                 && !testbits(mons.flags, MF_WAS_NEUTRAL))
         {
             hogs_to_humans();
         }
-        else if ((mons_is_mons_class(mons, MONS_NATASHA)
-                  || mons_genus(mons->type) == MONS_FELID)
-                 && !in_transit && !mons->pacified()
-                 && mons_felid_can_revive(mons))
+        else if ((mons_is_mons_class(&mons, MONS_NATASHA)
+                  || mons_genus(mons.type) == MONS_FELID)
+                 && !in_transit && !mons.pacified()
+                 && mons_felid_can_revive(&mons))
         {
             drop_items = false;
 
             // Like Boris, but her vault can't come back
-            if (mons_is_mons_class(mons, MONS_NATASHA))
+            if (mons_is_mons_class(&mons, MONS_NATASHA))
                 you.unique_creatures.set(MONS_NATASHA, false);
             if (!mons_reset && !wizard)
-                mons_felid_revive(mons);
+                mons_felid_revive(&mons);
         }
-        else if (mons_is_mons_class(mons, MONS_PIKEL))
+        else if (mons_is_mons_class(&mons, MONS_PIKEL))
         {
             // His slaves don't care if he's dead or not, just whether or not
             // he goes away.
             pikel_band_neutralise();
         }
-        else if (mons_is_elven_twin(mons))
-            elven_twin_died(mons, in_transit, killer, killer_index);
-        else if (mons->type == MONS_BENNU && !in_transit && !was_banished
-                 && !mons_reset && !mons->pacified()
+        else if (mons_is_elven_twin(&mons))
+            elven_twin_died(&mons, in_transit, killer, killer_index);
+        else if (mons.type == MONS_BENNU && !in_transit && !was_banished
+                 && !mons_reset && !mons.pacified()
                  && (!summoned || duration > 0) && !wizard
-                 && mons_bennu_can_revive(mons))
+                 && mons_bennu_can_revive(&mons))
         {
             // All this information may be lost by the time the monster revives.
-            const int revives = (mons->props.exists("bennu_revives"))
-                              ? mons->props["bennu_revives"].get_byte() : 0;
-            const beh_type att = mons->has_ench(ENCH_CHARM)
-                                     ? BEH_HOSTILE : SAME_ATTITUDE(mons);
+            const int revives = (mons.props.exists("bennu_revives"))
+                              ? mons.props["bennu_revives"].get_byte() : 0;
+            const beh_type att = mons.has_ench(ENCH_CHARM)
+                                     ? BEH_HOSTILE : SAME_ATTITUDE(&mons);
 
-            bennu_revive_fineff::schedule(mons->pos(), revives, att, mons->foe);
+            bennu_revive_fineff::schedule(mons.pos(), revives, att, mons.foe);
         }
     }
 
-    if (mons_is_tentacle_head(mons_base_type(*mons)))
+    if (mons_is_tentacle_head(mons_base_type(mons)))
     {
-        if (destroy_tentacles(mons)
+        if (destroy_tentacles(&mons)
             && !in_transit
-            && you.see_cell(mons->pos())
+            && you.see_cell(mons.pos())
             && !was_banished)
         {
-            if (mons_base_type(*mons) == MONS_KRAKEN)
+            if (mons_base_type(mons) == MONS_KRAKEN)
                 mpr("The dead kraken's tentacles slide back into the water.");
-            else if (mons->type == MONS_TENTACLED_STARSPAWN)
+            else if (mons.type == MONS_TENTACLED_STARSPAWN)
                 mpr("The starspawn's tentacles wither and die.");
         }
     }
-    else if (mons_is_tentacle_or_tentacle_segment(mons->type)
+    else if (mons_is_tentacle_or_tentacle_segment(mons.type)
              && killer != KILL_MISC
-                 || mons->type == MONS_ELDRITCH_TENTACLE
-                 || mons->type == MONS_SNAPLASHER_VINE)
+                 || mons.type == MONS_ELDRITCH_TENTACLE
+                 || mons.type == MONS_SNAPLASHER_VINE)
     {
-        if (mons->type == MONS_SNAPLASHER_VINE)
+        if (mons.type == MONS_SNAPLASHER_VINE)
         {
-            if (mons->props.exists("vine_awakener"))
+            if (mons.props.exists("vine_awakener"))
             {
                 monster* awakener =
-                        monster_by_mid(mons->props["vine_awakener"].get_int());
+                        monster_by_mid(mons.props["vine_awakener"].get_int());
                 if (awakener)
                     awakener->props["vines_awakened"].get_int()--;
             }
         }
-        destroy_tentacle(mons);
+        destroy_tentacle(&mons);
     }
-    else if (mons->type == MONS_ELDRITCH_TENTACLE_SEGMENT
+    else if (mons.type == MONS_ELDRITCH_TENTACLE_SEGMENT
              && killer != KILL_MISC)
     {
-       monster_die(monster_by_mid(mons->tentacle_connect), killer,
+       monster_die(*monster_by_mid(mons.tentacle_connect), killer,
                    killer_index, silent, wizard, fake);
     }
-    else if (mons->type == MONS_FLAYED_GHOST)
-        end_flayed_effect(mons);
+    else if (mons.type == MONS_FLAYED_GHOST)
+        end_flayed_effect(&mons);
     // Give the treant a last chance to release its hornets if it is killed in a
     // single blow from above half health
-    else if (mons->type == MONS_SHAMBLING_MANGROVE && !was_banished
-             && !mons->pacified() && (!summoned || duration > 0) && !wizard
+    else if (mons.type == MONS_SHAMBLING_MANGROVE && !was_banished
+             && !mons.pacified() && (!summoned || duration > 0) && !wizard
              && !mons_reset)
     {
-        treant_release_fauna(mons);
+        treant_release_fauna(&mons);
     }
-    else if (!mons->is_summoned() && mummy_curse_power(mons->type) > 0)
-        _mummy_curse(mons, mummy_curse_power(mons->type), killer, killer_index);
+    else if (!mons.is_summoned() && mummy_curse_power(mons.type) > 0)
+        _mummy_curse(&mons, mummy_curse_power(mons.type), killer, killer_index);
 
-    if (mons->has_ench(ENCH_INFESTATION) && !was_banished && !mons_reset)
-        _infestation_create_scarab(mons);
+    if (mons.has_ench(ENCH_INFESTATION) && !was_banished && !mons_reset)
+        _infestation_create_scarab(&mons);
 
-    if (mons->mons_species() == MONS_BALLISTOMYCETE)
+    if (mons.mons_species() == MONS_BALLISTOMYCETE)
     {
-        _activate_ballistomycetes(mons, mons->pos(),
+        _activate_ballistomycetes(&mons, mons.pos(),
                                   YOU_KILL(killer) || pet_kill);
     }
 
     if (!wizard && !submerged && !was_banished)
     {
-        _monster_die_cloud(mons, !fake_abjure && !timeout && !mons_reset,
+        _monster_die_cloud(&mons, !fake_abjure && !timeout && !mons_reset,
                            silent, summoned);
     }
 
@@ -2688,23 +2687,23 @@ item_def* monster_die(monster* mons, killer_type killer,
         // Have to add case for disintegration effect here? {dlb}
         item_def* daddy_corpse = nullptr;
 
-        if (mons->type == MONS_SPRIGGAN_RIDER)
+        if (mons.type == MONS_SPRIGGAN_RIDER)
         {
-            daddy_corpse = mounted_kill(mons, MONS_HORNET, killer, killer_index);
-            mons->type = MONS_SPRIGGAN;
+            daddy_corpse = mounted_kill(&mons, MONS_HORNET, killer, killer_index);
+            mons.type = MONS_SPRIGGAN;
         }
-        corpse = place_monster_corpse(*mons, silent);
+        corpse = place_monster_corpse(mons, silent);
         if (!corpse)
             corpse = daddy_corpse;
     }
-    if (corpse && mons->has_ench(ENCH_BOUND_SOUL))
-        _make_derived_undead(mons, !death_message, true);
+    if (corpse && mons.has_ench(ENCH_BOUND_SOUL))
+        _make_derived_undead(&mons, !death_message, true);
     if (you.duration[DUR_DEATH_CHANNEL] && was_visible && gives_player_xp)
-        _make_derived_undead(mons, !death_message, false);
+        _make_derived_undead(&mons, !death_message, false);
 
     const unsigned int player_xp = gives_player_xp
-        ? _calc_player_experience(mons) : 0;
-    const unsigned int monster_xp = _calc_monster_experience(mons, killer,
+        ? _calc_player_experience(&mons) : 0;
+    const unsigned int monster_xp = _calc_monster_experience(&mons, killer,
                                                              killer_index);
 
     // Player Powered by Death
@@ -2731,60 +2730,60 @@ item_def* monster_die(monster* mons, killer_type killer,
     }
 
     if (!crawl_state.game_is_arena() && leaves_corpse && !in_transit)
-        you.kills.record_kill(mons, killer, pet_kill);
+        you.kills.record_kill(&mons, killer, pet_kill);
 
     if (fake)
     {
-        if (corpse && _reaping(mons))
+        if (corpse && _reaping(&mons))
             corpse = nullptr;
         _give_experience(player_xp, monster_xp, killer, killer_index,
                          pet_kill, was_visible);
-        crawl_state.dec_mon_acting(mons);
+        crawl_state.dec_mon_acting(&mons);
 
         return corpse;
     }
 
-    mons_remove_from_grid(*mons);
-    fire_monster_death_event(mons, killer, killer_index, false);
+    mons_remove_from_grid(mons);
+    fire_monster_death_event(&mons, killer, killer_index, false);
 
     if (crawl_state.game_is_arena())
-        arena_monster_died(mons, killer, killer_index, silent, corpse);
+        arena_monster_died(&mons, killer, killer_index, silent, corpse);
 
-    const coord_def mwhere = mons->pos();
+    const coord_def mwhere = mons.pos();
     if (drop_items)
     {
         // monster_drop_things may lead to a level excursion (via
         // god_id_item -> ... -> ShoppingList::item_type_identified),
         // which fails to save/restore the dead monster. Keep it alive
         // since we still need it.
-        unwind_var<int> fakehp(mons->hit_points, 1);
-        monster_drop_things(mons, YOU_KILL(killer) || pet_kill);
+        unwind_var<int> fakehp(mons.hit_points, 1);
+        monster_drop_things(&mons, YOU_KILL(killer) || pet_kill);
     }
     else
     {
         // Destroy the items belonging to MF_HARD_RESET monsters so they
         // don't clutter up mitm[].
-        mons->destroy_inventory();
+        mons.destroy_inventory();
     }
 
     if (leaves_corpse && corpse)
     {
         if (!silent && !wizard)
-            _special_corpse_messaging(*mons);
+            _special_corpse_messaging(mons);
         // message ordering... :(
         if (corpse->base_type == OBJ_CORPSES) // not gold
             _maybe_drop_monster_hide(*corpse, silent);
     }
 
-    if (mons->is_divine_companion()
+    if (mons.is_divine_companion()
         && killer != KILL_RESET
-        && !(mons->flags & MF_BANISHED))
+        && !(mons.flags & MF_BANISHED))
     {
-        remove_companion(mons);
-        if (mons_is_hepliaklqana_ancestor(mons->type))
+        remove_companion(&mons);
+        if (mons_is_hepliaklqana_ancestor(mons.type))
         {
             ASSERT(hepliaklqana_ancestor() == MID_NOBODY);
-            if (!you.can_see(*mons))
+            if (!you.can_see(mons))
             {
                 mprf("%s has departed this plane of existence.",
                      hepliaklqana_ally_name().c_str());
@@ -2799,17 +2798,17 @@ item_def* monster_die(monster* mons, killer_type killer,
     // can see the monster. There are several edge cases where a monster
     // is visible to the player but we still need to turn autopickup
     // back on, such as TSO's halo or sticky flame. (jpeg)
-    if (you.see_cell(mons->pos()) && mons->has_ench(ENCH_INVIS)
-        && !mons->friendly())
+    if (you.see_cell(mons.pos()) && mons.has_ench(ENCH_INVIS)
+        && !mons.friendly())
     {
         autotoggle_autopickup(false);
     }
 
-    if (corpse && _reaping(mons))
+    if (corpse && _reaping(&mons))
         corpse = nullptr;
 
-    crawl_state.dec_mon_acting(mons);
-    monster_cleanup(mons);
+    crawl_state.dec_mon_acting(&mons);
+    monster_cleanup(&mons);
 
     // Force redraw for monsters that die.
     if (in_bounds(mwhere) && you.see_cell(mwhere))
@@ -2837,7 +2836,7 @@ void unawaken_vines(const monster* mons, bool quiet)
         {
             if (you.can_see(**mi))
                 ++vines_seen;
-            monster_die(*mi, KILL_RESET, NON_MONSTER);
+            monster_die(**mi, KILL_RESET, NON_MONSTER);
         }
     }
 
@@ -2968,7 +2967,7 @@ item_def* mounted_kill(monster* daddy, monster_type mc, killer_type killer,
         mon.props["reaper"].get_int() = daddy->props["reaper"].get_int();
     }
 
-    return monster_die(&mon, killer, killer_index, false, false, true);
+    return monster_die(mon, killer, killer_index, false, false, true);
 }
 
 /**
@@ -3030,7 +3029,7 @@ void mons_check_pool(monster* mons, const coord_def &oldpos,
     // Yredelemnul special, redux: It's the only one that can
     // work on drowned monsters.
     if (!_yred_enslave_soul(mons, killer))
-        monster_die(mons, killer, killnum, true);
+        monster_die(*mons, killer, killnum, true);
 }
 
 // Make all of the monster's original equipment disappear, unless it's a fixed
@@ -3073,7 +3072,7 @@ int dismiss_monsters(string pattern)
         {
             if (!keep_item)
                 _vanish_orig_eq(*mi);
-            monster_die(*mi, KILL_DISMISSED, NON_MONSTER, false, true);
+            monster_die(**mi, KILL_DISMISSED, NON_MONSTER, false, true);
             ++ndismissed;
         }
     }

--- a/crawl-ref/source/mon-death.h
+++ b/crawl-ref/source/mon-death.h
@@ -29,10 +29,10 @@
 
 struct bolt;
 
-item_def* monster_die(monster* mons, const actor *killer, bool silent = false,
+item_def* monster_die(monster& mons, const actor *killer, bool silent = false,
                       bool wizard = false, bool fake = false);
 
-item_def* monster_die(monster* mons, killer_type killer,
+item_def* monster_die(monster& mons, killer_type killer,
                       int killer_index, bool silent = false,
                       bool wizard = false, bool fake = false);
 

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -702,13 +702,13 @@ void monster::remove_enchantment_effect(const mon_enchant &me, bool quiet)
         if (berserk())
             simple_monster_message(*this, " is no longer berserk.");
 
-        monster_die(this, (me.ench == ENCH_FAKE_ABJURATION) ? KILL_MISC :
+        monster_die(*this, (me.ench == ENCH_FAKE_ABJURATION) ? KILL_MISC :
                             (quiet) ? KILL_DISMISSED : KILL_RESET, NON_MONSTER);
         break;
     case ENCH_SHORT_LIVED:
         // Conjured ball lightnings explode when they time out.
         suicide();
-        monster_die(this, KILL_TIMEOUT, NON_MONSTER);
+        monster_die(*this, KILL_TIMEOUT, NON_MONSTER);
         break;
     case ENCH_SUBMERGED:
         if (mons_is_wandering(*this))
@@ -1618,7 +1618,7 @@ void monster::apply_enchantment(const mon_enchant &me)
                 }
             }
 
-            monster_die(this, KILL_MISC, NON_MONSTER, true);
+            monster_die(*this, KILL_MISC, NON_MONSTER, true);
         }
         break;
 

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -233,7 +233,7 @@ static void _iood_stop(monster& mon, bool msg = true)
     if (msg)
         simple_monster_message(mon, " dissipates.");
     dprf("iood: dissipating");
-    monster_die(&mon, KILL_DISMISSED, NON_MONSTER);
+    monster_die(mon, KILL_DISMISSED, NON_MONSTER);
 }
 
 static void _fuzz_direction(const actor *caster, monster& mon, int pow)
@@ -325,7 +325,7 @@ static bool _iood_hit(monster& mon, const coord_def &pos, bool big_boom = false)
     beam.ex_size = 1;
     beam.loudness = 7;
 
-    monster_die(&mon, KILL_DISMISSED, NON_MONSTER);
+    monster_die(mon, KILL_DISMISSED, NON_MONSTER);
 
     if (big_boom)
         beam.explode(true, false);
@@ -463,7 +463,7 @@ move_again:
                 {
                     if (you.see_cell(pos))
                         mpr("The orb fizzles.");
-                    monster_die(mons, KILL_DISMISSED, NON_MONSTER);
+                    monster_die(*mons, KILL_DISMISSED, NON_MONSTER);
                 }
 
                 // Return, if the acting orb fizzled.
@@ -471,7 +471,7 @@ move_again:
                 {
                     if (you.see_cell(pos))
                         mpr("The orb fizzles.");
-                    monster_die(&mon, KILL_DISMISSED, NON_MONSTER);
+                    monster_die(mon, KILL_DISMISSED, NON_MONSTER);
                     return true;
                 }
             }
@@ -482,7 +482,7 @@ move_again:
                 else
                     mpr("You hear a loud magical explosion!");
                 noisy(40, pos);
-                monster_die(mons, KILL_DISMISSED, NON_MONSTER);
+                monster_die(*mons, KILL_DISMISSED, NON_MONSTER);
                 _iood_hit(mon, pos, true);
                 return true;
             }

--- a/crawl-ref/source/mon-tentacle.cc
+++ b/crawl-ref/source/mon-tentacle.cc
@@ -635,7 +635,7 @@ static void _purge_connectors(monster* tentacle)
             if (hp > 0 && hp < tentacle->hit_points)
                 tentacle->hit_points = hp;
 
-            monster_die(*mi, KILL_MISC, NON_MONSTER, true);
+            monster_die(**mi, KILL_MISC, NON_MONSTER, true);
         }
     }
     ASSERT(tentacle->alive());
@@ -937,7 +937,7 @@ void move_solo_tentacle(monster* tentacle)
              old_pos.x, old_pos.y, tentacle->mid, visited_count);
 
         // Is it ok to purge the tentacle here?
-        monster_die(tentacle, KILL_MISC, NON_MONSTER, true);
+        monster_die(*tentacle, KILL_MISC, NON_MONSTER, true);
         return;
     }
 
@@ -1031,7 +1031,7 @@ void move_child_tentacles(monster* mons)
             // Drop the tentacle if no enemies are in sight and it is
             // adjacent to the main body. This is to prevent players from
             // just sniping tentacles while outside the kraken's fov.
-            monster_die(tentacle, KILL_MISC, NON_MONSTER, true);
+            monster_die(*tentacle, KILL_MISC, NON_MONSTER, true);
             continue;
         }
 
@@ -1125,7 +1125,7 @@ void move_child_tentacles(monster* mons)
         if (!connected)
         {
             mgrd(tentacle->pos()) = tentacle->mindex();
-            monster_die(tentacle, KILL_MISC, NON_MONSTER, true);
+            monster_die(*tentacle, KILL_MISC, NON_MONSTER, true);
 
             continue;
         }
@@ -1168,14 +1168,14 @@ bool destroy_tentacle(monster* mons)
         {
             any = true;
             //mi->hurt(*mi, INSTANT_DEATH);
-            monster_die(*mi, KILL_MISC, NON_MONSTER, true);
+            monster_die(**mi, KILL_MISC, NON_MONSTER, true);
         }
     }
 
     if (mons != head)
     {
         any = true;
-        monster_die(head, KILL_MISC, NON_MONSTER, true);
+        monster_die(*head, KILL_MISC, NON_MONSTER, true);
     }
 
     return any;
@@ -1191,7 +1191,7 @@ bool destroy_tentacles(monster* head)
             any |= destroy_tentacle(*mi);
             if (!mi->is_child_tentacle_segment())
             {
-                monster_die(mi->as_monster(), KILL_MISC, NON_MONSTER, true);
+                monster_die(*mi->as_monster(), KILL_MISC, NON_MONSTER, true);
                 any = true;
             }
         }

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2877,7 +2877,7 @@ void monster::banish(actor *agent, const string &, const int, bool force)
                             true /*possibly wrong*/, this);
         }
     }
-    monster_die(this, KILL_BANISHED, NON_MONSTER);
+    monster_die(*this, KILL_BANISHED, NON_MONSTER);
 
     if (!cell_is_solid(old_pos))
         place_cloud(CLOUD_TLOC_ENERGY, old_pos, 5 + random2(8), 0);
@@ -4511,11 +4511,11 @@ int monster::hurt(const actor *agent, int amount, beam_type flavour,
         && type != MONS_NO_MONSTER)
     {
         if (agent == nullptr)
-            monster_die(this, KILL_MISC, NON_MONSTER);
+            monster_die(*this, KILL_MISC, NON_MONSTER);
         else if (agent->is_player())
-            monster_die(this, KILL_YOU, NON_MONSTER);
+            monster_die(*this, KILL_YOU, NON_MONSTER);
         else
-            monster_die(this, KILL_MON, agent->mindex());
+            monster_die(*this, KILL_MON, agent->mindex());
     }
 
     return amount;
@@ -5523,7 +5523,7 @@ void monster::apply_location_effects(const coord_def &oldpos,
 void monster::self_destruct()
 {
     suicide();
-    monster_die(as_monster(), KILL_MON, mindex());
+    monster_die(*as_monster(), KILL_MON, mindex());
 }
 
 /** A higher-level moving method than moveto().

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1015,7 +1015,7 @@ static bool _player_hurt_monster(monster& m, int damage,
         }
         else
         {
-            monster_die(&m, KILL_YOU, NON_MONSTER);
+            monster_die(m, KILL_YOU, NON_MONSTER);
             return true;
         }
     }
@@ -1633,7 +1633,7 @@ static int _ignite_poison_monsters(coord_def where, int pow, actor *agent)
     }
     else
     {
-        monster_die(mon,
+        monster_die(*mon,
                     agent->is_player() ? KILL_YOU : KILL_MON,
                     agent->mindex());
     }

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -443,7 +443,7 @@ bool MiscastEffect::_ouch(int dam, beam_type flavour)
                          "", "", false);
 
         if (!mon_target->alive())
-            monster_die(mon_target, kt, actor_to_death_source(act_source));
+            monster_die(*mon_target, kt, actor_to_death_source(act_source));
     }
     else
     {

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1206,7 +1206,7 @@ spret_type cast_shadow_creatures(int st, god_type god, level_id place,
 
             // If we didn't find a valid spell set yet, just give up
             if (tries > 20)
-                monster_die(mons, KILL_RESET, NON_MONSTER);
+                monster_die(*mons, KILL_RESET, NON_MONSTER);
             else
             {
                 // Choose a new duration based on HD.
@@ -1234,7 +1234,7 @@ spret_type cast_shadow_creatures(int st, god_type god, level_id place,
                     && (mid_t) mi->props["band_leader"].get_int() == mons->mid)
                 {
                     if (player_will_anger_monster(**mi))
-                        monster_die(*mi, KILL_RESET, NON_MONSTER);
+                        monster_die(**mi, KILL_RESET, NON_MONSTER);
 
                     mi->props["summon_id"].get_int() = mons->mid;
                 }
@@ -2625,7 +2625,7 @@ void end_battlesphere(monster* mons, bool killed)
         if (!cell_is_solid(mons->pos()))
             place_cloud(CLOUD_MAGIC_TRAIL, mons->pos(), 3 + random2(3), mons);
 
-        monster_die(mons, KILL_RESET, NON_MONSTER);
+        monster_die(*mons, KILL_RESET, NON_MONSTER);
     }
 }
 
@@ -3135,7 +3135,7 @@ void end_spectral_weapon(monster* mons, bool killed, bool quiet)
     }
 
     if (!killed)
-        monster_die(mons, KILL_RESET, NON_MONSTER);
+        monster_die(*mons, KILL_RESET, NON_MONSTER);
 }
 
 bool trigger_spectral_weapon(actor* agent, const actor* target)

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -233,7 +233,7 @@ static void _zap_los_monsters(bool items_also)
         mon->flags |= MF_HARD_RESET;
         // Do a silent, wizard-mode monster_die() just to be extra sure the
         // player sees nothing.
-        monster_die(mon, KILL_DISMISSED, NON_MONSTER, true, true);
+        monster_die(*mon, KILL_DISMISSED, NON_MONSTER, true, true);
     }
 }
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6152,7 +6152,7 @@ static void tag_read_level_monsters(reader &th)
             dprf("Killed elsewhere companion %s(%d) on %s",
                     m.name(DESC_PLAIN, true).c_str(), m.mid,
                     level_id::current().describe(false, true).c_str());
-            monster_die(&m, KILL_RESET, -1, true, false);
+            monster_die(m, KILL_RESET, -1, true, false);
             continue;
         }
 

--- a/crawl-ref/source/teleport.cc
+++ b/crawl-ref/source/teleport.cc
@@ -216,9 +216,9 @@ void mons_relocated(monster* mons)
                 for (monster_iterator connect; connect; ++connect)
                 {
                     if (connect->is_child_tentacle_of(*mi))
-                        monster_die(*connect, KILL_RESET, -1, true, false);
+                        monster_die(**connect, KILL_RESET, -1, true, false);
                 }
-                monster_die(*mi, KILL_RESET, -1, true, false);
+                monster_die(**mi, KILL_RESET, -1, true, false);
             }
         }
     }
@@ -228,10 +228,10 @@ void mons_relocated(monster* mons)
         for (monster_iterator connect; connect; ++connect)
         {
             if (connect->is_child_tentacle_of(mons))
-                monster_die(*connect, KILL_RESET, -1, true, false);
+                monster_die(**connect, KILL_RESET, -1, true, false);
         }
 
-        monster_die(mons, KILL_RESET, -1, true, false);
+        monster_die(*mons, KILL_RESET, -1, true, false);
     }
     // Kill an eldritch tentacle and all its segments.
     else if (mons->type == MONS_ELDRITCH_TENTACLE
@@ -243,10 +243,10 @@ void mons_relocated(monster* mons)
         for (monster_iterator mit; mit; ++mit)
         {
             if (mit->is_child_tentacle_of(tentacle))
-                monster_die(*mit, KILL_RESET, -1, true, false);
+                monster_die(**mit, KILL_RESET, -1, true, false);
         }
 
-        monster_die(tentacle, KILL_RESET, -1, true, false);
+        monster_die(*tentacle, KILL_RESET, -1, true, false);
     }
 
     mons->clear_clinging();

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -1158,7 +1158,7 @@ static void _catchup_monster_moves(monster* mon, int turns)
     {
         // You might still see them disappear if you were quick
         if (turns > 2)
-            monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+            monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
         else
         {
             mon_enchant abj  = mon->get_ench(ENCH_ABJ);
@@ -1351,7 +1351,7 @@ void monster::timeout_enchantments(int levels)
         {
             const int actdur = speed_to_duration(speed) * levels;
             if (lose_ench_duration(entry.first, actdur))
-                monster_die(this, KILL_MISC, NON_MONSTER, true);
+                monster_die(*this, KILL_MISC, NON_MONSTER, true);
             break;
         }
 

--- a/crawl-ref/source/wiz-fsim.cc
+++ b/crawl-ref/source/wiz-fsim.cc
@@ -304,7 +304,7 @@ static monster* _init_fsim()
 
     if (!adjacent(mon->pos(), you.pos()))
     {
-        monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+        monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
         mpr("Could not put monster adjacent to player.");
         return 0;
     }
@@ -322,7 +322,7 @@ static monster* _init_fsim()
 
 static void _uninit_fsim(monster *mon)
 {
-    monster_die(mon, KILL_DISMISSED, NON_MONSTER);
+    monster_die(*mon, KILL_DISMISSED, NON_MONSTER);
     reset_training();
 }
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -1350,7 +1350,7 @@ static void _xom_snakes_to_sticks(int sever)
 
         // Dismiss monster silently.
         move_item_to_grid(&item_slot, mi->pos());
-        monster_die(*mi, KILL_DISMISSED, NON_MONSTER, true, false);
+        monster_die(**mi, KILL_DISMISSED, NON_MONSTER, true, false);
     }
 }
 


### PR DESCRIPTION
Most of the changes are provably safe; a few may have been relying
on (now removed) nullptr checks in monster_die, but I don't think so.

Not really sure how to prove this commit introduces no errors; maybe
CI will find them? Otherwise, I dunno, merge and see if games crash.