### PR TITLE
Allow Fulminant Prism and Lightning Spire to be cast on traps.

### DIFF
--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -494,6 +494,10 @@ bool can_place_on_trap(monster_type mon_type, trap_type trap)
     if (mons_is_tentacle_segment(mon_type))
         return true;
 
+    // Things summoned by the player to a specific spot shouldn't protest.
+    if (mon_type == MONS_FULMINANT_PRISM || mon_type == MONS_LIGHTNING_SPIRE)
+        return true;
+
     if (trap == TRAP_TELEPORT || trap == TRAP_TELEPORT_PERMANENT
         || trap == TRAP_SHAFT)
     {


### PR DESCRIPTION
They work on known or unknown traps without protest. The summoned thing sits on the teleporter or shaft, does its job, and does not reveal the trap if it isn't already known. (Though somewhat weird, this is already how they behaved with respect to zot traps.)