### PR TITLE
Toggle setting for modifier prefix keys / and *

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2515,6 +2515,9 @@ show_player_species = false
         you're a Hill Orc, you will be shown as an 'o' rather than '@'. Has
         no effect in Tiles.
 
+use_modifier_prefix_keys = true
+        When true, '*' behaves as a CTRL keypress, and '/' as SHIFT.
+
 fake_lang = <lang1>[,<lang2>[,...]]
         Set one or more fake languages, applied in the order provided (order
         does matter!) The same language can be set more than once, though it

--- a/crawl-ref/source/cio.cc
+++ b/crawl-ref/source/cio.cc
@@ -75,28 +75,31 @@ private:
 };
 
 int unmangle_direction_keys(int keyin, KeymapContext keymap,
-                            bool fake_ctrl, bool fake_shift)
+                            bool allow_fake_modifiers)
 {
     // Kludging running and opening as two character sequences.
     // This is useful when you can't use control keys (macros, lua) or have
     // them bound to something on your system.
 
-    /* can we say yuck? -- haranp */
-    if (fake_ctrl && keyin == '*')
+    if (allow_fake_modifiers && Options.use_modifier_prefix_keys)
     {
-        unwind_cursor saved(1, crawl_view.msgsz.y, GOTO_MSG);
-        cprintf("CTRL");
-        keyin = getchm(keymap);
-        // return control-key
-        keyin = CONTROL(toupper(_numpad2vi(keyin)));
-    }
-    else if (fake_shift && keyin == '/')
-    {
-        unwind_cursor saved(1, crawl_view.msgsz.y, GOTO_MSG);
-        cprintf("SHIFT");
-        keyin = getchm(keymap);
-        // return shift-key
-        keyin = toupper(_numpad2vi(keyin));
+        /* can we say yuck? -- haranp */
+        if (keyin == '*')
+        {
+            unwind_cursor saved(1, crawl_view.msgsz.y, GOTO_MSG);
+            cprintf("CTRL");
+            keyin = getchm(keymap);
+            // return control-key
+            keyin = CONTROL(toupper(_numpad2vi(keyin)));
+        }
+        else if (keyin == '/')
+        {
+            unwind_cursor saved(1, crawl_view.msgsz.y, GOTO_MSG);
+            cprintf("SHIFT");
+            keyin = getchm(keymap);
+            // return shift-key
+            keyin = toupper(_numpad2vi(keyin));
+        }
     }
 
     // [dshaligram] More lovely keypad mangling.

--- a/crawl-ref/source/cio.h
+++ b/crawl-ref/source/cio.h
@@ -43,7 +43,7 @@ int m_getch();
 // to vi key sequences (shifted/control key directions are also handled). Non
 // direction keys (hopefully) pass through unmangled.
 int unmangle_direction_keys(int keyin, KeymapContext keymap = KMC_DEFAULT,
-                            bool fake_ctrl = true, bool fake_shift = true);
+                            bool allow_fake_modifiers = true);
 
 void nowrap_eol_cprintf(PRINTF(0, ));
 

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3602,7 +3602,7 @@ int targeting_behaviour::get_key()
     flush_prev_message();
     msgwin_got_input();
     return unmangle_direction_keys(getchm(KMC_TARGETING), KMC_TARGETING,
-                                   false, false);
+                                   false);
 }
 
 command_type targeting_behaviour::get_command(int key)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -202,6 +202,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(use_fake_cursor), USING_UNIX ),
         new BoolGameOption(SIMPLE_NAME(use_fake_player_cursor), true),
         new BoolGameOption(SIMPLE_NAME(show_player_species), false),
+        new BoolGameOption(SIMPLE_NAME(use_modifier_prefix_keys), true),
         new BoolGameOption(SIMPLE_NAME(easy_exit_menu), false),
         new BoolGameOption(SIMPLE_NAME(ability_menu), true),
         new BoolGameOption(SIMPLE_NAME(easy_floor_use), true),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -432,6 +432,8 @@ public:
     int         level_map_cursor_step;  // The cursor increment in the level
                                         // map.
 
+    bool        use_modifier_prefix_keys; // Treat '/' as SHIFT and '*' as CTRL
+
     // If the player prefers to merge kill records, this option can do that.
     int         kill_map[KC_NCATEGORIES];
 


### PR DESCRIPTION
A new setting is introduced called `use_modifier_prefix_keys` that
enables and disables '/' behaving as SHIFT and '*' as CTRL.

It's set to true by default.