### PR TITLE
Don't let Kiku wrath inflict infinite miscasts

### DIFF
--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -642,11 +642,9 @@ static bool _kikubaaqudgha_retribution()
     }
     else if (random2(you.experience_level) >= 4)
     {
-        // necromancy miscast, 20% chance of additional miscast
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
-                      2 + div_rand_round(you.experience_level, 9),
-                      random2avg(88, 3), _god_wrath_name(god));
-        if (one_chance_in(5))
+        // necromancy miscast, 25% chance of additional miscast
+        const int num_miscasts = one_chance_in(4) ? 2 : 1;
+        for (int i = 0; i < num_miscasts; i++)
             MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
                       2 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -643,13 +643,13 @@ static bool _kikubaaqudgha_retribution()
     else if (random2(you.experience_level) >= 4)
     {
         // necromancy miscast, 20% chance of additional miscast
-        do
-        {
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
+                      2 + div_rand_round(you.experience_level, 9),
+                      random2avg(88, 3), _god_wrath_name(god));
+        if (one_chance_in(5))
             MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
-                          2 + div_rand_round(you.experience_level, 9),
-                          random2avg(88, 3), _god_wrath_name(god));
-        }
-        while (one_chance_in(5));
+                      2 + div_rand_round(you.experience_level, 9),
+                      random2avg(88, 3), _god_wrath_name(god));
     }
 
     // Every act of retribution causes corpses in view to rise against


### PR DESCRIPTION
Kiku wrath has a fun bit of code that only runs if the player is less than level 27. (Level 27 players always get tormented, lower level players are more likely to be tormented the higher level they are). This code causes a necromancy miscast, then has a 20% chance to cause a second one, or so the comment implies. It also has a 1/125 chance of causing three miscasts, a 1/500 chance of causing 4, a 1/2500 chance of causing 5, and so on. Assuming the random number generator is random anyway, which it isn't. Kiku probably shouldn't be able to just lower all of an ex-follower's skill levels to 0, or damage of their attributes by 100, or rot away their entire health bar in an instant, or drop twenty reapers on their head, or kill them outright from 300+ HP, or all of these at the same time just because the player isn't level 27 and RNG said so.