### PR TITLE
Rebalance potion of mutation

### DIFF
--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -761,9 +761,9 @@ public:
     }
 };
 
-const int MIN_REMOVED = 2;
-const int MAX_REMOVED = 6;
-const int MIN_ADDED = 1;
+const int MIN_REMOVED = 1;
+const int MAX_REMOVED = 2;
+const int MIN_ADDED = 2;
 const int MAX_ADDED = 3;
 
 class PotionMutation : public PotionEffect
@@ -798,8 +798,8 @@ public:
         // Add mutations.
         for (int i = 0; i < add_mutations; i++)
             mutated |= mutate(RANDOM_MUTATION, "potion of mutation", false);
-        // Always one good mutation.
-        mutated |= mutate(RANDOM_GOOD_MUTATION, "potion of mutation", false);
+        // Always one bad mutation.
+        mutated |= mutate(RANDOM_BAD_MUTATION, "potion of mutation", false);
 
         learned_something_new(HINT_YOU_MUTATED);
         return mutated;

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -761,11 +761,6 @@ public:
     }
 };
 
-const int MIN_REMOVED = 1;
-const int MAX_REMOVED = 2;
-const int MIN_ADDED = 2;
-const int MAX_ADDED = 3;
-
 class PotionMutation : public PotionEffect
 {
 private:
@@ -789,19 +784,14 @@ public:
     {
         mpr("You feel extremely strange.");
         bool mutated = false;
-        int remove_mutations = random_range(MIN_REMOVED, MAX_REMOVED);
-        int add_mutations = random_range(MIN_ADDED, MAX_ADDED);
 
-        // Remove mutations.
-        for (int i = 0; i < remove_mutations; i++)
-            mutated |= delete_mutation(RANDOM_MUTATION, "potion of mutation", false);
-        // Add mutations.
-        for (int i = 0; i < add_mutations; i++)
-            mutated |= mutate(RANDOM_MUTATION, "potion of mutation", false);
-        // Always one bad mutation.
+        mutated |= delete_mutation(RANDOM_MUTATION, "potion of mutation", false);
+        mutated |= mutate(RANDOM_MUTATION, "potion of mutation", false);
+        mutated |= mutate(RANDOM_GOOD_MUTATION, "potion of mutation", false);
         mutated |= mutate(RANDOM_BAD_MUTATION, "potion of mutation", false);
 
-        learned_something_new(HINT_YOU_MUTATED);
+        if (mutated)
+            learned_something_new(HINT_YOU_MUTATED);
         return mutated;
     }
 


### PR DESCRIPTION
Previous behaviour:
Remove 2-6 mutations, add 1-3 mutations, add one good mutation.

New behaviour:
Remove 1-2 mutations, add 2-3 mutations, add one bad mutation.

Mutation is a complex area of game mechanics. Some general points
describing the context and justification for this change:
* Generally, positive mutations are considered "nice to have", most
  negative mutations are ignorable, and a few are considered "must fix"
  (subdued magic, berserkitis, etc).
* Mutations come from a few major sources: !mutation, the malmutation
  monster spell, and mutagenic chunks.
* In the current system, removing a specific bad mutation is generally
  quite easy. It is also easy to return to a nearly-unmutated state. You
  can do both of these things by quaffing (plentiful) potions of
  mutation.

On malmutation:
* In the previous mutation system (with !curemut), malmutation made
  players pay a limited resource if they were mutated. There was tension
  between curing some ignorable mutations now vs risking not having
  curemut in the future for a potentially worse malmutation.
* This wasn't great, because the choice was generally a no-brainer (only
  cure must fix mutations), and the effect of malmutators was zero until
  the player ran out of !curemut. Then, they became potentially
  game-ending threats. This binary behaviour wasn't especially
  enjoyable.
* In the current system, malmutation isn't a significant threat.
  Mutation potions are plentiful and can replace must-fix bad mutations
  with ignorable mutations reliably.
* This also isn't especially enjoyable, you can simply ignore
  malmutation as a serious threat.

On mutation roulette:
* In the current system, players are incentivised to quaff potions of
  mutation surplus to their anti-malmutation needs. They're likely to
  get a good set of mutations and can simple quaff again if not.
* The !mutation design allows players to eat mutagenic chunks (even
  scumming for OOD monsters) and gamble on getting good mutations. If
  they don't, a potion of mutation will reset them to a baseline state,
  since it removes more mutations than it adds.

On a desired behaviour of mutation potions, mutation chunks, and
malmutation:
* Mutation should be a system players cannot completely ignore. This is
  why rMut amulets were removed in the past.
* Malmutation should be a credible threat at all points in the game,
  regardless of how many potions of mutations you should have.
* Receiving bad mutations from any source should have a significant cost
  to remove.

On the approach this change is part of:
* There should be a concept (not neccessarily represented explicitly in
  game code) of "mutation level".
* As the player is mutated, their mutation level generally increases.
* There's no generally-available way to decrease mutation level.
* A higher mutation level implies more mutations.
* A higher mutation level implies more bad mutations.
* It's possible for players to shuffle their mutations, but not without
  increasing their mutation level.
* This means the player can remove must-fix mutations, but only by
  increasing their mutation level.

This change tries to implement such a system by making the potion of
mutation add mutations on average, and not guarantee any good mutations.
Players can use the potion to remove existing bad mutations (although
they'll remove fewer mutations on average than before), but it's very
unlikely for them to reduce their overall mutation level.

Potential future tweaks may be required. In particular, it might be a
good idea to also add a good mutation.