### PR TITLE
Add an autumn forest themed bazaar vault

### DIFF
--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1784,6 +1784,62 @@ x.......x     x.......x
 xxxxxxxxx     xxxxxxxxx
 ENDMAP
 
+# 3 to 4 shops, with an average of 3.5
+NAME:       bazaar_kenran_forest_clearing
+TAGS:       no_rotate no_vmirror
+ORIENT:     encompass
+WEIGHT:     5
+KITEM:      h = human skeleton
+KFEAT:      $ = any shop
+KFEAT:      A = abandoned_shop
+: if crawl.one_chance_in(4) then
+KFEAT:      F = V
+TILE:       t = dngn_tree_dead w:10 / dngn_tree_red w:3 / \
+                dngn_tree_lightred w:2
+COLOUR:     . = brown, t = brown w:10 / red w:3 / lightred w:2
+: else
+TILE:       t = dngn_tree w:3 / dngn_tree_yellow w:2 / \
+                dngn_tree_lightred w:2 / dngn_tree_red w:3
+KFEAT:      F = T
+COLOUR:     . = green, t = green w:3 / lightgreen w:2 / \
+                lightred w:3 / red w:2 / brown w:1
+: end
+NSUBST:     $ = 1=$A
+:           bazaar_setup(_G)
+MAP
+ttttttttttttttttttttttttt
+tttttttttttttttttttttt>tt
+ttttttttttttttttttttt.ttt
+ttttttttttttttttttttt.ttt
+ttttttttttttttGttt.t..ttt
+ttttttttttttttt.ttt..tttt
+tttt$.ttttttttt.....ttttt
+tt.t...ttttttt..t.ttttttt
+tt...ttttttt..ttttttt..tt
+tttt....ttt...tt..tt....t
+tttttt.t.t....t..t...t.$t
+ttttt..t..t.F..tttttttttt
+tttttt........t..Attttttt
+tttttttt.tt..t.t..ttttttt
+tttttt....t..t..htt.$tttt
+tttttt.t...t..t.tt...tttt
+ttt......t.....t....ttttt
+ttG.t..tt....tt...ttttttt
+t......tttt..tttttttttttt
+t$..t.tttttt....ttttttttt
+ttt....ttt...ttGttttttttt
+ttttttttt...ttttttttttttt
+ttttttttt..tttttttttttttt
+tttttttttt...tttttttttttt
+ttttttttttt..tttttttttttt
+ttttttttttt.t.ttttttttttt
+tttttttttt..ttttttttttttt
+ttttt.tt...tttttttttttttt
+ttt<.....tttttttttttttttt
+ttttttt.ttttttttttttttttt
+ttttttttttttttttttttttttt
+ENDMAP
+
 ##########################################################################
 # Generated maps
 ##########################################################################

--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1550,14 +1550,18 @@ ENDMAP
 
 # 3 to 4 shops, with an average of 3.5
 NAME:       bazaar_kenran_forest_clearing
-TAGS:       no_rotate no_vmirror
 ORIENT:     encompass
 WEIGHT:     5
 KITEM:      h = human skeleton
+KITEM:      c = black bear skeleton
 KFEAT:      $ = any shop
 KFEAT:      # = antique weapon shop / antique armour shop / \
                 antiques shop / book shop
 KFEAT:      A = abandoned_shop
+NSUBST:     $ = 1=$A
+NSUBST:     H = 1=h / *=.
+SUBST:      $ = #:20 $
+SUBST:      R = t:20 .
 : if crawl.one_chance_in(4) then
 KFEAT:      F = V
 TILE:       t = dngn_tree_dead w:10 / dngn_tree_red w:3 / \
@@ -1570,29 +1574,27 @@ KFEAT:      F = T
 COLOUR:     . = green, t = green w:3 / lightgreen w:2 / \
                 lightred w:3 / red w:2 / brown w:1
 : end
-NSUBST:     $ = 1=$A
-SUBST:      $ = #:20 $
 :           bazaar_setup(_G)
 MAP
 ttttttttttttttttttttttttt
 tttttttttttttttttttttt>tt
 ttttttttttttttttttttt.ttt
 ttttttttttttttttttttt.ttt
-ttttttttttttttGttt.t..ttt
+ttttttttttttttcttt.t..Rtt
 ttttttttttttttt.ttt..tttt
 tttt$.ttttttttt.....ttttt
