### PR TITLE
Spooky vaults

### DIFF
--- a/crawl-ref/docs/develop/levels/guidelines.md
+++ b/crawl-ref/docs/develop/levels/guidelines.md
@@ -2,6 +2,7 @@
 
 1. [Guidelines for D:1 arrival vaults](#guidelines-for-d1-arrival-vaults)
 2. [Guidelines for creating serial vaults](#guidelines-for-creating-serial-vaults)
+3. [Guidelines for creating ghost vaults](#guidelines-for-creating-ghost-vaults)
 
 ## Guidelines for D:1 arrival vaults
 
@@ -92,3 +93,30 @@ placement, you can:
 * Explicitly remove them with an empty depth line like this:
 
       DEPTH:
+
+## Guidelines for creating ghost vaults
+
+### Basic guidelines
+
+Ghost vaults should always be sealed. This means one of: runed doors,
+transporters, or perhaps diggable walls. They should also have the features
+`no_tele_into` and `no_trap_gen`. While placing some decent items (especially
+for deeper ghost vaults) can be a good idea, exercise restraint. In general,
+it should be apparent from the outside that the vault *is* a ghost vault, and
+ideally the ghost should be visible so that the player can xv it.
+
+### Distribution
+
+Outside of vaults, ghost vault distribution should usually be determined by a
+(relatively low) CHANCE setting rather than a weight. This means they should
+have the feature `chance_player_ghost`, so that the chance of player ghost
+vaults is specified as a group. Ghost vaults should also typically have the
+`luniq_player_ghost` tag, and the `allow_dup` tag.
+
+Within vaults, CHANCE can't be used, so you will need to use a WEIGHT tag,
+probably hand-adjusting it using mapstat to get a targeted percentage for the
+vault layout type.
+
+To summarize, for a non-vaults map, here is a typical TAGS value:
+
+    TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -1,0 +1,51 @@
+################################################################################
+# vaults_rooms_ghost.des: Ghost subvaults for the Vaults.
+#
+# Content: These are the subvaults that place a player ghost. All vaults here
+# should call the function ghost_vault_setup(). Until the Vaults layout can be
+# adapted to specially place these vaults, we tag them all with vaults_room so
+# they they can have a common rate of placement. Set a different WEIGHT to make
+# a specific vault more or less common
+################################################################################
+
+: require("dlua/ghost.lua")
+
+NAME:   advil_vaults_ghost_guards
+TAGS:   vaults_room
+KITEM:  12 = superb_item / star_item
+KMONS:  1 = vault guard / ironbrand convoker / ironheart preserver / \
+            vault warden
+KMONS:  2 = vault warden
+KMONS:  3 = player ghost
+SHUFFLE: 13
+: ghost_vault_setup(_G)
+MAP
+........
+........
+..nnnn..
+..n31n..
+..n12n..
+..n==n..
+........
+........
+ENDMAP
+
+# based on st_lines
+NAME:   advil_vaults_ghost_lines
+TAGS:   vaults_hard
+KITEM:  123 = superb_item / star_item
+KMONS:  1 = vault guard / ironbrand convoker / ironheart preserver / \
+            vault warden
+KMONS:  2 = vault warden
+KMONS:  3 = player ghost
+SHUFFLE: 1239
+SUBST: 9 = 98
+: ghost_vault_setup(_G)
+MAP
+........
+nnn==nnn
+..=92=..
+..=31=..
+nnn==nnn
+........
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -165,3 +165,29 @@ MAP
 ..nDxDxDx
 ..xxxxxxx
 ENDMAP
+
+NAME:   gammafunk_vaults_ghost_fury_of_okawaru
+TAGS:   vaults_room vaults_orient_s
+KFEAT:  O = altar_okawaru
+KMONS:  O = player ghost
+MONS:   centaur warrior / tengu warrior / orc knight / naga warrior / \
+        merfolk impaler / merfolk javelineer / deep elf knight / \
+        deep elf archer
+MONS:   minotaur / stone giant / orc warlord
+MONS:   fire giant / frost giant / deep elf blademaster / \
+        deep elf master archer / titan
+SUBST:  defgh = |*, i = *%, j = %$..
+NSUBST: - = 3=1 / 4=1- / 2=2 / 2=2- / 2=3- / 3--- / -
+: ghost_vault_setup(_G)
+MAP
+GvvvvvvvG
+-igvOvhj-
+---edf---
+-vG---Gv-
+---------
+-vG---Gv-
+---------
+nnn===nnn
+.........
+.........
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -94,6 +94,36 @@ MAP
 .............
 ENDMAP
 
+NAME:    gammafunk_vaults_ghost_cemetery
+TAGS:    vaults_room vaults_orient_s
+WEIGHT:  5 (D:3-7)
+KMONS:   DEF = player ghost
+KMONS:   p = withered plant
+# 1/12 chance for 5 ghosts, 1/6 for 4, 1/4 for 3, 1/2 for 2.
+SHUFFLE: DdqEerFfs / DdqZyzFfs / DdqZyzFfs / DdqEerZyz / DdqEerZyz / \
+         DdqEerZyz / DdqZyzZyz / DdqZyzZyz / DdqZyzZyz / DdqZyzZyz / \
+         DdqZyzZyz / DdqZyzZyz
+# 1.5 items per ghost, upgrading quality with depth.
+NSUBST:  d = 2=|* / |*--, e = |* / |*--, f = 2=|* / |*--
+SUBST:   qrs = G, Z = -, y = p, z = V, t : tp
+TILE:    G = dngn_gravestone
+TILE:    t = dngn_tree_dead
+FTILE:   -|*%$DEFpGt = floor_pebble_brown / floor_pebble_darkgray
+: set_feature_name("granite_statue", "a gravestone")
+: ghost_vault_setup(_G)
+MAP
+qd--ere--dq
+dD---E---Dd
+-----------
+-----------
+f---------f
+sF-------Fs
+f---------f
+xxnn===nnxx
+...........
+...........
+ENDMAP
+
 NAME:   gammafunk_vaults_ghost_necromancy
 TAGS:   vaults_room vaults_orient_w
 KMONS:  O = player ghost

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -32,7 +32,7 @@ ENDMAP
 
 # based on st_lines
 NAME:   advil_vaults_ghost_lines
-TAGS:   vaults_hard
+TAGS:   vaults_room
 KITEM:  123 = superb_item / star_item
 KMONS:  1 = vault guard / ironbrand convoker / ironheart preserver / \
             vault warden
@@ -48,4 +48,48 @@ nnn==nnn
 ..=31=..
 nnn==nnn
 ........
+ENDMAP
+
+NAME:  gammafunk_vaults_ghost_grave
+TAGS:  vaults_room vaults_orient_w
+KITEM: O = superb_item / star_item
+KMONS: p = withered plant
+KMONS: O = player ghost
+SUBST: de = |*, t : tp
+TILE:  G = dngn_gravestone
+TILE:  t = dngn_tree_dead
+: set_feature_name("granite_statue", "a gravestone")
+FTILE:  -|*%$OGt = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+..x.....
+..x.....
+..n.dt..
+..=.OGt.
+..n.et..
+..x.....
+..x.....
+ENDMAP
+
+NAME:  gammafunk_vaults_ghost_split
+TAGS:  vaults_room
+KMONS: O = player ghost
+SUBST:  defg = |*
+NSUBST: D = 2=0 / 2=0. / 9 / 2=9. / 8 / 8. / .
+SUBST: c : bcv, p : b., q : b., b : bcv
+: ghost_vault_setup(_G)
+MAP
+.............
+.............
+..xxxnnnxxx..
+..nD..D..Dx..
+..n..qpq..x..
+..=.Dpqpe.n..
+..=...OgdDn..
+..=.Dpqpf.n..
+..n..qpq..x..
+..nD..D..Dx..
+..xxxnnnxxx..
+.............
+.............
 ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -93,3 +93,45 @@ MAP
 .............
 .............
 ENDMAP
+
+NAME:   gammafunk_vaults_ghost_necromancy
+TAGS:   vaults_room vaults_orient_w
+KMONS:  O = player ghost
+MONS:   simulacrum place:Vaults:5 / spectre place:Vaults:5, lich
+SUBST:  defg = |*, h = *, i = %$, j = -
+NSUBST: 1 = 12 / 1, - = 3=1 / 6=1- / -
+FTILE:  -|*%$O12G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+..xxxxxxx
+..n1x1x1x
+..n---igx
+..=---exx
+..=---dOx
+..=---fxx
+..n---jhx
+..n1x1x1x
+..xxxxxxx
+ENDMAP
+
+NAME:   gammafunk_vaults_ghost_spectres
+TAGS:   vaults_room vaults_orient_w
+KMONS:  O = player ghost
+MONS:   wraith / shadow
+MONS:   freezing wraith / shadow wraith / phantasmal warrior / flayed ghost w:5
+MONS:   eidolon, revenant / curse skull
+SUBST:  defg = |*, h = *, i = %$
+NSUBST: D = 2 / 3 / 2=3- / 4-, - = 2=1 / 2=1- / 2 / 3=2- / -
+FTILE:  -|*%$O1234G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+..xxxxxxx
+..nDxDxDx
+..n----gx
+..=---exx
+..=--idOx
+..=---fxx
+..n----hx
+..nDxDxDx
+..xxxxxxx
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -1,0 +1,42 @@
+##############################################################################
+# Ghost vaults
+#
+##############################################################################
+
+###############################################################################
+# Two basic ghost vaults
+NAME:   basic_ghost_runed
+WEIGHT: 10000
+DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
+TAGS:   player_ghost luniq_player_ghost no_tele_into allow_dup
+KFEAT:  + = runed_door
+KITEM:  1 = acquire any / any useful good_item
+KMONS:  ! = player ghost
+MAP
+nnnn
++!1n
+nnnn
+ENDMAP
+
+NAME:   basic_ghost_transp
+WEIGHT: 10000
+DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
+TAGS:   player_ghost luniq_player_ghost no_tele_into allow_dup
+KITEM:  1 = acquire any / any useful good_item
+KMONS:  ! = player ghost
+SHUFFLE: 1AQR, PS
+MARKER: P = lua:transp_loc("basic_ghost_transp_entry")
+MARKER: Q = lua:transp_dest_loc("basic_ghost_transp_entry")
+MARKER: R = lua:transp_loc("basic_ghost_transp_exit")
+MARKER: S = lua:transp_dest_loc("basic_ghost_transp_exit")
+SUBST: A = .
+MAP
+ nnnnn
+nn.1.nn
+n.$.$.n
+nA.!.Rn
+n.$.$.n
+nn.Q.nn
+ nnnnn
+ .P@S.
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -40,3 +40,38 @@ nn.Q.nn
  nnnnn
  .P@S.
 ENDMAP
+
+NAME:   vaults_ghost_runed
+WEIGHT: 50
+TAGS:   vaults_room player_ghost luniq_player_ghost no_tele_into allow_dup
+KFEAT:  + = runed_door
+KITEM:  1 = any useful good_item / nothing
+KMONS:  ! = generate_awake player ghost
+SHUFFLE: 123!
+MAP
+......
+.nnnn.
+.n1.n.
+.n.!n.
+.n++n.
+......
+ENDMAP
+
+# based on st_lines
+NAME:   vaults_ghost_runed2
+WEIGHT: 100
+TAGS:   vaults_hard player_ghost luniq_player_ghost no_tele_into allow_dup
+KFEAT:  + = runed_door
+KITEM:  1 = acquire any / any useful good_item
+KMONS:  ! = player ghost
+KMONS:  2 = generate_awake patrolling vault warden
+KMONS:  3 = generate_awake patrolling vault guard
+SHUFFLE: 123!
+MAP
+........
+nnn++nnn
+..+!2+..
+..+31+..
+nnn++nnn
+........
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -6,9 +6,9 @@
 ###############################################################################
 # Two basic ghost vaults
 NAME:   basic_ghost_runed
-WEIGHT: 10000
+WEIGHT: 3000
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
-TAGS:   player_ghost luniq_player_ghost no_tele_into allow_dup
+TAGS:   player_ghost luniq_player_ghost no_tele_into no_trap_gen allow_dup
 KFEAT:  + = runed_door
 KITEM:  1 = acquire any / any useful good_item
 KMONS:  ! = player ghost
@@ -19,9 +19,9 @@ nnnn
 ENDMAP
 
 NAME:   basic_ghost_transp
-WEIGHT: 10000
+WEIGHT: 3000
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
-TAGS:   player_ghost luniq_player_ghost no_tele_into allow_dup
+TAGS:   player_ghost luniq_player_ghost no_tele_into no_trap_gen allow_dup
 KITEM:  1 = acquire any / any useful good_item
 KMONS:  ! = player ghost
 SHUFFLE: 1AQR, PS
@@ -43,7 +43,7 @@ ENDMAP
 
 NAME:   vaults_ghost_runed
 WEIGHT: 50
-TAGS:   vaults_room player_ghost luniq_player_ghost no_tele_into allow_dup
+TAGS:   vaults_room player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
 KFEAT:  + = runed_door
 KITEM:  1 = any useful good_item / nothing
 KMONS:  ! = generate_awake player ghost
@@ -60,7 +60,7 @@ ENDMAP
 # based on st_lines
 NAME:   vaults_ghost_runed2
 WEIGHT: 100
-TAGS:   vaults_hard player_ghost luniq_player_ghost no_tele_into allow_dup
+TAGS:   vaults_hard player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
 KFEAT:  + = runed_door
 KITEM:  1 = acquire any / any useful good_item
 KMONS:  ! = player ghost

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -6,9 +6,9 @@
 ###############################################################################
 # Two basic ghost vaults
 NAME:   basic_ghost_runed
-WEIGHT: 3000
+CHANCE: 25%
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
-TAGS:   player_ghost luniq_player_ghost no_tele_into no_trap_gen allow_dup
+TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
 KFEAT:  + = runed_door
 KITEM:  1 = acquire any / any useful good_item
 KMONS:  ! = player ghost
@@ -19,9 +19,9 @@ nnnn
 ENDMAP
 
 NAME:   basic_ghost_transp
-WEIGHT: 3000
+CHANCE: 25%
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
-TAGS:   player_ghost luniq_player_ghost no_tele_into no_trap_gen allow_dup
+TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
 KITEM:  1 = acquire any / any useful good_item
 KMONS:  ! = player ghost
 SHUFFLE: 1AQR, PS

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -6,25 +6,23 @@
 ###############################################################################
 # Two basic ghost vaults
 NAME:   basic_ghost_runed
-CHANCE: 25%
-DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
+CHANCE: 20%
+DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot
 TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
-KFEAT:  + = runed_door
-KITEM:  1 = acquire any / any useful good_item
-KMONS:  ! = player ghost
+KITEM:  ! = any useful good_item / nothing
+KMONS:  ! = generate_awake player ghost
 MAP
-nnnn
-+!1n
-nnnn
+nnn
+=!n
+nnn
 ENDMAP
 
 NAME:   basic_ghost_transp
-CHANCE: 25%
-DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot, Dis, Geh, Tar, Coc
+CHANCE: 20%
+DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt
 TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
-KITEM:  1 = acquire any / any useful good_item
-KMONS:  ! = player ghost
-SHUFFLE: 1AQR, PS
+KMONS:  ! = generate_awake player ghost
+SHUFFLE: |AQR, PS
 MARKER: P = lua:transp_loc("basic_ghost_transp_entry")
 MARKER: Q = lua:transp_dest_loc("basic_ghost_transp_entry")
 MARKER: R = lua:transp_loc("basic_ghost_transp_exit")
@@ -32,7 +30,7 @@ MARKER: S = lua:transp_dest_loc("basic_ghost_transp_exit")
 SUBST: A = .
 MAP
  nnnnn
-nn.1.nn
+nn.|.nn
 n.$.$.n
 nA.!.Rn
 n.$.$.n
@@ -41,19 +39,31 @@ nn.Q.nn
  .P@S.
 ENDMAP
 
+NAME:   basic_ghost_runed_special
+CHANCE: 10%
+DEPTH:  Depths, Crypt, Zot, Pan, Dis, Geh, Tar, Coc
+TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
+KITEM:  ! = acquire any / any useful good_item
+KMONS:  ! = generate_awake player ghost
+MAP
+nnn
+=!n
+nnn
+ENDMAP
+
 NAME:   vaults_ghost_runed
 WEIGHT: 50
 TAGS:   vaults_room player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
-KFEAT:  + = runed_door
 KITEM:  1 = any useful good_item / nothing
 KMONS:  ! = generate_awake player ghost
-SHUFFLE: 123!
+KMONS:  2 = vault_guard / nothing
+SHUFFLE: 12!
 MAP
 ......
 .nnnn.
-.n1.n.
-.n.!n.
-.n++n.
+.n12n.
+.n2!n.
+.n==n.
 ......
 ENDMAP
 
@@ -61,17 +71,16 @@ ENDMAP
 NAME:   vaults_ghost_runed2
 WEIGHT: 100
 TAGS:   vaults_hard player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
-KFEAT:  + = runed_door
-KITEM:  1 = acquire any / any useful good_item
-KMONS:  ! = player ghost
+KITEM:  1 = acquire any / any useful good_item / nothing
+KMONS:  ! = generate_awake player ghost
 KMONS:  2 = generate_awake patrolling vault warden
 KMONS:  3 = generate_awake patrolling vault guard
 SHUFFLE: 123!
 MAP
 ........
-nnn++nnn
-..+!2+..
-..+31+..
-nnn++nnn
+nnn==nnn
+..=!2=..
+..=31=..
+nnn==nnn
 ........
 ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -6,7 +6,7 @@
 ###############################################################################
 # Two basic ghost vaults
 NAME:   basic_ghost_runed
-CHANCE: 20%
+CHANCE: 10%
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot
 TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
 KITEM:  ! = any useful good_item / nothing
@@ -18,7 +18,7 @@ nnn
 ENDMAP
 
 NAME:   basic_ghost_transp
-CHANCE: 20%
+CHANCE: 10%
 DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt
 TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
 KMONS:  ! = generate_awake player ghost
@@ -40,7 +40,7 @@ nn.Q.nn
 ENDMAP
 
 NAME:   basic_ghost_runed_special
-CHANCE: 10%
+CHANCE: 5%
 DEPTH:  Depths, Crypt, Zot, Pan, Dis, Geh, Tar, Coc
 TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
 KITEM:  ! = acquire any / any useful good_item
@@ -52,7 +52,7 @@ nnn
 ENDMAP
 
 NAME:   vaults_ghost_runed
-WEIGHT: 50
+WEIGHT: 30
 TAGS:   vaults_room player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
 KITEM:  1 = any useful good_item / nothing
 KMONS:  ! = generate_awake player ghost
@@ -69,7 +69,7 @@ ENDMAP
 
 # based on st_lines
 NAME:   vaults_ghost_runed2
-WEIGHT: 100
+WEIGHT: 70
 TAGS:   vaults_hard player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
 KITEM:  1 = acquire any / any useful good_item / nothing
 KMONS:  ! = generate_awake player ghost

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -22,7 +22,7 @@
 {{
 -- Set up the non-flaming edged weapon "left" by the ghost in
 -- gammafunk_ghost_hydra_chop.
-function init_hydra_weapons(e)
+function init_hydra_weapon(e)
     make_arte = crawl.one_chance_in(3)
 
     -- Basic set of egos with weights.
@@ -563,6 +563,7 @@ ENDMAP
 NAME:   gammafunk_ghost_hydra_chop
 DEPTH:  D:8-, Lair, Swamp
 ORIENT: float
+: init_hydra_weapon(_G)
 KMONS:  O = player ghost
 {{
 -- Set up hydra monster entry with a range of possible extra heads based on
@@ -592,7 +593,6 @@ NSUBST:  ' = 2=|* / *% / %$-- / -, - = 1 / 2=1- / -
 : else
 NSUBST:  ' = 4=|* / -, - = 1 / 3=1- / -
 : end
-: init_hydra_weapons(_G)
 : ghost_vault_setup(_G)
 MAP
   ccccc

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -1,86 +1,42 @@
-##############################################################################
-# Ghost vaults
+###############################################################################
+# ghost.des
 #
-##############################################################################
+# Vaults that place player ghosts. For now, all such vaults that don't place in
+# the Vaults branch should appear in this file, even if they're
+# branch-specific. For Vaults ghost vaults, we currently use
+# branches/vaults_rooms_ghost.des. See the ghost vault guidelines in
+# docs/develop/levels/guidelines.md. All vaults here should call the function
+# ghost_vault_setup().
+#
+# Organization:
+
+# <<1>>      Generic/Abstract ghost vaults
+# <<2>>      Themed ghost vaults
+#
+# Generic ghost vaults in <<1>> use 098 monsters and any specified monsters
+# would be very generic. For more thematic vaults, put them in <<2>>.
+###############################################################################
+
+: require("dlua/ghost.lua")
+
+# Only the below levels and Vaults:1-4 place ghost vaults. A specific ghost
+# vault may only be appropriate for a subset of these levels, in which case
+# they should set their own DEPTH. Note that if this default depth is changed,
+# vaults below with branch-specific item/monster placement may need to be
+# updated.
+default-depth: D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, \
+               Crypt, Zot
 
 ###############################################################################
-# Two basic ghost vaults
-NAME:   basic_ghost_runed
-CHANCE: 10%
-DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt, Zot
-TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
-KITEM:  ! = any useful good_item / nothing
-KMONS:  ! = generate_awake player ghost
-MAP
-nnn
-=!n
-nnn
-ENDMAP
+#
+# <<1>> Generic/Abstract ghost vaults.
+#
+#
+###############################################################################
 
-NAME:   basic_ghost_transp
-CHANCE: 10%
-DEPTH:  D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, Vaults, Crypt
-TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
-KMONS:  ! = generate_awake player ghost
-SHUFFLE: |AQR, PS
-MARKER: P = lua:transp_loc("basic_ghost_transp_entry")
-MARKER: Q = lua:transp_dest_loc("basic_ghost_transp_entry")
-MARKER: R = lua:transp_loc("basic_ghost_transp_exit")
-MARKER: S = lua:transp_dest_loc("basic_ghost_transp_exit")
-SUBST: A = .
-MAP
- nnnnn
-nn.|.nn
-n.$.$.n
-nA.!.Rn
-n.$.$.n
-nn.Q.nn
- nnnnn
- .P@S.
-ENDMAP
-
-NAME:   basic_ghost_runed_special
-CHANCE: 5%
-DEPTH:  Depths, Crypt, Zot, Pan, Dis, Geh, Tar, Coc
-TAGS:   player_ghost luniq_player_ghost chance_player_ghost no_tele_into no_trap_gen allow_dup
-KITEM:  ! = acquire any / any useful good_item
-KMONS:  ! = generate_awake player ghost
-MAP
-nnn
-=!n
-nnn
-ENDMAP
-
-NAME:   vaults_ghost_runed
-WEIGHT: 30
-TAGS:   vaults_room player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
-KITEM:  1 = any useful good_item / nothing
-KMONS:  ! = generate_awake player ghost
-KMONS:  2 = vault_guard / nothing
-SHUFFLE: 12!
-MAP
-......
-.nnnn.
-.n12n.
-.n2!n.
-.n==n.
-......
-ENDMAP
-
-# based on st_lines
-NAME:   vaults_ghost_runed2
-WEIGHT: 70
-TAGS:   vaults_hard player_ghost luniq_player_ghost no_trap_gen no_tele_into allow_dup
-KITEM:  1 = acquire any / any useful good_item / nothing
-KMONS:  ! = generate_awake player ghost
-KMONS:  2 = generate_awake patrolling vault warden
-KMONS:  3 = generate_awake patrolling vault guard
-SHUFFLE: 123!
-MAP
-........
-nnn==nnn
-..=!2=..
-..=31=..
-nnn==nnn
-........
-ENDMAP
+###############################################################################
+#
+# <<2>> Themed ghost vaults.
+#
+#
+###############################################################################

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -205,3 +205,264 @@ ENDMAP
 #
 #
 ###############################################################################
+
+NAME:   gammafunk_ghost_necromancy
+# Omit Elf since that branch has few good monsters for derived undead.
+DEPTH:  D:3-, Lair, Orc, Shoals, Snake, Spider, Swamp, Crypt, Depths, Zot
+ORIENT: float
+KMONS:  O = player ghost
+# Progressive depth/numbers of zombies and type/amount of loot.
+# First handle Dungeon.
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+MONS:   skeleton place:D:6 / zombie place:D:6
+SUBST:  d = *%, e = %$, fghij = -
+NSUBST: 1 = 2=1 / 1---
+:     elseif you.depth() < 9 then
+MONS:   skeleton place:D:9 / zombie place:D:9 / spectre place:D:9 / \
+        simulacrum place:D:9
+SUBST:  d = *, e = *%, f = %$--, ghij = -, 1 = 111-
+NSUBST: 1 = 2=1 / 1-
+:     elseif you.depth() < 12 then
+MONS:   w:5 zombie place:D:12 / spectre place:D:12 / simulacrum place:D:12
+SUBST:  d = |*, e = *, f = %$, ghij = -
+NSUBST: 1 = 3=1 / 1-, - = 1- / -
+:     elseif you.depth() < 15 then
+MONS:   w:5 zombie place:D:15 / spectre place:D:15 / simulacrum place:D:15
+SUBST:  def = |*, g = *%, h = %$--, ij = -
+NSUBST: - = 4=1- / -
+:     else
+MONS:   place:Depths:1 zombie / place:Depths:1 spectre / \
+        place:Depths:1 simulacrum
+SUBST:  def = |*, g = *%, h = %$--, ij = -
+NSUBST: - = 1 / 4=1- / -
+:     end
+# Set up derived undead from branch end for non-Dungeon branches.
+: else
+{{
+  undead_place = "place:" .. you.branch() .. ":" .. dgn.br_depth(you.branch())
+  mons(undead_place .. " spectre / " .. undead_place .. " simulacrum")
+}}
+: end
+# Handle loot/monsters for non-Dungeon branches.
+: if you.in_branch("Lair") then
+SUBST:  de = |*, f = *%, g = %$--, hij = -
+NSUBST: 1 = 4=1 / 1-, - = 2=1- / -
+: elseif you.in_branch("Orc") then
+SUBST:  de = |*, f = *, g = %$, hij = -
+NSUBST: 1 = 5=1 / 1-, - = 3=1- / -
+: elseif you.in_branch("Crypt") then
+MONS: revenant / curse skull
+SUBST:  defg = |*, h = *, i = %$, j = -
+NSUBST: 1 = 12 / 1, - = 3=1 / 6=1- / -
+: elseif you.in_branch("Depths") then
+MONS: ancient lich
+SUBST:  defgh = |*, i = *%, j = %$--
+NSUBST: 1 = 2=12 / 1, - = 3=1 / 8=1- / -
+: elseif you.in_branch("Zot") then
+MONS: ancient lich, curse toe
+SUBST:  defghij = |*
+NSUBST: 1 = 12 / 123 / 1, - = 4=1 / 8=1- / -
+# Lair branches
+: else
+SUBST:  def = |*, g = *, h = %$, ij = -
+NSUBST: - = 2=1 / 4=1- / -
+: end
+FTILE:  -|*%$O12G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+ ccccccc
+.n1c1c1c
+.n---igc
+.=---ecc
+@=---dOc
+.=---fcc
+.n---jhc
+.n1c1c1c
+ ccccccc
+ENDMAP
+
+NAME:   gammafunk_ghost_spectres
+DEPTH:  D:8-, Crypt
+ORIENT: float
+KMONS:  O = player ghost
+# Dungeon levels
+: if you.absdepth() < 10 then
+MONS:   wraith, shadow / freezing wraith
+SUBST:  d = *, e = *%, f = %$--,  ghi = -
+NSUBST: D = 2=1 / 4=1- / -
+: elseif you.absdepth() < 12 then
+MONS:   wraith, shadow / freezing wraith
+SUBST:  d = |*, e = *, f = %$,  ghi = -
+NSUBST: D = 3=1 / 2=1- / 2-, - = 1- / -
+: elseif you.absdepth() < 14 then
+MONS:  wraith, shadow / freezing wraith
+MONS:  shadow wraith / flayed ghost / phantasmal warrior
+SUBST:  def = |*, g = *%, h = %$--, ij = -
+NSUBST: D = 4=1 / 1222 / 23--, - = 1- / -
+: elseif you.absdepth() < 16 then
+MONS:   wraith, shadow / freezing wraith
+MONS:   shadow wraith / flayed ghost / phantasmal warrior
+SUBST:  def = |*, g = *%, h = %$--, ij = -
+NSUBST: D = 2=1 / 12 / 2=2- / 3-, - = 1 / 3=1- / -
+# Crypt
+: else
+MONS:   wraith / shadow
+MONS:   freezing wraith / shadow wraith / phantasmal warrior / flayed ghost w:5
+MONS:   eidolon, revenant / curse skull
+SUBST:  defg = |*, h = *, i = %$
+NSUBST: D = 2 / 3 / 2=3- / 4-, - = 2=1 / 2=1- / 2 / 3=2- / -
+: end
+FTILE:  -|*%$O1234G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+MAP
+ ccccccc
+.nDcDcDc
+.n----gc
+.=---eGc
+@=--idOc
+.=---fGc
+.n----hc
+.nDcDcDc
+ ccccccc
+ENDMAP
+
+NAME:   gammafunk_ghost_ooze
+DEPTH:  D:8, Lair, Depths
+ORIENT: float
+KMONS:  O = player ghost
+MONS:   jelly, slime creature, death ooze
+: if you.in_branch("D") then
+:     if you.depth() < 10 then
+SUBST:  d = *, e = *%, f = %$--,  ghi = -
+NSUBST: - = 2=1 / 4=1. / 2=2 / 4=2. / .
+:     elseif you.depth() < 12 then
+SUBST:  d = |*, e = *, f = %$,  ghi = -
+NSUBST: e = %$-- / -, - = 2=1 / 4=1. / 3=2 / 6=2. / .
+:     elseif you.depth() < 14 then
+SUBST:  def = |*, g = *%, h = %$--, ij = -
+NSUBST: - =  2=1 / 4=1. / 4=2 / 8=2. / 1=3...
+:     else
+SUBST:  defg = |*, h = *, i = %$, j = -
+NSUBST: - = 2=1 / 4=1. / 3=2 / 6=2. / 1=3 / 2=3.
+:     end
+: elseif you.in_branch("Lair") then
+SUBST:  de = |*, f = *%, g = %$--, hij = -
+NSUBST: f = *%$ / -, - = 2=1 / 4=1. / 3=2 / 6=2. / 1=3 / 1=3...
+# Depths
+: else
+SUBST:  defgh = |*, i = *%, j = %$--
+NSUBST: - = 6=2 / 7=2. / 4=3 / 8=3.
+: end
+KFEAT:  _ = altar_jiyva
+COLOUR: c = green
+COLOUR: n = lightgreen
+FTILE:  -|*%$O01289G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+  ccccc
+ cc---cn.
+cci----n.
+ceg----=.
+c_dO---=@
+cfh----=.
+ccj----n.
+ cc---cn.
+  ccccc
+nnnn
+ENDMAP
+
+NAME:   gammafunk_ghost_mausoleum
+DEPTH:  D:3-, Swamp, Crypt, Depths, Zot
+WEIGHT: 2 (D:3-7), 5 (D:8-11)
+ORIENT: float
+KMONS:  O = player ghost
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+MONS:   skeleton place:D:6 / zombie place:D:6
+MONS:   mummy / shadow imp / wight / necrophage / phantom / hungry ghost
+SUBST:  d = *%, e = %$, f = %$--, ghij = -
+NSUBST: D = 2=1 / 2=1- / 2- / -
+:     elseif you.depth() < 9 then
+MONS:   skeleton place:D:9 / zombie place:D:9 / spectre place:D:9 / \
+        simulacrum place:D:9 / mummy / shadow imp / wight / necrophage / \
+        phantom / hungry ghost
+MONS:   wraith / vampire
+SUBST:  d = *, e = *%, f = %$,  ghi = -
+NSUBST: D = 2=1 / 3=1- / 2- / 2--- / -
+:     elseif you.depth() < 12 then
+MONS:   mummy / wight / zombie place:D:12 / spectre place:D:12 / \
+        simulacrum place:D:12 / phantom / hungry ghost / wraith / vampire
+MONS:   vampire mosquito band / shadow / death knight / skeletal warrior / \
+        freezing wraith w:5
+SUBST:  d = |*, e = *, f = *%,  g = %$--, hi = -
+NSUBST: D = 2=1 / 4=1- / 2=2- / -
+:     elseif you.depth() < 14 then
+MONS:   zombie place:D:15 / spectre place:D:15 / simulacrum place:D:15 / \
+        vampire mosquito band / death knight / skeletal warrior
+MONS:   freezing wraith / necromancer / shadow wraith / vampire knight / \
+        phantasmal warrior / flayed ghost
+SUBST:  def = |*, g = *, h = %$, ij = -
+NSUBST: D = 3=1 / 5=1- / 2 / 222- / -
+:     else
+MONS:   zombie place:Depths:1 / spectre place:Depths:1 / \
+        simulacrum place:Depths:1 / \
+        vampire mosquito band / death knight / skeletal warrior / \
+        freezing wraith
+MONS:   necromancer / shadow wraith / vampire knight / phantasmal warrior / \
+        flayed ghost
+SUBST:  def = |*, g = *, h = %$, ij = -
+NSUBST: D = 4=1 / 4=1- / 2 / 2=2- / -
+: end
+: elseif you.in_branch("Swamp") then
+MONS:   spectre place:Swamp:4 / simulacrum place:Swamp:4 / shadow / \
+        bog body / vampire mosquito band / tyrant leech
+MONS:   ghost crab / hydra spectre / hydra simulacrum
+SUBST:  defg = |*, h = *%, i = %$--, j = -
+NSUBST: D = 4=1 / 5=1- / 2 / 2=2- / 2--- / -
+: elseif you.in_branch("Crypt") then
+SUBST:  defgh = |*, i = *%, j = %$..
+NSUBST: D = 5=0 / 5=0- / 98 / 3=98-- / 98------ / -
+: elseif you.in_branch("Depths") then
+MONS:   spectre place:Depths:5 / simulacrum place:Depths:5 / \
+        necromancer / vampire knight / vampire mage / sphinx / flayed ghost w:5
+MONS:   lich / deep elf death mage / juggernaut simulacrum / \
+        juggernaut spectre / caustic shrike simulacrum / caustic shrike spectre
+MONS:   ancient lich
+SUBST:  defgh = |*, i = *, j = %$
+NSUBST: D = 5=0 / 6=0- / 2 / 4=2- / 3- / -
+: elseif you.in_branch("Zot") then
+MONS:   simulacrum place:Zot:5 / spectre place:Zot:5 / shadow dragon / \
+        death cob
+MONS:   golden dragon simulacrum / golden dragon spectre / \
+        quicksilver dragon simulacrum / quicksilver dragon spectre \
+        killer klown simulacrum / killer klown spectre / ancient lich
+MONS:   curse toe
+SUBST:  defghij = |*, 2 = 12
+NSUBST: D = 5=0 / 7=0- / 2=2 / 2=2- / 3- / -
+: end
+NSUBST: R = R / -
+MARKER: P = lua:transp_loc("ghost_mausoleum_entry")
+MARKER: Q = lua:transp_dest_loc("ghost_mausoleum_entry")
+MARKER: R = lua:transp_loc("ghost_mausoleum_exit")
+MARKER: S = lua:transp_dest_loc("ghost_mausoleum_exit")
+FTILE:  -|*%$O01289G = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+ ...............
+ .nnnnnnnnnnnnn.
+ .nR--D---D--Rn.
+ .n-D---D---D-n.
+ .n--ccc-ccc-in.
+ .n-DcGcDcGcDgn.
+..n----------en..
+@PnOD-D-Q-D-DdnS@
+..n----------fn..
+ .n-DcGcDcGcDhn.
+ .n--ccc-ccc-jn.
+ .n-D---D---D-n.
+ .nR--D---D--Rn.
+ .nnnnnnnnnnnnn.
+ ...............
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -19,6 +19,59 @@
 
 : require("dlua/ghost.lua")
 
+{{
+-- Set up the non-flaming edged weapon "left" by the ghost in
+-- gammafunk_ghost_hydra_chop.
+function init_hydra_weapons(e)
+    make_arte = crawl.one_chance_in(3)
+
+    -- Basic set of egos with weights.
+    egos  =  {["none"] = 30, ["vorpal"] = 15, ["freezing"] = 15,
+              ["electrocution"] = 10, ["venom"] = 10, ["protection"] = 10,
+              ["vampiric"] = 5, ["holy_wrath"] = 5, ["draining"] = 5,
+              ["pain"] = 2, ["distortion"] = 2, ["antimagic"] = 2,
+              ["speed"] = 1}
+
+    -- Possible weapon types with weights. We stick to weapons wieldable by all
+    -- non-felids.
+    weapons = {["long blade"] = 8, ["scimitar"] = 12, ["demon blade"] = 1,
+               ["double sword"] = 1, ["war axe"] = 8, ["broad axe"] = 12,
+               ["lajatang"] = 2}
+
+    for wname, wweight in pairs(weapons) do
+        -- We need the sum of ego weights to make an ego rarity scaling factor.
+        esum = 0
+        for ego, weight in pairs(egos) do
+            esum = esum + weight
+            -- Don't allow demon weapons to get holy wrath or artefacts with
+            -- no ego.
+            if (not wname:find("demon") or ego ~= "holy_wrath")
+               and (not make_arte or ego ~= "none") then
+                esum  = esum + weight
+            end
+        end
+
+        -- Define an item spec with all weapon+ego combinations, each with
+        -- weight scaled by weapon rarity and ego rarity.
+        for ename, eweight in pairs(egos) do
+            if (not wname:find("demon") or ename ~= "holy_wrath")
+               and (not make_arte or ename ~= "none") then
+                quality = make_arte and " randart" or " good_item"
+                -- Scale the final weight by 300 so the smallest is non-zero.
+                def = wname .. quality .. " ego:" .. ename .. " w:" ..
+                      math.floor(300 * wweight * eweight / esum)
+                if weapon_def == nil then
+                     weapon_def = def
+                else
+                     weapon_def = weapon_def .. " / " .. def
+                end
+            end
+        end
+    end
+    e.kitem("O = " .. weapon_def)
+end
+}}
+
 # Only the below levels and Vaults:1-4 place ghost vaults. A specific ghost
 # vault may only be appropriate for a subset of these levels, in which case
 # they should set their own DEPTH. Note that if this default depth is changed,
@@ -512,7 +565,8 @@ DEPTH:  D:8-, Lair, Swamp
 ORIENT: float
 KMONS:  O = player ghost
 {{
--- Set up hydra monster entry with a range of possible extra heads.
+-- Set up hydra monster entry with a range of possible extra heads based on
+-- depth.
 max_heads = 11 + math.floor((you.absdepth() - 8) / 2)
 for h = 9, max_heads do
     def = h .. "-headed hydra"
@@ -523,50 +577,10 @@ for h = 9, max_heads do
     end
 end
 mons(hydra_def)
-
--- Set up the non-flaming edged weapon "left" by the ghost.
-make_arte = crawl.one_chance_in(3)
-
--- Basic set of egos with weights.
-egos  =  {["none"] = 30, ["vorpal"] = 15, ["freezing"] = 15,
-          ["electrocution"] = 10, ["venom"] = 10, ["protection"] = 10,
-          ["vampiric"] = 5, ["draining"] = 5, ["pain"] = 2,
-          ["distortion"] = 2, ["anti-magic"] = 2, ["speed"] = 1}
-esum = 0
-for ego, weight in pairs(egos) do
-    esum = esum + weight
-    if not make_arte or ego ~= "none" then
-        esum  = esum + weight
-    end
-end
-
--- Possible weapon types with weights. We stick to weapons wieldable by all
--- non-felids.
-weapons = {["long blade"] = 8, ["scimitar"] = 12, ["demon blade"] = 1,
-           ["double sword"] = 1, ["war axe"] = 8, ["broad axe"] = 12,
-           ["lajatang"] = 2}
-for wname, wweight in pairs(weapons) do
-    for ename, eweight in pairs(egos) do
-        if not make_arte or ename ~= "none" then
-            quality = make_arte and " randart " or " good_item "
-            -- Scale the final weapon entry weight by weapon weight and ego
-            -- weight with a 100 scaling factor so the smallest weight value is
-            -- non-zero.
-            def = wname .. quality .. " ego:" .. ename .. " w:" ..
-                  math.floor(100 * wweight * eweight / esum)
-            if weapon_def == nil then
-                 weapon_def = def
-            else
-                 weapon_def = weapon_def .. " / " .. def
-            end
-        end
-    end
-end
-kitem("O = " .. weapon_def)
 }}
 KMONS:  pq = plant
 KFEAT:  q = W
-SUBST:  t = ttWpq''
+SUBST:  t = tttWpq'
 : if you.absdepth() < 10 then
 NSUBST: ' = * / *% / -, - = 1 / 1--- / -
 : elseif you.absdepth() < 12 then
@@ -578,6 +592,7 @@ NSUBST:  ' = 2=|* / *% / %$-- / -, - = 1 / 2=1- / -
 : else
 NSUBST:  ' = 4=|* / -, - = 1 / 3=1- / -
 : end
+: init_hydra_weapons(_G)
 : ghost_vault_setup(_G)
 MAP
   ccccc

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -34,6 +34,171 @@ default-depth: D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, \
 #
 ###############################################################################
 
+NAME:  gammafunk_ghost_grave
+ORIENT: float
+WEIGHT: 20 (D:3-11)
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+KITEM: O = star_item / any
+SUBST: de = -
+:     elseif you.depth() < 9 then
+KITEM: O = star_item
+SUBST: d = %$--, e = -
+:     elseif you.absdepth() < 12 then
+KITEM: O = superb_item / star_item
+SUBST: d = %$, e = -
+:     else
+KITEM: O = superb_item / star_item
+SUBST: d = |*, e = *$
+:     end
+: elseif you.in_branch("Lair") then
+KITEM: O = superb_item / star_item
+SUBST: d = *%, e = %$--
+: elseif you.in_branch("Orc") then
+KITEM: O = superb_item / star_item
+SUBST: d = |*, e = %$
+: else
+KITEM: O = superb_item / star_item
+SUBST: de = |*
+: end
+KMONS: O = player ghost
+KMONS: p = withered plant
+SUBST: t : tp
+TILE:  G = dngn_gravestone
+TILE:  t = dngn_tree_dead
+: set_feature_name("granite_statue", "a gravestone")
+FTILE:  -|*%$OGt = floor_pebble_brown / floor_pebble_darkgray
+: ghost_vault_setup(_G)
+MAP
+ cccc
+.ndtc
+@=OGc
+.netc
+ cccc
+ENDMAP
+
+NAME:  gammafunk_ghost_split
+WEIGHT: 2 (D:3-7), 5 (D:8-11)
+ORIENT: float
+KMONS: O = player ghost
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+SUBST:  d = *%, e = %$, fgh = .
+NSUBST: D = 2=0 / 2=0. / 9. / .
+:     elseif you.depth() < 9 then
+SUBST:  d = *, e = *%, f = %$..,  gh = .
+NSUBST: D = 2=0 / 3=0. / 9. / 98.. / .
+:     elseif you.depth() < 12 then
+SUBST:  d = |*, e = *, f = %$,  gh = .
+NSUBST: D = 2=0 / 4=0. / 2=9. / 8. / .
+:     elseif you.depth() < 14 then
+SUBST:  de = |*, f = *, g = %$, h = .
+NSUBST: D = 2=0 / 3=0. / 9 / 9. / 2=8. / 98.. / .
+:     else
+SUBST:  def = |*, g = *%, h = %$--
+NSUBST: D = 2=0 / 2=0. / 9 / 2=9. / 8 / 8. / .
+:     end
+# From this point the average monster count stays at 6.5, but the composition
+# increases the proporation of 9s and 8s.
+: elseif you.in_branch("Lair") then
+SUBST:  de = |*, f = *%, g = %$..
+NSUBST: D = 3=0 / 3=0. / 2=9. / 8. / 98.. / .
+: elseif you.in_branch("Orc") then
+SUBST:  de = |*, f = *, g = %$
+NSUBST: D = 2=0 / 4=0. / 9 / 9. / 2=8. / .
+: else
+SUBST:  defgh = |*
+NSUBST: D = 2=0 / 2=0. / 9 / 2=9. / 8 / 8. / .
+: end
+SUBST: c : bcv, p : b., q : b., b : bcv
+: ghost_vault_setup(_G)
+MAP
+...........
+.cccnnnccc.
+.nD..D..Dc.
+.n..qpqg.c.
+.=.Dpqpe.n.
+@=...O.dDn.
+.=.Dpqpf.n.
+.n..qpqh.c.
+.nD..D..Dc.
+.cccnnnccc.
+...........
+ENDMAP
+
+NAME:   gammafunk_ghost_arena
+WEIGHT: 2 (D:3-7), 5 (D:8-11)
+ORIENT: float
+# TODO: incorporate these into later depth placement and also add to
+# ghost_mausoleum.
+# ITEM:   any jewellery good_item
+# ITEM:   cloak good_item / scarf good_item / helmet good_item / \
+#        hat good_item / gloves good_item / pair of boots good_item
+KMONS: O = player ghost
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+SUBST:  d = *%, e = %$, f = %$.., ghij = .
+NSUBST: D = 2=0 / 2=0. / 9. / .
+:     elseif you.depth() < 9 then
+SUBST:  d = *, e = *%, f = %$,  ghi = .
+NSUBST: D = 2=0 / 2=0. / 098. / 9. / .
+:     elseif you.depth() < 12 then
+SUBST:  d = |*, e = *, f = *%,  g = %$.., hi = .
+NSUBST: D = 2=0 / 3=0. / 2=9. / 8. / .
+:     elseif you.depth() < 14 then
+SUBST:  def = |*, g = *, h = %$, ij = .
+NSUBST: D = 2=0 / 4=0. / 098. / 9 / 9. / 2=8. / .
+:     else
+SUBST:  def = |*, g = *, h = %$, ij = .
+NSUBST: D = 3=0 / 3=0. / 9 / 2=9. / 8 / 8. / .
+:     end
+: elseif you.in_branch("Lair") then
+SUBST:  de = |*, f = *, g = %$, hij = .
+NSUBST: D = 2=0 / 3=0. / 098. / 2=9. / 8. / .
+: elseif you.in_branch("Orc") then
+SUBST:  def = |*, g = *%, h = %$.., ij = .
+NSUBST: D = 2=0 / 4=0. / 9 / 9. / 2=8. / .
+: elseif you.in_branch("Elf") then
+SUBST:  defg = |*, h = *, i = %$, j = .
+SUBST:  de = |*, f = *, g = %$, hij = .
+NSUBST: D = 3=0 / 4=0. / 9 / 3=9. / 8 / 2=8. / .
+: elseif you.in_branch("Crypt") then
+SUBST:  defgh = |*, i = *%, j = %$..
+NSUBST: D = 3=0 / 4=0. / 098. / 9 / 3=9. / 8 / 2=8. / .
+: elseif you.in_branch("Depths") then
+SUBST:  defgh = |*, i = *, j = %$
+NSUBST: D = 3=0 / 5=0. / 2=9 / 2=9. / 8 / 3=8. / .
+: elseif you.in_branch("Zot") then
+SUBST:  defghij = |*
+NSUBST: D = 3=0 / 5=0. / 2=9 / 3=9. / 2=8 / 2=8. / .
+# Lair branches
+: else
+SUBST:  defg = |*, h = *%, i = %$.., j = .
+NSUBST: D = 3=0 / 3=0. / 098. / 9 / 2=9. / 8 / 8. / .
+: end
+SUBST:  r : b., s : b., b : bcvx
+NSUBST: R = R / .
+MARKER: P = lua:transp_loc("ghost_arena_entry")
+MARKER: Q = lua:transp_dest_loc("ghost_arena_entry")
+MARKER: R = lua:transp_loc("ghost_arena_exit")
+MARKER: S = lua:transp_dest_loc("ghost_arena_exit")
+: ghost_vault_setup(_G)
+MAP
+  ...........
+ ..nnnnnnnnn..
+ .nnRD...DRnn.
+ .nG.rsDsrDGn.
+ .nD.sr.rsqgn.
+..n.D..D.Djen..
+@Pn.O.DQD.idnS@
+..n.D..D.Dkfn..
+ .nD.sr.rsphn.
+ .nG.rsDsrDGn.
+ .nnRD...DRnn.
+ ..nnnnnnnnn..
+  ...........
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -491,7 +491,7 @@ MONS:   vampire mosquito band / shadow / death knight / skeletal warrior / \
         freezing wraith w:5
 SUBST:  d = |*, e = *, f = *%,  g = %$--, hi = -
 NSUBST: D = 2=1 / 4=1- / 2=2- / -
-:     elseif you.depth() < 14 then
+:     elseif you.depth() < 15 then
 MONS:   zombie place:D:15 / spectre place:D:15 / simulacrum place:D:15 / \
         vampire mosquito band / death knight / skeletal warrior
 MONS:   freezing wraith / necromancer / shadow wraith / vampire knight / \

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -506,3 +506,87 @@ MAP
  .nnnnnnnnnnnnn.
  ...............
 ENDMAP
+
+NAME:   gammafunk_ghost_hydra_chop
+DEPTH:  D:8-, Lair, Swamp
+ORIENT: float
+KMONS:  O = player ghost
+{{
+-- Set up hydra monster entry with a range of possible extra heads.
+max_heads = 11 + math.floor((you.absdepth() - 8) / 2)
+for h = 9, max_heads do
+    def = h .. "-headed hydra"
+    if hydra_def == nil then
+        hydra_def = def
+    else
+        hydra_def = hydra_def .. " / " .. def
+    end
+end
+mons(hydra_def)
+
+-- Set up the non-flaming edged weapon "left" by the ghost.
+make_arte = crawl.one_chance_in(3)
+
+-- Basic set of egos with weights.
+egos  =  {["none"] = 30, ["vorpal"] = 15, ["freezing"] = 15,
+          ["electrocution"] = 10, ["venom"] = 10, ["protection"] = 10,
+          ["vampiric"] = 5, ["draining"] = 5, ["pain"] = 2,
+          ["distortion"] = 2, ["anti-magic"] = 2, ["speed"] = 1}
+esum = 0
+for ego, weight in pairs(egos) do
+    esum = esum + weight
+    if not make_arte or ego ~= "none" then
+        esum  = esum + weight
+    end
+end
+
+-- Possible weapon types with weights. We stick to weapons wieldable by all
+-- non-felids.
+weapons = {["long blade"] = 8, ["scimitar"] = 12, ["demon blade"] = 1,
+           ["double sword"] = 1, ["war axe"] = 8, ["broad axe"] = 12,
+           ["lajatang"] = 2}
+for wname, wweight in pairs(weapons) do
+    for ename, eweight in pairs(egos) do
+        if not make_arte or ename ~= "none" then
+            quality = make_arte and " randart " or " good_item "
+            -- Scale the final weapon entry weight by weapon weight and ego
+            -- weight with a 100 scaling factor so the smallest weight value is
+            -- non-zero.
+            def = wname .. quality .. " ego:" .. ename .. " w:" ..
+                  math.floor(100 * wweight * eweight / esum)
+            if weapon_def == nil then
+                 weapon_def = def
+            else
+                 weapon_def = weapon_def .. " / " .. def
+            end
+        end
+    end
+end
+kitem("O = " .. weapon_def)
+}}
+KMONS:  pq = plant
+KFEAT:  q = W
+SUBST:  t = ttWpq''
+: if you.absdepth() < 10 then
+NSUBST: ' = * / *% / -, - = 1 / 1--- / -
+: elseif you.absdepth() < 12 then
+NSUBST:  ' = |* / * / %$-- / -, - = 1 / 1- / -
+: elseif you.absdepth() < 14 then
+NSUBST:  ' = 2=|* / %$ / -, - = 1 / 111- / -
+: elseif you.absdepth() <= 16 then
+NSUBST:  ' = 2=|* / *% / %$-- / -, - = 1 / 2=1- / -
+: else
+NSUBST:  ' = 4=|* / -, - = 1 / 3=1- / -
+: end
+: ghost_vault_setup(_G)
+MAP
+  ccccc
+ cctttcn.
+cct'''-n.
+ct''---=.
+ct'-O--=@
+ct''---=.
+cct'''-n.
+ cctttcn.
+  ccccc
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -316,7 +316,6 @@ NSUBST: D = 2 / 3 / 2=3- / 4-, - = 2=1 / 2=1- / 2 / 3=2- / -
 FTILE:  -|*%$O1234G = floor_pebble_brown / floor_pebble_darkgray
 : ghost_vault_setup(_G)
 MAP
-MAP
  ccccccc
 .nDcDcDc
 .n----gc
@@ -370,7 +369,6 @@ cfh----=.
 ccj----n.
  cc---cn.
   ccccc
-nnnn
 ENDMAP
 
 NAME:   gammafunk_ghost_mausoleum

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -605,3 +605,62 @@ cct'''-n.
  cctttcn.
   ccccc
 ENDMAP
+
+NAME:   gammafunk_ghost_fury_of_okawaru
+DEPTH:  D:12-, Orc, Elf, Crypt
+ORIENT: float
+KFEAT:  O = altar_okawaru
+KMONS:  O = player ghost
+: if you.in_branch("D") then
+:      if you.depth() < 14 then
+MONS:   orc warrior / centaur warrior / tengu warrior
+MONS:   orc knight / naga warrior / merfolk impaler
+MONS:   merfolk javelineer / deep elf knight / deep elf archer
+SUBST:  def = |*, g = *, h = %$, ij = -
+NSUBST: - = 2=1 / 4=1- / 12-- / 2 / 2=2- / 3- / -
+:      else
+MONS:   orc warrior / centaur warrior / tengu warrior / orc knight / \
+        naga warrior / merfolk impaler
+MONS:   merfolk javelineer / deep elf knight / deep elf archer
+MONS:   stone giant / minotaur / fire giant / frost giant / orc warlord
+SUBST:  def = |*, g = *, h = %$, ij = -
+NSUBST: - = 3=1 / 3=1- / 2 / 3=2- / 333- / -
+:      end
+: elseif you.in_branch("Orc") then
+MONS:   orc warrior / centaur warrior / tengu warrior / orc knight
+MONS:   naga warrior / merfolk impaler / merfolk javelineer / \
+        deep elf knight / deep elf archer
+MONS:   minotaur / stone giant / orc warlord
+NSUBST: - = 2=1 / 4=1- / 12-- / 2 / 2=2- / 3- / -
+: elseif you.in_branch("Elf") then
+MONS:   centaur warrior / tengu warrior / orc knight / naga warrior / \
+        merfolk impaler / merfolk javelineer / deep elf knight / \
+        deep elf archer
+MONS:   minotaur / stone giant / orc warlord
+MONS:   fire giant / frost giant / deep elf blademaster / \
+        deep elf master archer / titan
+SUBST:  defgh = |*, i = *%, j = %$..
+NSUBST: - = 3=1 / 4=1- / 2=2 / 2=2- / 2=3- / 3--- / -
+# Crypt
+: else
+MONS:   centaur warrior / tengu warrior / naga warrior / merfolk impaler / \
+        merfolk javelineer / deep elf knight / deep elf archer
+MONS:   minotaur / stone giant / orc warlord / fire giant / frost giant / \
+        deep elf blademaster / deep elf master archer
+MONS:   titan
+SUBST:  defgh = |*, i = *%, j = %$..
+NSUBST: - = 3=1 / 4=1- / 12-- / 2=2 / 2=2- / 3 / 3- / -
+: end
+: ghost_vault_setup(_G)
+MAP
+ccccccccccc
+cGvvvvvvvGc
+c-igvOvhj-c
+c---edf---c
+c-vG---Gv-c
+c---------c
+c-vG---Gv-c
+c---------c
+cnnn===nnnc
+ ....@....
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -199,6 +199,48 @@ MAP
   ...........
 ENDMAP
 
+NAME:    gammafunk_ghost_cemetery
+WEIGHT:  5 (D:3-7)
+ORIENT:  float
+KMONS:   DEF = player ghost
+KMONS:   p = withered plant
+# 1/12 chance for 5 ghosts, 1/6 for 4, 1/4 for 3, 1/2 for 2.
+SHUFFLE: DdqEerFfs / DdqZyzFfs / DdqZyzFfs / DdqEerZyz / DdqEerZyz / \
+         DdqEerZyz / DdqZyzZyz / DdqZyzZyz / DdqZyzZyz / DdqZyzZyz / \
+         DdqZyzZyz / DdqZyzZyz
+# 1.5 items per ghost, upgrading quality with depth.
+: if you.in_branch("D") then
+:     if you.depth() < 6 then
+NSUBST:  d = 2=*% / %$--, e = *% / %$--, f = 2=*% / %$--
+:     elseif you.depth() < 9 then
+NSUBST:  d = 2=* / *%--, e = * / *%--, f = 2=* / *%--
+:     elseif you.depth() < 12 then
+NSUBST:  d = 2=|* / *-, e = |* / *-, f = 2=|* / *-
+:     else
+NSUBST:  d = 2=|* / |*--, e = |* / |*--, f = 2=|* / |*--
+:     end
+: else
+NSUBST:  d = 2=|* / |*--, e = |* / |*--, f = 2=|* / |*--
+: end
+SUBST:   qrs = G, Z = -, y = p, z = V, t : tp
+TILE:    G = dngn_gravestone
+TILE:    t = dngn_tree_dead
+FTILE:   -|*%$DEFpGt = floor_pebble_brown / floor_pebble_darkgray
+: set_feature_name("granite_statue", "a gravestone")
+: ghost_vault_setup(_G)
+MAP
+   ccccc
+  ccerecc
+ ccd-E-dcc
+ccq-----qcc
+cd-D---D-dc
+cf-------fc
+csF-----Fsc
+cf-------fc
+ccnn===nncc
+  ...@...
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -380,7 +380,7 @@ SUBST:  d = *, e = *%, f = %$--,  ghi = -
 NSUBST: - = 2=1 / 4=1. / 2=2 / 4=2. / .
 :     elseif you.depth() < 12 then
 SUBST:  d = |*, e = *, f = %$,  ghi = -
-NSUBST: e = %$-- / -, - = 2=1 / 4=1. / 3=2 / 6=2. / .
+NSUBST: - = 2=1 / 4=1. / 3=2 / 6=2. / .
 :     elseif you.depth() < 14 then
 SUBST:  def = |*, g = *%, h = %$--, ij = -
 NSUBST: - =  2=1 / 4=1. / 4=2 / 8=2. / 1=3...
@@ -390,7 +390,7 @@ NSUBST: - = 2=1 / 4=1. / 3=2 / 6=2. / 1=3 / 2=3.
 :     end
 : elseif you.in_branch("Lair") then
 SUBST:  de = |*, f = *%, g = %$--, hij = -
-NSUBST: f = *%$ / -, - = 2=1 / 4=1. / 3=2 / 6=2. / 1=3 / 1=3...
+NSUBST: - = 2=1 / 4=1. / 3=2 / 6=2. / 1=3 / 1=3...
 # Depths
 : else
 SUBST:  defgh = |*, i = *%, j = %$--

--- a/crawl-ref/source/dat/dlua/ghost.lua
+++ b/crawl-ref/source/dat/dlua/ghost.lua
@@ -1,0 +1,13 @@
+-- This function should be called in every ghost vault, since it sets the
+-- minimal tags we want as well as the common ghost chance. If you want your
+-- vault to be less common, use a WEIGHT statement; don't set a difference
+-- CHANCE from the one here.
+function ghost_vault_setup(e)
+  e.tags("chance_player_ghost allow_dup luniq_player_ghost")
+  e.tags("no_tele_into no_trap_gen no_monster_gen")
+
+  if not you.in_branch("Vaults") then
+      e.tags("chance_player_ghost")
+      e.chance("10%")
+  end
+end

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3855,6 +3855,8 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
 
     case MONS_PLAYER_GHOST:
         inf.body << "The apparition of " << get_ghost_description(mi) << ".\n";
+        if (mi.props.exists(MIRRORED_GHOST_KEY))
+            inf.body << "It looks just like you...spooky!\n";
         break;
 
     case MONS_PLAYER_ILLUSION:

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -370,6 +370,8 @@ static bool _build_level_vetoable(bool enable_random_maps,
 #ifdef DEBUG_STATISTICS
         mapstat_report_map_veto(e.what());
 #endif
+        // try not to lose any ghosts that have been placed
+        save_ghosts(ghost_demon::find_ghosts(false));
         return false;
     }
 

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -371,7 +371,7 @@ static bool _build_level_vetoable(bool enable_random_maps,
         mapstat_report_map_veto(e.what());
 #endif
         // try not to lose any ghosts that have been placed
-        save_ghosts(ghost_demon::find_ghosts(false));
+        save_ghosts(ghost_demon::find_ghosts(false), false, false);
         return false;
     }
 

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1178,8 +1178,6 @@ static void _make_level(dungeon_feature_type stair_taken,
     _clear_env_map();
     builder(true, stair_type);
 
-    if (ghost_demon::ghost_eligible() && one_chance_in(3))
-        load_ghosts(ghost_demon::max_ghosts_per_level(env.absdepth0), true);
     env.turns_on_level = 0;
     // sanctuary
     env.sanctuary_pos  = coord_def(-1, -1);

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1724,8 +1724,22 @@ void save_game_state()
 
 static string _make_ghost_filename(bool store=false)
 {
-    return string("bones.") + (store ? "store." : "")
-           + replace_all(level_id::current().describe(), ":", "-");
+    // Only use level-numbered bones files for places where players die a lot.
+    // For the permastore, go even coarser (just D and Lair use level numbers).
+    // n.b. some branches here may not currently generate ghosts.
+    // TODO: further adjustments? Make Zot coarser?
+    const bool with_number = store ? player_in_branch(BRANCH_DUNGEON) ||
+                                     player_in_branch(BRANCH_LAIR)
+                                   : !(player_in_branch(BRANCH_ZIGGURAT) ||
+                                       player_in_branch(BRANCH_CRYPT) ||
+                                       player_in_branch(BRANCH_TOMB) ||
+                                       player_in_branch(BRANCH_ABYSS) ||
+                                       player_in_branch(BRANCH_SLIME));
+    // Players die so rarely in hell in practice that it doesn't even make
+    // sense to have per-hell bones. (Maybe vestibule should be separate?)
+    const string level_desc = player_in_hell() ? "Hells" :
+        replace_all(level_id::current().describe(false, with_number), ":", "-");
+    return string("bones.") + (store ? "store." : "") + level_desc;
 }
 
 static string _bones_permastore_file()

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -49,6 +49,7 @@
 #include "god-passive.h"
 #include "hints.h"
 #include "initfile.h"
+#include "item-name.h"
 #include "items.h"
 #include "jobs.h"
 #include "kills.h"
@@ -1700,13 +1701,26 @@ void save_game_state()
         save_game(true);
 }
 
-static string _make_ghost_filename()
+static string _make_ghost_filename(bool store=false)
 {
-    return "bones."
+    return string("bones.") + (store ? "store." : "")
            + replace_all(level_id::current().describe(), ":", "-");
 }
 
 #define BONES_DIAGNOSTICS (defined(WIZARD) || defined(DEBUG_BONES) | defined(DEBUG_DIAGNOSTICS))
+
+static string _bones_permastore_file()
+{
+    return _get_bonefile_directory() + _make_ghost_filename(true);
+}
+
+// Bones files
+//
+// There are two kinds of bones files: temporary bones files and the
+// permastore. Temporary bones files are ephemeral: ghosts will be reused only
+// if they are on the floor where the player dies. The permastore is a more
+// permanent stock of ghosts (per levle) to use as a backup in case the
+// temporary bones files are depleted.
 
 /**
  * Lists all bonefiles for the current level.
@@ -1723,7 +1737,10 @@ static vector<string> _list_bones()
     vector<string> bonefiles;
     for (const auto &filename : filenames)
         if (starts_with(filename, underscored_filename))
+        {
             bonefiles.push_back(bonefile_dir + filename);
+            dprf("bonesfile %s", (bonefile_dir + filename).c_str());
+        }
 
     string old_bonefile = _get_old_bonefile_directory() + base_filename;
     if (access(old_bonefile.c_str(), F_OK) == 0)
@@ -1748,61 +1765,103 @@ static string _find_ghost_file()
     return bonefiles[ui_random(bonefiles.size())];
 }
 
-static vector<ghost_demon> _load_ghost_vec(bool creating_level, bool wiz_cmd)
+static vector<ghost_demon> _load_bones_file(string ghost_filename, bool wiz_cmd)
 {
     vector<ghost_demon> result;
 
-    const string ghost_filename = _find_ghost_file();
     if (ghost_filename.empty())
     {
-        if (wiz_cmd && !creating_level)
-            mprf(MSGCH_PROMPT, "No ghost files for this level.");
+        if (wiz_cmd)
+            mprf(MSGCH_PROMPT, "No ephemeral ghost files for this level.");
         return result; // no such ghost.
     }
 
     reader inf(ghost_filename);
     if (!inf.valid())
     {
-        if (wiz_cmd && !creating_level)
-            mprf(MSGCH_PROMPT, "Ghost file invalidated before read.");
+        if (wiz_cmd)
+            mprf(MSGCH_PROMPT, "Ghost file '%s' invalidated before read.", ghost_filename.c_str());
         return result;
     }
 
     inf.set_safe_read(true); // don't die on 0-byte bones
-    if (_ghost_version_compatible(inf))
+    if (!_ghost_version_compatible(inf))
     {
-        try
-        {
-            result = tag_read_ghosts(inf);
-            inf.fail_if_not_eof(ghost_filename);
-        }
-        catch (short_read_exception &short_read)
-        {
-            mprf(MSGCH_ERROR, "Broken bones file: %s",
-                 ghost_filename.c_str());
-        }
+        string error = "Incompatible bones file: " + ghost_filename;
+        throw corrupted_save(error);
+    }
+    try
+    {
+        result = tag_read_ghosts(inf);
+        inf.fail_if_not_eof(ghost_filename);
+    }
+    catch (short_read_exception &short_read)
+    {
+        string error = "Broken bones file: " + ghost_filename;
+        throw corrupted_save(error);
     }
     inf.close();
 
-    // Remove bones file - ghosts are hardly permanent.
+    if (!debug_check_ghosts(result))
+    {
+        string error = "Bones file is buggy: " + ghost_filename;
+        throw corrupted_save(error);
+    }
+
+    return result;
+}
+
+static vector<ghost_demon> _load_ephemeral_ghosts(bool wiz_cmd)
+{
+    vector<ghost_demon> results;
+
+    string ghost_filename = _find_ghost_file();
+    if (ghost_filename.empty())
+    {
+        if (wiz_cmd)
+            mprf(MSGCH_PROMPT, "No ghost files for this level.");
+        return results; // no such ghost.
+    }
+
+    try
+    {
+        results = _load_bones_file(ghost_filename, wiz_cmd);
+    }
+    catch (corrupted_save &err)
+    {
+        mprf(MSGCH_ERROR, "%s", err.what());
+    }
+
     if (unlink(ghost_filename.c_str()) != 0)
     {
         mprf(MSGCH_ERROR, "Failed to unlink bones file: %s",
                 ghost_filename.c_str());
     }
+    return results;
+}
 
-    if (!debug_check_ghosts(result))
+static vector<ghost_demon> _load_permastore_ghosts(bool wiz_cmd)
+{
+    string ghost_filename = _bones_permastore_file();
+    vector<ghost_demon> results;
+    try
     {
-        mprf(MSGCH_DIAGNOSTICS,
-             "Refusing to load buggy ghost from file \"%s\"!",
-             ghost_filename.c_str());
-
-        result.clear();
-        return result;
+        results = _load_bones_file(ghost_filename, wiz_cmd);
     }
-
-    return result;
-
+    catch (corrupted_save &err)
+    {
+        mprf(MSGCH_ERROR, "%s", err.what());
+        string report;
+        // if we get to this point the permastore is unreadable and needs to
+        // be scrapped
+        if (unlink(ghost_filename.c_str()) != 0)
+            report = "Failed to unlink bad ghost permastore";
+        else
+            report = "Clearing bad ghost permastore";
+        mprf(MSGCH_ERROR, "%s: %s", report.c_str(), ghost_filename.c_str());
+    }
+    // otherwise, don't do anything to the permastore
+    return results;
 }
 
 /**
@@ -1815,52 +1874,45 @@ static vector<ghost_demon> _load_ghost_vec(bool creating_level, bool wiz_cmd)
 bool define_ghost_from_bones(monster& mons)
 {
     const bool wiz_cmd = (crawl_state.prev_cmd == CMD_WIZARD);
+    bool used_permastore = false;
 
-#ifdef BONES_DIAGNOSTICS
-    const bool do_diagnostics = true;
-#endif
-
-    vector<ghost_demon> loaded_ghosts = _load_ghost_vec(true, wiz_cmd);
+    vector<ghost_demon> loaded_ghosts = _load_ephemeral_ghosts(wiz_cmd);
     if (loaded_ghosts.empty())
-        return false;
-
-#ifdef BONES_DIAGNOSTICS
-    if (do_diagnostics)
     {
-        mprf(MSGCH_DIAGNOSTICS, "Loaded ghost file with %u ghost(s), placing %s",
-             (unsigned int)loaded_ghosts.size(), loaded_ghosts[0].name.c_str());
+        loaded_ghosts = _load_permastore_ghosts(wiz_cmd);
+        if (loaded_ghosts.empty())
+            return false;
+        used_permastore = true;
     }
-    bool          ghost_errors    = false;
-#endif
 
-    mons.set_ghost(loaded_ghosts[0]);
+    int place_i = random2(loaded_ghosts.size());
+    dprf("Loaded ghost file with %u ghost(s), placing %s",
+         (unsigned int)loaded_ghosts.size(), loaded_ghosts[place_i].name.c_str());
+    bool  ghost_errors    = false;
+
+    mons.set_ghost(loaded_ghosts[place_i]);
     mons.type = MONS_PLAYER_GHOST;
     mons.ghost_init(false);
 
-#ifdef BONES_DIAGNOSTICS
-    if (do_diagnostics)
+    if (!mons.alive())
     {
-        if (!mons.alive())
-        {
-            mprf(MSGCH_DIAGNOSTICS, "Placed ghost is not alive.");
-            ghost_errors = true;
-        }
-        else if (mons.type != MONS_PLAYER_GHOST)
-        {
-            mprf(MSGCH_DIAGNOSTICS,
-                 "Placed ghost is not MONS_PLAYER_GHOST, but %s",
-                 mons.name(DESC_PLAIN, true).c_str());
-            ghost_errors = true;
-        }
+        mprf(MSGCH_ERROR, "Placed ghost is not alive.");
+        ghost_errors = true;
     }
-    if (ghost_errors)
-        more();
-#endif
+    else if (mons.type != MONS_PLAYER_GHOST)
+    {
+        mprf(MSGCH_ERROR, "Placed ghost is not MONS_PLAYER_GHOST, but %s",
+             mons.name(DESC_PLAIN, true).c_str());
+        ghost_errors = true;
+    }
 
-    loaded_ghosts.erase(loaded_ghosts.begin());
+    if (!used_permastore)
+    {
+        loaded_ghosts.erase(loaded_ghosts.begin());
 
-    if (!loaded_ghosts.empty())
-        save_ghosts(loaded_ghosts);
+        if (!loaded_ghosts.empty())
+            save_ghosts(loaded_ghosts);
+    }
     return true;
 }
 
@@ -1900,7 +1952,7 @@ bool load_ghosts(int max_ghosts, bool creating_level)
         ;
 #endif // BONES_DIAGNOSTICS
 
-    vector<ghost_demon> loaded_ghosts = _load_ghost_vec(creating_level, wiz_cmd);
+    vector<ghost_demon> loaded_ghosts = _load_ephemeral_ghosts(wiz_cmd);
 
 #ifdef BONES_DIAGNOSTICS
     if (do_diagnostics)
@@ -2424,9 +2476,9 @@ static bool _ghost_version_compatible(reader &inf)
  **/
 static FILE* _make_bones_file(string * return_gfilename)
 {
-
     const string bone_dir = _get_bonefile_directory();
-    const string base_filename = _make_ghost_filename();
+    const string base_filename = _make_ghost_filename(false);
+
     for (int i = 0; i < GHOST_LIMIT; i++)
     {
         const string g_file_name = make_stringf("%s%s_%d", bone_dir.c_str(),
@@ -2449,6 +2501,69 @@ static FILE* _make_bones_file(string * return_gfilename)
     return nullptr;
 }
 
+#define GHOST_PERMASTORE_SIZE 10
+#define GHOST_PERMASTORE_REPLACE_CHANCE 5
+
+static bool _update_permastore(const vector<ghost_demon> &ghosts, bool wiz_cmd)
+{
+    if (ghosts.empty())
+        return false;
+
+    // this read is not locked...
+    vector<ghost_demon> permastore = _load_permastore_ghosts(wiz_cmd);
+
+    bool rewrite = false;
+    int i = 0;
+    while (permastore.size() < GHOST_PERMASTORE_SIZE && i < ghosts.size())
+    {
+        // TODO: heuristics to make this as distinct as possible; maybe
+        // create a new name?
+        permastore.push_back(ghosts[i]);
+#ifdef DGAMELAUNCH
+        // randomize name for online play
+        permastore.back().name = make_name();
+#endif
+        i++;
+        rewrite = true;
+    }
+    if (i > 0)
+        dprf("Permastoring %d ghosts", i);
+    if (!rewrite && x_chance_in_y(GHOST_PERMASTORE_REPLACE_CHANCE, 100))
+    {
+        int rewrite_i = random2(permastore.size());
+        permastore[rewrite_i] = ghosts[0];
+#ifdef DGAMELAUNCH
+        permastore[rewrite_i].name = make_name();
+#endif
+        rewrite = true;
+    }
+
+    if (rewrite)
+    {
+        string permastore_file = _bones_permastore_file();
+        FILE *gfil = lk_open("wb", permastore_file);
+
+        if (!gfil)
+        {
+            // this will fail silently if the lock fails, seems safest
+            // TODO: better lock system for servers?
+            dprf("Could not open ghost permastore: %s",
+                                                    permastore_file.c_str());
+            return false;
+        }
+
+        dprf("Rewriting ghost permastore %s with %u ghosts",
+                    permastore_file.c_str(), (unsigned int) permastore.size());
+        writer outw(permastore_file, gfil);
+        _write_ghost_version(outw);
+        tag_write_ghosts(outw, permastore);
+
+        lk_close(gfil, permastore_file);
+        return true;
+    }
+    return false;
+}
+
 /**
  * Attempt to save all ghosts from the current level.
  *
@@ -2458,38 +2573,24 @@ static FILE* _make_bones_file(string * return_gfilename)
  * @param force   Forces ghost generation even in otherwise-disallowed levels.
  **/
 
-void save_ghosts(const vector<ghost_demon> &ghosts, bool force)
+void save_ghosts(const vector<ghost_demon> &ghosts, bool force, bool use_store)
 {
-#ifdef BONES_DIAGNOSTICS
-    const bool do_diagnostics =
-#  if defined(DEBUG_BONES) || defined(DEBUG_DIAGNOSTICS)
-        true
-#  elif defined(WIZARD)
-        you.wizard
-#  else // Can't happen currently
-        false
-#  endif
-        ;
-#endif // BONES_DIAGNOSTICS
-
     if (ghosts.empty())
     {
-#ifdef BONES_DIAGNOSTICS
-        if (do_diagnostics)
-            mprf(MSGCH_DIAGNOSTICS, "Could not find any ghosts for this level.");
-#endif
+        dprf("Could not find any ghosts for this level.");
         return;
     }
 
     if (!force && !ghost_demon::ghost_eligible())
         return;
 
+    // TODO: fill temp store with ghosts unused by this
+    if (_update_permastore(ghosts, force))
+        return;
+
     if (_list_bones().size() >= static_cast<size_t>(GHOST_LIMIT))
     {
-#ifdef BONES_DIAGNOSTICS
-        if (do_diagnostics)
-            mprf(MSGCH_DIAGNOSTICS, "Too many ghosts for this level already!");
-#endif
+        dprf("Too many ghosts for this level already!");
         return;
     }
 
@@ -2498,10 +2599,7 @@ void save_ghosts(const vector<ghost_demon> &ghosts, bool force)
 
     if (!ghost_file)
     {
-#ifdef BONES_DIAGNOSTICS
-        if (do_diagnostics)
-            mprf(MSGCH_DIAGNOSTICS, "Could not open file to save ghosts.");
-#endif
+        dprf("Could not open file to save ghosts.");
         return;
     }
 
@@ -2512,10 +2610,7 @@ void save_ghosts(const vector<ghost_demon> &ghosts, bool force)
 
     lk_close(ghost_file, g_file_name);
 
-#ifdef BONES_DIAGNOSTICS
-    if (do_diagnostics)
-        mprf(MSGCH_DIAGNOSTICS, "Saved ghosts (%s).", g_file_name.c_str());
-#endif
+    dprf("Saved ghosts (%s).", g_file_name.c_str());
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1717,7 +1717,7 @@ static string _bones_permastore_file()
 // There are two kinds of bones files: temporary bones files and the
 // permastore. Temporary bones files are ephemeral: ghosts will be reused only
 // if they are on the floor where the player dies. The permastore is a more
-// permanent stock of ghosts (per levle) to use as a backup in case the
+// permanent stock of ghosts (per level) to use as a backup in case the
 // temporary bones files are depleted.
 
 /**
@@ -2481,10 +2481,10 @@ static FILE* _make_bones_file(string * return_gfilename)
     {
         const string g_file_name = make_stringf("%s%s_%d", bone_dir.c_str(),
                                                 base_filename.c_str(), i);
-        FILE *gfil = lk_open_exclusive(g_file_name);
+        FILE *ghost_file = lk_open_exclusive(g_file_name);
         // need to check file size, so can't open 'wb' - would truncate!
 
-        if (!gfil)
+        if (!ghost_file)
         {
             dprf("Could not open %s", g_file_name.c_str());
             continue;
@@ -2493,7 +2493,7 @@ static FILE* _make_bones_file(string * return_gfilename)
         dprf("found %s", g_file_name.c_str());
 
         *return_gfilename = g_file_name;
-        return gfil;
+        return ghost_file;
     }
 
     return nullptr;
@@ -2539,9 +2539,9 @@ static bool _update_permastore(const vector<ghost_demon> &ghosts, bool wiz_cmd)
     if (rewrite)
     {
         string permastore_file = _bones_permastore_file();
-        FILE *gfil = lk_open("wb", permastore_file);
+        FILE *ghost_file = lk_open("wb", permastore_file);
 
-        if (!gfil)
+        if (!ghost_file)
         {
             // this will fail silently if the lock fails, seems safest
             // TODO: better lock system for servers?
@@ -2552,11 +2552,11 @@ static bool _update_permastore(const vector<ghost_demon> &ghosts, bool wiz_cmd)
 
         dprf("Rewriting ghost permastore %s with %u ghosts",
                     permastore_file.c_str(), (unsigned int) permastore.size());
-        writer outw(permastore_file, gfil);
+        writer outw(permastore_file, ghost_file);
         _write_ghost_version(outw);
         tag_write_ghosts(outw, permastore);
 
-        lk_close(gfil, permastore_file);
+        lk_close(ghost_file, permastore_file);
         return true;
     }
     return false;

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -110,6 +110,7 @@ public:
 
 void save_ghosts(const vector<ghost_demon> &ghosts, bool force = false);
 bool load_ghosts(int max_ghosts, bool creating_level);
+bool define_ghost_from_bones(monster& mons);
 
 FILE *lk_open(const char *mode, const string &file);
 FILE *lk_open_exclusive(const string &file);

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -108,7 +108,8 @@ public:
     void go_to(const level_id &level);
 };
 
-void save_ghosts(const vector<ghost_demon> &ghosts, bool force = false);
+void save_ghosts(const vector<ghost_demon> &ghosts, bool force = false,
+                                                    bool use_store = true);
 bool load_ghosts(int max_ghosts, bool creating_level);
 bool define_ghost_from_bones(monster& mons);
 

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -662,11 +662,11 @@ spell_type ghost_demon::translate_spell(spell_type spell) const
     return spell;
 }
 
-const vector<ghost_demon> ghost_demon::find_ghosts()
+const vector<ghost_demon> ghost_demon::find_ghosts(bool include_player)
 {
     vector<ghost_demon> gs;
 
-    if (you.undead_state(false) == US_ALIVE)
+    if (include_player && you.undead_state(false) == US_ALIVE)
     {
         ghost_demon player;
         player.init_player_ghost();
@@ -693,7 +693,7 @@ void ghost_demon::find_transiting_ghosts(
             if (i->mons.type == MONS_PLAYER_GHOST)
             {
                 const monster& m = i->mons;
-                if (m.ghost.get())
+                if (m.ghost.get() && !m.props.exists("mirrored_ghost"))
                 {
                     announce_ghost(*m.ghost);
                     gs.push_back(*m.ghost);
@@ -714,7 +714,8 @@ void ghost_demon::find_extra_ghosts(vector<ghost_demon> &gs)
 {
     for (monster_iterator mi; mi; ++mi)
     {
-        if (mi->type == MONS_PLAYER_GHOST && mi->ghost.get())
+        if (mi->type == MONS_PLAYER_GHOST && mi->ghost.get()
+            && !mi->props.exists("mirrored_ghost"))
         {
             // Bingo!
             announce_ghost(*(mi->ghost));

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -693,7 +693,7 @@ void ghost_demon::find_transiting_ghosts(
             if (i->mons.type == MONS_PLAYER_GHOST)
             {
                 const monster& m = i->mons;
-                if (m.ghost.get() && !m.props.exists("mirrored_ghost"))
+                if (m.ghost.get() && !m.props.exists(MIRRORED_GHOST_KEY))
                 {
                     announce_ghost(*m.ghost);
                     gs.push_back(*m.ghost);
@@ -715,7 +715,7 @@ void ghost_demon::find_extra_ghosts(vector<ghost_demon> &gs)
     for (monster_iterator mi; mi; ++mi)
     {
         if (mi->type == MONS_PLAYER_GHOST && mi->ghost.get()
-            && !mi->props.exists("mirrored_ghost"))
+            && !mi->props.exists(MIRRORED_GHOST_KEY))
         {
             // Bingo!
             announce_ghost(*(mi->ghost));

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -13,6 +13,8 @@
 #include "mutant-beast.h"
 #include "species-type.h"
 
+#define MIRRORED_GHOST_KEY "mirrored_ghost"
+
 class ghost_demon
 {
 public:

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -51,7 +51,7 @@ public:
 
 
 public:
-    static const vector<ghost_demon> find_ghosts();
+    static const vector<ghost_demon> find_ghosts(bool include_player=true);
     static int max_ghosts_per_level(int absdepth);
     static bool ghost_eligible();
 

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1100,7 +1100,7 @@ int channel_to_colour(msg_channel_type channel, int param)
     return colour_msg(channel_to_msgcol(channel, param));
 }
 
-static void do_message_print(msg_channel_type channel, int param, bool cap,
+void do_message_print(msg_channel_type channel, int param, bool cap,
                              bool nojoin, const char *format, va_list argp)
 {
     va_list ap;

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -651,6 +651,8 @@ monster_info::monster_info(const monster* m, int milev)
         i_ghost.ac = quantise(ghost.ac, 5);
         i_ghost.damage = ghost.damage;
         props[KNOWN_MAX_HP_KEY] = (int)ghost.max_hp;
+        if (m->props.exists(MIRRORED_GHOST_KEY))
+            props[MIRRORED_GHOST_KEY] = m->props[MIRRORED_GHOST_KEY];
 
         // describe abnormal (branded) ghost weapons
         if (ghost.brand != SPWPN_NORMAL)

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -28,6 +28,7 @@
 #include "env.h"
 #include "errors.h"
 #include "fight.h"
+#include "files.h"
 #include "food.h"
 #include "fprop.h"
 #include "ghost.h"
@@ -2942,10 +2943,18 @@ void define_monster(monster& mons)
     }
 
     case MONS_PLAYER_GHOST:
+    {
+        if (define_ghost_from_bones(mons))
+            break;
+        dprf("No ghosts found in bones, falling back on mirrored player");
+        // intentional fallthrough -- fall back on mirroring the player
+    }
     case MONS_PLAYER_ILLUSION:
     {
         ghost_demon ghost;
         ghost.init_player_ghost(mcls == MONS_PLAYER_GHOST);
+        if (mcls == MONS_PLAYER_GHOST)
+            mons.props["mirrored_ghost"] = true;
         mons.set_ghost(ghost);
         mons.ghost_init(!mons.props.exists("fake"));
         break;

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -2954,7 +2954,7 @@ void define_monster(monster& mons)
         ghost_demon ghost;
         ghost.init_player_ghost(mcls == MONS_PLAYER_GHOST);
         if (mcls == MONS_PLAYER_GHOST)
-            mons.props["mirrored_ghost"] = true;
+            mons.props[MIRRORED_GHOST_KEY] = true;
         mons.set_ghost(ghost);
         mons.ghost_init(!mons.props.exists("fake"));
         break;

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1705,7 +1705,6 @@ bool mons_class_can_use_stairs(monster_type mc)
     return (!mons_class_is_zombified(mc) || mc == MONS_SPECTRAL_THING)
            && !mons_is_tentacle_or_tentacle_segment(mc)
            && mc != MONS_SILENT_SPECTRE
-           && mc != MONS_PLAYER_GHOST
            && mc != MONS_GERYON
            && mc != MONS_ROYAL_JELLY;
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1935,7 +1935,7 @@ mon_attack_def mons_attack_spec(const monster& m, int attk_number,
 
     if (mons_is_ghost_demon(mc))
     {
-        if (attk_number == 0)
+        if (attk_number == 0 && mon.ghost)
         {
             return { mon.ghost->att_type, mon.ghost->att_flav,
                      mon.ghost->damage };

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -2953,7 +2953,12 @@ void define_monster(monster& mons)
         ghost_demon ghost;
         ghost.init_player_ghost(mcls == MONS_PLAYER_GHOST);
         if (mcls == MONS_PLAYER_GHOST)
+        {
+            // still don't allow undead ghosts, even mirrored
+            if (you.undead_state(false) != US_ALIVE)
+                ghost.species = SP_HUMAN;
             mons.props[MIRRORED_GHOST_KEY] = true;
+        }
         mons.set_ghost(ghost);
         mons.ghost_init(!mons.props.exists("fake"));
         break;

--- a/crawl-ref/source/mpr.h
+++ b/crawl-ref/source/mpr.h
@@ -96,6 +96,9 @@ enum diag_type
 
 msg_colour_type msg_colour(int colour);
 
+void do_message_print(msg_channel_type channel, int param, bool cap,
+                             bool nojoin, const char *format, va_list argp);
+
 void mpr(const string &text);
 void mpr_nojoin(msg_channel_type channel, string text);
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1188,11 +1188,13 @@ void debug_miscast(int target_index)
 #ifdef DEBUG_BONES
 void debug_ghosts()
 {
-    mprf(MSGCH_PROMPT, "(C)reate or (L)oad bones file?");
+    mprf(MSGCH_PROMPT, "(C)reate, create (T)emporary, or (L)oad bones file?");
     const char c = toalower(getchm());
 
     if (c == 'c')
-        save_ghosts(ghost_demon::find_ghosts(), true);
+        save_ghosts(ghost_demon::find_ghosts(), true, true);
+    else if (c == 't')
+        save_ghosts(ghost_demon::find_ghosts(), true, false);
     else if (c == 'l')
         load_ghosts(ghost_demon::max_ghosts_per_level(env.absdepth0), false);
     else


### PR DESCRIPTION
This branch implements one of the ideas for ghost reform developed first in the 0.21 plan, ghost vaults. This proposal has three main aims: (i) keep ghosts, (ii) make ghost griefing harder, as well as make certain kinds of scumming pointless (e.g. shaftrobin), and (iii) provide more (or at least a different kind of) player agency in how to deal with ghosts. Under this proposal, player ghosts place only in vaults, and in particular in sealed vaults that the player can see into. This proposal will also allow buffing of ghosts, and so far this branch includes one such buff -- ghosts can use stairs.

Technical changes included in this branch:
1. Putting "player ghost" in vault will attempt to place a ghost from a bones file for that level.
2. Ghosts are placed only with vaults, rather than with a hard-coded post-levelgen placement system. I've attempted to keep the probabilities mostly the same.  See `dat/des/variable/ghost.des` for a few basic examples.  All of these are sealed vaults, either with runed doors or with transporters. (N.b. this isn't enforced in the code or anything.)
3. For each level, in addition to the regular bones database, the game keeps around a "permastore" of player ghosts, in order to have a semi-permanent stock of ghosts to place. In extreme circumstances, the game will fall back on mirroring the player to make a ghost. The point of this is to make it so that the probability of ghost vault placement is independent (as far as possible) from what has happened with previous games. Names in the permastore are randomized for online play at the moment. The permastore does slowly change. One idea that came up in chat is to hand-pick some ghosts to seed this with.

Side note: oldghosts could be easily implemented in the context of these technical changes by having a "dummy" vault that just places a ghost. This would still be better than the status quo because I think being able to explicitly place ghosts could be useful in vault design in any case. (Prior to this change, putting "player ghost" in a vault would parse, but only produce a mirrored ghost based on the player.)

A few issues:
* vault design is fairly basic at the moment. I haven't added any ghosts to existing vaults, one could do this with some high level runed door things for example. I also haven't included any multi-ghost vaults which could also be done. The vaults I wrote do place loot, which I suspect is too much.
* technical change 3 is not well tested and I don't know how it'll work on servers in practice.
* this change naturally would go with other changes to the ghost creation algorithm. Should the 0.21 speed nerf be reverted?
* I suspect that at the moment, a ghost vault placing will tend to crowd out a minivault, which is not ideal.