### PR TITLE
Improve trap interaction with fixed-position summons (Quatzecoatl, #11059)

### DIFF
--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -63,6 +63,7 @@
 #include "teleport.h"
 #include "terrain.h"
 #include "timed-effects.h"
+#include "traps.h"
 #include "unwind.h"
 #include "viewchar.h"
 #include "xom.h"
@@ -2990,6 +2991,34 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
                 canned_msg(MSG_GHOSTLY_OUTLINE);
         }
         return SPRET_SUCCESS;      // Don't give free detection!
+    }
+
+    // check for traps
+    // TODO: combine with above
+    const trap_def *ptrap = trap_at(where);
+    if (ptrap)
+    {
+        const trap_def& trap = *ptrap;
+        const bool player_knows_trap = (trap.is_known(&you));
+
+        // Only shaft and teleport traps should prevent prisms from being placed
+        if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
+        {
+            // can you see the trap?
+            if (player_knows_trap)
+            {    // then tell them straight up they can't target it
+                if (caster->is_player())
+                    mpr("You can't place the prism on this trap.");
+                return SPRET_ABORT;
+            }
+            else // Flavor text
+            {
+                //canned_msg(MSG_GHOSTLY_TRAP);
+                mpr("GHOSTLY TRAP");
+            }
+            // we charge mana for the detection of the trap
+            return SPRET_SUCCESS;
+        }
     }
 
     fail_check();

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -953,32 +953,9 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         return SPRET_SUCCESS;
     }
 
-    // check for traps
-    const trap_def *ptrap = trap_at(where);
-    if (ptrap)
-    {
-        const trap_def& trap = *ptrap;
-        const bool player_knows_trap = (trap.is_known(&you));
-
-        // Only shaft and teleport traps should prevent spires from being placed
-        if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
-        {
-            // if you can see the trap, tell the player straight up they can't target it
-            if (player_knows_trap)
-            {
-                mpr("You can't place the spire on this trap.");
-                return SPRET_ABORT;
-            }
-            //give a vague message. players won't know if it's a teleport or shaft trap
-            else
-            {
-                fail_check();
-                mpr("You see a shimmering outline there, and the spell fizzles.");
-            }
-            // we charge mana for the detection of the trap
-            return SPRET_SUCCESS;
-        }
-    }
+    spret_type handle_trap = handle_trap_at_target_location(where, fail);
+    if (handle_trap != SPRET_NONE)
+        return handle_trap;
 
     fail_check();
 
@@ -3020,33 +2997,9 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         return SPRET_SUCCESS;      // Don't give free detection!
     }
 
-    // check for traps
-    const trap_def *ptrap = trap_at(where);
-    if (ptrap)
-    {
-        const trap_def& trap = *ptrap;
-        const bool player_knows_trap = (trap.is_known(&you));
-
-        // Only shaft and teleport traps should prevent prisms from being placed
-        if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
-        {
-            // if you can see the trap, tell the player straight up they can't target it
-            if (player_knows_trap)
-            {
-                if (caster->is_player())
-                    mpr("You can't place the prism on this trap.");
-                return SPRET_ABORT;
-            }
-            //give a vague message. players won't know if it's a teleport or shaft trap
-            else
-            {
-                fail_check();
-                mpr("You see a shimmering outline there, and the spell fizzles.");
-            }
-            // we charge mana for the detection of the trap
-            return SPRET_SUCCESS;
-        }
-    }
+    spret_type handle_trap = handle_trap_at_target_location(where, fail);
+    if (handle_trap != SPRET_NONE)
+        return handle_trap;
 
     fail_check();
 
@@ -3494,4 +3447,35 @@ int count_summons(const actor *summoner, spell_type spell)
     }
 
     return count;
+}
+
+spret_type handle_trap_at_target_location(const coord_def& where, bool fail)
+{
+    // check for traps
+    const trap_def *ptrap = trap_at(where);
+    if (ptrap)
+    {
+        const trap_def& trap = *ptrap;
+        const bool player_knows_trap = (trap.is_known(&you));
+
+        // Only shaft and teleport traps should prevent spires from being placed
+        if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
+        {
+            // if you can see the trap, tell the player straight up they can't target it
+            if (player_knows_trap)
+            {
+                mpr("You can't place the spire on this trap.");
+                return SPRET_ABORT;
+            }
+            //give a vague message. players won't know if it's a teleport or shaft trap
+            else
+            {
+                fail_check();
+                mpr("You see a shimmering outline there, and the spell fizzles.");
+            }
+            // we charge mana for the detection of the trap
+            return SPRET_SUCCESS;
+        }
+    }
+    return SPRET_NONE;
 }

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -2994,7 +2994,6 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     }
 
     // check for traps