-tt.t...ttttttt..t.ttttttt
-tt...ttttttt..ttttttt..tt
+tt.t...ttttttt..t.ttRtttt
+tt...tRttttt..ttRtttt..tt
 tttt....ttt...tt..tt....t
-tttttt.t.t....t..t...t.$t
-ttttt..t..t.F..tttttttttt
-tttttt........t..Attttttt
-tttttttt.tt..t.t..ttttttt
-tttttt....t..t..htt.$tttt
+ttttRt.t.t....t..t...t.$t
+ttttt..t..t.F..ttttRttttt
+tttttt........tH.Attttttt
+tttttttt.tt..tHt..ttttttt
+tttttR....t..t.HHtR.$tttt
 tttttt.t...t..t.tt...tttt
 ttt......t.....t....ttttt
 ttG.t..tt....tt...ttttttt
-t......tttt..tttttttttttt
+t......tttt..tRtttttttttt
 t$..t.tttttt....ttttttttt
 ttt....ttt...ttGttttttttt
 ttttttttt...ttttttttttttt

--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1548,6 +1548,65 @@ xT.xxxxxxxxxxx.Tx
 xxxxxxxxxxxxxxxxx
 ENDMAP
 
+# 3 to 4 shops, with an average of 3.5
+NAME:       bazaar_kenran_forest_clearing
+TAGS:       no_rotate no_vmirror
+ORIENT:     encompass
+WEIGHT:     5
+KITEM:      h = human skeleton
+KFEAT:      $ = any shop
+KFEAT:      # = antique weapon shop / antique armour shop / \
+                antiques shop / book shop
+KFEAT:      A = abandoned_shop
+: if crawl.one_chance_in(4) then
+KFEAT:      F = V
+TILE:       t = dngn_tree_dead w:10 / dngn_tree_red w:3 / \
+                dngn_tree_lightred w:2
+COLOUR:     . = brown, t = brown w:10 / red w:3 / lightred w:2
+: else
+TILE:       t = dngn_tree w:3 / dngn_tree_yellow w:2 / \
+                dngn_tree_lightred w:2 / dngn_tree_red w:3
+KFEAT:      F = T
+COLOUR:     . = green, t = green w:3 / lightgreen w:2 / \
+                lightred w:3 / red w:2 / brown w:1
+: end
+NSUBST:     $ = 1=$A
+SUBST:      $ = #:20 $
+:           bazaar_setup(_G)
+MAP
+ttttttttttttttttttttttttt
+tttttttttttttttttttttt>tt
+ttttttttttttttttttttt.ttt
+ttttttttttttttttttttt.ttt
+ttttttttttttttGttt.t..ttt
+ttttttttttttttt.ttt..tttt
+tttt$.ttttttttt.....ttttt
+tt.t...ttttttt..t.ttttttt
+tt...ttttttt..ttttttt..tt
+tttt....ttt...tt..tt....t
+tttttt.t.t....t..t...t.$t
+ttttt..t..t.F..tttttttttt
+tttttt........t..Attttttt
+tttttttt.tt..t.t..ttttttt
+tttttt....t..t..htt.$tttt
+tttttt.t...t..t.tt...tttt
+ttt......t.....t....ttttt
+ttG.t..tt....tt...ttttttt
+t......tttt..tttttttttttt
+t$..t.tttttt....ttttttttt
+ttt....ttt...ttGttttttttt
+ttttttttt...ttttttttttttt
+ttttttttt..tttttttttttttt
+tttttttttt...tttttttttttt
+ttttttttttt..tttttttttttt
+ttttttttttt.t.ttttttttttt
+tttttttttt..ttttttttttttt
+ttttt.tt...tttttttttttttt
+ttt<.....tttttttttttttttt
+ttttttt.ttttttttttttttttt
+ttttttttttttttttttttttttt
+ENDMAP
+
 ##########################################################################
 # Very rare maps, including dangerous maps (weight 1)
 ##########################################################################
@@ -1782,62 +1841,6 @@ x.......x     x.......x
 x.>...!.x     x.!...>.x
 x.......x     x.......x
 xxxxxxxxx     xxxxxxxxx
