### PR TITLE
Remove monster spawns tweak level monster generation

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1338,12 +1338,12 @@ static int _num_mons_wanted()
         return 0;
 
     if (player_in_branch(BRANCH_CRYPT))
-        return roll_dice(3, 13);
+        return roll_dice(3, 10);
 
-    int mon_wanted = roll_dice(3, 15);
+    int mon_wanted = roll_dice(3, 12);
 
     if (player_in_hell())
-        mon_wanted += roll_dice(3, 13);
+        mon_wanted += roll_dice(3, 10);
 
     if (mon_wanted > 60)
         mon_wanted = 60;

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1338,12 +1338,12 @@ static int _num_mons_wanted()
         return 0;
 
     if (player_in_branch(BRANCH_CRYPT))
-        return roll_dice(3, 10);
+        return roll_dice(3, 13);
 
-    int mon_wanted = roll_dice(3, 12);
+    int mon_wanted = roll_dice(3, 15);
 
     if (player_in_hell())
-        mon_wanted += roll_dice(3, 10);
+        mon_wanted += roll_dice(3, 13);
 
     if (mon_wanted > 60)
         mon_wanted = 60;

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -3763,7 +3763,6 @@ static void _builder_monsters()
     int mon_wanted = _num_mons_wanted();
 
     const bool in_shoals = player_in_branch(BRANCH_SHOALS);
-    const bool in_pan    = player_in_branch(BRANCH_PANDEMONIUM);
     if (in_shoals)
         dgn_shoals_generate_flora();
 
@@ -3777,12 +3776,20 @@ static void _builder_monsters()
     for (int i = 0; i < mon_wanted; i++)
     {
         mgen_data mg;
-        if (!in_pan)
+        // Chance to generate the monster awake, but away from level stairs.
+        if (player_in_connected_branch()
+            // Exclude D:1 from generating these awake monsters.
+            && (!player_in_branch(BRANCH_DUNGEON) || you.depth > 1)
+            && one_chance_in(8))
+        {
+            mg.proximity = PROX_AWAY_FROM_STAIRS;
+        }
+        // Pan monsters always generate awake.
+        else if (!player_in_branch(BRANCH_PANDEMONIUM))
             mg.behaviour = BEH_SLEEP;
         mg.flags    |= MG_PERMIT_BANDS;
         mg.map_mask |= MMT_NO_MONS;
         mg.preferred_grid_feature = preferred_grid_feature;
-
         place_monster(mg);
     }
 

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1338,12 +1338,12 @@ static int _num_mons_wanted()
         return 0;
 
     if (player_in_branch(BRANCH_CRYPT))
-        return roll_dice(3, 8);
+        return roll_dice(3, 10);
 
-    int mon_wanted = roll_dice(3, 10);
+    int mon_wanted = roll_dice(3, 12);
 
     if (player_in_hell())
-        mon_wanted += roll_dice(3, 8);
+        mon_wanted += roll_dice(3, 10);
 
     if (mon_wanted > 60)
         mon_wanted = 60;

--- a/crawl-ref/source/mgen-enum.h
+++ b/crawl-ref/source/mgen-enum.h
@@ -128,6 +128,7 @@ enum proximity_type   // proximity to player to create monster
     PROX_ANYWHERE,
     PROX_CLOSE_TO_PLAYER,
     PROX_AWAY_FROM_PLAYER,
+    PROX_AWAY_FROM_STAIRS,
 };
 
 enum mgen_flag

--- a/crawl-ref/source/mgen-enum.h
+++ b/crawl-ref/source/mgen-enum.h
@@ -128,7 +128,6 @@ enum proximity_type   // proximity to player to create monster
     PROX_ANYWHERE,
     PROX_CLOSE_TO_PLAYER,
     PROX_AWAY_FROM_PLAYER,
