### PR TITLE
Improve spell failure % warning messages (tedric, Zenthirum, #9686)

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1127,14 +1127,17 @@ static bool _spellcasting_aborted(spell_type spell, bool fake_spell)
     }
 
     const int severity = fail_severity(spell);
+    const int failure = failure_rate_to_int(raw_spell_fail(spell));
     if (Options.fail_severity_to_confirm > 0
         && Options.fail_severity_to_confirm <= severity
         && !crawl_state.disables[DIS_CONFIRMATIONS]
         && !fake_spell)
     {
-        string prompt = make_stringf("The spell is %s to cast%s "
+        string prompt = make_stringf("The spell is %s to cast "
+                                     "(%d%% risk of failure)%s "
                                      "Continue anyway?",
                                      fail_severity_adjs[severity],
+                                     failure,
                                      severity > 1 ? "!" : ".");
 
         if (!yesno(prompt.c_str(), false, 'n'))

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1127,19 +1127,26 @@ static bool _spellcasting_aborted(spell_type spell, bool fake_spell)
     }
 
     const int severity = fail_severity(spell);
-    const int failure = failure_rate_to_int(raw_spell_fail(spell));
+    const string failure = failure_rate_to_string(raw_spell_fail(spell));
     if (Options.fail_severity_to_confirm > 0
         && Options.fail_severity_to_confirm <= severity
         && !crawl_state.disables[DIS_CONFIRMATIONS]
         && !fake_spell)
     {
         string prompt = make_stringf("The spell is %s to cast "
-                                     "(%d%% risk of failure)%s "
-                                     "Continue anyway?",
+                                     "(%s risk of failure)%s ",
                                      fail_severity_adjs[severity],
-                                     failure,
+                                     failure.c_str(),
                                      severity > 1 ? "!" : ".");
 
+        if (failure == "100%")
+        {
+            mprf(MSGCH_WARN, "%s", prompt.c_str());
+            mprf(MSGCH_WARN, "It is impossible to cast this spell!");
+            return true;
+        }
+
+        prompt = make_stringf("%s Continue anyway?", prompt.c_str());
         if (!yesno(prompt.c_str(), false, 'n'))
         {
             canned_msg(MSG_OK);

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -728,9 +728,18 @@ bool cast_a_spell(bool check_range, spell_type spell)
                 }
                 else
                 {
-                    mprf(MSGCH_PROMPT, "Casting: <w>%s</w>",
-                         spell_title(you.last_cast_spell));
-                    mprf(MSGCH_PROMPT, "Confirm with . or Enter, or press ? or * to list all spells.");
+                    ostringstream desc;
+                    const string failure = failure_rate_to_string(raw_spell_fail(you.last_cast_spell));
+                    int colour = failure_rate_colour(you.last_cast_spell);
+                    desc << "<" << colour_to_str(colour) << ">";
+                    desc << chop_string(failure, failure.length());
+                    desc << "</" << colour_to_str(colour) << ">";
+                    mprf(MSGCH_PROMPT, "Casting: <w>%s "
+                                       "(%s risk of failure)</w>",
+                                       spell_title(you.last_cast_spell),
+                                       desc.str().c_str());
+                    mprf(MSGCH_PROMPT, "Confirm with . or Enter, or press "
+                                       "? or * to list all spells.");
                 }
 
                 keyin = get_ch();


### PR DESCRIPTION
See https://crawl.develz.org/mantis/view.php?id=9686

tedric originally proposed this update.
Zenthirum uploaded a fix for the "dangerous" message.

Edited to keep consistent with current PR.
I made the following changes:

1. adds spell failure % for last_used_spell (z) menu.
2. colourizes spell failure % for last_used_spell (z) menu.
3. adds spell failure % for 'dangerous failure rate' warning prompt (not colour-coded because there are already adjectives that handle this)
4. prevents player from casting a spell with 100% failure rate (see rationale in commit message)

This feels pretty nice when playing since you don't have to keep pulling up z? every time you want to check fail %.

