### PR TITLE
Fixed no ability description on R-click (#11231)

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2935,15 +2935,13 @@ void describe_spell(spell_type spelled, const monster_info *mon_owner,
 void describe_ability(ability_type ability)
 {
 #ifdef USE_TILE_WEB
-    // XXX I have no idea what show_as_menu() does, can't find definition
     tiles_crt_control show_as_menu(CRT_MENU, "describe_ability");
 #endif
 
-    string desc = get_ability_desc(ability);
-    print_description(desc);
+    print_description(get_ability_desc(ability));
 
     mouse_control mc(MOUSE_MODE_MORE);
-    getchm();// FIXME description screen wouldn't show up without getchm()
+    getchm();// description screen wouldn't show up without getchm()
 }
 
 

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <string>
 
+#include "ability.h"
 #include "adjust.h"
 #include "areas.h"
 #include "art-enum.h"
@@ -2925,6 +2926,26 @@ void describe_spell(spell_type spelled, const monster_info *mon_owner,
         redraw_screen();
     }
 }
+
+/**
+ * Examine a given ability. List its description and details.
+ *
+ * @param ability   The ability in question.
+ */
+void describe_ability(ability_type ability)
+{
+#ifdef USE_TILE_WEB
+    // XXX I have no idea what show_as_menu() does, can't find definition
+    tiles_crt_control show_as_menu(CRT_MENU, "describe_ability");
+#endif
+
+    string desc = get_ability_desc(ability);
+    print_description(desc);
+
+    mouse_control mc(MOUSE_MODE_MORE);
+    getchm();// FIXME description screen wouldn't show up without getchm()
+}
+
 
 static string _describe_draconian(const monster_info& mi)
 {

--- a/crawl-ref/source/describe.h
+++ b/crawl-ref/source/describe.h
@@ -67,6 +67,8 @@ void describe_spell(spell_type spelled,
                     const monster_info *mon_owner = nullptr,
                     const item_def* item = nullptr);
 
+void describe_ability(ability_type ability);
+
 string short_ghost_description(const monster *mon, bool abbrev = false);
 string get_ghost_description(const monster_info &mi, bool concise = false);
 

--- a/crawl-ref/source/tilereg-abl.cc
+++ b/crawl-ref/source/tilereg-abl.cc
@@ -75,7 +75,7 @@ int AbilityRegion::handle_mouse(MouseEvent &event)
     }
     else if (ability != NUM_ABILITIES && event.button == MouseEvent::RIGHT)
     {
-        describe_talent(get_talent(ability, false));
+        describe_ability(ability);
         redraw_screen();
         return CK_MOUSE_CMD;
     }
@@ -112,6 +112,9 @@ bool AbilityRegion::update_tip_text(string& tip)
         tip = "[L-Click] Use (%)";
         cmd.push_back(CMD_USE_ABILITY);
     }
+
+    tip += "\n[R-Click] Describe";
+    insert_commands(tip, cmd);
 
     return true;
 }


### PR DESCRIPTION
The workaround is a bit ugly - I had to use getchm() in order to let the
screen appear, and I'm not sure what show_as_menu() does.

This change is a response to [this Mantis bug report](https://crawl.develz.org/mantis/view.php?id=11231),