### PR TITLE
Tiles, WIP: improve layout spacing on main dungeon view

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2048,7 +2048,7 @@ tile_show_player_species = false
         If enabled, displays the player using the monster tile for her species,
         instead of using the normal doll and showing equipment.
 
-tile_layout_priority = minimap, inventory, gold_turn, command, spell, monster
+tile_layout_priority = minimap, inventory, command, spell, monster
         (Ordered list option)
         This option allows you to control the order in which elements are
         placed on the right of the screen, below the stat area. On small

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -662,9 +662,6 @@ int show_keyhelp_menu(const vector<formatted_string> &lines,
         for (i = 0; i < blines.size(); ++i)
             cmd_help.add_item_formatted_string(blines[i]);
 
-        while (static_cast<int>(++i) < get_number_of_lines())
-            cmd_help.add_item_string("");
-
         // unscrollable
         cmd_help.add_entry(new MenuEntry(string(), MEL_TITLE));
     }

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -677,20 +677,13 @@ int show_keyhelp_menu(const vector<formatted_string> &lines,
             string fname = canonicalise_file_separator(help_files[i].name);
             FILE* fp = fopen_u(datafile_path(fname, false).c_str(), "r");
 
-            if (!fp)
-                continue;
+            if (fp)
+            {
+                _add_file_to_scroller(fp, cmd_help, help_files[i].hotkey,
+                                    help_files[i].auto_hotkey);
+                fclose(fp);
+            }
 
-            // Put in a separator...
-            cmd_help.add_item_string("");
-            cmd_help.add_item_string(string(get_number_of_cols()-1,'='));
-            cmd_help.add_item_string("");
-
-            // ...and the file itself.
-            _add_file_to_scroller(fp, cmd_help, help_files[i].hotkey,
-                                  help_files[i].auto_hotkey);
-
-            // Done with this file.
-            fclose(fp);
         }
     }
 

--- a/crawl-ref/source/fontwrapper-ft.h
+++ b/crawl-ref/source/fontwrapper-ft.h
@@ -140,6 +140,7 @@ protected:
     GenericTexture m_tex;
     GLShapeBuffer *m_buf;
 
+    FT_Byte *ttf;
     FT_Face face;
     bool    outl;
     unsigned char *pixels;

--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -78,6 +78,7 @@ OGLStateManager::OGLStateManager()
 #ifdef __ANDROID__
     m_last_tex = 0;
 #endif
+    m_window_height = 0;
 }
 
 void OGLStateManager::set(const GLState& state)
@@ -205,10 +206,22 @@ void OGLStateManager::set_transform(const GLW_3VF &trans, const GLW_3VF &scale)
     glScalef(scale.x, scale.y, scale.z);
 }
 
+void OGLStateManager::set_scissor(int x, int y, unsigned int w, unsigned int h)
+{
+    glEnable(GL_SCISSOR_TEST);
+    glScissor(x, m_window_height-y-h, w, h);
+}
+
+void OGLStateManager::reset_scissor()
+{
+    glDisable(GL_SCISSOR_TEST);
+}
+
 void OGLStateManager::reset_view_for_resize(const coord_def &m_windowsz,
                                             const coord_def &m_drawablesz)
 {
     glViewport(0, 0, m_drawablesz.x, m_drawablesz.y);
+    m_window_height = m_windowsz.y;
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();

--- a/crawl-ref/source/glwrapper-ogl.h
+++ b/crawl-ref/source/glwrapper-ogl.h
@@ -20,6 +20,8 @@ public:
                                        const coord_def &m_drawablesz) override;
     virtual void set_transform(const GLW_3VF &trans, const GLW_3VF &scale) override;
     virtual void reset_transform() override;
+    virtual void set_scissor(int x, int y, unsigned int w, unsigned int h) override;
+    virtual void reset_scissor() override;
 #ifdef __ANDROID__
     virtual void fixup_gl_state() override;
 #endif
@@ -36,6 +38,7 @@ protected:
 #ifdef __ANDROID__
     GLint m_last_tex;
 #endif
