### PR TITLE
Do not hear sounds from nowhere when changing levels

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -995,7 +995,8 @@ bool player_equip_unrand(int unrand_index)
 
 bool player_can_hear(const coord_def& p, int hear_distance)
 {
-    return !silenced(p)
+    return in_bounds(you.pos())
+           && !silenced(p)
            && !silenced(you.pos())
            && you.pos().distance_from(p) <= hear_distance;
 }


### PR DESCRIPTION
Fixes https://crawl.develz.org/mantis/view.php?id=11279

You can reproduce the bug consistently by entering a floor with a portal, leaving the floor, waiting for a while, and returning to that floor. While catching the floor up to the current time, the portal message is triggered while the player is not yet on the floor.