### PR TITLE
Fix Webtiles Visible Monsters/Features/Items Menu

### DIFF
--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -26,7 +26,7 @@ function ($, comm, client, enums, dungeon_renderer, cr, util, options) {
     {
         // Brutal Hack to fix Visible Monsters/Features/Items Menu
         if (menu.tag == 'pickup' && !item_selectable(item) && item.level != 1) {
-            elem.remove()
+            elem.remove();
             return;
         }
             

--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -24,6 +24,12 @@ function ($, comm, client, enums, dungeon_renderer, cr, util, options) {
 
     function set_item_contents(item, elem)
     {
+        // Brutal Hack to fix Visible Monsters/Features/Items Menu
+        if (menu.tag == 'pickup' && !item_selectable(item) && item.level != 1) {
+            elem.remove()
+            return;
+        }
+            
         elem.html(util.formatted_string_to_html(item_text(item)));
         var col = item_colour(item);
         elem.removeClass();


### PR DESCRIPTION
The Visible Monsters/Features/Items Menu has had a long standing bug where multi-line items wind up showing duplicated and tabbed inwards:

https://i.imgur.com/HUEZ2LA.png

So, I came up with a fairly brutal hack to fix it. so that my lovely Beogh Bros look much nicer:

https://i.imgur.com/WEYgWrf.png

I tried my best to make sure this didn't screw up any other menus.  I don't think it did, but would love an extra set of eyes.