### PR TITLE
Fix message displayed when Gh tries to quaff potion of mutation

### DIFF
--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -679,7 +679,7 @@ public:
  *
  * @param reason Pointer to a string where the reason will be stored if unable
  *               to mutate
- * @returns true if the player is able to mutate right now.
+ * @returns true if the player is able to mutate right now, otherwise false.
  */
 static bool _can_mutate(string *reason)
 {

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -679,7 +679,7 @@ public:
  *
  * @param reason Pointer to a string where the reason will be stored if unable
  *               to mutate
- * @returns true iff the player is able to mutate right now.
+ * @returns true if the player is able to mutate right now.
  */
 static bool _can_mutate(string *reason)
 {
@@ -689,7 +689,7 @@ static bool _can_mutate(string *reason)
     if (reason)
     {
         *reason = make_stringf("You cannot mutate%s.",
-                               you.can_safely_mutate(false) ? "" : " at present");
+                               you.can_safely_mutate(false) ? " at present" : "");
     }
     return false;
 }


### PR DESCRIPTION
After f20264c8 ghouls get the "You cannot mutate at present." message when they try to quaff an identified potion of mutation. The "at present" part is not correct, since it's a permanent restriction.

This commit fixes that and a typo in the function's description.