### PR TITLE
Remake god description UI with formatted_scroller

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -25,6 +25,7 @@
 #include "libutil.h"
 #include "macro.h"
 #include "menu.h"
+#include "message.h"
 #include "religion.h"
 #include "skills.h"
 #include "spl-util.h"
@@ -467,57 +468,10 @@ static string _describe_branch_bribability()
     return ret;
 }
 
-/**
- * Print a guide to cycling between description screens, and check if the
- * player does so.
- *
- * @return Whether the player chose to cycle to the next description screen.
- */
-static bool _check_description_cycle(god_desc_type gdesc)
-{
-    // Another function may have left a dangling recolour.
-    textcolour(LIGHTGREY);
-
-    const int bottom_line = min(30, get_number_of_lines());
-
-    cgotoxy(1, bottom_line);
-    const char* place = nullptr;
-    switch (gdesc)
-    {
-        case GDESC_OVERVIEW: place = "<w>Overview</w>|Powers|Wrath"; break;
-        case GDESC_DETAILED: place = "Overview|<w>Powers</w>|Wrath"; break;
-        case GDESC_WRATH:    place = "Overview|Powers|<w>Wrath</w>"; break;
-        default: die("Unknown god description type!");
-    }
-    formatted_string::parse_string(make_stringf("[<w>!</w>/<w>^</w>"
-#ifdef USE_TILE_LOCAL
-                                   "|<w>Right-click</w>"
-#endif
-    "]: %s", place)).display();
-
-    mouse_control mc(MOUSE_MODE_MORE);
-
-    const int keyin = getchm();
-    return keyin == '!' || keyin == CK_MOUSE_CMD || keyin == '^';
-}
-
-/**
- * Linewrap & print a provided string, if non-empty.
- *
- * Also adds a pair of newlines, if the string is non-empty. (Ugly hack...)
- *
- * @param str       The string in question. (May be empty.)
- * @param width     The width to wrap to.
- */
-static void _print_string_wrapped(string str, int width)
+static inline void _add_par(formatted_string &desc, const string &str)
 {
     if (!str.empty())
-    {
-        linebreak_string(str, width);
-        display_tagged_block(str);
-        cprintf("\n");
-        cprintf("\n");
-    }
+        desc += formatted_string::parse_string(trimmed_string(str) + "\n\n");
 }
 
 /**
@@ -579,14 +533,15 @@ static string _describe_god_wrath_causes(god_type which_god)
  * @param god       The god in question.
  * @param width     The width of the screen.
  */
-static void _print_top_line(god_type which_god, int width)
+static formatted_string _print_top_line(god_type which_god, int width)
 {
+    formatted_string line;
     const string godname = uppercase_first(god_name(which_god, true));
-    textcolour(god_colour(which_god));
+    line.textcolour(god_colour(which_god));
     const int len = width - strwidth(godname);
-    cprintf("%s%s\n", string(len / 2, ' ').c_str(), godname.c_str());
-    textcolour(LIGHTGREY);
-    cprintf("\n");
+    line.cprintf("%s%s\n\n", string(len / 2, ' ').c_str(), godname.c_str());
+    line.textcolour(LIGHTGREY);
+    return line;
 }
 
 /**
@@ -594,27 +549,23 @@ static void _print_top_line(god_type which_god, int width)
  *
  * @param which_god     The god in question.
  */
-static void _god_wrath_description(god_type which_god)
+static formatted_string _god_wrath_description(god_type which_god)
 {
-    clrscr();
+    formatted_string desc;
 
-    const int width = min(80, get_number_of_cols()) - 1;
-
-    _print_top_line(which_god, width);
-
-    _print_string_wrapped(get_god_dislikes(which_god), width);
-    _print_string_wrapped(_describe_god_wrath_causes(which_god), width);
-    _print_string_wrapped(getLongDescription(god_name(which_god) + " wrath"),
-                          width);
+    _add_par(desc, get_god_dislikes(which_god));
+    _add_par(desc, _describe_god_wrath_causes(which_god));
+    _add_par(desc, getLongDescription(god_name(which_god) + " wrath"));
 
     if (which_god != GOD_RU) // Permanent wrath.
     {
         const bool long_wrath = initial_wrath_penance_for(which_god) > 30;
-        _print_string_wrapped(apostrophise(uppercase_first(god_name(which_god)))
+        _add_par(desc, apostrophise(uppercase_first(god_name(which_god)))
                               + " wrath lasts for a relatively " +
-                              (long_wrath ? "long" : "short") + " duration.",
-                              width);
+                              (long_wrath ? "long" : "short") + " duration.");
     }
+
+    return desc;
 }
 
 /**
@@ -676,19 +627,13 @@ static string _get_god_misc_info(god_type which_god)
  *
  * @param god       The god in question.
  */
