### PR TITLE
Spooky cleanup

### DIFF
--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1183,7 +1183,7 @@ static void _make_level(dungeon_feature_type stair_taken,
         && (!player_in_branch(BRANCH_DUNGEON) || you.depth > 2)
         && one_chance_in(3))
     {
-        load_ghost(true);
+        load_ghosts(true);
     }
     env.turns_on_level = 0;
     // sanctuary
@@ -1821,7 +1821,7 @@ static vector<ghost_demon> _load_ghost_vec(bool creating_level, bool wiz_cmd)
  * @param creating_level    Whether a level is currently being generated.
  * @return                  Whether ghosts were actually generated.
  */
-bool load_ghost(bool creating_level)
+bool load_ghosts(bool creating_level)
 {
     const bool wiz_cmd = (crawl_state.prev_cmd == CMD_WIZARD);
 
@@ -2388,7 +2388,7 @@ static FILE* _make_bones_file(string * return_gfilename)
  * @param force   Forces ghost generation even in otherwise-disallowed levels.
  **/
 
-void save_ghost(bool force)
+void save_ghosts(const vector<ghost_demon> &ghosts, bool force)
 {
 #ifdef BONES_DIAGNOSTICS
     const bool do_diagnostics =
@@ -2401,8 +2401,6 @@ void save_ghost(bool force)
 #  endif
         ;
 #endif // BONES_DIAGNOSTICS
-
-    vector<ghost_demon> ghosts = ghost_demon::find_ghosts();
 
     if (ghosts.empty())
     {

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1873,9 +1873,6 @@ bool load_ghost(bool creating_level)
         mons->set_ghost(loaded_ghosts[0]);
         mons->type = MONS_PLAYER_GHOST;
         mons->ghost_init();
-        mons->bind_melee_flags();
-        if (mons->has_spells())
-            mons->bind_spell_flags();
 
         loaded_ghosts.erase(loaded_ghosts.begin());
 #ifdef BONES_DIAGNOSTICS

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -108,8 +108,8 @@ public:
     void go_to(const level_id &level);
 };
 
-void save_ghost(bool force = false);
-bool load_ghost(bool creating_level);
+void save_ghosts(const vector<ghost_demon> &ghosts, bool force = false);
+bool load_ghosts(bool creating_level);
 
 FILE *lk_open(const char *mode, const string &file);
 FILE *lk_open_exclusive(const string &file);

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -109,7 +109,7 @@ public:
 };
 
 void save_ghosts(const vector<ghost_demon> &ghosts, bool force = false);
-bool load_ghosts(bool creating_level);
+bool load_ghosts(int max_ghosts, bool creating_level);
 
 FILE *lk_open(const char *mode, const string &file);
 FILE *lk_open_exclusive(const string &file);

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -703,21 +703,18 @@ const vector<ghost_demon> ghost_demon::find_ghosts()
     // Pick up any other ghosts that happen to be on the level if we
     // have space. If the player is undead, add one to the ghost quota
     // for the level.
-    find_extra_ghosts(gs, n_extra_ghosts() + 1 - gs.size());
+    find_extra_ghosts(gs);
 
     return gs;
 }
 
 void ghost_demon::find_transiting_ghosts(
-    vector<ghost_demon> &gs, int n)
+    vector<ghost_demon> &gs)
 {
-    if (n <= 0)
-        return;
-
     const m_transit_list *mt = get_transit_list(level_id::current());
     if (mt)
     {
-        for (auto i = mt->begin(); i != mt->end() && n > 0; ++i)
+        for (auto i = mt->begin(); i != mt->end(); ++i)
         {
             if (i->mons.type == MONS_PLAYER_GHOST)
             {
@@ -726,7 +723,6 @@ void ghost_demon::find_transiting_ghosts(
                 {
                     announce_ghost(*m.ghost);
                     gs.push_back(*m.ghost);
-                    --n;
                 }
             }
         }
@@ -740,30 +736,26 @@ void ghost_demon::announce_ghost(const ghost_demon &g)
 #endif
 }
 
-void ghost_demon::find_extra_ghosts(vector<ghost_demon> &gs, int n)
+void ghost_demon::find_extra_ghosts(vector<ghost_demon> &gs)
 {
-    for (monster_iterator mi; mi && n > 0; ++mi)
+    for (monster_iterator mi; mi; ++mi)
     {
         if (mi->type == MONS_PLAYER_GHOST && mi->ghost.get())
         {
             // Bingo!
             announce_ghost(*(mi->ghost));
             gs.push_back(*(mi->ghost));
-            --n;
         }
     }
 
     // Check the transit list for the current level.
-    find_transiting_ghosts(gs, n);
+    find_transiting_ghosts(gs);
 }
 
-// Returns the number of extra ghosts allowed on the level.
-int ghost_demon::n_extra_ghosts()
+/// Returns the number of extra ghosts allowed on the specified level.
+int ghost_demon::max_ghosts_per_level(int absdepth)
 {
-    if (env.absdepth0 < 10)
-        return 0;
-
-    return MAX_GHOSTS - 1;
+    return absdepth < 10 ? 1 : MAX_GHOSTS;
 }
 
 bool debug_check_ghost(const ghost_demon &ghost)

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -688,7 +688,7 @@ spell_type ghost_demon::translate_spell(spell_type spell) const
     return spell;
 }
 
-vector<ghost_demon> ghost_demon::find_ghosts()
+const vector<ghost_demon> ghost_demon::find_ghosts()
 {
     vector<ghost_demon> gs;
 

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -29,8 +29,6 @@
 #define MAX_GHOST_HP        400
 #define MAX_GHOST_EVASION    60
 
-vector<ghost_demon> ghosts;
-
 // Pan lord AOE conjuration spell list.
 static spell_type search_order_aoe_conj[] =
 {
@@ -768,59 +766,65 @@ int ghost_demon::n_extra_ghosts()
     return MAX_GHOSTS - 1;
 }
 
+bool debug_check_ghost(const ghost_demon &ghost)
+{
+    // Values greater than the allowed maximum or less then the
+    // allowed minimum signalise bugginess.
+    if (ghost.damage < 0 || ghost.damage > MAX_GHOST_DAMAGE)
+        return false;
+    if (ghost.max_hp < 1 || ghost.max_hp > MAX_GHOST_HP)
+        return false;
+    if (ghost.xl < 1 || ghost.xl > 27)
+        return false;
+    if (ghost.ev > MAX_GHOST_EVASION)
+        return false;
+    if (get_resist(ghost.resists, MR_RES_ELEC) < 0)
+        return false;
+    if (ghost.brand < SPWPN_NORMAL || ghost.brand > MAX_GHOST_BRAND)
+        return false;
+    if (ghost.species < 0 || ghost.species >= NUM_SPECIES)
+        return false;
+    if (ghost.job < JOB_FIGHTER || ghost.job >= NUM_JOBS)
+        return false;
+    if (ghost.best_skill < SK_FIGHTING || ghost.best_skill >= NUM_SKILLS)
+        return false;
+    if (ghost.best_skill_level < 0 || ghost.best_skill_level > 27)
+        return false;
+    if (ghost.religion < GOD_NO_GOD || ghost.religion >= NUM_GODS)
+        return false;
+
+    if (ghost.brand == SPWPN_HOLY_WRATH)
+        return false;
+
+    // Only (very) ugly things get non-plain attack types and
+    // flavours.
+    if (ghost.att_type != AT_HIT || ghost.att_flav != AF_PLAIN)
+        return false;
+
+    // Name validation.
+    if (!validate_player_name(ghost.name, false))
+        return false;
+    // Many combining characters can come per every letter, but if there's
+    // that much, it's probably a maliciously forged ghost of some kind.
+    if (ghost.name.length() > MAX_NAME_LENGTH * 10 || ghost.name.empty())
+        return false;
+    if (ghost.name != trimmed_string(ghost.name))
+        return false;
+
+    // Check for non-existing spells.
+    for (const mon_spell_slot &slot : ghost.spells)
+        if (slot.spell < 0 || slot.spell >= NUM_SPELLS)
+            return false;
+
+    return true;
+}
+
 // Sanity checks for some ghost values.
-bool debug_check_ghosts()
+bool debug_check_ghosts(vector<ghost_demon> &ghosts)
 {
     for (const ghost_demon &ghost : ghosts)
-    {
-        // Values greater than the allowed maximum or less then the
-        // allowed minimum signalise bugginess.
-        if (ghost.damage < 0 || ghost.damage > MAX_GHOST_DAMAGE)
+        if (!debug_check_ghost(ghost))
             return false;
-        if (ghost.max_hp < 1 || ghost.max_hp > MAX_GHOST_HP)
-            return false;
-        if (ghost.xl < 1 || ghost.xl > 27)
-            return false;
-        if (ghost.ev > MAX_GHOST_EVASION)
-            return false;
-        if (get_resist(ghost.resists, MR_RES_ELEC) < 0)
-            return false;
-        if (ghost.brand < SPWPN_NORMAL || ghost.brand > MAX_GHOST_BRAND)
-            return false;
-        if (ghost.species < 0 || ghost.species >= NUM_SPECIES)
-            return false;
-        if (ghost.job < JOB_FIGHTER || ghost.job >= NUM_JOBS)
-            return false;
-        if (ghost.best_skill < SK_FIGHTING || ghost.best_skill >= NUM_SKILLS)
-            return false;
-        if (ghost.best_skill_level < 0 || ghost.best_skill_level > 27)
-            return false;
-        if (ghost.religion < GOD_NO_GOD || ghost.religion >= NUM_GODS)
-            return false;
-
-        if (ghost.brand == SPWPN_HOLY_WRATH)
-            return false;
-
-        // Only (very) ugly things get non-plain attack types and
-        // flavours.
-        if (ghost.att_type != AT_HIT || ghost.att_flav != AF_PLAIN)
-            return false;
-
-        // Name validation.
-        if (!validate_player_name(ghost.name, false))
-            return false;
-        // Many combining characters can come per every letter, but if there's
-        // that much, it's probably a maliciously forged ghost of some kind.
-        if (ghost.name.length() > MAX_NAME_LENGTH * 10 || ghost.name.empty())
-            return false;
-        if (ghost.name != trimmed_string(ghost.name))
-            return false;
-
-        // Check for non-existing spells.
-        for (const mon_spell_slot &slot : ghost.spells)
-            if (slot.spell < 0 || slot.spell >= NUM_SPELLS)
-                return false;
-    }
     return true;
 }
 

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -51,7 +51,7 @@ public:
 
 
 public:
-    static vector<ghost_demon> find_ghosts();
+    static const vector<ghost_demon> find_ghosts();
 
 private:
     static int n_extra_ghosts();

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -52,11 +52,11 @@ public:
 
 public:
     static const vector<ghost_demon> find_ghosts();
+    static int max_ghosts_per_level(int absdepth);
 
 private:
-    static int n_extra_ghosts();
-    static void find_extra_ghosts(vector<ghost_demon> &ghosts, int n);
-    static void find_transiting_ghosts(vector<ghost_demon> &gs, int n);
+    static void find_extra_ghosts(vector<ghost_demon> &ghosts);
+    static void find_transiting_ghosts(vector<ghost_demon> &gs);
     static void announce_ghost(const ghost_demon &g);
 
 private:

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -66,8 +66,7 @@ private:
                                    attack_flavour u_att_flav);
 };
 
