### PR TITLE
Replace spell success breakpoints with minmay's polynomial

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -9,6 +9,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <cmath>
 
 #include "areas.h"
 #include "art-enum.h"
@@ -324,12 +325,14 @@ int raw_spell_fail(spell_type spell)
     int chance = 60;
 
     // Don't cap power for failure rate purposes.
-    chance -= 6 * calc_spell_power(spell, false, true, false);
-    chance -= (you.intel() * 2);
+    // scale by 6, which I guess was chosen because it seems to work.
+    chance -= calc_spell_power(spell, false, true, false, 6); // realistic range: -6 to -366 (before scale -1 to -61)
+    chance -= (you.intel() * 2); // realistic range: -2 to -70
 
     const int armour_shield_penalty = player_armour_shield_spell_penalty();
     dprf("Armour+Shield spell failure penalty: %d", armour_shield_penalty);
-    chance += armour_shield_penalty;
+    chance += armour_shield_penalty; // realistic range: 0 to 500 in extreme cases.
+                                     // A midlevel melee character in plate might have 40 or 50, and a caster in a robe would usually have 0.
 
     static const int difficulty_by_level[] =
     {
@@ -348,22 +351,29 @@ int raw_spell_fail(spell_type spell)
     };
     const int spell_level = spell_difficulty(spell);
     ASSERT_RANGE(spell_level, 0, (int) ARRAYSZ(difficulty_by_level));
-    chance += difficulty_by_level[spell_level];
+    chance += difficulty_by_level[spell_level]; // between 0 and 330
 
-    int chance2 = chance;
-
-    const int chance_breaks[][2] =
-    {
-        {45, 45}, {42, 43}, {38, 41}, {35, 40}, {32, 38}, {28, 36},
-        {22, 34}, {16, 32}, {10, 30}, {2, 28}, {-7, 26}, {-12, 24},
-        {-18, 22}, {-24, 20}, {-30, 18}, {-38, 16}, {-46, 14},
-        {-60, 12}, {-80, 10}, {-100, 8}, {-120, 6}, {-140, 4},
-        {-160, 2}, {-180, 0}
-    };
-
-    for (const int (&cbrk)[2] : chance_breaks)
-        if (chance < cbrk[0])
-            chance2 = cbrk[1];
+    // This polynomial is a smoother approximation of a breakpoint-based
+    // calculation that originates pre-DCSS, mapping `chance` at this point to
+    // values from around 0 to around 45. (see
+    // https://crawl.develz.org/tavern/viewtopic.php?f=8&t=23414 for some of
+    // the history.)  It was calculated by |amethyst (based on one from minmay
+    // in that thread) and converted to integer values using 262144 as a
+    // convenient power of 2 denominator, then converted to its current form
+    // by Horner's rule.
+    //
+    // The regular (integer) polynomial form before Horner's rule is:
+    //          (x*x*x + 426*x*x + 82670*x + 6983254) / 262144
+    //
+    // Following the old calculation, it is linear above 43.  (In fact, the
+    // old version was linear above 45, but 43 is where this version
+    // converges.) This hits 0 at a `chance` of -173, 10 at a `chance` of -72,
+    // and of course 43 at a `chance` of 43.
+    //
+    // https://www.wolframalpha.com/input/?i=graph+of+(((x+%2B+426)*x+%2B+82670)*x+%2B+6983254)+%2F+262144+with+x+from+-200+to+100
+    //
+    // If you think this is weird, you should see what was here before.
+    int chance2 = chance > 43 ? chance : max((((chance + 426) * chance + 82670) * chance + 6983254) / 262144, 0);
 
     chance2 += get_form()->spellcasting_penalty;
 
@@ -379,19 +389,37 @@ int raw_spell_fail(spell_type spell)
     // Apply the effects of Vehumet and items of wizardry.
     chance2 = _apply_spellcasting_success_boosts(spell, chance2);
 
-    if (chance2 > 100)
-        chance2 = 100;
-
-    return chance2;
+    return min(max(chance2, 0), 100);
 }
 
-int stepdown_spellpower(int power)
+/*
+ * Given some spellpower in centis, do a stepdown at around 50 (5000 in centis) and return a rescaled value.
+ *
+ * @param power the input spellpower in centis.
+ * @param scale a value to scale the result by, between 1 and 1000. Default is 1, which returns a regular spellpower.  1000 gives you millis, 100 centis.
+ */
+int stepdown_spellpower(int power, int scale)
 {
-    return stepdown_value(power / 100, 50, 50, 150, 200);
+    // use millis internally
+    ASSERT_RANGE(scale, 1, 1000);
+    const int divisor = 1000 / scale;
+    int result = stepdown_value(power * 10, 50000, 50000, 150000, 200000) / divisor;
+    return result;
 }
 
+/*
+ * Calculate spell power.
+ *
+ * @param spell         the spell to check
+ * @param apply_intel   whether to include intelligence in the calculation
+ * @param fail_rate_check is this just a plain failure rate check or should it incorporate situational facts and mutations?
+ * @param cap_power     whether to apply the power cap for the spell (from `spell_power_cap(spell)`)
+ * @param scale         what scale to apply to the result internally?  This function has higher internal resolution than the default argument, so use this rather than dividing. This must be between 1 and 1000.
+ *
+ * @return the resulting spell power.
+ */
 int calc_spell_power(spell_type spell, bool apply_intel, bool fail_rate_check,
-                     bool cap_power)
+                     bool cap_power, int scale)
 {
     int power = 0;
 
@@ -442,11 +470,13 @@ int calc_spell_power(spell_type spell, bool apply_intel, bool fail_rate_check,
         power /= 10 + (you.props[HORROR_PENALTY_KEY].get_int() * 3) / 2;
     }
 
-    power = stepdown_spellpower(power);
+    // at this point, `power` is assumed to be basically in centis.
+    // apply a stepdown, and scale.
+    power = stepdown_spellpower(power, scale);
 
     const int cap = spell_power_cap(spell);
     if (cap > 0 && cap_power)
-        power = min(power, cap);
+        power = min(power, cap * scale);
 
     return power;
 }

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -81,9 +81,10 @@ int list_spells(bool toggle_with_I = true, bool viewing = false,
                 const string &title = "Your Spells",
                 spell_selector selector = nullptr);
 int raw_spell_fail(spell_type spell);
-int stepdown_spellpower(int power);
+int stepdown_spellpower(int power, int scale = 1);
 int calc_spell_power(spell_type spell, bool apply_intel,
-                     bool fail_rate_chk = false, bool cap_power = true);
+                     bool fail_rate_chk = false, bool cap_power = true,
+                     int scale = 1);
 int calc_spell_range(spell_type spell, int power = 0);
 
 bool cast_a_spell(bool check_range, spell_type spell = SPELL_NO_SPELL);


### PR DESCRIPTION
Lots of consensus that something like this is a good idea -- replacing
these pre-dcss breakpoints has been under discussion since at least
2014. This version uses minmay's polynomial solution explained at:
https://crawl.develz.org/tavern/viewtopic.php?f=8&t=23414

The argument that swayed me to make a branch: "One great effect of
getting rid of chance_breaks is that spells transition from 100% to 99%
to 98% etc. etc. earlier, instead of staying at 100% for ages and then
quickly falling. A 99% fail spell is still useless but it makes it much
easier for unspoiled players to tell how close they are to getting it
castable, compared to seeing both level 5 and level 9 spells as 100%
fail."

I've done some quick checking but not careful checking, and have mixed
feelings about introducing doubles where there were only wholesome ints,
but it's just one line, what could go wrong.