### PR TITLE
Don't let players win by tripping out the dungeon (minmay, mong, #10708)

### DIFF
--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -427,7 +427,6 @@ static void _new_level_amuses_xom(dungeon_feature_type feat,
  *
  * @param how         How the player is trying to travel.
  *                    (e.g. stairs, traps, portals, etc)
- * @param whence      Not currently used
  * @param forced      True if the player is forcing the traveling attempt.
  *                    (e.g. forcibly exiting the abyss, etc)
  * @param going_up    True if the player is going upstairs.
@@ -439,7 +438,6 @@ static void _new_level_amuses_xom(dungeon_feature_type feat,
  *                    when attempting to leave the dungeon, depth = 1.
  */
 static level_id _travel_destination(const dungeon_feature_type how,
-                                    const dungeon_feature_type whence,
                                     bool forced, bool going_up,
                                     bool known_shaft)
 {
@@ -855,8 +853,8 @@ void take_stairs(dungeon_feature_type force_stair, bool going_up,
     // Latter case is falling down a shaft.
     const bool shaft = known_shaft || force_stair == DNGN_TRAP_SHAFT;
 
-    level_id whither = _travel_destination(how, old_feat,
-                           bool(force_stair), going_up, known_shaft);
+    level_id whither = _travel_destination(how, bool(force_stair), going_up,
+                                           known_shaft);
 
     if (_stop_transition(whither, old_feat, going_up))
         return;

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -422,6 +422,22 @@ static void _new_level_amuses_xom(dungeon_feature_type feat,
     }
 }
 
+/**
+ * Determine destination level.
+ *
+ * @param how         How the player is trying to travel.
+ *                    (e.g. stairs, traps, portals, etc)
+ * @param whence      Not currently used
+ * @param forced      True if the player is forcing the traveling attempt.
+ *                    (e.g. forcibly exiting the abyss, etc)
+ * @param going_up    True if the player is going upstairs.
+ * @param known_shaft True if the player is intentionally shafting themself.
+ * @return            The destination level, if valid. Note the default value
+ *                    of dest is not valid (since depth = -1) and this is
+ *                    generally what is returned for invalid destinations.
+ *                    But note the special case when failing to climb stairs
+ *                    when attempting to leave the dungeon, depth = 1.
+ */
 static level_id _travel_destination(const dungeon_feature_type how,
                                     const dungeon_feature_type whence,
                                     bool forced, bool going_up,
@@ -469,6 +485,9 @@ static level_id _travel_destination(const dungeon_feature_type how,
         // going 'down' into the vestibule are twice as likely to fall, because
         // they have to pass a check here, and later in floor_transition
         // Right solution is probably to use the canonicalized direction everywhere
+
+        // If player falls down the stairs trying to leave the dungeon, we set
+        // the destination depth to 1 (i.e. D:1)
         if (how == DNGN_EXIT_DUNGEON)
             dest.depth = 1;
         return dest;
@@ -814,10 +833,12 @@ void floor_transition(dungeon_feature_type how,
 /**
  * Try to go up or down stairs.
  *
- * @param force_stair The type of stair/portal to take. By default, use whatever
- *      tile is under the player. But this can be overridden (e.g. passing
- *      DNGN_EXIT_ABYSS forces the player out of the abyss)
- * @param force_known_shaft true if the player is shafting themselves via ability
+ * @param force_stair         The type of stair/portal to take. By default,
+ *      use whatever tile is under the player. But this can be overridden
+ *      (e.g. passing DNGN_EXIT_ABYSS forces the player out of the abyss)
+ * @param going_up            True if the player is going upstairs
+ * @param force_known_shaft   True if player is shafting themselves via ability.
+ * @param update_travel_cache True if travel cache should be updated.
  */
 void take_stairs(dungeon_feature_type force_stair, bool going_up,
                  bool force_known_shaft, bool update_travel_cache)

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -533,6 +533,26 @@ static level_id _travel_destination(const dungeon_feature_type how,
 }
 
 /**
+ * Check to see if the level transition should be stopped
+ *
+ * @param dest      The destination level (branch and depth).
+ * @param feat      The dungeon feature the player is standing on.
+ * @param going_up  True if the player is trying to go up stairs.
+ * @return          True if the level transition should be stopped.
+ */
+static bool _stop_transition(level_id dest, dungeon_feature_type feat,
+                             bool going_up)
+{
+    bool trying_to_win = feat == DNGN_EXIT_DUNGEON && going_up;
+
+    // When actually leaving the dungeon, dest is invalid, so if the player is
+    // trying to win, but the destination is valid, something caused the player
+    // to remain in the dungeon (i.e. slipped back downstairs while confused).
+    return (!dest.is_valid() && !trying_to_win) ||
+            (dest.is_valid() &&  trying_to_win);
+}
+
+/**
  * Transition to a different level.
  *
  * @param how The type of stair/portal tile the player is being conveyed through
@@ -817,8 +837,7 @@ void take_stairs(dungeon_feature_type force_stair, bool going_up,
     level_id whither = _travel_destination(how, old_feat,
                            bool(force_stair), going_up, known_shaft);
 
-    if ((!whither.is_valid() && !(old_feat == DNGN_EXIT_DUNGEON && going_up)) ||
-         (whither.is_valid() &&  (old_feat == DNGN_EXIT_DUNGEON && going_up)))
+    if (_stop_transition(whither, old_feat, going_up))
         return;
 
     floor_transition(how, old_feat, whither,

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -464,11 +464,15 @@ static level_id _travel_destination(const dungeon_feature_type how,
     // Falling down is checked before the transition if going upstairs, since
     // it might prevent the transition itself.
     if (going_up && _check_fall_down_stairs(how, true))
+    {
         // TODO: This probably causes an obscure bug where confused players
         // going 'down' into the vestibule are twice as likely to fall, because
         // they have to pass a check here, and later in floor_transition
         // Right solution is probably to use the canonicalized direction everywhere
+        if (how == DNGN_EXIT_DUNGEON)
+            dest.depth = 1;
         return dest;
+    }
 
     if (shaft)
     {
@@ -813,7 +817,8 @@ void take_stairs(dungeon_feature_type force_stair, bool going_up,
     level_id whither = _travel_destination(how, old_feat,
                            bool(force_stair), going_up, known_shaft);
 
-    if (!whither.is_valid() && !(old_feat == DNGN_EXIT_DUNGEON && going_up))
+    if ((!whither.is_valid() && !(old_feat == DNGN_EXIT_DUNGEON && going_up)) ||
+         (whither.is_valid() &&  (old_feat == DNGN_EXIT_DUNGEON && going_up)))
         return;
 
     floor_transition(how, old_feat, whither,


### PR DESCRIPTION
See: https://crawl.develz.org/mantis/view.php?id=10708

Previously, confused players who tripped up the stairs could actually win,
despite getting a message saying they tripped back down.

This update modifies the returned travel destination after tripping if
the player is standing on the dungeon exit. Before, the destination
returned was the default branch with a depth of -1, which would be an
invalid destination. This was ok since this invalid destination would be
interpreted later to prevent going up-stairs after tripping.
However, there was special casing for standing on the dungeon
exit to skip being blocked from transitioning to the destination. This
logic was also updated.

I also refactored some of the logic that handles stopping players from transitioning to an invalid level.  There's also some new docstrings for the functions related to level transitioning, but I'm not happy with the current explanations and I would appreciate any improvements on wording or the formatting.

