### PR TITLE
Fix wizmode mutation resistance bug

### DIFF
--- a/crawl-ref/source/unwind.h
+++ b/crawl-ref/source/unwind.h
@@ -32,7 +32,9 @@ public:
 
     ~unwind_var()
     {
-        val = oldval;
+        if (active) {
+            val = oldval;
+        }
     }
 
     /** Get the current (temporary) value of the wrapped lvalue. */
@@ -47,9 +49,16 @@ public:
         return oldval;
     }
 
+    /** Prevent the wrapped value from being reset. */
+    void deactivate()
+    {
+        active = false;
+    }
+
 private:
     T &val;
     T oldval;
+    bool active = true;
 };
 
 typedef unwind_var<bool> unwind_bool;

--- a/crawl-ref/source/unwind.h
+++ b/crawl-ref/source/unwind.h
@@ -32,9 +32,7 @@ public:
 
     ~unwind_var()
     {
-        if (active) {
-            val = oldval;
-        }
+        val = oldval;
     }
 
     /** Get the current (temporary) value of the wrapped lvalue. */
@@ -49,16 +47,9 @@ public:
         return oldval;
     }
 
-    /** Prevent the wrapped value from being reset. */
-    void deactivate()
-    {
-        active = false;
-    }
-
 private:
     T &val;
     T oldval;
-    bool active = true;
 };
 
 typedef unwind_var<bool> unwind_bool;

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -563,6 +563,11 @@ bool wizard_add_mutation()
                 if (delete_mutation(mutat, "wizard power", true, true))
                     success = true;
         }
+
+        // prevent mutation resistance from being reset if it was modified here
+        if (mutat == MUT_MUTATION_RESISTANCE) {
+        	mut_res.deactivate();
+        }
     }
 
     return success;

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -491,7 +491,6 @@ bool wizard_add_mutation()
 
     if (you.has_mutation(MUT_MUTATION_RESISTANCE))
         mpr("Ignoring mut resistance to apply mutation.");
-    unwind_var<uint8_t> mut_res(you.mutation[MUT_MUTATION_RESISTANCE], 0);
 
     msgwin_get_line("Which mutation (name, 'good', 'bad', 'any', "
                     "'xom', 'slime', 'qazlal')? ",
@@ -562,11 +561,6 @@ bool wizard_add_mutation()
             for (int i = 0; i < -levels; ++i)
                 if (delete_mutation(mutat, "wizard power", true, true))
                     success = true;
-        }
-
-        // prevent mutation resistance from being reset if it was modified here
-        if (mutat == MUT_MUTATION_RESISTANCE) {
-        	mut_res.deactivate();
         }
     }
 


### PR DESCRIPTION
Currently, the player can't give their character the mutation resistance mutation in wizard mode. This fixes that, by adding a way to invalidate unwind_var's if they are no longer needed.

Also, first PR, nice to meet you.