### PR TITLE
Allow setting attitude of cloned monsters (damerell, #11171)

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1551,7 +1551,7 @@ static spret_type _phantom_mirror()
     const int surge = pakellas_surge_devices();
     surge_power(you.spec_evoke() + surge);
 
-    monster* mon = clone_mons(victim, true);
+    monster* mon = clone_mons(victim, true, nullptr, ATT_FRIENDLY);
     if (!mon)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
@@ -1565,7 +1565,6 @@ static spret_type _phantom_mirror()
                              surge)
                          * (100 - victim->check_res_magic(power)) / 100));
 
-    mon->attitude = ATT_FRIENDLY;
     mon->mark_summoned(dur, true, SPELL_PHANTOM_MIRROR);
 
     mon->summoner = MID_PLAYER;

--- a/crawl-ref/source/mon-attitude-type.h
+++ b/crawl-ref/source/mon-attitude-type.h
@@ -7,5 +7,4 @@ enum mon_attitude_type
     ATT_STRICT_NEUTRAL,                // neutral, won't attack player. Used by Jiyva.
     ATT_GOOD_NEUTRAL,                  // neutral, but won't attack friendlies
     ATT_FRIENDLY,                      // created friendly (or tamed?)
-    ATT_SAME,                          // cloned monster attitude
 };

--- a/crawl-ref/source/mon-attitude-type.h
+++ b/crawl-ref/source/mon-attitude-type.h
@@ -7,4 +7,5 @@ enum mon_attitude_type
     ATT_STRICT_NEUTRAL,                // neutral, won't attack player. Used by Jiyva.
     ATT_GOOD_NEUTRAL,                  // neutral, but won't attack friendlies
     ATT_FRIENDLY,                      // created friendly (or tamed?)
+    ATT_SAME,                          // cloned monster attitude
 };

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -259,6 +259,18 @@ bool mons_clonable(const monster* mon, bool needs_adjacent)
  * @param orig          The original monster to clone.
  * @param quiet         If true, suppress messages
  * @param obvious       If true, player can see the orig & cloned monster
+ * @return              Returns the cloned monster
+ */
+monster* clone_mons(const monster* orig, bool quiet, bool* obvious)
+{
+    // Pass temp_attitude to handle enslaved monsters cloning monsters
+    return clone_mons(orig, quiet, obvious, orig->temp_attitude());
+}
+
+/**
+ * @param orig          The original monster to clone.
+ * @param quiet         If true, suppress messages
+ * @param obvious       If true, player can see the orig & cloned monster
  * @param mon_att       The attitude to set for the cloned monster
  * @return              Returns the cloned monster
  */
@@ -290,8 +302,7 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
     *mons          = *orig;
     mons->set_new_monster_id();
     mons->move_to_pos(pos);
-    mons->attitude = mon_att == ATT_SAME ?
-            orig->attitude : mon_att;
+    mons->attitude = mon_att;
 
     // The monster copy constructor doesn't copy constriction, so no need to
     // worry about that.

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -86,25 +86,12 @@ static void _mons_summon_monster_illusion(monster* caster,
         return;
 
     bool cloning_visible = false;
-    monster *clone = nullptr;
 
-    // [ds] Bind the original target's attitude before calling
-    // clone_mons, since clone_mons also updates arena bookkeeping.
-    //
     // If an enslaved caster creates a clone from a regular hostile,
     // the clone should still be friendly.
-    //
-    // This is all inside its own block so the unwind_var will be unwound
-    // before we use foe->name below.
-    {
-        const mon_attitude_type clone_att =
-            caster->friendly() ? ATT_FRIENDLY : caster->attitude;
-
-        unwind_var<mon_attitude_type> att(foe->attitude, clone_att);
-        clone = clone_mons(foe, true, &cloning_visible);
-    }
-
-    if (clone)
+    if (monster *clone = clone_mons(foe, true, &cloning_visible,
+                                    caster->friendly() ?
+                                    ATT_FRIENDLY : caster->attitude))
     {
         const string clone_id = _monster_clone_id_for(foe);
         clone->props[CLONE_SLAVE_KEY] = clone_id;

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -269,7 +269,7 @@ bool mons_clonable(const monster* mon, bool needs_adjacent)
 }
 
 monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
-                    coord_def pos)
+                    mon_attitude_type mon_att, coord_def pos)
 {
     // Is there an open slot in menv?
     monster* mons = get_free_monster();
@@ -299,6 +299,9 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
     *mons          = *orig;
     mons->set_new_monster_id();
     mons->move_to_pos(pos);
+    mons->attitude = mon_att == ATT_SAME ?
+            orig->attitude : mon_att;
+
     // The monster copy constructor doesn't copy constriction, so no need to
     // worry about that.
 

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -256,32 +256,29 @@ bool mons_clonable(const monster* mon, bool needs_adjacent)
 }
 
 monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
