### PR TITLE
(Console) Use magic mapping colors

### DIFF
--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -47,6 +47,8 @@ static unsigned short _cell_feat_show_colour(const map_cell& cell,
     {
         if (cell.flags & MAP_EMPHASIZE)
             colour = fdef.seen_em_colour();
+        else if (cell.flags & MAP_MAGIC_MAPPED_FLAG)
+            colour = fdef.map_colour();
         else
             colour = fdef.seen_colour();
 


### PR DESCRIPTION
Allows the magic-mapping color of the "feature" option to have an effect.

For instance, if your rcfile has the line
`    feature += rock wall {,+,,cyan}`
Then you would expect to get +'s as the glyphs for magically-mapped rock walls and to get cyan as the color of these magic-mapped walls. However, the magic-mapping color was normally ignored (due to not being called), so it defaulted to the seen_colour() -- usually blue or darkgrey.

Console players should now be able to change the color of magic-mapped features, which might be useful if they've played the tiles versions and are used to the standout color of magic-mapped features.

This should close [bug 11009](https://crawl.develz.org/mantis/view.php?id=11009) on Mantis.