### PR TITLE
Fix Whirlwind pin

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1862,16 +1862,16 @@ void wu_jian_wall_jump_effects(const coord_def& old_pos)
     }
 }
 
-void wu_jian_end_of_turn_effects(bool attacking, bool did_wall_jump, bool turn_over, const coord_def& initial_position)
+void wu_jian_end_of_turn_effects()
 {
     // This guarantees that the whirlwind pin status is capped to one turn of monster movement.
     for (monster_iterator mi; mi; ++mi)
         if (mi->has_ench(ENCH_WHIRLWIND_PINNED) && !you.attribute[ATTR_SERPENTS_LASH])
             mi->lose_ench_levels(mi->get_ench(ENCH_WHIRLWIND_PINNED), 1, true);
+}
 
-    if (attacking)
-        return;
-
+void wu_jian_post_move_effects(bool did_wall_jump, bool turn_over, const coord_def& initial_position)
+{
     if (!did_wall_jump)
         _wu_jian_trigger_martial_arts(initial_position);
 

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -299,5 +299,6 @@ bool wu_jian_can_wall_jump(const coord_def& target, bool messaging=false);
 void wu_jian_wall_jump_effects(const coord_def& old_pos);
 bool wu_jian_has_momentum(wu_jian_attack_type);
 void wu_jian_heaven_tick();
-void wu_jian_end_of_turn_effects(bool attacking, bool did_wall_jump, bool turn_over, const coord_def& initial_position);
+void wu_jian_post_move_effects(bool did_wall_jump, bool turn_over, const coord_def& initial_position);
+void wu_jian_end_of_turn_effects();
 void end_heavenly_storm();

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -2267,6 +2267,8 @@ void world_reacts()
     if (!crawl_state.game_is_arena())
         player_reacts_to_monsters();
 
+    wu_jian_end_of_turn_effects();
+
     viewwindow();
 
     if (you.cannot_act() && any_messages()
@@ -3316,8 +3318,8 @@ static void _move_player(coord_def move)
         did_god_conduct(DID_HASTY, 1, true);
     }
 
-    if (you_worship(GOD_WU_JIAN))
-        wu_jian_end_of_turn_effects(attacking, did_wall_jump, you.turn_is_over, initial_position);
+    if (you_worship(GOD_WU_JIAN) && !attacking)
+        wu_jian_post_move_effects(did_wall_jump, you.turn_is_over, initial_position);
 }
 
 static int _get_num_and_char(const char* prompt, char* buf, int buf_len)


### PR DESCRIPTION
Used to only be cleared after a movement turn, instead of after any time consuming action, which made it able to kite enemies for longer.