### PR TITLE
Rework strength damage modifier

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1112,7 +1112,7 @@ int attack::player_stat_modify_damage(int damage)
     // Each point of strength over 10 increases this by 0.025 (2.5%),
     // strength below 10 reduces the multiplied by the same amount.
     // Minimum multiplier is 0.01 (1%) (reached at -30 str).
-    damage *= max(1, 75 + 2.5 * you.strength());
+    damage *= max(1.0, 75 + 2.5 * you.strength());
     damage /= 100;
 
     return damage;

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1108,8 +1108,11 @@ string attack::defender_name(bool allow_reflexive)
 
 int attack::player_stat_modify_damage(int damage)
 {
-    // 11 strength is ~1.0x damage multiplier.
-    damage *= random2(36 + div_rand_round(you.strength() * 57, 10));
+    // At 10 strength, damage is multiplied by 1.0
+    // Each point of strength over 10 increases this by 0.025 (2.5%),
+    // strength below 10 reduces the multiplied by the same amount.
+    // Minimum multiplier is 0.01 (1%) (reached at -30 str).
+    damage *= max(1, 75 + 2.5 * you.strength());
     damage /= 100;
 
     return damage;

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1108,15 +1108,9 @@ string attack::defender_name(bool allow_reflexive)
 
 int attack::player_stat_modify_damage(int damage)
 {
-    int dammod = 39;
-
-    if (you.strength() > 10)
-        dammod += (random2(you.strength() - 9) * 2);
-    else if (you.strength() < 10)
-        dammod -= (random2(11 - you.strength()) * 3);
-
-    damage *= dammod;
-    damage /= 39;
+    // 11 strength is ~1.0x damage multiplier.
+    damage *= random2(36 + div_rand_round(you.strength() * 57, 10));
+    damage /= 100;
 
     return damage;
 }


### PR DESCRIPTION
![chart](https://user-images.githubusercontent.com/379509/28657096-c2fceba6-72e8-11e7-91b0-d4de3c085c80.png)
[Spreadsheet with full numbers](https://docs.google.com/spreadsheets/d/1-ZZlhxy0iUUthRvxJHaZ9ZkqmBexBE36h0JWvYmEIUU/edit?usp=sharing)

Previously, the strength damage modifier had three forms depending on
your strength, from 0-9, 10, and 11+. The formulas were almost but not
quite the same, damage growth was fastest in the 0-9 range with +7.6%
per str compared to +5% per str in the 11+ range.

(Note: these +% figures are the max increase, since the algorithm
includes random2 the average increase is about half the quoted numbers.)

The way this formula changes based on strength isn't great because either:
1) If it should affect attribute increase choices, it's a non-continuous
breakpoint and therefore spoilery.
2) It it's too subtle to change attribute increase choices it's probably
pointless.

Change the damage modifier calculation to use a single continuous
formula for all strength values. The new formula grows at 5.8% with a
base (at 0 str) of 35%.

Replacing the formula neccessarily changes damage modifier values at
different strengths. The modifier is a little lower at typical strength
values, but gets higher at very low (<7) and very high (>28) strengths.
The biggest loss is around 11-14str, where players will lose about +10%
modifier.

```
Comparison of damage modifier at various strengths:
STR    Old    New
-------------------------
1       25%    35%
5       60%    65%
10     100%    95%
15     130%   120%
20     150%   150%
30     210%   210%
40     260%   270%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crawl/crawl/581)
<!-- Reviewable:end -->
