### PR TITLE
Clarify failure message for quaffing !invis while haloed (Yermak, #11104)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4750,18 +4750,19 @@ bool invis_allowed(bool quiet, string *fail_reason)
 
     if (you.haloed() && you.halo_radius() != -1)
     {
-        if (player_equip_unrand(UNRAND_EOS))
-            reason = "Your weapon shines too brightly";
-        if (you.attribute[ATTR_HEAVENLY_STORM] > 0 ||
-            you.religion == GOD_SHINING_ONE)
-        {
-            if (reason.empty())
-                reason = "Your divine halo glows too radiantly";
-            else
-                reason = "Your weapon and divine halo glow too brightly";
-        }
+        bool divine = you.attribute[ATTR_HEAVENLY_STORM] > 0 ||
+                you.religion == GOD_SHINING_ONE;
+        bool weapon = player_equip_unrand(UNRAND_EOS);
 
-        ASSERT(!reason.empty());
+        if (divine && weapon)
+            reason = "Your weapon and divine halo glow too brightly";
+        else if (divine)
+            reason = "Your divine halo glows too radiantly";
+        else if (weapon)
+            reason = "Your weapon shines too brightly";
+        else
+            die("haloed by an unknown source");
+
         msg = reason + " to become invisible.";
         success = false;
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4751,15 +4751,18 @@ bool invis_allowed(bool quiet, string *fail_reason)
     if (you.haloed() && you.halo_radius() != -1)
     {
         if (player_equip_unrand(UNRAND_EOS))
-            reason = "weapon";
+            reason = "Your weapon shines too brightly";
         if (you.attribute[ATTR_HEAVENLY_STORM] > 0 ||
             you.religion == GOD_SHINING_ONE)
         {
-            reason = (reason == "" ? "Divine Halo" : reason + " and Divine Halo");
+            if (reason.empty())
+                reason = "Your divine halo glows too radiantly";
+            else
+                reason = "Your weapon and divine halo glow too brightly";
         }
 
-        ASSERT(reason != "");
-        msg = "Your " + reason + " prevents invisibility.";
+        ASSERT(!reason.empty());
+        msg = reason + " to become invisible.";
         success = false;
     }
     else if (you.backlit())

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4745,11 +4745,21 @@ void dec_channel_player(int delay)
 bool invis_allowed(bool quiet, string *fail_reason)
 {
     string msg;
+    string reason = "";
     bool success = true;
 
     if (you.haloed() && you.halo_radius() != -1)
     {
-        msg = "Your halo prevents invisibility.";
+        if (player_equip_unrand(UNRAND_EOS))
+            reason = "weapon";
+        if (you.attribute[ATTR_HEAVENLY_STORM] > 0 ||
+            you.religion == GOD_SHINING_ONE)
+        {
+            reason = (reason == "" ? "Divine Halo" : reason + " and Divine Halo");
+        }
+
+        ASSERT(reason != "");
+        msg = "Your " + reason + " prevents invisibility.";
         success = false;
     }
     else if (you.backlit())


### PR DESCRIPTION
See: https://crawl.develz.org/mantis/view.php?id=11104

Currently, self-haloing prevents !invis, even when umbraed.

The issue is, the msg to the player is vague and doesn't clarify that the reason the player can't go invisible at all is due to their weapon (EOS) or their Divine Halo (TSO or Wu Jian). Additionally, since the player is actually able to quaff !invis when non-self-haloed haloed (angels, sunshine, etc) + umbraed, it could be confusing and feel inconsistent. 

With this fix, the actual reason for preventing quaffing !invis is provided to the player.

I don't know if I'm using ASSERT appropriately, but my concern was a future halo source that wouldn't get properly handled by this message.  I'm assuming there may be a better way to do what I'm trying to do.

I also briefly considered just allowing quaffing !invis always if you were haloed (any source) + umbraed, but the code seems to intentionally make the distinction between self-halos and simply being backlit by an external halo source, so I didn't change the behavior.

