### PR TITLE
Improve bear berserk

### DIFF
--- a/crawl-ref/source/mon-spell.h
+++ b/crawl-ref/source/mon-spell.h
@@ -284,7 +284,8 @@ static const mon_spellbook mspell_list[] =
 
     {  MST_BEAR,
       {
-       { SPELL_BERSERKER_RAGE, 57, MON_SPELL_NATURAL | MON_SPELL_EMERGENCY },
+       { SPELL_BERSERKER_RAGE, 100, MON_SPELL_NATURAL | MON_SPELL_EMERGENCY
+                                   | MON_SPELL_INSTANT},
       }
     },
 


### PR DESCRIPTION
Bears mostly die before they can berserk, or they berserk and then die a
turn or two later. Let them cast it instantly when in an emergency (like
orc battlecry) and double the cast frequency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crawl/crawl/591)
<!-- Reviewable:end -->
