### PR TITLE
Add auto_butcher_max_chunks option

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -268,6 +268,7 @@ const vector<GameOption*> game_options::build_options_list()
         new IntGameOption(SIMPLE_NAME(level_map_cursor_step), 7, 1, 50),
         new IntGameOption(SIMPLE_NAME(dump_item_origin_price), -1, -1),
         new IntGameOption(SIMPLE_NAME(dump_message_count), 20),
+        new IntGameOption(SIMPLE_NAME(auto_butcher_max_chunks), 0, 0),
         new ListGameOption<text_pattern>(SIMPLE_NAME(confirm_action)),
         new ListGameOption<text_pattern>(SIMPLE_NAME(drop_filter)),
         new ListGameOption<text_pattern>(SIMPLE_NAME(note_monsters)),

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2843,12 +2843,21 @@ static bool _is_option_autopickup(const item_def &item, bool ignore_force)
     return Options.autopickups[item.base_type];
 }
 
+static int _get_chunk_count() {
+    auto it = find_if(you.inv.begin(), you.inv.end(), [&](const item_def& item) {
+        return item.base_type == OBJ_FOOD && item.sub_type == FOOD_CHUNK && !is_bad_food(item);
+    });
+    return it == you.inv.end() ? 0 : it->quantity;
+}
+
 /// Should the player automatically butcher the given item?
 static bool _should_autobutcher(const item_def &item)
 {
     return Options.auto_butcher >= you.hunger_state
            && item.base_type == OBJ_CORPSES
-           && !is_inedible(item) && !is_bad_food(item);
+           && !is_inedible(item) && !is_bad_food(item) 
+           && (Options.auto_butcher_max_chunks == 0
+               || _get_chunk_count() < Options.auto_butcher_max_chunks);
 }
 
 /** Is the item something that we should try to autopickup?

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -230,6 +230,8 @@ public:
     bool        enable_recast_spell; // Allow recasting spells with 'z' Enter.
     int         confirm_butcher; // When to prompt for butchery
     hunger_state_t auto_butcher; // auto-butcher corpses while travelling
+    int         auto_butcher_max_chunks; // if nonzero, only auto-butcher if player
+                                         // has fewer than this many chunks
     bool        easy_eat_chunks; // make 'e' auto-eat the oldest safe chunk
     bool        auto_eat_chunks; // allow eating chunks while resting or travelling
     skill_focus_mode skill_focus; // is the focus skills available


### PR DESCRIPTION
If auto_butcher is set, and this option is greater than zero, it prevents auto-butchering from happening when you have more than this many chunks in your inventory. Defaults to zero, which is the current behavior.

I don't know if this code needs to handle vampires (does auto_butcher work for them?), but if it does, it probably does not handle them properly.