### PR TITLE
Remove hard-coded colors from the levdes syntax definitions (vim)

### DIFF
--- a/crawl-ref/source/dat/vim/syntax/levdes.vim
+++ b/crawl-ref/source/dat/vim/syntax/levdes.vim
@@ -253,51 +253,25 @@ hi link desBranchname  Special
 hi link desColour      Type
 hi link desTransparent Type
 
-" It would be really nice if this worked for people who switch bg
-" post-loading, like "normal" highlights do. Does someone know how?
-if &bg == "dark"
-  hi desMapWall guifg=darkgray term=bold gui=bold ctermfg=white
-  hi desMapPermaWall guifg=#a0a000 gui=bold ctermfg=yellow
-  hi desMapStoneWall guifg=black gui=bold ctermfg=gray
-  hi desMapGlassWall guifg=lightcyan ctermfg=lightcyan
-  hi desMapMetalWall guifg=#004090 term=bold gui=bold ctermfg=lightblue
-  hi desMapCrystalWall guifg=#009040 term=bold gui=bold ctermfg=green
-  hi desMapTree guifg=#00aa00 ctermfg=darkgreen
-  hi desMapFloor guifg=#008000 ctermfg=darkgray
-  hi desMapDoor guifg=brown gui=bold ctermfg=white
-  hi desMapShallow guifg=lightcyan ctermfg=darkcyan
-  hi desMapWater guifg=lightblue ctermfg=darkblue
-  hi desMapLava guifg=red gui=bold ctermfg=darkred
-
-  hi desMapEntry guifg=black guibg=white gui=bold ctermfg=white ctermbg=black
-  hi desMapStairs guifg=orange gui=bold ctermfg=magenta
-  hi desMapTrap guifg=red gui=bold ctermfg=darkred
-
-  hi desMapGold guifg=#c09000 ctermfg=yellow
-  hi desMapValuable guifg=darkgreen gui=bold ctermfg=yellow
-  hi desMapMonst guifg=red ctermfg=red
-else
-  hi desMapWall guifg=darkgray term=bold gui=bold ctermfg=brown
-  hi desMapPermaWall guifg=#a0a000 gui=bold ctermfg=yellow
-  hi desMapStoneWall guifg=black gui=bold ctermfg=darkgray
-  hi desMapGlassWall guifg=lightcyan ctermfg=lightcyan
-  hi desMapMetalWall guifg=#004090 term=bold gui=bold ctermfg=blue
-  hi desMapCrystalWall guifg=#009040 term=bold gui=bold ctermfg=green
-  hi desMapTree guifg=#00aa00 ctermfg=darkgreen
-  hi desMapFloor guifg=#008000 ctermfg=lightgray
-  hi desMapDoor guifg=brown gui=bold ctermfg=black ctermbg=brown
-  hi desMapShallow guifg=lightcyan ctermfg=darkcyan
-  hi desMapWater guifg=lightblue ctermfg=darkblue
-  hi desMapLava guifg=red gui=bold ctermfg=red
-
-  hi desMapEntry guifg=black guibg=white gui=bold ctermfg=white ctermbg=black
-  hi desMapStairs guifg=orange gui=bold ctermfg=white
-  hi desMapTrap guifg=red gui=bold ctermfg=red
-
-  hi desMapGold guifg=#c09000 ctermfg=yellow
-  hi desMapValuable guifg=darkgreen gui=bold ctermfg=lightgreen
-  hi desMapMonst guifg=red ctermfg=darkred
-endif
+" Highlight of MAP features.
+hi link desMapWall        Statement
+hi link desMapStoneWall   Type
+hi link desMapMetalWall   Type
+hi link desMapPermaWall   Define
+hi link desMapGlassWall   Constant
+hi link desMapCrystalWall Function
+hi link desMapTree        String
+hi link desMapFloor       Normal
+hi link desMapDoor        Special
+hi link desMapShallow     Identifier
+hi link desMapWater       Define
+hi link desMapLava        Error
+hi link desMapEntry       Special
+hi link desMapStairs      Special
+hi link desMapTrap        Special
+hi link desMapGold        Operator
+hi link desMapValuable    Operator
+hi link desMapMonst       String
 
 syn sync minlines=45
 


### PR DESCRIPTION
I discussed with gammafunk about the levdes syntax and he agreed that having hard-coded color definitions in the syntax file (where they should not be in the first place) which do not play well with a lot of popular vim colorschemes is rather undesirable.

This is my attempt to replace the old hard-coded colors with links to syntax elements which are available in every colorscheme. Here are some screenshots of how it currently looks for various colorschemes:

https://i.imgur.com/HOREmFQ.png

And here is how it looks for the same colorschemes without my changes:

https://i.imgur.com/r8GEzvH.png

If this is not wanted I would propose to create a fully hard-coded colorscheme for the MAP area instead (i.e. defining background colors so that we can guarantee good contrast). However I don't think this would be a good solution since it would be a rather harsh intrusion into the users color settings.

Here is the explanation I gave in the original commit:

> The hard-coded color definitions in the .des syntax file did not play well
> together with a lot of vim colorschemes. This commit removes the
> hard-coded colors and links instead to predefined syntax elements which
> should be recognized by every Vim colorscheme.
> 
> Of course this means that it is no longer guaranteed that water is
> displayed in a blueish color in every colorscheme. But I think being
> readable in every colorscheme is much more important. If someone is not
> happy with how the map is displayed in their favorite colorscheme, they
> still can use an autocmd to change the colorscheme just for the des
> filetype.
> 
> The only thing I am not completely happy with is stone (c) and metal (v)
> walls using the same color definitions. I would link metal walls to
> something else, but if you use Vim in 8 color mode the fallbacks will
> usually result in 'v' having either the same color as 'w' or 'W'. And I
> definitely want to avoid that since it can get quite hard to distinguish
> in that case. I think 'c' and 'v' are distinct enough to share the same
> color (and usually they are not used right next to each other).
> 
> This commit should also resolve the issue of the syntax coloring breaking
> when changing the colorscheme with an open des file. The issue here was
> that vim syntax files are not reevaluated when changing colorschemes. This
> resulted in the hard-coded definitions of the syntax file being overridden
> by the colorscheme change and not being reapplied afterwards.