### PR TITLE
Normalize number of attacks under Serpent's Lash

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1596,7 +1596,10 @@ static bool _can_attack_martial(const monster* mons)
 // made the same amount of attacks as tabbing.
 static int _wu_jian_number_of_attacks(bool wall_jump)
 {
-    const int move_delay = player_movement_speed() * player_speed();
+    // Under the effect of serpent's lash, move delay is normalized to 
+    // 10 aut for every character, to avoid punishing fast races.
+    const int move_delay = you.attribute[ATTR_SERPENTS_LASH] ? 100 : player_movement_speed() * player_speed();
+
     int attack_delay;
 
     {


### PR DESCRIPTION
As it stands right now, fast races are unfairly punished and slow races rewarded when using Serpent's Lash.

There is an aspect of SL that is unavoidable and makes it valuable for slow characters; a free move is worth more for them. However, since number of attacks scales proportionally to the character's move delay, they also enjoyed the additional advantage of hitting more often when lashing.

This fix makes it so all characters calculate their number of attacks based on a normalized 10 aut move delay when using Serpent's Lash, regardless of their movement speed. Keep in mind that the formula still factors in attack delay as usual, so it won't allow a character to perform multiple hits with a long attack delay weapon.