### PR TITLE
Discourage summoned creatures from Bolting their summoners (jwoodward48ss, #10710)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4108,8 +4108,12 @@ void bolt::tracer_nonenchantment_affect_monster(monster* mon)
         }
         else
         {
-            friend_info.power
-                += 2 * final * mon->get_experience_level() / preac;
+            // Discourage summoned monsters firing on their summoner.
+            if (monster_by_mid(source_id)->summoner == mon->mid)
+                friend_info.power = 100;
+            else
+                friend_info.power
+                    += 2 * final * mon->get_experience_level() / preac;
             friend_info.count++;
         }
     }


### PR DESCRIPTION
See https://crawl.develz.org/mantis/view.php?id=10710

In the mantis item, PleasingFungus recommended just setting friend_info.power to a high number if a summoned monster targets its own summoner, so that's what this does.

I didn't know if 100 is the correct value, but it gets the job done. 

Boggarts will now last indefinitely since their minions will no longer pulverise them with bolts.