-    // TODO: combine with above
     const trap_def *ptrap = trap_at(where);
     if (ptrap)
     {
@@ -3004,17 +3003,18 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         // Only shaft and teleport traps should prevent prisms from being placed
         if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
         {
-            // can you see the trap?
+            // if you can see the trap, tell the player straight up they can't target it
             if (player_knows_trap)
-            {    // then tell them straight up they can't target it
+            {
                 if (caster->is_player())
                     mpr("You can't place the prism on this trap.");
                 return SPRET_ABORT;
             }
-            else // Flavor text
+            //give a vague message. players won't know if it's a teleport or shaft trap
+            else
             {
-                //canned_msg(MSG_GHOSTLY_TRAP);
-                mpr("GHOSTLY TRAP");
+                fail_check();
+                mpr("You see a shimmering outline there, and the spell fizzles.");
             }
             // we charge mana for the detection of the trap
             return SPRET_SUCCESS;

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -953,7 +953,7 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         return SPRET_SUCCESS;
     }
 
-    spret_type handle_trap = handle_trap_at_target_location(where, fail);
+    spret_type handle_trap = handle_trap_at_target_location(where, &you, fail);
     if (handle_trap != SPRET_NONE)
         return handle_trap;
 
@@ -2997,7 +2997,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         return SPRET_SUCCESS;      // Don't give free detection!
     }
 
-    spret_type handle_trap = handle_trap_at_target_location(where, fail);
+    spret_type handle_trap = handle_trap_at_target_location(where, caster, fail);
     if (handle_trap != SPRET_NONE)
         return handle_trap;
 
@@ -3449,7 +3449,7 @@ int count_summons(const actor *summoner, spell_type spell)
     return count;
 }
 
-spret_type handle_trap_at_target_location(const coord_def& where, bool fail)
+spret_type handle_trap_at_target_location(const coord_def& where, actor* caster, bool fail)
 {
     // check for traps
     const trap_def *ptrap = trap_at(where);
@@ -3464,7 +3464,8 @@ spret_type handle_trap_at_target_location(const coord_def& where, bool fail)
             // if you can see the trap, tell the player straight up they can't target it
             if (player_knows_trap)
             {
-                mpr("You can't place the spire on this trap.");
+                if (caster->is_player())
+                    mpr("The trap prevents you from targeting this location.");
                 return SPRET_ABORT;
             }
             //give a vague message. players won't know if it's a teleport or shaft trap

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -100,7 +100,6 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
  * If the trap is unknown, player is given a mysterious flavor message.
  *
  * @param where        The target coordinate to check.
- * @param caster       The actor casting the spell.
  * @param monster_type The type of monster to be checked for placement.
  * @param fail         If true, return SPRET_FAIL unless the spell is aborted.
  * @returns Returns SPRET_ABORT if the target location is not valid,
@@ -108,7 +107,6 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
  *          SPRET_SUCCESS or SPRET_FAIL based on fail.
  */
 static spret_type _cast_on_trap_location(const coord_def& where,
-                                 actor* caster,
                                  monster_type mon_type,
                                  bool fail)
 {
@@ -125,8 +123,7 @@ static spret_type _cast_on_trap_location(const coord_def& where,
             // Tell player they can't target this kind of trap.
             if (player_knows_trap)
             {
-                if (caster->is_player())
-                    mpr("The trap prevents you from targeting this location.");
+                mpr("The trap prevents you from targeting this location.");
                 return SPRET_ABORT;
             }
 
@@ -134,8 +131,7 @@ static spret_type _cast_on_trap_location(const coord_def& where,
 
             // If player can't see the trap, give a vague message.
             // Players won't know if it's a teleport or shaft trap.
-            if (caster->is_player())
-                mpr("You see a mysterious outline, and the spell fizzles.");
+            mpr("You see a mysterious outline, and the spell fizzles.");
 
             // We charge mana for the detection of the trap.
             return SPRET_SUCCESS;
@@ -1009,7 +1005,7 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         return SPRET_SUCCESS;
     }
 
-    spret_type handle_trap = _cast_on_trap_location(where, &you,
+    spret_type handle_trap = _cast_on_trap_location(where,
                                                     MONS_LIGHTNING_SPIRE,
                                                     fail);
 
@@ -3060,7 +3056,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         return SPRET_SUCCESS;
     }
 
-    spret_type handle_trap = _cast_on_trap_location(where, caster,
+    spret_type handle_trap = _cast_on_trap_location(where,
                                                     MONS_FULMINANT_PRISM,
                                                     fail);
 

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -954,6 +954,7 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
     }
 
     spret_type handle_trap = handle_trap_at_target_location(where, &you, fail);
+
     if (handle_trap != SPRET_NONE)
         return handle_trap;
 
@@ -2998,6 +2999,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     }
 
     spret_type handle_trap = handle_trap_at_target_location(where, caster, fail);
+
     if (handle_trap != SPRET_NONE)
         return handle_trap;
 
@@ -3468,12 +3470,14 @@ spret_type handle_trap_at_target_location(const coord_def& where, actor* caster,
                     mpr("The trap prevents you from targeting this location.");
                 return SPRET_ABORT;
             }
-            //give a vague message. players won't know if it's a teleport or shaft trap
-            else
-            {
-                fail_check();
-                mpr("You see a shimmering outline there, and the spell fizzles.");
-            }
+
+            fail_check();
+
+            // give a vague message. players won't know if it's a teleport or shaft trap
+            // we only provide a message if the player is the caster
+            if (caster->is_player())
+                mpr("You see a mysterious outline, and the spell fizzles.");
+
             // we charge mana for the detection of the trap
             return SPRET_SUCCESS;
         }

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -949,8 +949,35 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         fail_check();
 
         // invisible monster
-        mpr("Something you can't see is blocking your construction!");
+        canned_msg(MSG_GHOSTLY_OUTLINE);
         return SPRET_SUCCESS;
+    }
+
+    // check for traps
+    const trap_def *ptrap = trap_at(where);
+    if (ptrap)
+    {
+        const trap_def& trap = *ptrap;
+        const bool player_knows_trap = (trap.is_known(&you));
+
+        // Only shaft and teleport traps should prevent spires from being placed
+        if (trap.type == TRAP_TELEPORT || trap.type == TRAP_TELEPORT_PERMANENT || trap.type == TRAP_SHAFT)
+        {
+            // if you can see the trap, tell the player straight up they can't target it
+            if (player_knows_trap)
+            {
+                mpr("You can't place the spire on this trap.");
+                return SPRET_ABORT;
+            }
+            //give a vague message. players won't know if it's a teleport or shaft trap
+            else
+            {
+                fail_check();
+                mpr("You see a shimmering outline there, and the spell fizzles.");
+            }
+            // we charge mana for the detection of the trap
+            return SPRET_SUCCESS;
+        }
     }
 
     fail_check();

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -950,6 +950,7 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
 
         // invisible monster
         canned_msg(MSG_GHOSTLY_OUTLINE);