-ENDMAP
-
-# 3 to 4 shops, with an average of 3.5
-NAME:       bazaar_kenran_forest_clearing
-TAGS:       no_rotate no_vmirror
-ORIENT:     encompass
-WEIGHT:     5
-KITEM:      h = human skeleton
-KFEAT:      $ = any shop
-KFEAT:      A = abandoned_shop
-: if crawl.one_chance_in(4) then
-KFEAT:      F = V
-TILE:       t = dngn_tree_dead w:10 / dngn_tree_red w:3 / \
-                dngn_tree_lightred w:2
-COLOUR:     . = brown, t = brown w:10 / red w:3 / lightred w:2
-: else
-TILE:       t = dngn_tree w:3 / dngn_tree_yellow w:2 / \
-                dngn_tree_lightred w:2 / dngn_tree_red w:3
-KFEAT:      F = T
-COLOUR:     . = green, t = green w:3 / lightgreen w:2 / \
-                lightred w:3 / red w:2 / brown w:1
-: end
-NSUBST:     $ = 1=$A
-:           bazaar_setup(_G)
-MAP
-ttttttttttttttttttttttttt
-tttttttttttttttttttttt>tt
-ttttttttttttttttttttt.ttt
-ttttttttttttttttttttt.ttt
-ttttttttttttttGttt.t..ttt
-ttttttttttttttt.ttt..tttt
-tttt$.ttttttttt.....ttttt
-tt.t...ttttttt..t.ttttttt
-tt...ttttttt..ttttttt..tt
-tttt....ttt...tt..tt....t
-tttttt.t.t....t..t...t.$t
-ttttt..t..t.F..tttttttttt
-tttttt........t..Attttttt
-tttttttt.tt..t.t..ttttttt
-tttttt....t..t..htt.$tttt
-tttttt.t...t..t.tt...tttt
-ttt......t.....t....ttttt
-ttG.t..tt....tt...ttttttt
-t......tttt..tttttttttttt
-t$..t.tttttt....ttttttttt
-ttt....ttt...ttGttttttttt
-ttttttttt...ttttttttttttt
-ttttttttt..tttttttttttttt
-tttttttttt...tttttttttttt
-ttttttttttt..tttttttttttt
-ttttttttttt.t.ttttttttttt
-tttttttttt..ttttttttttttt
-ttttt.tt...tttttttttttttt
-ttt<.....tttttttttttttttt
-ttttttt.ttttttttttttttttt
-ttttttttttttttttttttttttt
 ENDMAP
 
 ##########################################################################


### PR DESCRIPTION
This adds a medium-sized bazaar vault that places the player in an autumn forest (or, in 1 out of 4 cases, a rather dead one). Upon entering, the player has to follow a path that suddenly widens and leads to a clearing in the forest where a few secretive shopkeepers have settled down and are offering their wares. After a successful shopping trip, the player can resume their voyage to follow the path out of the forest and the bazaar.

This vault contains 3 to 4 normal shops (one is abandoned half the time) and one that is always abandoned.

Note: I don't know what type of bazaar vault is more useful at the moment (common or more rare ones), so I've taken 5 as a somewhat rare `WEIGHT`. I have in the meantime made antique shops more likely to appear to justify this. I guess it could arguably also be made very rare (if this pull request makes it in, anyway) as it differs from most/all of the other bazaar layouts in that it has no regular or symmetrical shape.

Here you can see a couple of pictures showcasing the vault and its two variants - dead trees/no dead trees, aka autumn/winter - in tiles and console mode (floor and shop halo can vary ingame as they are generated automatically):

![bkfc_rare_entering](https://user-images.githubusercontent.com/5188977/27374294-8a801256-566b-11e7-863a-495beadca540.png)
![bkfc_rare_shops_exit](https://user-images.githubusercontent.com/5188977/27374296-8a83c2c0-566b-11e7-893d-2f8aacf34631.png)
![bkfc_green_full](https://user-images.githubusercontent.com/5188977/27374292-8a7e723e-566b-11e7-97e6-85de5de5b17f.png)
![bkfc_green_console](https://user-images.githubusercontent.com/5188977/27374293-8a7f15fe-566b-11e7-9d12-dfe50718cbb1.png)
![bkfc_rare_console](https://user-images.githubusercontent.com/5188977/27374295-8a8035f6-566b-11e7-9d6c-930711677d86.png)