### PR TITLE
Remove a bunch of #if 0 clauses

### DIFF
--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -560,9 +560,6 @@ void OGLShapeBuffer::add_line(const GLWPrim &rect)
 }
 
 // Draw the buffer
-#if 0
-void OGLShapeBuffer::draw(const GLState &state, const GLW_3VF *pt, const GLW_3VF *ps)
-#endif
 void OGLShapeBuffer::draw(const GLState &state)
 {
     if (m_position_buffer.empty())

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -1481,24 +1481,3 @@ void insert_commands(string &desc, vector<command_type> cmds, bool formatted)
     }
     desc = replace_all(desc, "percent", "%");
 }
-
-#if 0
-// Currently unused, might be useful somewhere.
-static void _list_all_commands(string &commands)
-{
-    for (int i = CMD_NO_CMD; i < CMD_MAX_CMD; i++)
-    {
-        const command_type cmd = (command_type) i;
-
-        const string command_name = command_to_name(cmd);
-        if (command_name == "CMD_NO_CMD")
-            continue;
-
-        if (_context_for_command(cmd) != KMC_DEFAULT)
-            continue;
-
-        commands += command_name + ": " + command_to_string(cmd) + "\n";
-    }
-    commands += "\n";
-}
-#endif

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1187,14 +1187,6 @@ bool monster_info::less_than(const monster_info& m1, const monster_info& m2,
     if (fullname || mons_is_pghost(m1.type))
         return m1.mname < m2.mname;
 
-#if 0 // for now, sort mb together.
-    // By descending mb, so no mb sorts to the end
-    if (m1.mb > m2.mb)
-        return true;
-    else if (m1.mb < m2.mb)
-        return false;
-#endif
-
     return false;
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3078,9 +3078,6 @@ int player_stealth()
         // Now 2 * EP^2 / 3 after EP rescaling.
         const int evp = you.unadjusted_body_armour_penalty();
         const int penalty = evp * evp * 2 / 3;
-#if 0
-        dprf("Stealth penalty for armour (ep: %d): %d", ep, penalty);
-#endif
         stealth -= penalty;
 
         const int pips = armour_type_prop(arm->sub_type, ARMF_STEALTH);

--- a/crawl-ref/source/tilereg-abl.cc
+++ b/crawl-ref/source/tilereg-abl.cc
@@ -110,13 +110,6 @@ bool AbilityRegion::update_tip_text(string& tip)
         cmd.push_back(CMD_USE_ABILITY);
     }
 
-    // TODO: command to display abilities outside of use
-#if 0
-    tip += "\n[R-Click] Describe (%)";
-    cmd.push_back(CMD_DISPLAY_SPELLS);
-    insert_commands(tip, cmd);
-#endif
-
     return true;
 }
 

--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -169,10 +169,6 @@ void MapRegion::update_bounds()
         }
 
     recenter();
-#if 0
-    // Not needed? (jpeg)
-    m_dirty = true;
-#endif
 }
 
 void MapRegion::set_window(const coord_def &start, const coord_def &end)

--- a/crawl-ref/source/tilereg-menu.cc
+++ b/crawl-ref/source/tilereg-menu.cc
@@ -107,14 +107,6 @@ int MenuRegion::handle_mouse(MouseEvent &event)
 
             return m_entries[entry].key;
         }
-#if 0
-        // TODO enne - these events are wonky on OS X.
-        // TODO enne - fix menus so that mouse wheeling doesn't easy exit
-        case MouseEvent::SCROLL_UP:
-            return CK_UP;
-        case MouseEvent::SCROLL_DOWN:
-            return CK_DOWN;
-#endif
         default:
             return 0;
         }

--- a/crawl-ref/source/tilereg-text.cc
+++ b/crawl-ref/source/tilereg-text.cc
@@ -162,14 +162,6 @@ void TextRegion::cgotoxy(int x, int y)
     print_x = x-1;
     print_y = y-1;
 
-#if 0
-    if (cursor_region != nullptr && cursor_flag)
-    {
-        cursor_x = -1;
-        cursor_y = -1;
-        cursor_region = nullptr;
-    }
-#endif
     if (cursor_flag)
     {
         cursor_x = print_x;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -591,27 +591,6 @@ int TilesFramework::handle_mouse(MouseEvent &event)
             return CK_MOUSE_CMD;
     }
 
-    // TODO enne - in what cases should the buttons be returned?
-#if 0
-    // If nothing else, return the mouse button that was pressed.
-    switch (event.button)
-    {
-    case MouseEvent::LEFT:
-        return CK_MOUSE_B1;
-    case MouseEvent::RIGHT:
-        return CK_MOUSE_B2;
-    case MouseEvent::MIDDLE:
-        return CK_MOUSE_B3;
-    case MouseEvent::SCROLL_UP:
-        return CK_MOUSE_B4;
-    case MouseEvent::SCROLL_DOWN:
-        return CK_MOUSE_B5;
-    default:
-    case MouseEvent::NONE:
-        return 0;
-    }
-#endif
-
     return 0;
 }
 


### PR DESCRIPTION
Mostly these were many-years-old TODOs that never got done,
or some debugging code meant to be toggled by editing the source.
The former are never going to get done, and the latter are doing
things the wrong way: they should use some debug variable, if they
are important toggles to keep. But I think they're not important, and
the authors of these debug options have moved on, so away goes the
dead code. If you miss any of these badly, feel free to add them back
in controlled by a flag.

I left in two `#if 0` clauses that looked like they might be valuable
someday:

- One in dbg-asrt.cc representing partial work towards a solution of
  a difficult problem (better ASSERTs on Windows tiles) that someone
  with more expertise in the right area could pick up someday.
- One in fontwrapper-ft.cc that enabled some detailed debug logging
  for font rendering in tiles. This one looks better than most for
  being converted into a proper flag-toggled log macro.