+        autotoggle_autopickup(true);
         return SPRET_SUCCESS;
     }
 
@@ -2983,7 +2984,6 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
 
         fail_check();
 
-        // FIXME: maybe should do _paranoid_option_disable() here?
         if (caster->is_player()
             || (you.can_see(*caster) && you.see_cell(where)))
         {
@@ -2993,7 +2993,10 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
                                victim->conj_verb("twitch").c_str());
             }
             else
+            {
                 canned_msg(MSG_GHOSTLY_OUTLINE);
+                autotoggle_autopickup(true);
+            }
         }
         return SPRET_SUCCESS;      // Don't give free detection!
     }

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -96,19 +96,14 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
  * Check target location to ensure it's valid for fixed position summons.
  * Only players can cast spells that target a location.
  *
- * Currently, this function only checks for proper trap interaction.
- * Players cannot target Teleport and shaft traps.
- * If the trap is known, player is simply informed they cannot target it.
- * If the trap is unknown, player is given a mysterious flavor message.
- *
  * @param where         The target coordinate to check.
  * @param monster_type  The type of monster to be checked for placement.
  * @param spell         The spell being cast.
  * @param pow           The spell power.
  * @param fail          If true, return SPRET_FAIL unless the spell is aborted.
- * @returns Returns SPRET_ABORT if the target location is not valid,
- *          SPRET_NONE if there is no trap, otherwise
- *          SPRET_SUCCESS or SPRET_FAIL based on fail.
+ * @returns             Returns SPRET_ABORT if target location is not valid,
+ *                      SPRET_NONE if there is no trap, otherwise
+ *                      SPRET_SUCCESS or SPRET_FAIL based on fail.
  */
 static spret_type _check_fixed_summon_loc(const coord_def& where,
                                           monster_type mon_type,
@@ -167,8 +162,7 @@ static spret_type _check_fixed_summon_loc(const coord_def& where,
 
             fail_check();
 
-            // If player can't see the trap, give a vague message.
-            // Players won't know if it's a teleport or shaft trap.
+            // Let the player know there's a shaft or teleport trap here
             mpr("You see a mysterious outline, and the spell fizzles.");
 
             // We charge mana for the detection of the trap.

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -93,8 +93,10 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
 
 
 /**
- * Handle trap interaction for spells with fixed-position summons.
- * Currently, only players can cast spells that target a location.
+ * Check target location to ensure it's valid for fixed position summons.
+ * Only players can cast spells that target a location.
+ *
+ * Currently, this function only checks for proper trap interaction.
  * Players cannot target Teleport and shaft traps.
  * If the trap is known, player is simply informed they cannot target it.
  * If the trap is unknown, player is given a mysterious flavor message.
@@ -106,9 +108,9 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
  *          SPRET_NONE if there is no trap, otherwise
  *          SPRET_SUCCESS or SPRET_FAIL based on fail.
  */
-static spret_type _cast_on_trap_location(const coord_def& where,
-                                 monster_type mon_type,
-                                 bool fail)
+static spret_type _check_fixed_summon_loc(const coord_def& where,
+                                          monster_type mon_type,
+                                          bool fail)
 {
     // Look for a trap at the target location.
     const trap_def *ptrap = trap_at(where);
@@ -1005,9 +1007,9 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         return SPRET_SUCCESS;
     }
 
-    spret_type handle_trap = _cast_on_trap_location(where,
-                                                    MONS_LIGHTNING_SPIRE,
-                                                    fail);
+    spret_type handle_trap = _check_fixed_summon_loc(where,
+                                                     MONS_LIGHTNING_SPIRE,
+                                                     fail);
 
     if (handle_trap != SPRET_NONE)
         return handle_trap;
@@ -3056,9 +3058,9 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         return SPRET_SUCCESS;
     }
 
-    spret_type handle_trap = _cast_on_trap_location(where,
-                                                    MONS_FULMINANT_PRISM,
-                                                    fail);
+    spret_type handle_trap = _check_fixed_summon_loc(where,
+                                                     MONS_FULMINANT_PRISM,
+                                                     fail);
 
     if (handle_trap != SPRET_NONE)
         return handle_trap;

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -125,3 +125,4 @@ void summoned_monster(const monster* mons, const actor* caster,
 bool summons_are_capped(spell_type spell);
 int summons_limit(spell_type spell);
 int count_summons(const actor *summoner, spell_type spell);
+spret_type handle_trap_at_target_location(const coord_def& where, bool fail);

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -125,4 +125,3 @@ void summoned_monster(const monster* mons, const actor* caster,
 bool summons_are_capped(spell_type spell);
 int summons_limit(spell_type spell);
 int count_summons(const actor *summoner, spell_type spell);
-spret_type handle_trap_at_target_location(const coord_def& where, actor* caster, bool fail);

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -125,4 +125,4 @@ void summoned_monster(const monster* mons, const actor* caster,
 bool summons_are_capped(spell_type spell);
 int summons_limit(spell_type spell);
 int count_summons(const actor *summoner, spell_type spell);
-spret_type handle_trap_at_target_location(const coord_def& where, bool fail);
+spret_type handle_trap_at_target_location(const coord_def& where, actor* caster, bool fail);


### PR DESCRIPTION
EDIT: I just saw this PR that addresses the same issue by simply allowing the prisms/spires to be placed on the traps in question: https://github.com/crawl/crawl/pull/536 , rather than the approach I was taking to warn about the hidden traps (similarly to the warnings about hidden monsters).  Is the other approach preferred? the code is simpler.

See https://crawl.develz.org/mantis/view.php?id=11059

Situation: when casting f. prism or lightning spire on a known or unknown teleport or shaft trap, the spell fizzles without really explaining why to the user.  "You see a puff of smoke. Nothing appears to happen".

Target: warn user when trying to cast f prism or spire on a known teleport or shaft trap.  give a flavor warning for unknown teleport or shaft traps (similar to the existing warning for invisible monsters).

Bonus: handle FIXME suggestion to turn off auto-pickup when you "find" an invisible monster.

This is still WIP but wanted to start getting some feedback.

DONE:
-updated cast_fulminating_prism to handle trap interaction.
1. Only special case teleport traps and shafts. Other traps (known and unknown) are not affected.
2. If trap is known, directly inform player it's not possible to place the prism and abort the spell.
--"You can't place the prism on this trap."
3. If trap is not known, provide a flavorful message, similar to trying to place on an invisible monster. (still charge the MP if the spell doesn't fail)
-- "You see a shimmering outline there, and the spell fizzles."
The idea is, you don't know if it's a tele trap or shaft. Might not be a huge deal but it seemed a bit too easy to just reveal the trap.

- Handle lightning_spire (refactor f. prism logic into new function that both spells can use)
- Pass caster info to function. No monsters use the spell, so it should just be to handle ghosts
- Reworded some messages and made them more generic to handle spire and prism
- Turn off auto-pickup when casting on invis monsters
- Add some docstrings/documentation

ToDo: more testing and get feedback.
Do I need more documentation? the two cast_ functions (f prism and l. spire) don't have docstrings, but neither do nearly all of the functions in spl-summoning.  Should I add them to the two functions I modified?
