### PR TITLE
Clip tall menu entry tiles to top section

### DIFF
--- a/crawl-ref/source/tilereg-menu.cc
+++ b/crawl-ref/source/tilereg-menu.cc
@@ -220,8 +220,7 @@ void MenuRegion::_place_entries(const int left_offset, const int top_offset,
                     // sorted by texture first, e.g. you can never draw
                     // a dungeon tile over a monster tile.
                     TextureID tex  = tile.tex;
-                    m_tile_buf[tex].add_unscaled(tile.tile, entry.sx, entry.sy,
-                                                 tile.ymax);
+                    m_tile_buf[tex].add(tile.tile, entry.sx, entry.sy, 0, 0, false, tile.ymax, 1, 1);
                 }
             }
             else

--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -1073,7 +1073,7 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
         draw_from_texture: function (idx, x, y, tex, ofsx, ofsy, y_max)
         {
             var mod = tileinfos(tex);
-            this.draw_tile(idx, x, y, mod, ofsx, ofsy);
+            this.draw_tile(idx, x, y, mod, ofsx, ofsy, y_max);
         },
     });
 

--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -1006,7 +1006,7 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
 
 
         // Helper functions for drawing from specific textures
-        draw_tile: function(idx, x, y, mod, ofsx, ofsy, y_max)
+        draw_tile: function(idx, x, y, mod, ofsx, ofsy, y_max, centre)
         {
             var info = mod.get_tile_info(idx);
             var img = get_img(mod.get_img(idx));
@@ -1014,8 +1014,9 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
             {
                 throw ("Tile not found: " + idx);
             }
-            var size_ox = 32 / 2 - info.w / 2;
-            var size_oy = 32 - info.h;
+            centre = centre === undefined ? true : centre;
+            var size_ox = !centre ? 0 : 32 / 2 - info.w / 2;
+            var size_oy = !centre ? 0 : 32 - info.h;
             var pos_sy_adjust = (ofsy || 0) + info.oy + size_oy;
             var pos_ey_adjust = pos_sy_adjust + info.ey - info.sy;
             var sy = pos_sy_adjust;
@@ -1070,10 +1071,10 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
             this.draw_tile(idx, x, y, icons, ofsx, ofsy);
         },
 
-        draw_from_texture: function (idx, x, y, tex, ofsx, ofsy, y_max)
+        draw_from_texture: function (idx, x, y, tex, ofsx, ofsy, y_max, centre)
         {
             var mod = tileinfos(tex);
-            this.draw_tile(idx, x, y, mod, ofsx, ofsy, y_max);
+            this.draw_tile(idx, x, y, mod, ofsx, ofsy, y_max, centre);
         },
     });
 

--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -50,7 +50,7 @@ function ($, comm, client, enums, dungeon_renderer, cr, util, options) {
             renderer.init(canvas[0]);
 
             $.each(item.tiles, function () {
-                renderer.draw_from_texture(this.t, 0, 0, this.tex, 0, 0, this.ymax);
+                renderer.draw_from_texture(this.t, 0, 0, this.tex, 0, 0, this.ymax, false);
             });
 
             elem.prepend(canvas);


### PR DESCRIPTION
This makes the ?/M menu much nicer when big uniques (e.g. hell lords)
are shown:

![out](https://user-images.githubusercontent.com/10691965/33949674-41add976-e065-11e7-85ed-4d5a16236099.png)

Fix included for both webtiles and local tiles

Edit: this fixes mantis issue https://crawl.develz.org/mantis/view.php?id=10213