### PR TITLE
Increase priority of checking for hated spells when memorising

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3905,11 +3905,26 @@ bool god_likes_spell(spell_type spell, god_type god)
     }
 }
 
+/**
+ * Does your god hate spellcasting?
+ *
+ * @param god           The god to check against
+ * @return              Whether the god hates spellcasting
+ */
 bool god_hates_spellcasting(god_type god)
 {
     return god == GOD_TROG;
 }
 
+/**
+ * Will your god put you under penance if you actually cast spell?
+ *
+ * @param spell         The spell to check against
+ * @param god           The god to check against
+ * @param fake_spell    true if the spell is evoked or from an innate or divine ability
+ *                      false if it is a spell being cast normally.
+ * @return              true if the god hates the spell
+ */
 bool god_hates_spell(spell_type spell, god_type god, bool fake_spell)
 {
     if (god_hates_spellcasting(god))
@@ -3938,6 +3953,13 @@ bool god_hates_spell(spell_type spell, god_type god, bool fake_spell)
     return false;
 }
 
+/**
+ * Will your god excommunicate you if you actually cast spell?
+ *
+ * @param spell         The spell to check against
+ * @param god           The god to check against
+ * @return              Whether the god loathes the spell
+ */
 bool god_loathes_spell(spell_type spell, god_type god)
 {
     if (spell == SPELL_NECROMUTATION && is_good_god(god))
@@ -3945,6 +3967,27 @@ bool god_loathes_spell(spell_type spell, god_type god)
     if (spell == SPELL_STATUE_FORM && god == GOD_YREDELEMNUL)
         return true;
     return false;
+}
+
+/**
+ * Checks to see if your god hates or loathes this spell,
+ * or just hates spellcasting in general, and returns a warning string
+ *
+ * @param spell         The spell to check against
+ * @param god           The god to check against
+ * @return              Warning string if god has strong opinions on spell
+ *                      Empty string if god doesn't care about spell
+ */
+string god_spell_warn_string(spell_type spell, god_type god)
+{
+    if (god_loathes_spell(spell, god))
+        return "Your god extremely despises this spell!";
+    else if (god_hates_spellcasting(god))
+        return "Your god hates spellcasting!";
+    else if (god_hates_spell(spell, god))
+        return "Your god hates this spell!";
+    else
+        return "";
 }
 
 bool god_hates_ability(ability_type ability, god_type god)

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -103,6 +103,7 @@ bool god_likes_spell(spell_type spell, god_type god);
 bool god_hates_spellcasting(god_type god);
 bool god_hates_spell(spell_type spell, god_type god, bool fake_spell = false);
 bool god_loathes_spell(spell_type spell, god_type god);
