### PR TITLE
Fully suppress the 'blink' and 'teleportitis' mutations when in tree form

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -368,6 +368,12 @@ mutation_activity_type mutation_activity_level(mutation_type mut)
     if (you.form == transformation::blade_hands && mut == MUT_PAWS)
         return mutation_activity_type::INACTIVE;
 
+    if (you.form == transformation::tree
+        && (mut == MUT_BLINK || mut == MUT_TELEPORT))
+    {
+        return mutation_activity_type::INACTIVE;
+    }
+
     if (you_worship(GOD_DITHMENOS) && mut == MUT_IGNITE_BLOOD)
         return mutation_activity_type::INACTIVE;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6322,7 +6322,8 @@ string player::no_tele_reason(bool calc_unid, bool blinking) const
     if (problems.empty())
         return ""; // no problem
 
-    return make_stringf("You cannot teleport because you are %s.",
+    return make_stringf("You cannot %s because you are %s.",
+                        blinking ? "blink" : "teleport",
                         comma_separated_line(problems.begin(),
                                              problems.end()).c_str());
 }


### PR DESCRIPTION
This is an attempt at fixing the issue mentioned in https://crawl.develz.org/mantis/view.php?id=11116. I found that teleportitis wasn't suppressed either. This change also removes the evokable Blink ability gained from the mutation when in tree form, but not the one you get from, say, jewellery. This should be in line with how mutation-suppression works in other cases, notably draconian breath (thanks amalloy).

The second commit corrects the general message you get when trying to use either blink or teleport (any source) while not being able to for some reason. Before, it would always say "You cannot teleport because ..."; now it distinguishes between blinking and teleporting by using the already present `blinking` flag.