### PR TITLE
Don't let apocalypse crab breath attacks ignore player clarity

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3482,7 +3482,7 @@ void bolt::affect_player_enchantment(bool resistible)
         break;
 
     case BEAM_BERSERK:
-        you.go_berserk(blame_player, true);
+        you.go_berserk(blame_player);
         obvious_effect = true;
         break;
 


### PR DESCRIPTION
As far as I can tell, the only thing that uses BEAM_BERSERK and is capable of affecting the player is BEAM_CHAOS, which in turn is only used by apocalypse crab breath, and only the actual breath attack, not the clouds. I don't see any reason for this attack to ignore clarity, especially since the clouds (which are handled elsewhere) respect clarity. Monsters don't seem to actually check clarity when berserking so that case is untouched.