### PR TITLE
Make aptitudes table display '--' instead of '0' for unusable skills

### DIFF
--- a/crawl-ref/docs/template/apt-tmpl-wide.txt
+++ b/crawl-ref/docs/template/apt-tmpl-wide.txt
@@ -8,6 +8,7 @@ two other ways:
 - Read the species section in the manual about strengths and weaknesses.
 - Look at which combinations of species and background are recommended.
 
+ --  no aptitude (cannot learn this skill at all)
  -5  abysmal aptitude
  -4  terrible aptitude (learning half as fast as at 0 aptitude)
  -3  very poor aptitude

--- a/crawl-ref/docs/template/apt-tmpl.txt
+++ b/crawl-ref/docs/template/apt-tmpl.txt
@@ -8,6 +8,7 @@ two other ways:
 - Read the species section in the manual about strengths and weaknesses.
 - Look at which combinations of species and background are recommended.
 
+ --  no aptitude (cannot learn this skill at all)
  -5  abysmal aptitude
  -4  terrible aptitude (learning half as fast as at 0 aptitude)
  -3  very poor aptitude

--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -147,7 +147,11 @@ sub aptitude_table
 
             my $fmt = "%+3d";
             $fmt = "%3d" if $skill == 0;
-            $fmt = " NA" if $skill == -99;
+            if ($skill == -99)
+            {
+                $skill = '--';
+                $fmt = "%3s";
+            }
             if ($abbr eq 'HP')
             {
                 $skill = $skill * 10;
@@ -221,7 +225,7 @@ sub load_aptitudes
         }
         else
         {
-            if (/APT\(\s*SP_(\w+)\s*,\s*SK_(\w+)\s*,\s*(-?\d+)\s*\)/)
+            if (/APT\(\s*SP_(\w+)\s*,\s*SK_(\w+)\s*,\s*(-?\d+|UNUSABLE_SKILL)\s*\)/)
             {
                 $species = propercase_string(fix_underscores($1));
                 if (!$SEEN_SPECIES{$species})
@@ -231,6 +235,7 @@ sub load_aptitudes
                 }
 
                 my $apt = $3;
+                $apt = -99 if $apt eq "UNUSABLE_SKILL";
                 my $skill = skill_name($2);
                 next if $skill eq "Stabbing";
                 next if $skill eq "Traps";


### PR DESCRIPTION
Since e2bf7478f97, `aptitudes.txt` displays an aptitude of `0` for skills that cannot be learned by a species, which is misleading/confusing. This commit fixes the document generation to display `--` instead.

```
...
                 Arm Ddg Sth Shd     Inv Evo        HP  MP Exp  MR
----------------------------------------------------------------------
Human              0   0  +1   0      +1   0       +0%   0  +1  +3
Barachi           +2  +1   0  +1      -1  +1       +0%   0   0  +3
Centaur           -3  -3  -4  -3      +1  -1      +10%   0  -1  +3
Demigod           -1  -1   0  -1      --  -1      +10%  +2  -2  +4
Demonspawn        -1  -1   0  -1      +3   0       +0%   0  -1  +3
Draconian         --  -1   0   0      +1   0      +10%   0  -1  +3
         Black    --  -1   0   0      +1   0      +10%   0  -1  +3
         Green    --  -1   0   0      +1   0      +10%   0  -1  +3
          Grey    --  -1   0   0      +1   0      +10%   0  -1  +3
       Mottled    --  -1   0   0      +1   0      +10%   0  -1  +3
          Pale    --  -1   0   0      +1  +1      +10%   0  -1  +3
        Purple    --  -1   0   0      +1  +1      +10%   0  -1  +6
           Red    --  -1   0   0      +1   0      +10%   0  -1  +3
         White    --  -1   0   0      +1   0      +10%   0  -1  +3
        Yellow    --  -1   0   0      +1   0      +10%   0  -1  +3
Deep Dwarf        +1  +1  +3  +1      +3  +3      +20%   0  -1  +6
Deep Elf          -2  +2  +3  -2      +1  +1      -20%  +2  -1  +4
Felid             --  +3  +4  --       0  +1      -40%  +1  -1  +6
Formicid          +1  -1  +3  +2      +2  +1       +0%   0  +1  +4
Gargoyle          +1  -2  +2  +1      +1  -1      -20%   0   0  +3
...
```