### PR TITLE
Tiles: fix title screen lingering when tile_skip_title = true

### DIFF
--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -147,7 +147,6 @@ static void _initialize()
 
 #ifdef USE_TILE_LOCAL
     if (!crawl_state.tiles_disabled
-        && !Options.tile_skip_title
         && crawl_state.title_screen)
     {
         tiles.update_title_msg("Loading complete, press any key to start.");

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -256,7 +256,8 @@ void TilesFramework::hide_title()
     TitleRegion* reg = dynamic_cast<TitleRegion*>(
             m_layers[LAYER_TILE_CONTROL].m_regions.at(0));
     redraw();
-    reg->run();
+    if (!Options.tile_skip_title)
+        reg->run();
     delete reg;
     m_layers[LAYER_TILE_CONTROL].m_regions.clear();
 }


### PR DESCRIPTION
Fixes the tile screen showing on other LAYER_TILE_CONTROL layouts
(scenes?) when tile_skip_title = true, such as the doll edit screen.

Not sure if the redraw should be conditional, but it works fine like this.