-bool debug_check_ghosts();
+bool debug_check_ghosts(vector<ghost_demon> &ghosts);
+bool debug_check_ghost(const ghost_demon &ghost);
 int ghost_level_to_rank(const int xl);
 int ghost_rank_to_level(const int rank);
-
-extern vector<ghost_demon> ghosts;

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -2948,8 +2948,6 @@ void define_monster(monster& mons)
         ghost.init_player_ghost(mcls == MONS_PLAYER_GHOST);
         mons.set_ghost(ghost);
         mons.ghost_init(!mons.props.exists("fake"));
-        mons.bind_melee_flags();
-        mons.bind_spell_flags();
         break;
     }
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4604,6 +4604,9 @@ void monster::ghost_init(bool need_pos)
     // if we have a home first. {due}
     if (need_pos && !in_bounds(pos()))
         find_place_to_live();
+
+    bind_melee_flags();
+    bind_spell_flags(); // does this even do anything on ghosts?
 }
 
 void monster::uglything_init(bool only_mutate)

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -34,6 +34,7 @@
 #include "fight.h"
 #include "files.h"
 #include "fineff.h"
+#include "ghost.h"
 #include "god-abil.h"
 #include "god-conduct.h"
 #include "god-passive.h"
@@ -1108,7 +1109,7 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
 
     // Never generate bones files of wizard or tutorial characters -- bwr
     if (!non_death && !crawl_state.game_is_tutorial() && !you.wizard)
