### PR TITLE
Mention Oka ammo gifting when you reach 3*

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -151,6 +151,8 @@ const vector<god_power> god_powers[NUM_GODS] =
 
     // Okawaru
     { { 1, ABIL_OKAWARU_HEROISM, "gain great but temporary skills" },
+      { 3, "Okawaru will gift you ammunition as your piety grows.",
+           "Okawaru will no longer gift you ammunition." },
       { 5, ABIL_OKAWARU_FINESSE, "speed up your combat" },
       { 5, "Okawaru will gift you equipment as your piety grows.",
            "Okawaru will no longer gift you equipment." },


### PR DESCRIPTION
It's a bit of a pointless message for players that Oka doesn't think
need ammunition (since they will never recieve ammunition gifts), but
prevents the case where ammunition-needing players receive gifts before
the 5* message about receiving gifts.