### PR TITLE
Add 'Dispel Undead' to the Necromancer Starting Spellbook

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -161,6 +161,7 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_VAMPIRIC_DRAINING,
     SPELL_REGENERATION,
     SPELL_ANIMATE_DEAD,
+    SPELL_DISPEL_UNDEAD,
 },
 
 {   // Book of Callings


### PR DESCRIPTION
With the removal of 'Control Undead', necromancer is lacking options to deal with undead foes, particularly early on, without diversifying into melee or other spell schools.

Adding 'Dispel Undead' is a simple addition, that will not be as overwhelmingly powerful as Borgnjor's Vile Clutch, as it will only affect undead enemies and patches up the 'blindspots' in the necromancer starting spellbook.

Also, 'Dispel Undead' only affects single targets and doesn't have:
a) the AoE and smite-targeting capabilities of BVC
b) The ally-making ability of 'Control Undead'

so it is far less problematic to have in the starting spellbook.