-        save_ghost();
+        save_ghosts(ghost_demon::find_ghosts());
 
     end_game(se, hiscore_index);
 }

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -86,6 +86,8 @@
 #include "unwind.h"
 #include "version.h"
 
+vector<ghost_demon> global_ghosts; // only for reading/writing
+
 // defined in dgn-overview.cc
 extern map<branch_type, set<level_id> > stair_level;
 extern map<level_pos, shop_type> shops_present;
@@ -315,8 +317,8 @@ static void tag_read_level_tiles(reader &th);
 static void _regenerate_tile_flavour();
 static void _draw_tiles();
 
-static void tag_construct_ghost(writer &th);
-static void tag_read_ghost(reader &th);
+static void tag_construct_ghost(writer &th, vector<ghost_demon> &);
+static vector<ghost_demon> tag_read_ghost(reader &th);
 
 static void marshallGhost(writer &th, const ghost_demon &ghost);
 static ghost_demon unmarshallGhost(reader &th);
@@ -1165,7 +1167,7 @@ void tag_write(tag_type tagID, writer &outf)
         tag_construct_level_tiles(th);
         break;
     case TAG_GHOST:
-        tag_construct_ghost(th);
+        tag_construct_ghost(th, global_ghosts);
         break;
     default:
         // I don't know how to make that!
