### PR TITLE
Make Dith hate all fire spells (bepbepimjep, #10969)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -695,6 +695,8 @@ void bolt::apply_beam_conducts()
             break;
         case BEAM_FIRE:
         case BEAM_STICKY_FLAME:
+        case BEAM_LAVA:
+        case BEAM_INNER_FLAME:
             did_god_conduct(DID_FIRE,
                             pierce || is_explosion ? 6 + random2(3)
                                                    : 2 + random2(3),

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -206,7 +206,6 @@ public:
 private:
     void do_fire();
     void initialise_fire();
-    void apply_beam_conducts();
 
     // Lots of properties of the beam.
     coord_def pos() const;
@@ -266,6 +265,7 @@ private:
     void enchantment_affect_monster(monster* mon);
 public:
     mon_resist_type apply_enchantment_to_monster(monster* mon);
+    void apply_beam_conducts();
 private:
     void apply_bolt_paralysis(monster* mons);
     void apply_bolt_petrify(monster* mons);

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -920,6 +920,11 @@ static void _spellcasting_god_conduct(spell_type spell)
     if (is_corpse_violating_spell(spell))
         did_god_conduct(DID_CORPSE_VIOLATION, conduct_level);
 
+    // not is_fiery_spell since the other ones handle the conduct themselves.
+    // need to handle ignite poison separately since it's not handled elsewhere.
+    if (spell == SPELL_IGNITE_POISON)
+        did_god_conduct(DID_FIRE, conduct_level);
+
     // not is_hasty_spell since the other ones handle the conduct themselves.
     if (spell == SPELL_SWIFTNESS)
         did_god_conduct(DID_HASTY, conduct_level);

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -10,6 +10,7 @@
 
 #include "act-iter.h"
 #include "areas.h"
+#include "beam.h"
 #include "butcher.h"
 #include "cloud.h"
 #include "colour.h"
@@ -124,6 +125,7 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
 
     fail_check();
 
+    beam.apply_beam_conducts();
     beam.refine_for_explosion();
     beam.explode(false);
 
@@ -1891,6 +1893,7 @@ spret_type cast_ignition(const actor *agent, int pow, bool fail)
         beam_actual.ex_size       = 0;
         beam_actual.is_explosion  = true;
         beam_actual.loudness      = 0;
+        beam_actual.apply_beam_conducts();
 
 #ifdef DEBUG_DIAGNOSTICS
         dprf(DIAG_BEAM, "ignition dam=%dd%d",


### PR DESCRIPTION
See: https://crawl.develz.org/mantis/view.php?id=10969

Currently, not all fire spells are causing Dith to dish out
penance/wrath.

inner flame
ignite poison
bolt of magma
ignition
firestorm

Had to add some extra BEAMS to apply_beam_conducts() and then point
cast_ignition and cast_fire_storm to the same function.

Ignite_poison is handled similar to how SPELL_SWIFTNESS is handled for
the is_hasty conduct (check for the spell and send a DID_FIRE to
did_god_conduct).