### PR TITLE
SDL Tiles: Don't disable screen saver

### DIFF
--- a/crawl-ref/source/windowmanager-sdl.cc
+++ b/crawl-ref/source/windowmanager-sdl.cc
@@ -480,6 +480,9 @@ int SDLWrapper::init(coord_def *m_windowsz, int *densityNum, int *densityDen)
     *densityDen = m_windowsz->x;
     SDL_SetWindowMinimumSize(m_window, MIN_SDL_WINDOW_SIZE_X,
                              MIN_SDL_WINDOW_SIZE_Y);
+
+    SDL_EnableScreenSaver();
+
     return true;
 }
 


### PR DESCRIPTION
I don't know if I'm the only one, but I find it very annoying that Crawl locks the screen saver. [Apparently](https://forums.libsdl.org/viewtopic.php?t=4672&sid=867766d41acba06758c5315edc5c8641) it's the default behaviour set by SDL.

I tried setting `SDL_HINT_VIDEO_ALLOW_SCREENSAVER` but it didn't work. Calling `SDL_EnableScreenSaver()` did.