### PR TITLE
Gozag: don't offer useless haste/berserk in petition

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4021,6 +4021,15 @@ static void _gozag_add_potions(CrawlVector &vec, potion_type *which)
 {
     for (; *which != NUM_POTIONS; which++)
     {
+        // Even god powers cannot override racial berserk/haste restrictions.
+        if (*which == POT_BERSERK_RAGE
+            && !you.can_go_berserk(true, true, true))
+        {
+            continue;
+        }
+        if (*which == POT_HASTE && you.stasis())
+            continue;
+        // Don't add potions which are already in the list
         bool dup = false;
         for (unsigned int i = 0; i < vec.size(); i++)
             if (vec[i].get_int() == *which)


### PR DESCRIPTION
This change was inspired by the request here:
https://crawl.develz.org/tavern/viewtopic.php?f=8&t=23992

Since even gods cannot override racial restrictions against berserk
(undead, formicid) or haste (formicid), don't let Gozag offer these
potions to ineligible species. Previously, the effects would be added to
offered potions but have no effect (except increasing the potion cost).

This makes offered potions slightly better on average for affected
species.