### PR TITLE
Don't let local-tiles players use god abilities under penance

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1300,15 +1300,12 @@ static bool _check_ability_possible(const ability_def& abil,
         }
     }
 
-    const god_power* god_power;
-    if (god_power_from_ability(abil.ability, &god_power))
+    const god_power* god_power = god_power_from_ability(abil.ability);
+    if (god_power && !god_power_usable(*god_power))
     {
-        if (!god_power_usable(*god_power))
-        {
-            if (!quiet)
-                canned_msg(MSG_GOD_DECLINES);
-            return false;
-        }
+        if (!quiet)
+            canned_msg(MSG_GOD_DECLINES);
+        return false;
     }
 
     vector<text_pattern> &actions = Options.confirm_action;

--- a/crawl-ref/source/canned-message-type.h
+++ b/crawl-ref/source/canned-message-type.h
@@ -41,4 +41,5 @@ enum canned_message_type
     MSG_MAGIC_DRAIN,
     MSG_SOMETHING_IN_WAY,
     MSG_CANNOT_SEE,
+    MSG_GOD_DECLINES,
 };

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1823,6 +1823,9 @@ void canned_msg(canned_message_type which_message)
         case MSG_CANNOT_SEE:
             mpr("You can't see that place.");
             break;
+        case MSG_GOD_DECLINES:
+            mpr("Your god isn't willing to do this for you now.");
+            break;
     }
 }
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4673,16 +4673,16 @@ bool god_power_usable(const god_power& power, bool ignore_piety, bool ignore_pen
         return false;
     const ability_type abil = fixup_ability(power.abil);
     ASSERT(abil != ABIL_NON_ABILITY);
-    return ((power.rank <= 0
-             || power.rank == 7 && can_do_capstone_ability(you.religion)
-             || piety_rank() >= power.rank
-             || ignore_piety)
-            && (!player_under_penance()
-                || power.rank == -1
-                || ignore_penance));
+    return (power.rank <= 0
+            || power.rank == 7 && can_do_capstone_ability(you.religion)
+            || piety_rank() >= power.rank
+            || ignore_piety)
+           && (!player_under_penance()
+               || power.rank == -1
+               || ignore_penance);
 }
 
-bool god_power_from_ability(ability_type abil, const god_power** result)
+const god_power* god_power_from_ability(ability_type abil)
 {
     for (int god = GOD_NO_GOD; god < NUM_GODS; god++)
     {
@@ -4690,10 +4690,9 @@ bool god_power_from_ability(ability_type abil, const god_power** result)
         {
             if (power.abil == abil)
             {
-                *result = &power;
-                return true;
+                return &power;
             }
         }
     }
-    return false;
+    return nullptr;
 }

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4665,3 +4665,35 @@ vector<god_type> nontemple_god_list()
     sort(god_list.begin(), god_list.end(), _cmp_god_by_name);
     return god_list;
 }
+
+bool god_power_usable(const god_power& power, bool ignore_piety, bool ignore_penance)
+{
+    // not an activated power
+    if (power.abil == ABIL_NON_ABILITY)
+        return false;
+    const ability_type abil = fixup_ability(power.abil);
+    ASSERT(abil != ABIL_NON_ABILITY);
+    return ((power.rank <= 0
+             || power.rank == 7 && can_do_capstone_ability(you.religion)
+             || piety_rank() >= power.rank
+             || ignore_piety)
+            && (!player_under_penance()
+                || power.rank == -1
+                || ignore_penance));
+}
+
+bool god_power_from_ability(ability_type abil, const god_power** result)
+{
+    for (int god = GOD_NO_GOD; god < NUM_GODS; god++)
+    {
+        for (const auto& power : god_powers[god])
+        {
+            if (power.abil == abil)
+            {
+                *result = &power;
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -195,5 +195,5 @@ struct god_power
 
 void set_god_ability_slots();
 vector<god_power> get_god_powers(god_type god);
-bool god_power_from_ability(ability_type abil, const god_power** result);
+const god_power* god_power_from_ability(ability_type abil);
 bool god_power_usable(const god_power& power, bool ignore_piety=false, bool ignore_penance=false);

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -195,3 +195,5 @@ struct god_power
 
 void set_god_ability_slots();
 vector<god_power> get_god_powers(god_type god);
+bool god_power_from_ability(ability_type abil, const god_power** result);
+bool god_power_usable(const god_power& power, bool ignore_piety=false, bool ignore_penance=false);

--- a/crawl-ref/source/tilereg-abl.cc
+++ b/crawl-ref/source/tilereg-abl.cc
@@ -65,6 +65,9 @@ int AbilityRegion::handle_mouse(MouseEvent &event)
 
         m_last_clicked_item = item_idx;
         tiles.set_need_redraw();
+        // TODO get_talent returns ABIL_NON_ABILITY if you are confused,
+        // but not if you're silenced/penanced, so you only get a message in the
+        // latter case. We'd like these three cases to behave similarly.
         talent tal = get_talent(ability, true);
         if (tal.which == ABIL_NON_ABILITY || !activate_talent(tal))
             flush_input_buffer(FLUSH_ON_FAILURE);


### PR DESCRIPTION
In https://crawl.develz.org/mantis/view.php?id=11203, UsaSatsui reports that when playing local tiles, you can use god abilities while under penance, provided that you click their icon rather than trying to use them through the (a) menu.

I fixed this by adding a `god_power_usable` function, and then referencing that from within the existing `_check_ability_possible` function, which is used by the tiles renderer to decide how to draw the ability as well as whether to activate it or print an error message when clicked.

I would welcome a style or functionality review before merging. I did test the change, and it appears to work, but of course there could be edge cases I'm not thinking of.