### PR TITLE
Unify helmet & hat mutation restrictions

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -922,45 +922,6 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
                 mpr("You can't wear any headgear with your large antennae!");
             return false;
         }
-
-        // Soft helmets (caps and wizard hats) always fit, otherwise.
-        if (is_hard_helmet(item))
-        {
-            if (you.get_mutation_level(MUT_HORNS, false))
-            {
-                if (verbose)
-                    mpr("You can't wear that with your horns!");
-                return false;
-            }
-
-            if (you.get_mutation_level(MUT_BEAK, false))
-            {
-                if (verbose)
-                    mpr("You can't wear that with your beak!");
-                return false;
-            }
-
-            if (you.get_mutation_level(MUT_ANTENNAE, false))
-            {
-                if (verbose)
-                    mpr("You can't wear that with your antennae!");
-                return false;
-            }
-
-            if (species_is_draconian(you.species))
-            {
-                if (verbose)
-                    mpr("You can't wear that with your reptilian head.");
-                return false;
-            }
-
-            if (you.species == SP_OCTOPODE)
-            {
-                if (verbose)
-                    mpr("You can't wear that!");
-                return false;
-            }
-        }
     }
 
     // Can't just use Form::slot_available because of shroom caps.

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1651,15 +1651,6 @@ bool mutate(mutation_type which_mutation, const string &reason, bool failMsg,
 
             if (cur_base_level >= 3 && !you.melded[EQ_HELMET])
                 remove_one_equip(EQ_HELMET, false, true);
-            // Intentional fall-through
-        case MUT_BEAK:
-            // Horns, beaks, and antennae force hard helmets off.
-            if (you.equip[EQ_HELMET] != -1
-                && is_hard_helmet(you.inv[you.equip[EQ_HELMET]])
-                && !you.melded[EQ_HELMET])
-            {
-                remove_one_equip(EQ_HELMET, false, true);
-            }
             // Recheck Ashenzari bondage in case our available slots changed.
             ash_check_bondage();
             break;


### PR DESCRIPTION
Helmets can now be worn with any mutation except horns 3 or antennae 3.

Previously, helmets were the only equipment item that was broken by
getting level 1 in a facet mutation. This lead to players (especially
those worshipping Jiyva/Xom) having to juggle both a helmet and a hat as
possible items to wear, since they would often get a facet mutation
(horns 1, antennae 1, or beak 1) that would unequip their helmet.

Given helmets are only marginally better than hats (+1 AC), just give
them the same equipment limitations as hats. Note: helmets are still
equippable by fewer species, due to size limitations.

TODO: does _slot_conflict need to be updated?