### PR TITLE
Stop diagonal running when encountering doors

### DIFF
--- a/crawl-ref/source/externs.h
+++ b/crawl-ref/source/externs.h
@@ -698,6 +698,7 @@ public:
     bool notified_hp_full;
     coord_def pos;
     int travel_speed;
+    int direction;
 
     FixedVector<run_check_dir,3> run_check; // array of grids to check
 
@@ -735,6 +736,7 @@ public:
 private:
     void set_run_check(int index, int compass_dir);
     bool run_should_stop() const;
+    bool diag_run_passes_door() const;
 };
 
 enum mon_spell_slot_flag

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4026,6 +4026,7 @@ void runrest::initialise(int dir, int mode)
     // Note HP and MP for reference.
     hp = you.hp;
     mp = you.magic_points;
+    direction = dir;
     notified_hp_full = false;
     notified_mp_full = false;
     init_travel_speed();
@@ -4141,6 +4142,30 @@ bool runrest::run_should_stop() const
             _base_feat_type(env.map_knowledge(p).feat());
 
         if (run_check[i].grid != feat)
+            return true;
+    }
+
+    bool is_running_diag = (direction % 2 == 1);
+    if (is_running_diag && diag_run_passes_door())
+        return true;
+
+    return false;
+}
+
+// Checks whether the player passes a door when running diagonally, since
+// in certain situations those could be overlooked by only checking "left"
+// and "right".
+// Can be extended if other features should lead to stopping as well.
+bool runrest::diag_run_passes_door() const
+{
+    const int diag_left = (direction + 6) % 8;
+    const int diag_right = (direction + 2) % 8;
+    const int diag_dirs[2] = { diag_left, diag_right };
+    for (int dir : diag_dirs)
+    {
+        const coord_def p = you.pos() + Compass[dir];
+        const auto feat = env.map_knowledge(p).feat();
+        if (feat_is_door(feat))
             return true;
     }
 


### PR DESCRIPTION
Consider the following scenario:

```
  ######+##
   @
```

When running (Shift-moving) east, the player will stop before the door in the wall. When moving through the Vaults, I encountered the following situation and noticed a different behaviour:

```
  @
  #
   #
   +#
     #
      #
```

When running SE, the player will just pass the door without stopping. This happens for any of the 4 diagonal directions.

This is due to the methods checking only the tiles to the left and the right relative to the movement direction. When moving horizontally or vertically, this does suffice. In the above example (and analogously for other diagonal movement) however, "left" means the directional vector `(1,0)`, and "right" is `(0,1)`. So when trying to find out whether the movement should stop, only the wall tiles are actually checked and the door isn't, even though it's passed by the player.

To fix this (in case it needs fixing), I've added another check that runs after the usual "left" and "right" ones and that is only executed if the player is moving diagonally. It is testing the "far-left" and "far-right" directions specifically, that is, perpendicular to the movement direction.
This check is only handling the exact case of "passing a door"; that is, only doors are tested for. It can easily be extended to include other features the player should stop at though.

The reason I didn't incorporate those "far-left" and "far-right" tiles into the `run_check` array is because then the diagonal movement would stop way more often and it could be considered annoying. So I've tried to restrict the actual change in behaviour to this one case only.