+    int m_window_height;
 
 private:
     void glDebug(const char* msg);

--- a/crawl-ref/source/glwrapper.h
+++ b/crawl-ref/source/glwrapper.h
@@ -142,6 +142,8 @@ public:
                                        const coord_def &m_drawablesz) = 0;
     virtual void set_transform(const GLW_3VF &trans, const GLW_3VF &scale) = 0;
     virtual void reset_transform() = 0;
+    virtual void set_scissor(int x, int y, unsigned int w, unsigned int h) = 0;
+    virtual void reset_scissor() = 0;
 #ifdef __ANDROID__
     virtual void fixup_gl_state() = 0;
 #endif

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -342,10 +342,10 @@ const vector<GameOption*> game_options::build_options_list()
         new TileColGameOption(SIMPLE_NAME(tile_window_col), "#558855"),
         new ListGameOption<string>(SIMPLE_NAME(tile_layout_priority),
 #ifdef TOUCH_UI
-            split_string(",", "minimap, command, gold_turn, inventory, "
+            split_string(",", "minimap, command, inventory, "
                               "command2, spell, ability, monster")),
 #else
-            split_string(",", "minimap, inventory, gold_turn, command, "
+            split_string(",", "minimap, inventory, command, "
                               "spell, ability, monster")),
 #endif
 #endif

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -715,7 +715,7 @@ static keyseq _getch_mul(int (*rgetch)() = nullptr)
 
     // The a == 0 test is legacy code that I don't dare to remove. I
     // have a vague recollection of it being a kludge for conio support.
-    while (kbhit() || a == 0)
+    while ((kbhit() || a == 0) && a != CK_REDRAW)
         keys.push_back(a = rgetch());
 
     return keys;

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -1309,7 +1309,11 @@ void Menu::draw_menu()
     if (end > (int) items.size()) end = items.size();
 
     for (int i = first_entry; i < end; ++i)
+    {
+        if (items[i]->level == MEL_TITLE)
+            break;
         draw_item(i);
+    }
 
     if (end < (int) items.size() || is_set(MF_ALWAYS_SHOW_MORE))
         mdisplay->draw_more();
@@ -2020,10 +2024,16 @@ bool formatted_scroller::page_down()
     if ((int) items.size() <= first_entry + pagesize)
         return false;
 
+    int target;
+    // First, search for a MEL_TITLE in the current page
+    for (target = first_entry; target < first_entry + pagesize; ++target)
+    {
+        if (items[target]->level == MEL_TITLE)
+            return false;
+    }
     // If, when scrolling forward, we encounter a MEL_TITLE
     // somewhere in the newly displayed page, stop scrolling
     // just before it becomes visible
-    int target;
     for (target = first_entry; target < first_entry + pagesize; ++target)
     {
         const int offset = target + pagesize;
@@ -2061,12 +2071,16 @@ bool formatted_scroller::page_up()
 
 bool formatted_scroller::line_down()
 {
-    if (first_entry + pagesize < static_cast<int>(items.size())
-        && items[first_entry + pagesize]->level != MEL_TITLE)
+    if ((int) items.size() <= first_entry + pagesize)
+        return false;
+
+    // Search [first, first+pagesize] inclusive for a MEL_TITLE
+    for (int target = first_entry; target <= first_entry + pagesize; ++target)
     {
-        ++first_entry;
-        return true;
+        if (items[target]->level == MEL_TITLE)
+            return false;
     }
+    ++first_entry;
     return false;
 }
 

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -275,11 +275,12 @@ enum MenuFlag
 class MenuDisplay
 {
 public:
-    MenuDisplay(Menu *menu);
+    MenuDisplay(Menu *menu) : m_menu(menu) {};
     virtual ~MenuDisplay() {}
     virtual void draw_stock_item(int index, const MenuEntry *me) = 0;
     virtual void set_offset(int lines) = 0;
     virtual void draw_more() = 0;
+    virtual int get_maxpagesize() = 0;
     virtual void set_num_columns(int columns) = 0;
 protected:
     Menu *m_menu;
@@ -288,9 +289,10 @@ protected:
 class MenuDisplayText : public MenuDisplay
 {
 public:
-    MenuDisplayText(Menu *menu);
+    MenuDisplayText(Menu *menu) : MenuDisplay(menu), m_starty(1) {};
     virtual void draw_stock_item(int index, const MenuEntry *me) override;
     virtual void draw_more() override;
+    virtual int get_maxpagesize() override;
     virtual void set_offset(int lines) override { m_starty = lines; }
     virtual void set_num_columns(int columns) override {}
 protected:
@@ -300,9 +302,10 @@ protected:
 class MenuDisplayTile : public MenuDisplay
 {
 public:
-    MenuDisplayTile(Menu *menu);
+    MenuDisplayTile(Menu *menu) : MenuDisplay(menu) {};
     virtual void draw_stock_item(int index, const MenuEntry *me) override;
     virtual void set_offset(int lines) override;
+    virtual int get_maxpagesize() override;
     virtual void draw_more() override;
     virtual void set_num_columns(int columns) override;
 };
@@ -428,6 +431,7 @@ protected:
     void check_add_formatted_line(int firstcol, int nextcol,
                                   string &line, bool check_eol);
     void do_menu();
+    void recalculate_page_sizes();
     virtual string get_select_count_string(int count) const;
     virtual void draw_select_count(int count, bool force = false);
     virtual void draw_item(int index) const;

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -188,7 +188,9 @@ void DungeonRegion::render()
     }
 
     set_transform();
+    glmanager->set_scissor(0, 0, tile_iw, tile_ih);
     m_buf_dngn.draw();
+    glmanager->reset_scissor();
     draw_minibars();
     m_buf_flash.draw();
 
@@ -353,6 +355,11 @@ void DungeonRegion::clear()
 void DungeonRegion::on_resize()
 {
     // TODO enne
+}
+
+bool DungeonRegion::inside(int x, int y)
+{
+    return x >= 0 && y >= 0 && x <= tile_iw && y <= tile_ih;
 }
 
 // FIXME: If the player is targeted, the game asks the player to target

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -108,6 +108,10 @@ void DungeonRegion::pack_buffers()
     if (m_vbuf.empty())
         return;
 
+    coord_def m_vbuf_sz = m_vbuf.size();
+    ASSERT(m_vbuf_sz.x == crawl_view.viewsz.x);
+    ASSERT(m_vbuf_sz.y == crawl_view.viewsz.y);
+
     screen_cell_t *vbuf_cell = m_vbuf;
     for (int y = 0; y < crawl_view.viewsz.y; ++y)
         for (int x = 0; x < crawl_view.viewsz.x; ++x)

--- a/crawl-ref/source/tilereg-dgn.h
+++ b/crawl-ref/source/tilereg-dgn.h
@@ -32,6 +32,7 @@ public:
     virtual bool update_tip_text(string &tip) override;
     virtual bool update_alt_text(string &alt) override;
     virtual void on_resize() override;
+    virtual bool inside(int px, int py) override;
 
     void load_dungeon(const crawl_view_buffer &vbuf, const coord_def &gc);
     void place_cursor(cursor_type type, const coord_def &gc);
@@ -46,6 +47,8 @@ public:
     void add_overlay(const coord_def &gc, int idx);
     void clear_overlays();
     void zoom(bool in);
+
+    int tile_iw, tile_ih;
 
 protected:
     void pack_buffers();

--- a/crawl-ref/source/tilereg-grid.cc
+++ b/crawl-ref/source/tilereg-grid.cc
@@ -28,18 +28,11 @@ bool InventoryTile::empty() const
 
 GridRegion::GridRegion(const TileRegionInit &init) :
     TileRegion(init),
-    m_flavour(nullptr),
     m_cursor(NO_CURSOR),
     m_last_clicked_item(-1),
     m_grid_page(0),
     m_buf(init.im)
 {
-}
-
-GridRegion::~GridRegion()
-{
-    delete[] m_flavour;
-    m_flavour = nullptr;
 }
 
 void GridRegion::clear()
@@ -50,18 +43,8 @@ void GridRegion::clear()
 
 void GridRegion::on_resize()
 {
-    if (m_flavour)
-    {
-        delete[] m_flavour;
-        m_flavour = nullptr;
-    }
-
-    if (mx * my <= 0)
-        return;
-
-    m_flavour = new unsigned char[mx * my];
-    for (int i = 0; i < mx * my; ++i)
-        m_flavour[i] = random2((unsigned char)~0);
+    // probably needed? mimicking MenuRegion::on_resize()
+    m_dirty = true;
 }
 
 unsigned int GridRegion::cursor_index() const

--- a/crawl-ref/source/tilereg-grid.h
+++ b/crawl-ref/source/tilereg-grid.h
@@ -29,7 +29,6 @@ class GridRegion : public TileRegion
 {
 public:
     GridRegion(const TileRegionInit &init);
-    virtual ~GridRegion();
 
     virtual void clear() override;
     virtual void render() override;
@@ -54,7 +53,6 @@ protected:
     void draw_number(int x, int y, int number);
     void draw_desc(const char *desc);
 
-    unsigned char *m_flavour;
     coord_def m_cursor;
     int m_last_clicked_item;
     int m_grid_page;

--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -55,7 +55,7 @@ void InventoryRegion::pack_buffers()
                     break;
 
                 int num_floor = tile_dngn_count(env.tile_default.floor);
-                tileidx_t t = env.tile_default.floor + m_flavour[i] % num_floor;
+                tileidx_t t = env.tile_default.floor + i % num_floor;
                 m_buf.add_dngn_tile(t, x, y);
             }
             else

--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -115,8 +115,10 @@ void MapRegion::render()
     }
 
     set_transform();
+    glmanager->set_scissor(sx, sy, wx, wy);
     m_buf_map.draw();
     m_buf_lines.draw();
+    glmanager->reset_scissor();
 }
 
 void MapRegion::recenter()

--- a/crawl-ref/source/tilereg-mon.cc
+++ b/crawl-ref/source/tilereg-mon.cc
@@ -191,7 +191,7 @@ void MonsterRegion::pack_buffers()
             }
 
             // Fill the rest of the space with out of sight floor tiles.