-    PROX_NEAR_STAIRS,
 };
 
 enum mgen_flag

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -619,7 +619,7 @@ static bool _valid_monster_generation_location(const mgen_data &mg,
     // Check that the location is not proximal to level stairs.
     else if (mg.proximity == PROX_AWAY_FROM_STAIRS)
     {
-        for (distance_iterator di(mg_pos, false, LOS_RADIUS); di; ++di)
+        for (distance_iterator di(mg_pos, false, false, LOS_RADIUS); di; ++di)
             if (feat_is_stone_stair(grd(*di)))
                 return false;
     }

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -616,6 +616,13 @@ static bool _valid_monster_generation_location(const mgen_data &mg,
     {
         return false;
     }
+    // Check that the location is not proximal to level stairs.
+    else if (mg.proximity == PROX_AWAY_FROM_STAIRS)
+    {
+        for (distance_iterator di(mg_pos, false, LOS_RADIUS); di; ++di)
+            if (feat_is_stone_stair(grd(*di)))
+                return false;
+    }
 
     // Don't generate monsters on top of teleport traps.
     // (How did they get there?)

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -950,7 +950,7 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
         while (true)
         {
             if (tries++ >= 45)
-                return 0;
+                return nullptr;
 
             // Placement already decided for PROX_NEAR_STAIRS.
             // Else choose a random point on the map.
@@ -1029,17 +1029,16 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
             break;
         } // end while... place first monster
     }
+    // Sanity check that the specified position is valid.
     else if (!_valid_monster_generation_location(mg) && !dont_place)
-    {
-        // Sanity check that the specified position is valid.
-        return 0;
-    }
+        return nullptr;
 
-    monster* mon = _place_monster_aux(mg, 0, place, force_pos, dont_place);
+    monster* mon
+        = _place_monster_aux(mg, nullptr, place, force_pos, dont_place);
 
     // Bail out now if we failed.
     if (!mon)
-        return 0;
+        return nullptr;
 
     if (mg.props.exists("map"))
         mon->set_originating_map(mg.props["map"].get_string());
@@ -1216,7 +1215,8 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
     // If the space is occupied, try some neighbouring square instead.
     if (dont_place)
         fpos.reset();
-    else if (leader == 0 && in_bounds(mg.pos)
+    else if (!leader
+        && in_bounds(mg.pos)
         && (mg.behaviour == BEH_FRIENDLY ||
             (!is_sanctuary(mg.pos) || mons_is_tentacle_segment(montype)))
         && !monster_at(mg.pos)


### PR DESCRIPTION
This PR is to review this branch for any technical issues (mostly a bunch of removed monster placement code) and discuss any needed changes to monster generation.

In this branch, monster spawns are gone from connected branches, taking place only on the Orb run in Abyss and Pan with the behavior in those branches essentially unchanged. Monsters no longer have a chance to try to spawn "from" staircases and using the monster lists of those stair's destination level. The code that did this was quite broken, placing fewer than intended "stair monsters", but it's generally just not a useful mechanic, since it either makes weaker monsters from earlier levels or out-of-branch monsters that could be done using vaults.  Also gone is a very weird and extremely rare mechanic that tried to push the player off stairs if the monster spawned on a staircase that the player occupied.

The recently addes xp_by_level table shows that 8-13% of XP in won games comes from spawns. This table is enabled by default in trunk and should be accurate for any game on or after 0.21-a0-218-g8aba26b (use keyword `xpinfo` with `!lg` to find such games). To compensate for XP loss from spawn removal, I've increased level monster generation from 3d10 to 3d12  in all branches except Crypt, with Crypt going from 3d8 to 3d10 instead and Vestibul's extra monsters going from 3d8 to 3d10 (the comment in the relevant commit incorrectly says 2d6 more for most branches). Objstat says this will give about 9% more XP for the Dungeon branch, but I will have to rerun this for an entire set of branches. 

You can find the morgue for a qw GrBe win from this branch [here](http://dpaste.com/3PTBSNA), and [here](http://dpaste.com/00BFNHR) is a qw GrBe win from trunk for comparison. It looks like nospawn is giving qw closer to 33% more XP. If this is not just variance betwen the runs, we might want to make the number of level monsters depend a bit on absdepth. A complete objstat run should give a better picture when I have time to run that.

Another issue is whether we want to do more to prevent players from lingering a long time on the level. The old OOD spawns were bad for just giving scumming potential, but it might be possible to use no-XP durable summons or perhaps even normal summons just spawned near the player. If find these solutions to be fairly annoying, especially durable summons, and we do have the food clock for the time being.