### PR TITLE
Fix tiles not properly processing mouse move events

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -803,6 +803,16 @@ int TilesFramework::getch_ck()
 
             case WME_MOUSEMOTION:
                 {
+                    // For consecutive mouse events, ignore all but the last,
+                    // since these can come in faster than crawl can redraw.
+                    //
+                    // Note that get_event_count() is misleadingly named and only
+                    // peeks at the first event, and so will only return 0 or 1.
+                    unsigned int count = wm->get_event_count(WME_MOUSEMOTION);
+                    ASSERT(count >= 0);
+                    if (count > 0)
+                        continue;
+
                     // Record mouse pos for tooltip timer
                     if (m_mouse.x != (int)event.mouse_event.px
                         || m_mouse.y != (int)event.mouse_event.py)
@@ -848,19 +858,6 @@ int TilesFramework::getch_ck()
                         prev_msg_alt_text = m_region_msg->alt_text();
                         set_need_redraw();
                     }
-
-                    // Don't break back to Crawl and redraw for every mouse
-                    // event, because there's a lot of them.
-                    //
-                    // If there are other mouse events in the queue
-                    // (possibly because redrawing is slow or the user
-                    // is moving the mouse really quickly), process those
-                    // first, before bothering to redraw the screen.
-                    unsigned int count = wm->get_event_count(WME_MOUSEMOTION);
-                    ASSERT(count >= 0);
-                    if (count > 0)
-                        continue;
-
                 }
                break;
 


### PR DESCRIPTION
The old continue statement never worked at all: its while loop had
(!key) as a condition, so it was equivalent to a break. I've moved
the check to the start of the MOUSEMOTION handling: there's no point
partially processing the event if there's another mouse motion event
right behind it. Also updated the comment text a little to clarify.

This fix makes targeting mode gloriously smooth when rapidly moving the
mouse; probably fixes lag in other places as well.