-            int tileidx = env.tile_default.floor + m_flavour[i-1] % num_floor;
+            int tileidx = env.tile_default.floor + i % num_floor;
             m_buf.add_dngn_tile(tileidx, x, y);
             m_buf.add_icons_tile(TILEI_MESH, x, y);
         }

--- a/crawl-ref/source/tilereg-tab.cc
+++ b/crawl-ref/source/tilereg-tab.cc
@@ -301,6 +301,16 @@ void TabbedRegion::draw_tag()
     draw_desc(tab->name().c_str());
 }
 
+int TabbedRegion::min_height_for_items() const
+{
+    for (int i = (int)m_tabs.size()-1; i >= 0; --i)
+    {
+        if (m_tabs[i].enabled)
+            return m_tabs[i].max_y;
+    }
+    return 0;
+}
+
 void TabbedRegion::on_resize()
 {
     int reg_sx = sx + ox;

--- a/crawl-ref/source/tilereg-tab.h
+++ b/crawl-ref/source/tilereg-tab.h
@@ -28,6 +28,7 @@ public:
     void deactivate_tab();
     int active_tab() const;
     int num_tabs() const;
+    int min_height_for_items() const;
     void enable_tab(int idx);
     void disable_tab(int idx);
     int find_tab(string tab_name) const;

--- a/crawl-ref/source/tilereg-text.cc
+++ b/crawl-ref/source/tilereg-text.cc
@@ -52,11 +52,6 @@ TextRegion::~TextRegion()
     delete[] abuf;
 }
 
