### PR TITLE
Fix tiles UI not being redrawn on expose

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -803,6 +803,11 @@ int TilesFramework::getch_ck()
                 set_need_redraw();
                 return CK_REDRAW;
 
+            case WME_EXPOSE:
+                set_need_redraw();
+                // AFAIK no need to return CK_REDRAW, as resize() hasn't been called
+                break;
+
             case WME_CUSTOMEVENT:
             default:
                 // This is only used to refresh the tooltip.


### PR DESCRIPTION
Small fix this time :)

I use the awesomewm window manager, and when switching to a workspace
(tag) with a running instance of crawl-tiles, the tiles window takes
several seconds to redraw. Before it redraws, the window contains
whatever was in that section of the screen on the previous workspace.
This bug does not appear when minimizing and then restoring tiles.