### PR TITLE
Ghoul HP regeneration near submerged enemies

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1077,7 +1077,8 @@ bool regeneration_is_inhibited()
         {
             if (mons_is_threatening(**mi)
                 && !mi->wont_attack()
-                && !mi->neutral())
+                && !mi->neutral()
+                && !mi->submerged())
             {
                 return true;
             }


### PR DESCRIPTION
While waiting in an area if there are submerged enemies nearby ghoul hp does not regenerate. Occurs very often in swamp with swamp worms.
Mutation text in game states: You do not regenerate when monsters are visible.

Changed the mutation to ignore submerged enemies.

(Issue's: 0011199, 0011197 on Mantis.)