### PR TITLE
Don't warn for stat zero from changing items on Gnolls (11151)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1316,6 +1316,10 @@ static bool _safe_to_remove_or_wear(const item_def &item, bool remove, bool quie
     if (remove && !safe_to_remove(item, quiet))
         return false;
 
+    //Gnolls don't get stat changes from items, so don't warn about stat zero
+    if(you.species == SP_GNOLL)
+        return true;
+
     int prop_str = 0;
     int prop_dex = 0;
     int prop_int = 0;


### PR DESCRIPTION
Gnolls can't have their stats modified by items, so it makes no sense to
warn them about reaching stat zero if they equip/unequip items that change
their stats.