### PR TITLE
Remove Mottled Draconians from table of aptitudes

### DIFF
--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -124,6 +124,7 @@ sub aptitude_table
     my $seen_draconian_length;
     for my $sp (sort_species(@SPECIES))
     {
+        next if $sp eq 'Mottled Draconian';
         next if $sp eq 'High Elf';
         next if $sp eq 'Sludge Elf';
         next if $sp eq 'Djinni';


### PR DESCRIPTION
Self-explanatory, since Mottled Draconians are no more in 0.20 and on.

This should close [bug 11120](https://crawl.develz.org/mantis/view.php?id=11120) on Mantis.