-static void _detailed_god_description(god_type which_god)
+static formatted_string _detailed_god_description(god_type which_god)
 {
-    clrscr();
-
-    const int width = min(80, get_number_of_cols()) - 1;
-
-    _print_top_line(which_god, width);
-
-    _print_string_wrapped(getLongDescription(god_name(which_god) + " powers"),
-                          width);
-
-    _print_string_wrapped(get_god_likes(which_god), width);
-    _print_string_wrapped(_get_god_misc_info(which_god), width);
+    formatted_string desc;
+    _add_par(desc, getLongDescription(god_name(which_god) + " powers"));
+    _add_par(desc, get_god_likes(which_god));
+    _add_par(desc, _get_god_misc_info(which_god));
+    return desc;
 }
 
 /**
@@ -750,14 +695,16 @@ static string _god_penance_message(god_type which_god)
  *
  * @param which_god     The god in question.
  */
-static void _describe_god_powers(god_type which_god)
+static formatted_string _describe_god_powers(god_type which_god)
 {
+    formatted_string desc;
+
     int piety = you_worship(which_god) ? you.piety : 0;
 
-    textcolour(LIGHTGREY);
+    desc.textcolour(LIGHTGREY);
     const char *header = "Granted powers:";
     const char *cost   = "(Cost)";
-    cprintf("\n\n%s%*s%s\n", header,
+    desc.cprintf("\n\n%s%*s%s\n", header,
             min(80, get_number_of_cols()) - 1 - strwidth(header) - strwidth(cost),
             "", cost);
 
@@ -766,9 +713,9 @@ static void _describe_god_powers(god_type which_god)
     // set default color here, so we don't have to set in multiple places for
     // always available passive abilities
     if (!you_worship(which_god))
-        textcolour(DARKGREY);
+        desc.textcolour(DARKGREY);
     else
-        textcolour(god_colour(which_god));
+        desc.textcolour(god_colour(which_god));
 
     // mv: Some gods can protect you from harm.
     // The god isn't really protecting the player - only sometimes saving
@@ -802,7 +749,7 @@ static void _describe_god_powers(god_type which_god)
                           (prot_chance >= 25) ? "sometimes"
                                               : "occasionally";
 
-        cprintf("%s %s watches over you%s.\n",
+        desc.cprintf("%s %s watches over you%s.\n",
                 uppercase_first(god_name(which_god)).c_str(),
                 how,
                 when);
@@ -819,7 +766,7 @@ static void _describe_god_powers(god_type which_god)
             (piety >= piety_breakpoint(1)) ? "sometimes" :
                                              "occasionally";
 
-        cprintf("%s %s shields you from chaos.\n",
+        desc.cprintf("%s %s shields you from chaos.\n",
                 uppercase_first(god_name(which_god)).c_str(), how);
         break;
     }
@@ -827,26 +774,26 @@ static void _describe_god_powers(god_type which_god)
     case GOD_SHINING_ONE:
     {
         have_any = true;
-        cprintf("%s prevents you from stabbing unaware foes.\n",
+        desc.cprintf("%s prevents you from stabbing unaware foes.\n",
                 uppercase_first(god_name(which_god)).c_str());
         if (piety < piety_breakpoint(1))
-            textcolour(DARKGREY);
+            desc.textcolour(DARKGREY);
         else
-            textcolour(god_colour(which_god));
+            desc.textcolour(god_colour(which_god));
         const char *how =
             (piety >= piety_breakpoint(5)) ? "completely" :
             (piety >= piety_breakpoint(3)) ? "mostly" :
                                              "partially";
 
-        cprintf("%s %s shields you from negative energy.\n",
+        desc.cprintf("%s %s shields you from negative energy.\n",
                 uppercase_first(god_name(which_god)).c_str(), how);
 
         const int halo_size = you_worship(which_god) ? you.halo_radius() : -1;
         if (halo_size < 0)
-            textcolour(DARKGREY);
+            desc.textcolour(DARKGREY);
         else
-            textcolour(god_colour(which_god));
-        cprintf("You radiate a%s righteous aura, and others within it are "
+            desc.textcolour(god_colour(which_god));
+        desc.cprintf("You radiate a%s righteous aura, and others within it are "
                 "easier to hit.\n",
                 halo_size > 5 ? " large" :
                 halo_size > 3 ? "" :
@@ -857,17 +804,17 @@ static void _describe_god_powers(god_type which_god)
     case GOD_JIYVA:
         have_any = true;
         if (have_passive(passive_t::resist_corrosion))
-            textcolour(god_colour(which_god));
+            desc.textcolour(god_colour(which_god));
         else
-            textcolour(DARKGREY);
-        cprintf("%s shields you from corrosive effects.\n",
+            desc.textcolour(DARKGREY);
+        desc.cprintf("%s shields you from corrosive effects.\n",
                 uppercase_first(god_name(which_god)).c_str());
 
         if (have_passive(passive_t::slime_feed))
-            textcolour(god_colour(which_god));
+            desc.textcolour(god_colour(which_god));
         else
-            textcolour(DARKGREY);
-        cprintf("You gain nutrition%s when your fellow slimes consume items.\n",
+            desc.textcolour(DARKGREY);
+        desc.cprintf("You gain nutrition%s when your fellow slimes consume items.\n",
                 have_passive(passive_t::slime_hp) ? ", magic and health" :
                 have_passive(passive_t::slime_mp) ? " and magic" :
                                                     "");
@@ -875,26 +822,26 @@ static void _describe_god_powers(god_type which_god)
 
     case GOD_FEDHAS:
         have_any = true;
-        cprintf("You can walk through plants and fire through allied plants.\n");
+        desc.cprintf("You can walk through plants and fire through allied plants.\n");
         break;
 
     case GOD_ASHENZARI:
         have_any = true;
-        cprintf("You are provided with a bounty of information.\n");
+        desc.cprintf("You are provided with a bounty of information.\n");
         break;
 
     case GOD_CHEIBRIADOS:
         have_any = true;
         if (have_passive(passive_t::stat_boost))
-            textcolour(god_colour(which_god));
+            desc.textcolour(god_colour(which_god));
         else
-            textcolour(DARKGREY);
-        cprintf("%s %sslows your movement.\n",
+            desc.textcolour(DARKGREY);
+        desc.cprintf("%s %sslows your movement.\n",
                 uppercase_first(god_name(which_god)).c_str(),
                 piety >= piety_breakpoint(5) ? "greatly " :
                 piety >= piety_breakpoint(2) ? "" :
                                                "slightly ");
-        cprintf("%s supports your attributes. (+%d)\n",
+        desc.cprintf("%s supports your attributes. (+%d)\n",
                 uppercase_first(god_name(which_god)).c_str(),
                 chei_stat_boost(piety));
         break;
@@ -906,12 +853,12 @@ static void _describe_god_powers(god_type which_god)
             const char* offer = numoffers == 1
                                ? spell_title(*you.vehumet_gifts.begin())
                                : "some of Vehumet's most lethal spells";
-            cprintf("You can memorise %s.\n", offer);
+            desc.cprintf("You can memorise %s.\n", offer);
         }
         else
         {
-            textcolour(DARKGREY);
-            cprintf("You can memorise some of Vehumet's spells.\n");
+            desc.textcolour(DARKGREY);
+            desc.cprintf("You can memorise some of Vehumet's spells.\n");
         }
         break;
 
@@ -920,10 +867,10 @@ static void _describe_god_powers(god_type which_god)
         have_any = true;
         const int umbra_size = you_worship(which_god) ? you.umbra_radius() : -1;
         if (umbra_size < 0)
-            textcolour(DARKGREY);
+            desc.textcolour(DARKGREY);
         else
-            textcolour(god_colour(which_god));
-        cprintf("You radiate a%s aura of darkness, enhancing your stealth "
+            desc.textcolour(god_colour(which_god));
+        desc.cprintf("You radiate a%s aura of darkness, enhancing your stealth "
                 "and reducing the accuracy of your foes.\n",
                 umbra_size > 5 ? " large" :
                 umbra_size > 3 ? "n" :
@@ -933,32 +880,32 @@ static void _describe_god_powers(god_type which_god)
 
     case GOD_GOZAG:
         have_any = true;
-        cprintf("You passively detect gold.\n");
-        cprintf("%s turns your defeated foes' bodies to gold.\n",
+        desc.cprintf("You passively detect gold.\n");
+        desc.cprintf("%s turns your defeated foes' bodies to gold.\n",
                 uppercase_first(god_name(which_god)).c_str());
-        cprintf("Your enemies may become distracted by gold.\n");
+        desc.cprintf("Your enemies may become distracted by gold.\n");
         break;
 
     case GOD_HEPLIAKLQANA:
         have_any = true;
-        cprintf("Your life essence is reduced. (-10% HP)\n");
+        desc.cprintf("Your life essence is reduced. (-10%% HP)\n");
         break;
 
     case GOD_PAKELLAS:
     {
         have_any = true;
-        cprintf("%s prevents your magic from regenerating.\n",
+        desc.cprintf("%s prevents your magic from regenerating.\n",
                 uppercase_first(god_name(which_god)).c_str());
-        cprintf("%s identifies device charges for you.\n",
+        desc.cprintf("%s identifies device charges for you.\n",
                 uppercase_first(god_name(which_god)).c_str());
         if (!you_foodless_normally())
         {
             if (have_passive(passive_t::bottle_mp))
-                textcolour(god_colour(which_god));
+                desc.textcolour(god_colour(which_god));
             else
-                textcolour(DARKGREY);
+                desc.textcolour(DARKGREY);
 
-            cprintf("%s will collect and distill excess magic from your "
+            desc.cprintf("%s will collect and distill excess magic from your "
                     "kills.\n",
                     uppercase_first(god_name(which_god)).c_str());
         }
@@ -969,6 +916,7 @@ static void _describe_god_powers(god_type which_god)
         break;
     }
 
+    const int numcols = min(80, get_number_of_cols()) - 1;
     for (const auto& power : get_god_powers(which_god))
     {
         // hack: don't mention the necronomicon alone unless it
@@ -987,10 +935,10 @@ static void _describe_god_powers(god_type which_god)
             && (!player_under_penance()
                 || power.rank == -1))
         {
-            textcolour(god_colour(which_god));
+            desc.textcolour(god_colour(which_god));
         }
         else
-            textcolour(DARKGREY);
+            desc.textcolour(DARKGREY);
 
         string buf = power.gain;
         if (!isupper(buf[0])) // Complete sentence given?
@@ -1001,86 +949,114 @@ static void _describe_god_powers(god_type which_god)
         if (abil_cost == "(None)")
             abil_cost = "";
 
-        cprintf("%s%*s%s\n", buf.c_str(),
-                min(80, get_number_of_cols()) - 1 - desc_len - abil_cost.size(),
+        desc.cprintf("%s%*s%s\n", buf.c_str(), numcols - desc_len - (int)abil_cost.size(),
                 "", abil_cost.c_str());
-        textcolour(god_colour(which_god));
+        desc.textcolour(god_colour(which_god));
     }
 
     if (!have_any)
-        cprintf("None.\n");
+        desc.cprintf("None.\n");
+
+    return desc;
 }
 
-static void _god_overview_description(god_type which_god, bool give_title)
+static formatted_string _god_overview_description(god_type which_god)
 {
-    clrscr();
-
-    const int numcols = min(80, get_number_of_cols()) - 1;
-    if (give_title)
-    {
-        textcolour(WHITE);
-        cprintf("Religion");
-        textcolour(LIGHTGREY);
-    }
-    // Center top line even if it already contains "Religion" (len = 8)
-    _print_top_line(which_god, numcols - (give_title ? 2*8 : 0));
+    formatted_string desc;
 
     // Print god's description.
-    string god_desc = getLongDescription(god_name(which_god));
-    cprintf("%s\n", get_linebreak_string(god_desc, numcols).c_str());
+    const string god_desc = getLongDescription(god_name(which_god));
+    desc += formatted_string(trimmed_string(god_desc) + "\n");
 
     // Title only shown for our own god.
     if (you_worship(which_god))
     {
         // Print title based on piety.
-        cprintf("\nTitle  - ");
-        textcolour(god_colour(which_god));
+        desc.cprintf("\nTitle  - ");
+        desc.textcolour(god_colour(which_god));
 
         string title = god_title(which_god, you.species, you.piety);
-        cprintf("%s", title.c_str());
+        desc.cprintf("%s", title.c_str());
     }
 
     // mv: Now let's print favour as Brent suggested.
     // I know these messages aren't perfect so if you can think up
     // something better, do it.
 
-    textcolour(LIGHTGREY);
-    cprintf("\nFavour - ");
-    textcolour(god_colour(which_god));
+    desc.textcolour(LIGHTGREY);
+    desc.cprintf("\nFavour - ");
+    desc.textcolour(god_colour(which_god));
 
     if (!you_worship(which_god))
-        cprintf(_god_penance_message(which_god).c_str());
+        desc.cprintf("%s", _god_penance_message(which_god).c_str());
     else
     {
-        cprintf(_describe_favour(which_god).c_str());
+        desc.cprintf("%s", _describe_favour(which_god).c_str());
         if (which_god == GOD_ASHENZARI)
-            cprintf("\n%s", ash_describe_bondage(ETF_ALL, true).c_str());
+            desc.cprintf("\n%s", ash_describe_bondage(ETF_ALL, true).c_str());
     }
-    _describe_god_powers(which_god);
+    desc += _describe_god_powers(which_god);
+    desc.cprintf("\n\n");
+
+    return desc;
 }
 
-static god_desc_type _describe_god_by_type(god_type which_god, bool give_title,
-                                           god_desc_type gdesc)
+static int _describe_god_by_type(god_type which_god, bool give_title, god_desc_type gdesc, string more)
 {
+#ifdef USE_TILE_LOCAL
+    // Ensure we get the full screen size when calling get_number_of_cols()
+    cgotoxy(1, 1);
+#endif
+
+    formatted_string desc;
+
+    // Title: has extra left-aligned text on first pane
+    const int numcols = min(80, get_number_of_cols()) - 1;
+    if (give_title)
+    {
+        desc.textcolour(WHITE);
+        desc.cprintf("Religion");
+        desc.textcolour(LIGHTGREY);
+    }
+    // Center top line even if it already contains "Religion" (len = 8)
+    desc += _print_top_line(which_god, numcols - (give_title ? 2*8 : 0));
+
+    // Contents of each pane
     switch (gdesc)
     {
     case GDESC_OVERVIEW:
-        _god_overview_description(which_god, give_title);
+        desc += _god_overview_description(which_god);
         break;
     case GDESC_DETAILED:
-        _detailed_god_description(which_god);
+        desc += _detailed_god_description(which_god);
         break;
     case GDESC_WRATH:
-        _god_wrath_description(which_god);
+        desc += _god_wrath_description(which_god);
         break;
     default:
         die("Unknown god description type!");
     }
 
-    if (_check_description_cycle(gdesc))
-        return static_cast<god_desc_type>((gdesc + 1) % NUM_GDESCS);
-    else
-        return NUM_GDESCS;
+    formatted_scroller fs;
+    const char* place = nullptr;
+    switch (gdesc)
+    {
+        case GDESC_OVERVIEW: place = "<w>Overview</w>|Powers|Wrath"; break;
+        case GDESC_DETAILED: place = "Overview|<w>Powers</w>|Wrath"; break;
+        case GDESC_WRATH:    place = "Overview|Powers|<w>Wrath</w>"; break;
+        default: die("Unknown god description type!");
+    }
+    more = !more.empty() ? more : make_stringf("[<w>!</w>/<w>^</w>"
+#ifdef USE_TILE_LOCAL
+            "|<w>Right-click</w>"
+#endif
+            "]: %s", place);
+    fs.set_more(formatted_string::parse_string(more));
+
+    fs.set_flags(MF_ALWAYS_SHOW_MORE | MF_NOSELECT | MF_NOWRAP, false);
+    fs.wrap_formatted_string(desc, numcols);
+    fs.show();
+    return fs.getkey();
 }
 
 void describe_god(god_type which_god, bool give_title)
@@ -1090,9 +1066,89 @@ void describe_god(god_type which_god, bool give_title)
         mpr("You are not religious.");
         return;
     }
+    god_desc_type gdesc = GDESC_OVERVIEW;
+    while (true)
+    {
+        int keyin = _describe_god_by_type(which_god, give_title && gdesc == GDESC_OVERVIEW, gdesc, string(""));
+        if (!(keyin == '!' || keyin == CK_MOUSE_CMD || keyin == '^'))
+            break;
+        gdesc = static_cast<god_desc_type>((gdesc + 1) % NUM_GDESCS);
+    }
+}
+
+bool describe_god_with_join(god_type which_god)
+{
+    const int fee = (which_god == GOD_GOZAG) ? gozag_service_fee() : 0;
+    string service_fee = "";
+    if (which_god == GOD_GOZAG)
+    {
+        if (fee == 0)
+        {
+            service_fee = string("Gozag will waive the service fee if you ")
+                          + random_choose("act now", "join today") + "!\n";
+        }
+        else
+        {
+            service_fee = make_stringf(
+                    "The service fee for joining is currently %d gold; you"
+                    " have %d.\n",
+                    fee, you.gold);
+        }
+    }
+
+    enum join_step_type { INIT = 0, JOIN, ABANDON };
+
+    const string prompts[] = {
+        "",
+        make_stringf("%sDo you wish to %sjoin this religion?",
+                service_fee.c_str(),
+                (you.worshipped[which_god]) ? "re" : ""),
+        make_stringf("Are you sure you want to abandon %s?",
+                god_name(you.religion).c_str())
+    };
 
     god_desc_type gdesc = GDESC_OVERVIEW;
-    while ((gdesc = _describe_god_by_type(which_god, give_title, gdesc))
-            != NUM_GDESCS)
-    {}
+    join_step_type step = INIT;
+    bool yesno_only = false;
+    while (true)
+    {
+        formatted_string prompt;
+        if (step != INIT)
+        {
+            prompt.textcolour(channel_to_colour(MSGCH_PROMPT));
+            prompt.cprintf("%s%s", prompts[step].c_str(),
+                    yesno_only ? " [Y]es or [n]o only, please." : "");
+        }
+        int keyin = _describe_god_by_type(which_god, false, gdesc, prompt.to_colour_string());
+
+        if (keyin == CK_ESCAPE)
+            break;
+
+        if (step == INIT)
+        {
+            if (keyin == '!' || keyin == CK_MOUSE_CMD || keyin == '^')
+                gdesc = static_cast<god_desc_type>((gdesc + 1) % NUM_GDESCS);
+            else
+                step = JOIN;
+            continue;
+        }
+
+        if (keyin != 'Y' && toupper(keyin) != 'N')
+        {
+            yesno_only = true;
+            continue;
+        }
+        yesno_only = false;
+
+        if (toupper(keyin) == 'N')
+        {
+            canned_msg(MSG_OK);
+            break;
+        }
+
+        if (step == ABANDON || (step == JOIN && you_worship(GOD_NO_GOD)))
+            return true;
+        step = static_cast<join_step_type>(step + 1);
+    }
+    return false;
 }

--- a/crawl-ref/source/describe-god.h
+++ b/crawl-ref/source/describe-god.h
@@ -11,3 +11,4 @@
 int god_favour_rank(god_type which_god);
 string god_title(god_type which_god, species_type which_species, int piety);
 void describe_god(god_type which_god, bool give_title);
+bool describe_god_with_join(god_type which_god);

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -1158,10 +1158,6 @@ static int _describe_god(const string &key, const string &/*suffix*/,
 {
     const god_type which_god = str_to_god(key);
     ASSERT(which_god != GOD_NO_GOD);
-
-#ifdef USE_TILE_WEB
-    tiles_crt_control show_as_menu(CRT_MENU, "describe_god");
-#endif
     describe_god(which_god, true);
 
     return 0; // no exact matches for gods, so output doesn't matter

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1893,10 +1893,6 @@ void process_command(command_type cmd)
 
     case CMD_DISPLAY_RELIGION:
     {
-#ifdef USE_TILE_WEB
-        if (!you_worship(GOD_NO_GOD))
-            tiles_crt_control show_as_menu(CRT_MENU, "describe_god");
-#endif
         describe_god(you.religion, true);
         redraw_screen();
         break;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3751,54 +3751,13 @@ void god_pitch(god_type which_god)
         return;
     }
 
-#ifdef USE_TILE_WEB
-    tiles_crt_control show_as_menu(CRT_MENU, "god_pitch");
-#endif
-
-    describe_god(which_god, false);
-
-    string service_fee = "";
-    if (which_god == GOD_GOZAG)
-    {
-        if (fee == 0)
-        {
-            service_fee = string("Gozag will waive the service fee if you ")
-                          + random_choose("act now", "join today") + "!\n";
-        }
-        else
-        {
-            service_fee = make_stringf(
-                    "The service fee for joining is currently %d gold; you"
-                    " have %d.\n",
-                    fee, you.gold);
-        }
-    }
-    const string prompt = make_stringf("%sDo you wish to %sjoin this religion?",
-                                       service_fee.c_str(),
-                                       (you.worshipped[which_god]) ? "re" : "");
-
-    cgotoxy(1, 21, GOTO_CRT);
-    textcolour(channel_to_colour(MSGCH_PROMPT));
-    if (!yesno(prompt.c_str(), false, 'n', true, true, false, nullptr, GOTO_CRT))
-    {
-        you.turn_is_over = false; // Okay, opt out.
-        redraw_screen();
-        return;
-    }
-
-    const string abandon = make_stringf("Are you sure you want to abandon %s?",
-                                        god_name(you.religion).c_str());
-    if (!you_worship(GOD_NO_GOD) && !yesno(abandon.c_str(), false, 'n', true,
-                                           true, false, nullptr, GOTO_CRT))
+    if (describe_god_with_join(which_god))
+        join_religion(which_god);
+    else
     {
         you.turn_is_over = false;
-        canned_msg(MSG_OK);
         redraw_screen();
-        return;
     }
-
-    // OK, so join the new religion.
-    join_religion(which_god);
 }
 
 /** Ask the user for a god by name.


### PR DESCRIPTION
This commit moves the describe-god UI to a formatted_scroller, and
reimplements the religion join yesno prompts as a small state machine.
This helps get rid of cgotoxy/the CRT abstraction: the god description
functions now build formatted_strings.

The god joining prompts are stuffed into the more string of the
formatted_scroller, which is... not ideal, but should work until I get a
replacement for formatted_scroller up and running.

Fixes:
 - on webtiles, ^ will now show the religion UI in a popup box,
   instead of clearing the full screen: this matches ?/G behaviour.
 - religion join prompts can no longer fill up the screen.
 - the page indicator is now hidden when asking the player to join.

Changes:
 - Message about yes/no only no longer changes based on the key that's
   pressed. To compensate, adjusted the string slightly to indicate that
   uppercase Y is required, while N and n are acceptable.
 - Pressing escape now always leaves the join-religion prompt loop and
   closes the menu.

Regressions:
 - on webtiles, switching between religion pages now closes the popup
   before reopening it to the new page.
 - religion prompts now appear at the bottom of the screen, with the
   page indicator: not a problem on console, but is sub-optimal on local
   tiles (until I make local tiles menus boxed, like webtiles menus).