### PR TITLE
Add a lighthouse-themed bazaar vault

### DIFF
--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1880,7 +1880,7 @@ KFEAT:  s = w
 KFEAT:  m = W
 KFEAT:  x = open_sea
 FTILE:  _A>1+ = floor_pebble, - = floor_rough, .< = floor_sand
-TILE:   X = wall_brick, n = dngn_transparent_stone
+TILE:   X = wall_brick_lightgray, n = dngn_transparent_stone
 COLOUR: . = brown, -_n+> = white, o = yellow, X = lightgrey
 : set_border_fill_type("open_sea")
 : bazaar_setup(_G, false)

--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1866,6 +1866,63 @@ x.......x     x.......x
 xxxxxxxxx     xxxxxxxxx
 ENDMAP
 
+NAME:   bazaar_kenran_lighthouse
+TAGS:   no_pool_fixup
+ORIENT: encompass
+WEIGHT: 1
+KMONS:  1 = ophan
+SUBST:  m =.WWW
+SUBST:  d = wwW
+SUBST:  s = xxw
+KFEAT:  A = any shop
+KFEAT:  _- = .
+KFEAT:  s = w
+KFEAT:  m = W
+KFEAT:  x = open_sea
+FTILE:  _A>1+ = floor_pebble, - = floor_rough, .< = floor_sand
+TILE:   X = wall_brick, n = dngn_transparent_stone
+COLOUR: . = brown, -_n+ = white, o = yellow, X = lightgrey
+: set_border_fill_type("open_sea")
+: bazaar_setup(_G, false)
+MAP
+              ssssssssssss
+           sssswwwwwwwwwwsss
+         ssswwwwwwwwwwwwwwwssss
+       ssswwwwwwwddddddwwwwwwwssss
+      sswwwwwwdddddWWWdddwwwwwwwws
+      swwwwwdddWWWWWWWWWddddwwwwwss
+     sswwwdddWWWWW.m..WWWWWddddwwws
+   ssswwwddWWWWWm.-...mWWWWWWWdwwwss
+  sswwwwwdWWWWm...--.....WWmWWddwwws
+  swwwwwddWWW...------.....WWWWdwwwss
+  swwwdddWW...--XnXnX---....mWWddwwws
+  swwddWWWm.--XXX___XXX--...WWWWdwwwsss
+  swwdWWWW.--Xn_______nX--...WWWddwwwwss
+ sswwdW.m..-Xn_________nX-..mmWWWdwwwwws
+sswwwdWW..--X__A_____A__X--...WWWdddwwwss
+swwwwdWW..-XX___________Xn-....WWWWddwwws
+swwwddW..--n_____ooo_____X--..m.WWWWdwwss
+swwddW.m.--X_>___o1o_____+___.....WWddwws
+swwwdWWW.--n_____ooo_____X-.___<.WWWddwws
+sswwddWW..-XX___________Xn-.....mWWddwwss
+swwwddW...--X__A_____A__X--...m.WWWWdwwws
+swwddWW...--Xn_________nX-...mW.mWWWdwwss
+swwwddWm...--Xn_______nX---.m.WWWWWddwws
+swwwddWW....--XXX___XXX---..WWWWWWddwwss
+sswwwdWWWW....--XnXnX---.....WWWWWWddwws
+ swwwdWWW.m...--------..W.....WWWWWdwwws
+ sswwddWWWWm...--......WWm.W..mWWWWddwws
+  swwwdWWWW.......WW...WWWWWW.WWWWWdwwss
+  swwwddWWWWWmm..WWW..WWWWWWWWWWWWddwwws
+  sswwwddddWWWWWWWWWWWWWWWWWWdWWWWdwwwss
+   swwwwwwddWWWWWdddWWWWddddddddWddwwws
+   sswwwwwwdddWWdddddddddwwwwwwdddwwwss
+    sssswwwwwddddwwwwwwwwwwwwwwwwwwwws
+       sswwwwwwwwwwwwwwwwwssswswwwwwss
+        ssswwwwwwwwssssssss sssssssss
+          ssssssssss
+ENDMAP
+
 ##########################################################################
 # Generated maps
 ##########################################################################

--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -1881,7 +1881,7 @@ KFEAT:  m = W
 KFEAT:  x = open_sea
 FTILE:  _A>1+ = floor_pebble, - = floor_rough, .< = floor_sand
 TILE:   X = wall_brick, n = dngn_transparent_stone
-COLOUR: . = brown, -_n+ = white, o = yellow, X = lightgrey
+COLOUR: . = brown, -_n+> = white, o = yellow, X = lightgrey
 : set_border_fill_type("open_sea")
 : bazaar_setup(_G, false)
 MAP


### PR DESCRIPTION
This is an(other) attempt at straying away a bit from the classical bazaar vault looks by using some more irregular shapes. The vault `bazaar_kenran_lighthouse` features a circular hut built on an island containing 4 random shops. Its aim is to make the player think of a lighthouse in the sea.

The shoreline, as well as the transitions from shallow to deep water, and from deep water to open sea, respectively, vary slightly in each generated map.

At the moment, the centre of the lighthouse contains a trapped ophan (as to provide a source of light). Of course this is rather gimmicky, but I found it fun. It can easily be replaced by another shop or decorative interior though, should monster generation in this case be frowned upon.

Here are screenshots to show how it looks in tiles/console mode:
![console](https://user-images.githubusercontent.com/5188977/27470391-f88cc742-57f3-11e7-90b7-bdc427844d7b.png)
![enter](https://user-images.githubusercontent.com/5188977/27470390-f884d050-57f3-11e7-8d3f-0e0dfdf4b153.png)
![full](https://user-images.githubusercontent.com/5188977/27470388-f8834320-57f3-11e7-94ad-908660065469.png)
![interior](https://user-images.githubusercontent.com/5188977/27470389-f884ab20-57f3-11e7-8930-5ded3b033b59.png)

