### PR TITLE
Fix crash in player doll editor (GuideCritic, #11333)

### DIFF
--- a/crawl-ref/source/tile-player-flags.h
+++ b/crawl-ref/source/tile-player-flags.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "tiledef-player.h"
+
 enum tile_player_flags
 {
-    TILEP_SHOW_EQUIP    = 0x1000,
+    TILEP_SHOW_EQUIP    = 0x10000000,
 };
+
+static_assert(static_cast<int>(TILEP_SHOW_EQUIP) > static_cast<int>(TILEP_PLAYER_MAX),
+        "TILEP_SHOW_EQUIP must be distinct from all player tile enums");


### PR DESCRIPTION
See https://crawl.develz.org/mantis/view.php?id=11333

Crash was caused by a collision between this enum and a player doll part
tripping up an assertion.

No save incompatibility: player doll data is serialized in a manner
independently of this enum's value, and mcache_ghost entries have their
dolls reconstructed from species and equipment on creation.