+string god_spell_warn_string(spell_type spell, god_type god);
 bool god_hates_ability(ability_type ability, god_type god);
 lifesaving_chance elyvilon_lifesaving();
 bool god_protects_from_harm();

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -689,10 +689,6 @@ static spell_type _choose_mem_spell(spell_list &spells,
         int colour = LIGHTGRAY;
         if (vehumet_is_offering(spell))
             colour = LIGHTBLUE;
-        // Grey out spells for which you lack experience or spell levels.
-        else if (spell_difficulty(spell) > you.experience_level
-                 || player_spell_levels() < spell_levels_required(spell))
-            colour = DARKGRAY;
         else
             colour = spell_highlight_by_utility(spell);
 
@@ -874,6 +870,11 @@ static bool _learn_spell_checks(spell_type specspell, bool wizard = false)
 */
 bool learn_spell(spell_type specspell, bool wizard)
 {
+    string mem_spell_warning_string = god_spell_warn_string(specspell, you.religion);
+
+    if (mem_spell_warning_string != "")
+        mprf(MSGCH_WARN, "%s", mem_spell_warning_string.c_str());
+
     if (!_learn_spell_checks(specspell, wizard))
         return false;
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -956,8 +956,8 @@ static void _majin_speak(spell_type spell)
  *
  * @param spell         The type of spell just cast.
  * @param god           Which god is casting the spell; NO_GOD if it's you.
- * @param fake_spell    Whether the spell is evoked, or from an innate or
- *                      divine ability.
+ * @param fake_spell    true if the spell is evoked or from an innate or divine ability
+ *                      false if it is a spell being cast normally.
  */
 static void _spellcasting_side_effects(spell_type spell, god_type god,
                                        bool fake_spell)
@@ -1075,9 +1075,9 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
  * it can't legally be cast in this circumstance, or because the player opts
  * to cancel it in response to a prompt?
  *
- * @param spell         The spell to be checked.
- * @param fake_spell    Whether the spell is evoked, or from an innate or
- *                      divine ability.
+ * @param spell         The spell to be checked
+ * @param fake_spell    true if the spell is evoked or from an innate or divine ability
+ *                      false if it is a spell being cast normally.
  * @return              Whether the spellcasting should be aborted.
  */
 static bool _spellcasting_aborted(spell_type spell, bool fake_spell)
@@ -1285,7 +1285,9 @@ vector<string> desc_success_chance(const monster_info& mi, int pow, bool evoked,
  *
  * @param spell         The type of spell being cast.
  * @param powc          Spellpower.
- * @param allow_fail    Whether spell-fail chance applies.
+ * @param allow_fail    true if it is a spell being cast normally.
+ *                      false if the spell is evoked or from an innate or divine ability
+ *
  * @param evoked_item   The wand the spell was evoked from if applicable, or
                         nullptr.
  * @return SPRET_SUCCESS if spell is successfully cast for purposes of

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1068,7 +1068,8 @@ bool spell_is_form(spell_type spell)
  *                   (status effects, mana, gods, items, etc.)
  * @param prevent    Whether to only check for effects which prevent casting,
  *                   rather than just ones that make it unproductive.
- * @param fake_spell Is the spell evoked, or from an innate or divine ability?
+ * @param fake_spell true if the spell is evoked or from an innate or divine ability
+ *                   false if it is a spell being cast normally.
  * @return           Whether the given spell has no chance of being useful.
  */
 bool spell_is_useless(spell_type spell, bool temp, bool prevent,
@@ -1086,7 +1087,8 @@ bool spell_is_useless(spell_type spell, bool temp, bool prevent,
  *                   (status effects, mana, gods, items, etc.)
  * @param prevent    Whether to only check for effects which prevent casting,
  *                   rather than just ones that make it unproductive.
- * @param fake_spell Is the spell evoked, or from an innate or divine ability?
+ * @param fake_spell true if the spell is evoked or from an innate or divine ability
+ *                   false if it is a spell being cast normally.
  * @return           The reason a spell is useless to the player, if it is;
  *                   "" otherwise. The string should be a full clause, but
  *                   begin with a lowercase letter so callers can put it in
@@ -1344,9 +1346,15 @@ int spell_highlight_by_utility(spell_type spell, int default_colour,
     {
         return COL_FORBIDDEN;
     }
+    // Grey out spells for which you lack experience or spell levels.
+    if (spell_difficulty(spell) > you.experience_level
+        || player_spell_levels() < spell_levels_required(spell))
+    {
+        return COL_INAPPLICABLE;
+    }
 
-    if (spell_is_useless(spell, transient))
-        default_colour = COL_USELESS;
+    else if (spell_is_useless(spell, transient))
+        return COL_USELESS;
 
     return default_colour;
 }


### PR DESCRIPTION
see **https://crawl.develz.org/mantis/view.php?id=11169**

This update always makes hated or loathed spells show up red in the
memorisation menu and always provides a warning message if the user
tries to memorise these spells.

Additionally, for Trog, all spells are red in the memorisation menu.

There's a couple minor fixups with using a color enum instead of the color directly, and mixing up the warning priorities to something that seems to flow well. (i.e. check if Trog hates spellcasting before checking if Trog hates that particular spell to avoid a redundant warning)

Finally, added 3 docstrings in religion.cc for the functions I needed to use for the warnings.

Latest update 8/8/2017 implements amalloy's suggestions.
- Make some docstrings more consistent
- Move some warnings into a new function
- Fix some formatting 

Previously, the memorisation screen would prioritise "not enough spell
levels" over "divinely forbidden or hated". So if you worshiped Yred and
didn't have enough spell levels for Statue Form, it would show up as
gray, until you finally had enough levels, at which point it would
finally show up as red.

Similarly, after selecting the spell for memorisation, there were no
additional warning messages reminding the user that their god didn't
like the spell.