### PR TITLE
Let shallow water be like floors for water species

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -210,9 +210,9 @@ static inline bool _is_safe_cloud(const coord_def& c)
 // This is done, so traps etc. will usually be circumvented where possible.
 static inline int _feature_traverse_cost(dungeon_feature_type feature)
 {
-    if ((feature == DNGN_SHALLOW_WATER && !player_likes_water(true)
-        || you.species == SP_MERFOLK)
-            || feat_is_closed_door(feature))
+    if (feat_is_closed_door(feature) || feature == DNGN_SHALLOW_WATER
+                                        && (!player_likes_water(true)
+                                            || you.species == SP_MERFOLK))
     {
         return 2;
     }

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -210,8 +210,12 @@ static inline bool _is_safe_cloud(const coord_def& c)
 // This is done, so traps etc. will usually be circumvented where possible.
 static inline int _feature_traverse_cost(dungeon_feature_type feature)
 {
-    if (feature == DNGN_SHALLOW_WATER || feat_is_closed_door(feature))
+    if ((feature == DNGN_SHALLOW_WATER && !player_likes_water(true)
+        || you.species == SP_MERFOLK)
+            || feat_is_closed_door(feature))
+    {
         return 2;
+    }
     else if (feat_is_trap(feature))
         return 3;
 


### PR DESCRIPTION
...for autoexplore/autotravel purposes. Merfolk are excluded, since they likely won't want to go through leg transformations except for when the travel formula deems optimal.

The change is intended to fix the occasionally odd travel behavior of Octopodes and Barachim, who suffer no movement penalty in shallow water and no annoying transformation effects (like Merfolk).

This may close [bug 11114](https://crawl.develz.org/mantis/view.php?id=11114) on Mantis.