### PR TITLE
Add Cling flag to monster info

### DIFF
--- a/crawl-ref/source/util/monster/monster-main.cc
+++ b/crawl-ref/source/util/monster/monster-main.cc
@@ -1175,6 +1175,7 @@ int main(int argc, char* argv[])
         mons_check_flag(bool(me->bitfields & M_FLIES), monsterflags, "fly");
         mons_check_flag(bool(me->bitfields & M_FAST_REGEN), monsterflags,
                         "regen");
+        mons_check_flag(mon.can_cling_to_walls(), monsterflags, "cling");
         mons_check_flag(bool(me->bitfields & M_WEB_SENSE), monsterflags,
                         "web sense");
         mons_check_flag(mon.is_unbreathing(), monsterflags, "unbreathing");


### PR DESCRIPTION
This commit adds Cling to the list of flags displayed by the monster
utility.

The result looks like this:
![dart_slug](https://user-images.githubusercontent.com/3328424/33687248-a57fb528-dae8-11e7-9a4c-1373f6f5b4ce.png)
