### PR TITLE
Change oka and trog acquirement texts to be more informative

### DIFF
--- a/crawl-ref/source/dat/defaults/messages.txt
+++ b/crawl-ref/source/dat/defaults/messages.txt
@@ -159,7 +159,7 @@ force_more_message += The gate opens wide
 force_more_message += With a loud hiss the gate opens wide
 
 # God gifts
-force_more_message += grants you a gift
+force_more_message += grants you (a gift|ammunition|armour|a weapon)
 force_more_message += offers you knowledge of
 force_more_message += believes you are ready to make a new sacrifice
 force_more_message += may now remember your ancestor

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1817,13 +1817,16 @@ bool do_god_gift(bool forced)
             success = acquirement(gift_type, you.religion);
             if (success)
             {
-                simple_god_message(" grants you a gift!");
-                // included in default force_more_message
-
-                if (gift_type == OBJ_MISSILES)
+                if (gift_type == OBJ_MISSILES) {
+                    simple_god_message(" grants you ammunition!");
                     _inc_gift_timeout(4 + roll_dice(2, 4));
+                }
                 else
                 {
+                    if (gift_type == OBJ_WEAPONS)
+                        simple_god_message(" grants you a weapon!");
+                    else
+                        simple_god_message(" grants you armour!");
                     // Okawaru charges extra for armour acquirements.
                     if (you_worship(GOD_OKAWARU) && gift_type == OBJ_ARMOUR)
                         _inc_gift_timeout(30 + random2avg(15, 2));


### PR DESCRIPTION
I think this should be pretty self explanatory. I have always found it mildly annoying when you get a gift in the middle of being shot at by a pack of yaktaurs, only to wonder where it went afterwards since it was just bolts. 

This changes the gift message text for Oka and Trog to be more specific as to what it gave, specifically ammo, weapon, or armour