### PR TITLE
Fixed issue where draconian hat was not shown when equipped

### DIFF
--- a/crawl-ref/source/tiledoll.cc
+++ b/crawl-ref/source/tiledoll.cc
@@ -567,12 +567,6 @@ void pack_doll_buf(SubmergedTileBuffer& buf, const dolls_data &doll,
         flags[TILEP_PART_BOOTS] = is_cent ? TILEP_FLAG_NORMAL : TILEP_FLAG_HIDE;
     }
 
-    // Special case for draconians missing their headgear
-    const bool is_drac = is_player_tile(doll.parts[TILEP_PART_BASE],
-                                        TILEP_BASE_DRACONIAN);
-    if (doll.parts[TILEP_PART_HELM] >= TILEP_PART_DRCHEAD)
-      flags[TILEP_PART_HELM] = is_drac ? TILEP_FLAG_NORMAL : TILEP_FLAG_HIDE;
-
     // Set up mcache data based on equipment. We don't need this lookup if both
     // pairs of offsets are defined in Options.
     int draw_info_count = 0, dind = 0;

--- a/crawl-ref/source/tiledoll.cc
+++ b/crawl-ref/source/tiledoll.cc
@@ -530,10 +530,10 @@ void pack_doll_buf(SubmergedTileBuffer& buf, const dolls_data &doll,
         TILEP_PART_ARM,
         TILEP_PART_HAIR,
         TILEP_PART_BEARD,
+        TILEP_PART_DRCHEAD,
         TILEP_PART_HELM,
         TILEP_PART_HAND1,
-        TILEP_PART_HAND2,
-        TILEP_PART_DRCHEAD
+        TILEP_PART_HAND2
     };
 
     int flags[TILEP_PART_MAX];
@@ -566,6 +566,12 @@ void pack_doll_buf(SubmergedTileBuffer& buf, const dolls_data &doll,
     {
         flags[TILEP_PART_BOOTS] = is_cent ? TILEP_FLAG_NORMAL : TILEP_FLAG_HIDE;
     }
+
+    // Special case for draconians missing their headgear
+    const bool is_drac = is_player_tile(doll.parts[TILEP_PART_BASE],
+                                        TILEP_BASE_DRACONIAN);
+    if (doll.parts[TILEP_PART_HELM] >= TILEP_PART_DRCHEAD)
+      flags[TILEP_PART_HELM] = is_drac ? TILEP_FLAG_NORMAL : TILEP_FLAG_HIDE;
 
     // Set up mcache data based on equipment. We don't need this lookup if both
     // pairs of offsets are defined in Options.

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -994,7 +994,7 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
     else if (doll.parts[TILEP_PART_BASE] >= TILEP_BASE_DRACONIAN_FIRST
              && doll.parts[TILEP_PART_BASE] <= TILEP_BASE_DRACONIAN_LAST)
     {
-        flag[TILEP_PART_HAIR] = flag[TILEP_PART_HELM] = TILEP_FLAG_HIDE;
+        flag[TILEP_PART_HAIR] = TILEP_FLAG_HIDE;
     }
     else if (is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_FELID))
     {


### PR DESCRIPTION
Reordered `pack_doll_buf` enum and added special case to ensure draconians can always flaunt their fancy hats.