-                    mon_attitude_type mon_att, coord_def pos)
+                    mon_attitude_type mon_att)
 {
     // Is there an open slot in menv?
     monster* mons = get_free_monster();
+    coord_def pos(0, 0);
 
     if (!mons)
         return nullptr;
 
-    if (!in_bounds(pos))
+    for (fair_adjacent_iterator ai(orig->pos()); ai; ++ai)
     {
-        for (fair_adjacent_iterator ai(orig->pos()); ai; ++ai)
+        if (in_bounds(*ai)
+            && !actor_at(*ai)
+            && monster_habitable_grid(orig, grd(*ai)))
         {
-            if (in_bounds(*ai)
-                && !actor_at(*ai)
-                && monster_habitable_grid(orig, grd(*ai)))
-            {
-                pos = *ai;
-            }
+            pos = *ai;
         }
-
-        if (!in_bounds(pos))
-            return nullptr;
     }
 
+    if (!in_bounds(pos))
+        return nullptr;
+
     ASSERT(!actor_at(pos));
-    ASSERT_IN_BOUNDS(pos);
 
     *mons          = *orig;
     mons->set_new_monster_id();

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -255,6 +255,13 @@ bool mons_clonable(const monster* mon, bool needs_adjacent)
     return true;
 }
 
+/*
+ * @param orig          The original monster to clone.
+ * @param quiet         If true, suppress messages
+ * @param obvious       If true, player can see the orig & cloned monster
+ * @param mon_att       The attitude to set for the cloned monster
+ * @return              Returns the cloned monster
+ */
 monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
                     mon_attitude_type mon_att)
 {

--- a/crawl-ref/source/mon-clone.h
+++ b/crawl-ref/source/mon-clone.h
@@ -9,8 +9,7 @@
 bool mons_clonable(const monster* orig, bool needs_adjacent = true);
 monster *clone_mons(const monster* orig, bool quiet = false,
                     bool* obvious = nullptr,
-                    mon_attitude_type mon_att = ATT_SAME,
-                    coord_def pos = coord_def(0, 0));
+                    mon_attitude_type mon_att = ATT_SAME);
 
 void mons_summon_illusion_from(monster* mons, actor *foe,
                                spell_type spell_cast = SPELL_NO_SPELL,

--- a/crawl-ref/source/mon-clone.h
+++ b/crawl-ref/source/mon-clone.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include "mon-attitude-type.h"
+
 #define CLONE_MASTER_KEY "mcloneorig"
 #define CLONE_SLAVE_KEY "mclonedupe"
 
 // Formerly in mon-stuff:
 bool mons_clonable(const monster* orig, bool needs_adjacent = true);
 monster *clone_mons(const monster* orig, bool quiet = false,
-                    bool* obvious = nullptr, coord_def pos = coord_def(0, 0));
+                    bool* obvious = nullptr,
+                    mon_attitude_type mon_att = ATT_SAME,
+                    coord_def pos = coord_def(0, 0));
 
 void mons_summon_illusion_from(monster* mons, actor *foe,
                                spell_type spell_cast = SPELL_NO_SPELL,

--- a/crawl-ref/source/mon-clone.h
+++ b/crawl-ref/source/mon-clone.h
@@ -8,8 +8,10 @@
 // Formerly in mon-stuff:
 bool mons_clonable(const monster* orig, bool needs_adjacent = true);
 monster *clone_mons(const monster* orig, bool quiet = false,
-                    bool* obvious = nullptr,
-                    mon_attitude_type mon_att = ATT_SAME);
+                    bool* obvious = nullptr);
+
+monster *clone_mons(const monster* orig, bool quiet,
+                    bool* obvious, mon_attitude_type mon_att);
 
 void mons_summon_illusion_from(monster* mons, actor *foe,
                                spell_type spell_cast = SPELL_NO_SPELL,


### PR DESCRIPTION
See https://crawl.develz.org/mantis/view.php?id=11171

This implements option 3 from the bug report.
clone_mons() now accepts monster_attitude_type as a default parameter.  This allows us to directly set the monster attitude to handle the bug in question and maybe bypass some funky gymnastics related to the bug in question.

Additionally, an unused default parameter, pos, is removed from clone_mons() because it is not passed by any of the other locations that call clone_mons().

Finally, the call to clone_mons() from _phantom_mirror() has been updated to pass ATT_FRIENDLY.