### PR TITLE
Fix Incorrectly grayed-out spells in casting menu (#11180)

### DIFF
--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -690,7 +690,12 @@ static spell_type _choose_mem_spell(spell_list &spells,
         if (vehumet_is_offering(spell))
             colour = LIGHTBLUE;
         else
-            colour = spell_highlight_by_utility(spell);
+        {
+            bool transient = false;
+            bool memcheck = true;
+            colour = spell_highlight_by_utility(spell, COL_UNKNOWN, transient, memcheck);
+        }
+
 
         desc << "<" << colour_to_str(colour) << ">";
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1335,10 +1335,11 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
  * @param spell           The type of spell to be coloured.
  * @param default_colour   Colour to be used if the spell is unremarkable.
  * @param transient       If true, check if spell is temporarily useless.
+ * @param memcheck        If true, check if spell can be memorised
  * @return                The colour to highlight the spell.
  */
 int spell_highlight_by_utility(spell_type spell, int default_colour,
-                               bool transient)
+                               bool transient, bool memcheck)
 {
     // If your god hates the spell, that overrides all other concerns.
     if (god_hates_spell(spell, you.religion)
@@ -1347,13 +1348,13 @@ int spell_highlight_by_utility(spell_type spell, int default_colour,
         return COL_FORBIDDEN;
     }
     // Grey out spells for which you lack experience or spell levels.
-    if (spell_difficulty(spell) > you.experience_level
-        || player_spell_levels() < spell_levels_required(spell))
+    if (memcheck && (spell_difficulty(spell) > you.experience_level
+        || player_spell_levels() < spell_levels_required(spell)))
     {
         return COL_INAPPLICABLE;
     }
-
-    else if (spell_is_useless(spell, transient))
+    // Check if the spell is considered useless based on your current status
+    if (spell_is_useless(spell, transient))
         return COL_USELESS;
 
     return default_colour;

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -128,7 +128,8 @@ string spell_uselessness_reason(spell_type spell, bool temp = true,
 
 int spell_highlight_by_utility(spell_type spell,
                                 int default_colour = COL_UNKNOWN,
-                                bool transient = false);
+                                bool transient = false,
+                                bool memcheck = false);
 bool spell_no_hostile_in_range(spell_type spell);
 
 bool spell_is_soh_breath(spell_type spell);


### PR DESCRIPTION
See https://crawl.develz.org/mantis/view.php?id=11180

This issue was caused by: https://github.com/crawl/crawl/commit/175666845826aeb963ffe902c9405cd886483b7f

When refactoring the code in spl-book.cc to Gray out spells that the player is not able to learn (not enough spell levels or too low XL), the function, spell_highlight_by_utility, in spl-util.cc wasn't properly modified to handle being used by both the spell memorisation menu and the spell casting menu (which was the only thing that used it previously).

I thought of 2 options.

1. revert the refactoring. Move the check back to spl-book.cc.
2. modify spell_highlight_by_utility in spl-util.cc to accept an additional boolean argument indicating if a check against being able to memorise the spell is requested (similar to the existing boolean to check if the spell is situationally useless). 

This PR implements option 2, but I would appreciate some feedback on whether this is the preferred option. I assumed it would be better for a single function to handle spell name highlighting. 

Additionally, when calling spell_highlight_by_utility from spl-book.cc, rather than passing 'false,true' for the boolean parameters, I created a couple variables, which increased the else block from 1 line to 5 (since it needed braced). I don't know if this is the preferred style or if it's better to just pass the raw boolean values.

Here are the reproduction steps for a head-to-head comparison I did between current trunk and this version:
hill orc fighter + rapier

desc                         cmd        observation
get all books		&o:all
check mem screen	M		trunk = PR= looks correct
set skills to 10	&A10		
check mem screen	M		trunk = PR = looks correct
set XL to 10		&l10		
check mem screen	M 		trunk = PR = looks correct
learn spells:
blade hands
beastly appendage
summon butterflies
song of slaying
swiftness

(these first checks aren't really great examples since you can never learn a spell, then lose XL to be in a situation where you have fewer XL than the spell's level)

check spell screen	z?		all spells white in trunk & PR= looks correct
set XL to 4		&l4
check spell screen	z?		all spells should all be white still, but trunk has blade hands gray. PR looks OK
set XL to 1		&l1	
check spell screen	z?		all spells should all be white still, but trunk has the lvl 2 and blade hands gray. PR  looks OK
set XL to 10             &l10        

Now, the main issue, exhaust your spell levels and trunk grays out the spell names.
memorize enough spells to exhaust all player spell levels
tornado
shatter
create a monster     &morc     (for tornado to target)
check spell screen   z?             all spells should all be white still, but trunk shows all gray. PR looks OK.


