### PR TITLE
Reduce Deep Dwarf HP modifier from +20% to 0%

### DIFF
--- a/crawl-ref/source/species-data.h
+++ b/crawl-ref/source/species-data.h
@@ -102,7 +102,7 @@ static const map<species_type, species_def> species_data =
     "DD",
     "Deep Dwarf", "Dwarven", "Dwarf",
     SPF_NONE,
-    -1, 2, 0, 6,
+    -1, 0, 0, 6,
     MONS_DEEP_DWARF,
     HT_LAND, US_ALIVE, SIZE_MEDIUM,
     11, 8, 8, // 27


### PR DESCRIPTION
Inspired by this thread:
https://crawl.develz.org/tavern/viewtopic.php?f=8&t=23991

Deep Dwarf has been an extremely strong species for a long time now.
Their power is derived from effectively unlimited heal wounds, as well
as strong skill aptitudes for playing a primarily melee fighter. On top
of these, DD get the equal-second best health aptitude in game, beaten
only by Troll & Ogre.

Beyond the obvious benefits of a high health pool, DDs benefit from it
by having greater freedom to heal only when their missing health is
greater than the max potential heal. Reducing DD's health aptitude will
make optimal healing riskier for a longer period of the game.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crawl/crawl/576)
<!-- Reviewable:end -->
