### PR TITLE
Prevent split slimes from inheriting HELD enchantments (heteroy)

### DIFF
--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -134,7 +134,9 @@ bool ugly_thing_mutate(monster& ugly, bool force)
 static void _split_ench_durations(monster* initial_slime, monster* split_off)
 {
     for (const auto &entry : initial_slime->enchantments)
-        split_off->add_ench(entry.second);
+        // Don't let new slimes inherit being held by a web or net
+        if (entry.second.ench != ENCH_HELD)
+            split_off->add_ench(entry.second);
 }
 
 // What to do about any enchantments these two creatures may have?


### PR DESCRIPTION
After slimes were prevented from eating nets, they seem to have begun
inheriting the HELD enchantment if the parent slime was in a net.

This manifested as a 'webbed' slime, which was kinda weird.

Now, when a slime in a net splits, the new slime has no HELD ench, which
actually looks like the slime is oozing through the net.