### PR TITLE
Lessen spam w/ autobutcher on full inventory

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -3138,7 +3138,11 @@ static void _do_autopickup()
 
             const bool pickup_result = move_item_to_inv(o, mi.quantity);
             if (mi.is_type(OBJ_FOOD, FOOD_CHUNK))
+            {
                 mi.flags |= ISFLAG_DROPPED;
+                o = next;
+                continue;
+            }
 
             if (pickup_result)
             {


### PR DESCRIPTION
Stop chunk autopickup and its messages ("Your pack is full" and eventually the "Could not pick up...." prompt) when autobutchering with a full inventory.

The above behavior was most notable when chunks were in your autopickup list (the default state). Still, you'd also get the stopping and "Your pack is full" message (but not the prompt) even if you had chunks as autopickup exceptions.

This change stops the messages for chunks and, as a result, makes autoexplore somewhat less clunky with regards to chunks when your pack is full. Even if perfectly implemented, this may not be 100% desired behavior, as it's occasionally good to make room for chunks and so a prompt isn't all bad. But since auto_eat_chunks is true by default and you're still eating them when you find that you need to, this isn't the worst behavior, either.

Some kinks I've found in this from testing (which belie this commit's simplicity):
* Butchering a corpse (but not having picked it up) will consider its chunks to be dropped. Thus, they won't be autopickup'd, since any "dropped" item is ignored by the greedy autotraveler. However, because a lot of these butchering/eating functions rely on you standing on top of a stack that you want to autopickup, this change will lead to some imperfect/non-player-like behavior. Take this scenario:
    1) be hungry with a full inventory,
    2) butcher a corpse and make three chunks,
    3) eat one chunk off the ground,
    4) spam some spells/abilities that make you hungry again, and then
    5) expect to be led back to those original two chunks if no new edible corpses appear.

    That doesn't quite happen here: the chunks are considered dropped by the player, and thus the traveler just doesn't care.

* That said, the traveler *will* eat if he happen to land on top of those chunks (and is hungry, and of course has auto_eat_chunks on). You can see this in a narrow hallway, or simply by starting autoexplore while standing on chunks.

In testing, these do seem like fairly noticeable/buggy behavioral changes, but in practice, they're not really a big deal. Ctrl+f solves finding chunks; auto_butcher will normally only butcher as few corpses as possible, so it can very well just find another corpse to butcher in the same time. Behavior with an empty inventory slot is the same as before if chunks are on the autopickup list.

> An attempt at closing [issue 11102](https://crawl.develz.org/mantis/view.php?id=11102) and [10991](https://crawl.develz.org/mantis/view.php?id=10991) from Mantis.