-void TextRegion::adjust_region(int *x1, int *x2, int y)
-{
-    *x2 = *x2 + 1;
-}
-
 void TextRegion::addstr(const char *buffer)
 {
     char32_t buf2[1024], c;
@@ -108,11 +103,8 @@ void TextRegion::addstr_aux(const char32_t *buffer, int len)
     int x = print_x - cx_ofs;
     int y = print_y - cy_ofs;
     int adrs = y * mx;
-    int head = x;
-    int tail = x + len - 1;
 
-    // XXX: What does this even do?
-    adjust_region(&head, &tail, y);
+    ASSERT(y < my);
 
     for (int i = 0; i < len && x + i < mx; i++)
     {

--- a/crawl-ref/source/tilereg.h
+++ b/crawl-ref/source/tilereg.h
@@ -20,7 +20,7 @@ public:
     // If true, then cx and cy are set in the range [0..mx-1], [0..my-1]
     virtual bool mouse_pos(int mouse_x, int mouse_y, int &cx, int &cy);
 
-    bool inside(int px, int py);
+    virtual bool inside(int px, int py);
     virtual bool update_tip_text(string &tip) { return false; }
     virtual bool update_alt_text(string &alt) { return false; }
     virtual int handle_mouse(MouseEvent &event) = 0;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1255,19 +1255,6 @@ void TilesFramework::resize_inventory()
     m_statcol_bottom -= delta_y;
 }
 
-void TilesFramework::place_gold_turns()
-{
-    if (m_statcol_bottom - m_statcol_top < m_region_stat->dy)
-        return;
-
-    ++crawl_view.hudsz.y;
-    m_region_stat->resize(m_region_stat->mx, crawl_view.hudsz.y);
-    if (m_region_map)
-        m_region_map->place(m_region_stat->sx, m_region_stat->ey);
-
-    m_statcol_top += m_region_stat->dy;
-}
-
 void TilesFramework::layout_statcol()
 {
     bool use_small_layout = is_using_small_layout();
@@ -1337,9 +1324,7 @@ void TilesFramework::layout_statcol()
                 resize_inventory();
             else if (str == "minimap" || str == "map")
                 place_minimap();
-            else if (str == "gold_turn" || str == "gold_turns")
-                place_gold_turns();
-            else
+            else if (!(str == "gold_turn" || str == "gold_turns")) // gold_turns no longer does anything
                 place_tab(m_region_tab->find_tab(str));
         }
         // We stretch the minimap so it is centered in the space left.

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1239,12 +1239,13 @@ void TilesFramework::resize_inventory()
 {
     int lines = min(max_inv_height - min_inv_height,
                     (m_statcol_bottom - m_statcol_top) / m_region_tab->dy);
-    if (lines == 0)
-        return;
 
     int prev_size = m_region_tab->wy;
 
-    m_region_tab->resize(m_region_tab->mx, min_inv_height + lines);
+    int tabs_height = m_region_tab->min_height_for_items();
+    tabs_height = round_up_to_multiple(tabs_height, m_region_tab->dx)/m_region_tab->dx;
+
+    m_region_tab->resize(m_region_tab->mx, max(min_inv_height + lines, tabs_height));
     m_region_tab->place(m_stat_col, m_windowsz.y - m_region_tab->wy);
 
     int delta_y = m_region_tab->wy - prev_size;

--- a/crawl-ref/source/tilesdl.h
+++ b/crawl-ref/source/tilesdl.h
@@ -262,7 +262,6 @@ protected:
     void autosize_minimap();
     void place_minimap();
     void resize_inventory();
-    void place_gold_turns();
 
     ImageManager *m_image;
 


### PR DESCRIPTION
General tiles UI streamlining:
 - The gridded tabs in the sidebar are now flush with the right side of the window.
 - The sidebar now has fixed width, and is always flush against the right side of the window.
 - The main dungeon view expands to fill all remaining space, showing parts of partially visible tiles.
 - The messages box sticks to the bottom of the screen.

There's some other fixes/enhancements as well. Some of them aren't really tiles related and should perhaps be in a separate PR...