### PR TITLE
Different messages for cloaks and scarves in _xom_pseudo_miscast

### DIFF
--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2010,14 +2010,10 @@ static void _xom_pseudo_miscast(int /*sever*/)
     {
         item_def* item = you.slot_item(EQ_CLOAK);
 
-        if(item->sub_type == ARM_CLOAK)
-        {
+        if (item->sub_type == ARM_CLOAK)
             messages.emplace_back("Your cloak billows in an unfelt wind.");
-        }
-        else if(item->sub_type == ARM_SCARF)
-        {
+        else if (item->sub_type == ARM_SCARF)
             messages.emplace_back("Your scarf briefly wraps itself around your head!");
-        }
     }
 
     if (item_def* item = you.slot_item(EQ_HELMET))

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2016,7 +2016,7 @@ static void _xom_pseudo_miscast(int /*sever*/)
         }
         else if(item->sub_type == ARM_SCARF)
         {
-            messages.emplace_back("Your scarf is twisted by an unfelt wind.");
+            messages.emplace_back("Your scarf briefly wraps itself around your head!");
         }
     }
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2018,7 +2018,7 @@ static void _xom_pseudo_miscast(int /*sever*/)
         {
             messages.emplace_back("Your scarf is twisted by an unfelt wind.");
         }
-	}
+    }
 
     if (item_def* item = you.slot_item(EQ_HELMET))
     {

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2007,7 +2007,18 @@ static void _xom_pseudo_miscast(int /*sever*/)
     }
 
     if (you.slot_item(EQ_CLOAK))
-        messages.emplace_back("Your cloak billows in an unfelt wind.");
+	{
+    	item_def* item = you.slot_item(EQ_CLOAK);
+    	
+    	if(item->sub_type == ARM_CLOAK)
+		{
+			messages.emplace_back("Your cloak billows in an unfelt wind.");
+		}
+		else if(item->sub_type == ARM_SCARF)
+		{
+			messages.emplace_back("Your scarf is twisted by an unfelt wind.");
+		}
+	}
 
     if (item_def* item = you.slot_item(EQ_HELMET))
     {

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2007,17 +2007,17 @@ static void _xom_pseudo_miscast(int /*sever*/)
     }
 
     if (you.slot_item(EQ_CLOAK))
-	{
-    	item_def* item = you.slot_item(EQ_CLOAK);
-    	
-    	if(item->sub_type == ARM_CLOAK)
-		{
-			messages.emplace_back("Your cloak billows in an unfelt wind.");
-		}
-		else if(item->sub_type == ARM_SCARF)
-		{
-			messages.emplace_back("Your scarf is twisted by an unfelt wind.");
-		}
+    {
+        item_def* item = you.slot_item(EQ_CLOAK);
+
+        if(item->sub_type == ARM_CLOAK)
+        {
+            messages.emplace_back("Your cloak billows in an unfelt wind.");
+        }
+        else if(item->sub_type == ARM_SCARF)
+        {
+            messages.emplace_back("Your scarf is twisted by an unfelt wind.");
+        }
 	}
 
     if (item_def* item = you.slot_item(EQ_HELMET))


### PR DESCRIPTION
First contribution, please be gentle.
This is just a simple fix for something I noticed while playing a Xom character.
The pseudo miscast code just looked for anything in the cloak slot, and would display "Your cloak billows in an unfelt wind" even if you had a scarf equipped.
It seemed appropriate to change it so that you get a different message if you have a scarf. I initially chose "Your scarf is twisted by an unfelt wind", but changed it to "Your scarf briefly wraps itself around your head!" which I think is funnier.
I have compiled and tested that it works as intended.