### PR TITLE
Fix issue orders prompt when not berserk

### DIFF
--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -541,8 +541,7 @@ static int _issue_orders_prompt()
     }
     mpr(" Anything else - Cancel.");
 
-    if (you.berserk())
-        flush_prev_message(); // buffer doesn't get flushed otherwise
+    flush_prev_message(); // buffer doesn't get flushed otherwise
 
     const int keyn = get_ch();
     clear_messages();


### PR DESCRIPTION
The previous message should be flushed regardless of whether the player
is berserk. The if-condition is causing the "Anything else - Cancel"
text to not appear.