### PR TITLE
Disperse clouds under player when evoking wind blasts (#10709)

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1336,7 +1336,7 @@ void wind_blast(actor* agent, int pow, coord_def target, bool card)
 
     // Now move clouds
     vector<coord_def> cloud_list;
-    for (distance_iterator di(agent->pos(), true, true, radius + 2); di; ++di)
+    for (distance_iterator di(agent->pos(), true, false, radius + 2); di; ++di)
     {
         if (cloud_at(*di)
             && cell_see_cell(agent->pos(), *di, LOS_SOLID)
@@ -1354,6 +1354,13 @@ void wind_blast(actor* agent, int pow, coord_def target, bool card)
 
         int dist = cloud_list[i].distance_from(agent->pos());
         int push = (dist > 5 ? 2 : dist > 2 ? 3 : 4);
+
+        if (dist == 0 && agent->is_player())
+        {
+            delete_cloud(agent->pos());
+            mpr("The clouds under your feet have been blown away!");
+            break;
+        }
 
         for (unsigned int j = 0;
              j < wind_beam.path_taken.size() - 1 && push;


### PR DESCRIPTION
See: https://crawl.develz.org/mantis/view.php?id=10709
and
https://crawl.develz.org/mantis/view.php?id=8420

Pretty straightforward. When using Fan of Gales or Storm Card, the cloud under the player's feet is not dispersed.

The main issue was the distance_iterator's 3rd argument is a bool that excludes the center, which was set to true.  All I did was flip to false then handle the case where the distance from the player to a cloud == 0 and just delete the cloud.

Tested by evoking fans and storm cards and summoning sojobo and a couple wind drakes.