### PR TITLE
break up a swastika or two

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_features.des
+++ b/crawl-ref/source/dat/des/variable/mini_features.des
@@ -1200,17 +1200,17 @@ SUBST:  @ = x
 SUBST:  + = x+
 : end
 MAP
-.........@.
-@xxxxxxx.x.
-.......x.x.
+@x........@
+..xxxxxx..x
+.x.....x.x.
 .xxxxx.x.x.
 .x...x.x.x.
 .x.xx+xx.x.
 .x.x.x...x.
 .x.x.xxxxx.
-.x.x.......
-.x.xxxxxxx@
-.@.........
+.x.x.....x.
+x.xxxxxxx..
+@........x@
 ENDMAP
 
 NAME:   roderic_curled_sauvastika
@@ -1407,15 +1407,15 @@ SUBST:   " : x
 
 MAP
 ...........
-.x'''x"""x.
+.x'''""""x.
 .".?.x...'.
 .".?.x.??'.
-."...x...'.
-.xxxxxxxxx.
-.'...x...".
+."..x.x..'.
+.'xx.x.xx'.
+.'..x.x..".
 .'??.x.?.".
 .'...x.?.".
-.x"""x'''x.
+.x""""'''x.
 ...........
 ENDMAP
 


### PR DESCRIPTION
roderic_ancient_swastika swastika could, on an unlucky shuffle, wind up looking highly similar to the symbol now associated with the NSDAP of the 1920s.

roderic_greek_sauvastika could as well, when flipped by the dungeon builder.

Folks are more than welcome to make further edits to the PR; I have ticked the checkbox that allows it.
![image](https://cloud.githubusercontent.com/assets/16616851/25097317/117a7332-2372-11e7-9f6f-4be835da0e93.png)