### PR TITLE
Don't (auto)travel via stairs into exclusions

### DIFF
--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -75,6 +75,17 @@ bool check_annotation_exclusion_warning()
         might_be_dangerous = true;
     }
 
+    if (feat_is_travelable_stair(grd(you.pos())))
+    {
+        LevelInfo *li = travel_cache.find_level_info(level_id::current());
+        const stair_info *si = li->get_stair(you.pos());
+        if (stairs_destination_is_excluded(*si))
+        {
+            mprf(MSGCH_WARN, "This staircase leads to a travel-excluded area!");
+            might_be_dangerous = true;
+        }
+    }
+
     if (might_be_dangerous
         && !yesno("Enter next level anyway?", true, 'n', true, false))
     {

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -2692,6 +2692,8 @@ static int _find_transtravel_stair(const level_id &cur,
 
     for (stair_info &si : stairs)
     {
+        if (stairs_destination_is_excluded(si))
+            continue;
 
         // Skip placeholders and excluded stairs.
         if (!si.can_travel() || is_excluded(si.position, li.get_excludes()))
@@ -4776,4 +4778,26 @@ int travel_trail_index(const coord_def& gc)
         return idx;
     else
         return -1;
+}
+
+bool stairs_destination_is_excluded(const stair_info &si)
+{
+    level_pos dest = si.destination;
+    LevelInfo &dest_li = travel_cache.get_level_info(dest.id);
+
+    if (is_unknown_stair(si.position) || !is_excluded(dest.pos, dest_li.get_excludes()))
+        return false;
+
+    // Check for exclusions that cover the stair destination, but ignore those that
+    // have radius 1: those exclude travel in the _other_ direction only (from the
+    // destination to here, not from here to the destination)
+    const exclude_set &excludes = dest_li.get_excludes();
+    for (exclude_set::const_iterator it = excludes.begin(); it != excludes.end(); ++it)
+    {
+        const travel_exclude &ex = it->second;
+        if (ex.in_bounds(dest.pos) && ex.radius > 1)
+            return true;
+    }
+
+    return false;
 }

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -644,3 +644,5 @@ void clear_level_target();
 
 void clear_travel_trail();
 int travel_trail_index(const coord_def& gc);
+
+bool stairs_destination_is_excluded(const stair_info &si);


### PR DESCRIPTION
This prevents auto-travel via staircases that lead to excluded areas,
and asks when traversing staircases into an excluded area. This works
only when the staircase's destination is known, and single-tile
exclusions on the destination staircase (indicating excluded travel in
the reverse direction) are ignored.