### PR TITLE
Remove manual's reference to Ogres' especially good maces aptitude

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -1519,10 +1519,10 @@ Ogres
   talent for magic, but are poor at making use of magical devices.
 
   Their preferred methods of avoiding beatings are dodging and the use of
-  shields. Many Ogres find it natural to wield some large and blunt weapon.
-  (Countless lethal incidents have taught them to leave most edged weapons be.)
-  While all sophisticated forms of missile combat are too awkward for them, they
-  are good at throwing things, in particular boulders.
+  shields. Ogres find it most natural to fight using maces, polearms, staves,
+  and even their bare hands. While all sophisticated forms of missile combat are
+  too awkward for them, they are good at throwing things, in particular
+  boulders.
 
 Trolls
   Trolls are monstrous creatures with powerful claws. They have thick, knobbly


### PR DESCRIPTION
Ogres no longer have a particularly good aptitude with maces and
flails, as mentioned in the manual. This commit replaces that line
with a more up-to-date take on what melee options they find natural.