@@ -1296,7 +1298,7 @@ void tag_read(reader &inf, tag_type tag_id)
 #endif
         break;
     case TAG_GHOST:
-        tag_read_ghost(th);
+        global_ghosts = tag_read_ghost(th);
         break;
     default:
         // I don't know how to read that!
@@ -6816,7 +6818,7 @@ static ghost_demon unmarshallGhost(reader &th)
     return ghost;
 }
 
-static void tag_construct_ghost(writer &th)
+static void tag_construct_ghost(writer &th, vector<ghost_demon> &ghosts)
 {
     // How many ghosts?
     marshallShort(th, ghosts.size());
@@ -6825,13 +6827,28 @@ static void tag_construct_ghost(writer &th)
         marshallGhost(th, ghost);
 }
 
-static void tag_read_ghost(reader &th)
+static vector<ghost_demon> tag_read_ghost(reader &th)
 {
+    vector<ghost_demon> result;
     int nghosts = unmarshallShort(th);
 
     if (nghosts < 1 || nghosts > MAX_GHOSTS)
-        return;
+        return result;
 
     for (int i = 0; i < nghosts; ++i)
-        ghosts.push_back(unmarshallGhost(th));
+        result.push_back(unmarshallGhost(th));
+    return result;
+}
+
+vector<ghost_demon> tag_read_ghosts(reader &th)
+{
+    global_ghosts.clear();
+    tag_read(th, TAG_GHOST);
+    return global_ghosts; // should use copy semantics?
+}
+
+void tag_write_ghosts(writer &th, vector<ghost_demon> &ghosts)
+{
+    global_ghosts = ghosts;
+    tag_write(TAG_GHOST, th);
 }

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6847,7 +6847,7 @@ vector<ghost_demon> tag_read_ghosts(reader &th)
     return global_ghosts; // should use copy semantics?
 }
 
