### PR TITLE
Upgrade mask of the dragon guarded vault

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6413,7 +6413,6 @@ ITEM:    hat randart no_pickup
 : else
 ITEM:    mask_of_the_dragon no_pickup
 : end
-MONS:    storm dragon, shadow dragon, golden dragon, ghost moth, moth of wrath
 # Shuffle one transporter destination location
 NSUBST:  r = 1:R / *:-
 # Randomly swap which transporter is the entrance, and mask location
@@ -6421,7 +6420,9 @@ SHUFFLE: PQD/SRE
 # Place the mask
 SUBST: D = d, E = -
 # Place monsters randomly
-NSUBST:  - = 3:1 / 3:2 / 3:3 / 3:4 / 3:5 / *:.
+# 3 of each dragon (and up to 4 random extras), 3 ghost moth, 3 moth of wrath
+MONS:    storm dragon, shadow dragon, golden dragon, ghost moth, moth of wrath
+NSUBST:  - = 3:1 / 3:2 / 3:3 / 4=123... / 3:4 / 3:5 / *:.
 # Place transporters
 MARKER: P = lua:transp_loc("mask_of_the_dragon_entry")
 MARKER: Q = lua:transp_dest_loc("mask_of_the_dragon_entry")
@@ -6432,13 +6433,13 @@ MAP
  .........ccccccc.
  .ccccccccc-----c..
  .ccr--------c--cc..
- ..cc-------ccc--cc..
-  ..cc-----ccc----cc.
+ .cc--------ccc--cc..
+  .ccc-----ccc----cc.
    ..c-----cc------c.
-   S.nD----rcE----QnP@
+   S.nD----rcE---Q-nP@
    ..c-----cc------c.
-  ..cc-----ccc----cc.
- ..cc-------ccc--cc..
+  .ccc-----ccc----cc.
+ .cc--------ccc--cc..
  .ccr--------c--cc..
  .ccccccccc-----c..
  .........ccccccc.

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6407,28 +6407,42 @@ ENDMAP
 
 NAME:    chequers_guarded_unrand_mask_of_the_dragon
 DEPTH:   Zot, !Zot:$
-TAGS:    no_monster_gen no_item_gen transparent
+TAGS:    no_monster_gen no_item_gen
 : if you.unrands("mask_of_the_dragon") then
 ITEM:    hat randart no_pickup
 : else
 ITEM:    mask_of_the_dragon no_pickup
 : end
-MONS:    nonbase draconian, storm dragon, shadow dragon, golden dragon, ghost moth
-NSUBST:  . = 6:1 / 4:5 / 2:2 / 2:3 / 2:4
+MONS:    storm dragon, shadow dragon, golden dragon, ghost moth, moth of wrath
+# Shuffle one transporter destination location
+NSUBST:  r = 1:R / *:-
+# Shuffle the mask location
+NSUBST:  d = 1:d / *:.
+# Randomly swap which transporter is the entrance
+SHUFFLE: PS/QR
+# Place monsters randomly
+NSUBST:  - = 3:1 / 3:2 / 3:3 / 3:4 / 3:5 / *:.
+# Place transporters
+MARKER: P = lua:transp_loc("mask_of_the_dragon_entry")
+MARKER: Q = lua:transp_dest_loc("mask_of_the_dragon_entry")
+MARKER: R = lua:transp_loc("mask_of_the_dragon_exit")
+MARKER: S = lua:transp_dest_loc("mask_of_the_dragon_exit")
 MAP
-   @@     ccccccc
-  c==cccccc.....c
-  cc.........c..cc
-   cc.......ccc..cc
-    cc.....cccc...cc
-     c.....cc......c
-     c......cd.....n
-     c.....cc......c
-    cc.....cccc...cc
-   cc.......ccc..cc
-  cc.........c..cc
-  c==cccccc.....c
-   @@     ccccccc
+         .........
+ .........ccccccc.
+ .ccccccccc-----c..
+ .ccr--------c--cc..
+ ..cc-------ccc--cc..
+  ..cc-----ccc----cc.
+   ..c-----cc------c.
+   S.n--d--rcd--Q--nP@
+   ..c-----cc------c.
+  ..cc-----ccc----cc.
+ ..cc-------ccc--cc..
+ .ccr--------c--cc..
+ .ccccccccc-----c..
+ .........ccccccc.
+         .........
 ENDMAP
 
 ####

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6416,10 +6416,10 @@ ITEM:    mask_of_the_dragon no_pickup
 MONS:    storm dragon, shadow dragon, golden dragon, ghost moth, moth of wrath
 # Shuffle one transporter destination location
 NSUBST:  r = 1:R / *:-
-# Shuffle the mask location
-NSUBST:  d = 1:d / *:.
-# Randomly swap which transporter is the entrance
-SHUFFLE: PS/QR
+# Randomly swap which transporter is the entrance, and mask location
+SHUFFLE: PQD/SRE
+# Place the mask
+SUBST: D = d, E = -
 # Place monsters randomly
 NSUBST:  - = 3:1 / 3:2 / 3:3 / 3:4 / 3:5 / *:.
 # Place transporters
@@ -6435,7 +6435,7 @@ MAP
  ..cc-------ccc--cc..
   ..cc-----ccc----cc.
    ..c-----cc------c.
-   S.n--d--rcd--Q--nP@
+   S.nD----rcE----QnP@
    ..c-----cc------c.
   ..cc-----ccc----cc.
  ..cc-------ccc--cc..


### PR DESCRIPTION
This vault isn't very lethal currently. It's essentially just a slightly
higher density section of Zot, and the lack of speed>10 monsters means
the open layout isn't a huge problem. So, make two changes:

1) Tweak the monster sets.
Old:
6 draconian, 6 dragon, 6(!) ghost moth
New:
9 dragon, 3 ghost moth, 3 moth of wrath

2) Replace the runed doors with transporters. Now, the player has to
step in, walk around the central stone feature, pick up the mask, then
get to the exit transporter. There is some randomness built in to which
direction the transporters operate in and where they are placed
internally.

Some players might get lucky and find the mask a few steps from where
they arrive, but it's not guaranteed, and Zot's -tele status means a
quick escape isn't that possible anyway.