### PR TITLE
Fix an nsubst (minmay)

### DIFF
--- a/crawl-ref/source/dat/des/branches/lair.des
+++ b/crawl-ref/source/dat/des/branches/lair.des
@@ -2353,7 +2353,7 @@ KMONS:   P = plant / fungus w:5
 SHUFFLE: "', ABC
 SUBST:   A = ., BC = x, D = x .:2
 NSUBST:  " = 7:1 / *:., ' = 2:2 / *:.
-NSUBST:  - = 6:3 / *:., ; = 5:3 / *:.
+NSUBST:  - = 6:P / *:., ; = 5:3 / *:.
 MAP
   ...........
  ..DDDDCDDDD..


### PR DESCRIPTION
cheibrodos_lair_reptile_den was placing 6 monsters adjacent to the
player when they were probably intended to be plants.