### PR TITLE
Squelch Chei 'lowering attributes' after piety loss for Gnolls (mibe)

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2544,7 +2544,8 @@ void lose_piety(int pgn)
         _grant_temporary_waterwalk();
     }
     if (will_have_passive(passive_t::stat_boost)
-        && chei_stat_boost(old_piety) > chei_stat_boost())
+        && chei_stat_boost(old_piety) > chei_stat_boost()
+        && you.species != SP_GNOLL)
     {
         string msg = " lowers the support of your attributes";
         if (will_have_passive(passive_t::slowed))


### PR DESCRIPTION
The messages for gaining attributes from initially joining Chei or gaining
piety were already squelched, but the message for losing attributes from
losing piety was not.