### PR TITLE
Update Haste spell description.

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -642,8 +642,7 @@ Speeds the actions of a nearby ally.
 %%%%
 Haste spell
 
-Speeds the actions of a targeted creature. While hasted you will gain magical
-contamination.
+Speeds the actions of a targeted creature.
 %%%%
 Haunt spell
 


### PR DESCRIPTION
Removes the reference to contaminating the player from the Haste spell
description (it should be impossible for a monster to cast Haste on the
player anyway, but this should reduce confusion just in case).