### PR TITLE
Fix ghost doll cycling through parts

### DIFF
--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -359,7 +359,6 @@ monster_info::monster_info(monster_type p_type, monster_type p_base_type)
 
     fire_blocker = DNGN_UNSEEN;
 
-    i_ghost.acting_part = MONS_0;
     if (mons_is_pghost(type))
     {
         i_ghost.species = SP_HUMAN;

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -276,7 +276,6 @@ struct monster_info : public monster_info_base
         short xl_rank;
         short damage;
         short ac;
-        monster_type acting_part;
     } i_ghost;
 
     inline bool is(unsigned mbflag) const


### PR DESCRIPTION
The acting_part member was entirely unused. The i_ghost struct it is
part of is hashed to determine ghost appearances. While it is cleared
in the (monster_type, monster_type) constructor, it isn't cleared in
the (monster*, int) constructor, which seems to be used when monsters
move between cells.