### PR TITLE
initfile.cc: Make sure unistd.h is included for Cygwin targets.

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -77,12 +77,12 @@
 #include <windows.h>
 #include <shlwapi.h>
 #include <shlobj.h>
-#elif defined (__APPLE__)
+#elif defined(TARGET_OS_MACOSX)
 extern char **NXArgv;
 #ifndef DATA_DIR_PATH
 #include <unistd.h>
 #endif
-#elif defined (__linux__)
+#elif defined(TARGET_OS_LINUX) || defined(TARGET_OS_CYGWIN)
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
Also, update other target checks in the #ifdef chain to check against
 an appropriate TARGET_OS macro.

Needed for the readlink() call in _find_executable_path().