### PR TITLE
Fix identification of floor items in edge cases.

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3975,6 +3975,7 @@ bool dithmenos_shadow_step()
         }
     }
 
+    const coord_def old_pos = you.pos();
     // XXX: This only ever fails if something's on the landing site;
     // perhaps this should be handled more gracefully.
     if (!you.move_to_pos(tgt.landing_site))
@@ -3986,6 +3987,9 @@ bool dithmenos_shadow_step()
     const actor *victim = actor_at(sdirect.target);
     mprf("You step into %s shadow.",
          apostrophise(victim->name(DESC_THE)).c_str());
+    // Using 'stepped = true' here because it's Shadow *Step*.
+    // This helps to evade splash upon landing on water.
+    moveto_location_effects(grd(old_pos), true, old_pos);
 
     return true;
 }

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1454,6 +1454,7 @@ static void _take_transporter()
             explored_tracked_feature(DNGN_TRANSPORTER);
         }
         mpr("You enter the transporter and appear at another place.");
+        id_floor_items();
     }
 }
 
@@ -1490,6 +1491,8 @@ static void _take_stairs(bool down)
         you.turn_is_over = (you.pos() != old_pos);
         if (!you.turn_is_over)
             mpr("This passage doesn't lead anywhere!");
+        else
+            id_floor_items();
     }
     else
     {
@@ -1498,6 +1501,7 @@ static void _take_stairs(bool down)
             start_delay<DescendingStairsDelay>(1);
         else
             start_delay<AscendingStairsDelay>(1);
+        id_floor_items();
     }
 }
 


### PR DESCRIPTION
Items (wands and books) under player will be identified after using Shadow Step, transport, stairs or passage of Golubria.

Also Merfolk will now properly change its form after shadowstepping into water. moveto_location_effects() uses 'stepped = true' here because it prevents splash upon landing on water, which fits current behaviour. The only side effect here is that Tonado will run for its full duration while usual blink shortens it severely.