### PR TITLE
Fix sidebar for large tile_font_stat_size

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -897,6 +897,7 @@ void TilesFramework::do_layout()
     m_region_tile->dx = m_viewsc.x;
     m_region_tile->dy = m_viewsc.y;
     int message_y_divider = 0;
+    int sidebar_pw;
 
     // if the screen estate is very small, or if the option is set, choose
     // a layout that is optimal for very small screens
@@ -927,7 +928,8 @@ void TilesFramework::do_layout()
         m_region_tab->set_small_layout(true, m_windowsz);
         m_region_tab->resize_to_fit(m_windowsz.x, m_windowsz.y);
         //  * ox tells us the width of screen obscured by the tabs
-        m_stat_x_divider = m_windowsz.x - (m_region_tab->ox*m_region_tab->dx/32) - get_crt_font()->char_width()*10;
+        sidebar_pw = (m_region_tab->ox*m_region_tab->dx/32) + get_crt_font()->char_width()*10;
+        m_stat_x_divider = m_windowsz.x - sidebar_pw;
         // old logic, if we're going to impinge upon a nice square dregion
         if (available_height_in_tiles * m_region_tile->dx > m_stat_x_divider)
             m_stat_x_divider = available_height_in_tiles * m_region_tile->dx;
@@ -941,30 +943,15 @@ void TilesFramework::do_layout()
     {
         // normal layout code
 
+        int sidebar_min_pw = stat_width * m_region_stat->dx; // Ensure we can fit everything
+        sidebar_pw = m_region_tab->dx*7 - 10;
+        while (sidebar_pw < sidebar_min_pw)
+            sidebar_pw += m_region_tab->dx;
+
         // Locations in pixels. stat_x_divider is the dividing vertical line
         // between dungeon view on the left and status area on the right.
         // message_y_divider is the horizontal line between dungeon view on
         // the top and message window at the bottom.
-        m_stat_x_divider = 0;
-
-        // We ignore Options.view_max_width and use the maximum space available.
-        int available_width_in_tiles = 0;
-
-        available_width_in_tiles = (m_windowsz.x - stat_width
-                                    * m_region_stat->dx) / m_region_tile->dx;
-
-        // Scale the dungeon region tiles so we have enough space to
-        // display full LOS.
-        if (available_width_in_tiles < ENV_SHOW_DIAMETER)
-        {
-            m_region_tile->dx = (m_windowsz.x - stat_width * m_region_stat->dx)
-                / ENV_SHOW_DIAMETER;
-            m_region_tile->dy = m_region_tile->dx;
-            available_width_in_tiles = ENV_SHOW_DIAMETER;
-        }
-
-        // XXX: this ignores above calculations for available width
-        static const int sidebar_pw = m_region_tab->dx*13 - 10;
         m_stat_x_divider = m_windowsz.x - sidebar_pw - map_stat_margin;
 
         // Calculate message_y_divider. First off, if we have already decided to
@@ -1053,7 +1040,7 @@ void TilesFramework::do_layout()
         m_stat_col = m_stat_x_divider;
     else
         m_stat_col = m_stat_x_divider + map_stat_margin;
-    m_region_stat->resize_to_fit(m_windowsz.x - m_stat_x_divider, m_windowsz.y);
+    m_region_stat->resize_to_fit(sidebar_pw, m_windowsz.y);
     m_region_stat->place(m_stat_col, 0, 0);
     m_region_stat->resize(m_region_stat->mx, min_stat_height);
 
@@ -1303,7 +1290,7 @@ void TilesFramework::layout_statcol()
     }
     else
     {
-        crawl_view.hudsz.x = m_region_stat->mx-1;
+        crawl_view.hudsz.x = m_region_stat->mx;
         crawl_view.hudsz.y = min_stat_height;
         m_region_stat->resize(m_region_stat->mx, crawl_view.hudsz.y);
 


### PR DESCRIPTION
Earlier changes hardcoded the sidebar pixel width. This change now bases
the sidebar width mostly on the width of the stat HUD (dependent on its
font size), but with a minimum width in tiles as well.

There's also a bunch of dead code removal, and the way the stat HUD is
fitted into the sidebar is improved slightly as well.