-void tag_write_ghosts(writer &th, vector<ghost_demon> &ghosts)
+void tag_write_ghosts(writer &th, const vector<ghost_demon> &ghosts)
 {
     global_ghosts = ghosts;
     tag_write(TAG_GHOST, th);

--- a/crawl-ref/source/tags.h
+++ b/crawl-ref/source/tags.h
@@ -172,7 +172,7 @@ void tag_write(tag_type tagID, writer &outf);
 void tag_read_char(reader &th, uint8_t format, uint8_t major, uint8_t minor);
 
 vector<ghost_demon> tag_read_ghosts(reader &th);
-void tag_write_ghosts(writer &th, vector<ghost_demon> &ghosts);
+void tag_write_ghosts(writer &th, const vector<ghost_demon> &ghosts);
 
 /* ***********************************************************************
  * misc

--- a/crawl-ref/source/tags.h
+++ b/crawl-ref/source/tags.h
@@ -12,6 +12,7 @@
 struct show_type;
 struct monster_info;
 struct map_cell;
+class ghost_demon;
 
 enum tag_type   // used during save/load process to identify data blocks
 {
@@ -169,6 +170,9 @@ static inline void unmarshallSigned(reader& th, T& v)
 void tag_read(reader &inf, tag_type tag_id);
 void tag_write(tag_type tagID, writer &outf);
 void tag_read_char(reader &th, uint8_t format, uint8_t major, uint8_t minor);
+
+vector<ghost_demon> tag_read_ghosts(reader &th);
+void tag_write_ghosts(writer &th, vector<ghost_demon> &ghosts);
 
 /* ***********************************************************************
  * misc

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -177,10 +177,12 @@ void wizard_create_spec_monster_name()
         }
         ghost.job = static_cast<job_type>(job_id);
         ghost.xl = 7;
+        ghost.max_hp = 20;
 
         mon.set_ghost(ghost);
 
         ghosts.push_back(ghost);
+        ASSERT(debug_check_ghosts());
     }
 }
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -178,11 +178,9 @@ void wizard_create_spec_monster_name()
         ghost.job = static_cast<job_type>(job_id);
         ghost.xl = 7;
         ghost.max_hp = 20;
+        ASSERT(debug_check_ghost(ghost));
 
         mon.set_ghost(ghost);
-
-        ghosts.push_back(ghost);
-        ASSERT(debug_check_ghosts());
     }
 }
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1192,9 +1192,9 @@ void debug_ghosts()
     const char c = toalower(getchm());
 
     if (c == 'c')
-        save_ghost(true);
+        save_ghosts(ghost_demon::find_ghosts(), true);
     else if (c == 'l')
-        load_ghost(false);
+        load_ghosts(false);
     else
         canned_msg(MSG_OK);
 }

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1194,7 +1194,7 @@ void debug_ghosts()
     if (c == 'c')
         save_ghosts(ghost_demon::find_ghosts(), true);
     else if (c == 'l')
-        load_ghosts(false);
+        load_ghosts(ghost_demon::max_ghosts_per_level(env.absdepth0), false);
     else
         canned_msg(MSG_OK);
 }


### PR DESCRIPTION
These are cleanup changes that are a precondition for doing pretty much any of the non-remove plans for ghosts, leading up the ability to load ghosts one by one.  They shouldn't change the status quo much if at all.

Would be helpful to get a sanity check on these changes, since the ghost save/load code is a bit of a mess, so I'm opening them as a PR.