### PR TITLE
Simplify code for making mimics cackle

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1063,12 +1063,10 @@ static void _mimic_vanish(const coord_def& pos, const string& name)
     const char* const smoke_str = can_place_smoke ? " in a puff of smoke" : "";
 
     const bool can_cackle = !silenced(pos) && !silenced(you.pos());
-    const string db_cackle = getSpeakString("_laughs_");
-    const string cackle = db_cackle != "" ? db_cackle : "cackles";
-    const string cackle_str = can_cackle ? cackle + " and " : "";
+    const string cackle = can_cackle ? getSpeakString("_laughs_") + " and " : "";
 
     mprf("The %s mimic %svanishes%s!",
-         name.c_str(), cackle_str.c_str(), smoke_str);
+         name.c_str(), cackle.c_str(), smoke_str);
     interrupt_activity(AI_MIMIC);
 }
 


### PR DESCRIPTION
A huge chunk of it is defending against `"_laughs_"` not being in monspeak.txt,
which is not a very likely scenario. Even if that did happen, the only
consequence of removing this extra logic is displaying a worse string
to the user (not a segfault or a machanics change).

Sending as a PR instead of committing directly since it sounded like geekosaur might disagree with my priorities, so here's a chance for someone to tell me not to merge it.