### PR TITLE
Menu refactor

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3130,15 +3130,8 @@ static void _pay_ability_costs(const ability_def& abil)
 
 int choose_ability_menu(const vector<talent>& talents)
 {
-#ifdef USE_TILE_LOCAL
-    const bool text_only = false;
-#else
-    const bool text_only = true;
-#endif
-
     ToggleableMenu abil_menu(MF_SINGLESELECT | MF_ANYPRINTABLE
-                             | MF_TOGGLE_ACTION | MF_ALWAYS_SHOW_MORE,
-                             text_only);
+                             | MF_TOGGLE_ACTION | MF_ALWAYS_SHOW_MORE);
 
     abil_menu.set_highlighter(nullptr);
 #ifdef USE_TILE_LOCAL

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -712,9 +712,6 @@ void show_levelmap_help()
 void show_targeting_help()
 {
     column_composer cols(2, 40);
-    // Page size is number of lines - one line for --more-- prompt.
-    cols.set_pagesize(get_number_of_lines() - 1);
-
     cols.add_formatted(0, targeting_help_1, true);
 #ifdef WIZARD
     if (you.wizard)
@@ -1233,9 +1230,6 @@ void list_commands(int hotkey, bool do_redraw_screen, string highlight_string)
 {
     // 2 columns, split at column 40.
     column_composer cols(2, 41);
-
-    // Page size is number of lines - one line for --more-- prompt.
-    cols.set_pagesize(get_number_of_lines() - 1);
 
     if (crawl_state.game_is_hints_tutorial())
         _add_formatted_hints_help(cols);

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -517,6 +517,10 @@ static int _keyhelp_keyfilter(int ch)
         }
         break;
 
+    case CK_HOME:
+        list_commands(0, true);
+        return -1;
+
     case '#':
         // If the game has begun, show dump.
         if (crawl_state.need_save)

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -518,7 +518,9 @@ static int _keyhelp_keyfilter(int ch)
         break;
 
     case CK_HOME:
-        list_commands(0, true);
+        list_commands(0);
+        clrscr();
+        redraw_screen();
         return -1;
 
     case '#':
@@ -1230,7 +1232,7 @@ static void _add_formatted_hints_help(column_composer &cols)
             false);
 }
 
-void list_commands(int hotkey, bool do_redraw_screen, string highlight_string)
+void list_commands(int hotkey, string highlight_string)
 {
     // 2 columns, split at column 40.
     column_composer cols(2, 41);
@@ -1242,10 +1244,4 @@ void list_commands(int hotkey, bool do_redraw_screen, string highlight_string)
 
     show_keyhelp_menu(cols.formatted_lines(), true, Options.easy_exit_menu,
                        hotkey, highlight_string);
-
-    if (do_redraw_screen)
-    {
-        clrscr();
-        redraw_screen();
-    }
 }

--- a/crawl-ref/source/command.h
+++ b/crawl-ref/source/command.h
@@ -24,8 +24,7 @@ void show_stash_search_help();
 void show_butchering_help();
 void show_skill_menu_help();
 
-void list_commands(int hotkey = 0, bool do_redraw_screen = false,
-                   string highlight_string = "");
+void list_commands(int hotkey = 0, string highlight_string = "");
 
 int show_keyhelp_menu(const vector<formatted_string> &lines,
                       bool with_manual, bool easy_exit = false,

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2551,6 +2551,7 @@ bool describe_item(item_def &item, function<void (string&)> fixup_desc)
                                      || crawl_state.updating_scores);
         vector<command_type> actions;
         formatted_scroller menu;
+        menu.set_flags(MF_SINGLESELECT);
         menu.add_text(desc, false, get_number_of_cols());
         if (do_actions)
         {

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -626,13 +626,6 @@ void full_describe_view()
     desc_menu.action_cycle = Menu::CYCLE_TOGGLE;
     desc_menu.menu_action  = InvMenu::ACT_EXECUTE;
 
-    // Don't make a menu so tall that we recycle hotkeys on the same page.
-    if (list_mons.size() + list_items.size() + list_features.size() > 52
-        && (desc_menu.maxpagesize() > 52 || desc_menu.maxpagesize() == 0))
-    {
-        desc_menu.set_maxpagesize(52);
-    }
-
     // Start with hotkey 'a' and count from there.
     menu_letter hotkey;
     // Build menu entries for monsters.

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -304,7 +304,7 @@ void InvEntry::set_show_glyph(bool doshow)
 }
 
 InvMenu::InvMenu(int mflags)
-    : Menu(mflags, "inventory", false), type(MT_INVLIST), pre_select(nullptr),
+    : Menu(mflags, "inventory"), type(MT_INVLIST), pre_select(nullptr),
       title_annotate(nullptr)
 {
 #ifdef USE_TILE_LOCAL

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -847,10 +847,6 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
         }
     }
 
-    // Don't make a menu so tall that we recycle hotkeys on the same page.
-    if (mitems.size() > 52 && (max_pagesize > 52 || max_pagesize == 0))
-        set_maxpagesize(52);
-
     return ckey;
 }
 

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -309,8 +309,8 @@ InvMenu::InvMenu(int mflags)
 {
 #ifdef USE_TILE_LOCAL
     if (Options.tile_menu_icons)
+        set_flags(mflags | MF_USE_TWO_COLUMNS);
 #endif
-        mdisplay->set_num_columns(2);
 
     InvEntry::set_show_cursor(false);
 }
@@ -979,6 +979,7 @@ vector<SelItem> select_items(const vector<const item_def*> &items,
         }
 
         new_flags |= MF_SHOW_PAGENUMBERS | MF_ALLOW_FORMATTING;
+        new_flags |= menu.get_flags() & MF_USE_TWO_COLUMNS;
         menu.set_flags(new_flags);
         menu.show();
         selected = menu.get_selitems();

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2285,7 +2285,7 @@ protected:
         {
             //return the menu title to its previous text.
             set_title(temp_title);
-            update_title();
+            draw_title();
             num = -2;
 
             // Disarm ^D here, because process_key doesn't always set lastch.
@@ -2322,7 +2322,7 @@ protected:
                 lastch = CONTROL('D');
                 temp_title = title->text;
                 set_title("Select to reset item to default: ");
-                update_title();
+                draw_title();
             }
 
             return true;

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2608,7 +2608,7 @@ void check_item_knowledge(bool unknown_items)
                              ' ') + prompt;
 
     menu.set_preselect(&selected_items);
-    menu.set_flags( MF_QUIET_SELECT | MF_ALLOW_FORMATTING
+    menu.set_flags( MF_QUIET_SELECT | MF_ALLOW_FORMATTING | MF_USE_TWO_COLUMNS
                     | ((unknown_items) ? MF_NOSELECT
                                        : MF_MULTISELECT | MF_ALLOW_FILTER));
     menu.set_type(MT_KNOW);

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -279,7 +279,7 @@ public:
 
         for (unsigned int i = 0, size = items.size(); i < size; i++)
         {
-            const char letter = index_to_letter(i);
+            const char letter = index_to_letter(i % 52);
 
             items[i]->hotkeys.clear();
             items[i]->add_hotkey(letter);
@@ -891,16 +891,19 @@ void LookupType::display_keys(vector<string> &key_list) const
     true;
 #endif
 
-    DescMenu desc_menu(MF_SINGLESELECT | MF_ANYPRINTABLE | MF_ALLOW_FORMATTING,
-                       toggleable_sort(), text_only);
+    DescMenu desc_menu(MF_SINGLESELECT | MF_ANYPRINTABLE | MF_ALLOW_FORMATTING
+#ifdef USE_TILE_LOCAL
+            | (flags & lookup_type::support_tiles ? MF_USE_TWO_COLUMNS : 0)
+#endif
+            , toggleable_sort(), text_only);
     desc_menu.set_tag("description");
 
     // XXX: ugh
     const bool doing_mons = type == "monster";
-    monster_info monster_list[52];
+    vector<monster_info> monster_list(key_list.size());
     for (unsigned int i = 0, size = key_list.size(); i < size; i++)
     {
-        const char letter = index_to_letter(i);
+        const char letter = index_to_letter(i % 52);
         string &key = key_list[i];
         // XXX: double ugh
         if (doing_mons)
@@ -1433,18 +1436,6 @@ static string _keylist_invalid_reason(const vector<string> &key_list,
         if (by_symbol)
             return "No " + plur_type + " with symbol '" + regex + "'.";
         return "No matching " + plur_type + ".";
-    }
-
-    if (key_list.size() > 52)
-    {
-        if (by_symbol)
-        {
-            return "Too many " + plur_type + " with symbol '" + regex +
-                    "' to display.";
-        }
-
-        return make_stringf("Too many matching %s (%d) to display.",
-                            plur_type.c_str(), (int) key_list.size());
     }
 
     // we're good!

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -68,10 +68,8 @@ enum class lookup_type
     db_suffix       = 1<<0,
     /// whether the sorting functionality should be turned off
     disable_sort    = 1<<1,
-    /// whether the display menu for this supports tiles
-    support_tiles   = 1<<2,
     /// whether the display menu for this has toggleable sorting
-    toggleable_sort = 1<<3,
+    toggleable_sort = 1<<2,
 };
 DEF_BITFIELD(lookup_type_flags, lookup_type);
 
@@ -238,8 +236,7 @@ static bool _compare_mon_toughness(MenuEntry *entry_a, MenuEntry* entry_b)
 class DescMenu : public Menu
 {
 public:
-    DescMenu(int _flags, bool _toggleable_sort, bool _text_only)
-    : Menu(_flags, "", _text_only), sort_alpha(true),
+    DescMenu(int _flags, bool _toggleable_sort) : Menu(_flags, ""), sort_alpha(true),
     toggleable_sort(_toggleable_sort)
     {
         set_highlighter(nullptr);
@@ -883,19 +880,8 @@ static string _mons_desc_key(monster_type type)
  */
 void LookupType::display_keys(vector<string> &key_list) const
 {
-    // For tiles builds use a tiles menu to display monsters.
-    const bool text_only =
-#ifdef USE_TILE_LOCAL
-    !(flags & lookup_type::support_tiles);
-#else
-    true;
-#endif
-
     DescMenu desc_menu(MF_SINGLESELECT | MF_ANYPRINTABLE | MF_ALLOW_FORMATTING
-#ifdef USE_TILE_LOCAL
-            | (flags & lookup_type::support_tiles ? MF_USE_TWO_COLUMNS : 0)
-#endif
-            , toggleable_sort(), text_only);
+            | MF_USE_TWO_COLUMNS , toggleable_sort());
     desc_menu.set_tag("description");
 
     // XXX: ugh
@@ -1310,48 +1296,37 @@ static int _describe_branch(const string &key, const string &suffix,
 static const vector<LookupType> lookup_types = {
     LookupType('M', "monster", _recap_mon_keys, _monster_filter,
                _get_monster_keys, nullptr, nullptr,
-               _describe_monster,
-               lookup_type::support_tiles | lookup_type::toggleable_sort),
+               _describe_monster, lookup_type::toggleable_sort),
     LookupType('S', "spell", _recap_spell_keys, _spell_filter,
                nullptr, nullptr, _spell_menu_gen,
-               _describe_spell,
-               lookup_type::db_suffix | lookup_type::support_tiles),
+               _describe_spell, lookup_type::db_suffix),
     LookupType('K', "skill", nullptr, nullptr,
                nullptr, _get_skill_keys, _skill_menu_gen,
-               _describe_generic,
-               lookup_type::support_tiles),
+               _describe_generic, lookup_type::none),
     LookupType('A', "ability", _recap_ability_keys, _ability_filter,
                nullptr, nullptr, _ability_menu_gen,
-               _describe_generic,
-               lookup_type::db_suffix | lookup_type::support_tiles),
+               _describe_generic, lookup_type::db_suffix),
     LookupType('C', "card", _recap_card_keys, _card_filter,
                nullptr, nullptr, _card_menu_gen,
-               _describe_card,
-               lookup_type::db_suffix | lookup_type::support_tiles),
+               _describe_card, lookup_type::db_suffix),
     LookupType('I', "item", nullptr, _item_filter,
                item_name_list_for_glyph, nullptr, _item_menu_gen,
-               _describe_item,
-               lookup_type::none | lookup_type::support_tiles),
+               _describe_item, lookup_type::none),
     LookupType('F', "feature", _recap_feat_keys, _feature_filter,
                nullptr, nullptr, _feature_menu_gen,
-               _describe_generic,
-               lookup_type::support_tiles),
+               _describe_generic, lookup_type::none),
     LookupType('G', "god", nullptr, nullptr,
                nullptr, _get_god_keys, _god_menu_gen,
-               _describe_god,
-               lookup_type::support_tiles),
+               _describe_god, lookup_type::none),
     LookupType('B', "branch", nullptr, nullptr,
                nullptr, _get_branch_keys, _branch_menu_gen,
-               _describe_branch,
-               lookup_type::disable_sort | lookup_type::support_tiles),
+               _describe_branch, lookup_type::disable_sort),
     LookupType('L', "cloud", nullptr, nullptr,
                nullptr, _get_cloud_keys, _cloud_menu_gen,
-               _describe_cloud,
-               lookup_type::db_suffix | lookup_type::support_tiles),
+               _describe_cloud, lookup_type::db_suffix),
     LookupType('T', "status", nullptr, _status_filter,
                nullptr, nullptr, _simple_menu_gen,
-               _describe_generic,
-               lookup_type::db_suffix),
+               _describe_generic, lookup_type::db_suffix),
 };
 
 /**

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1882,7 +1882,7 @@ void process_command(command_type cmd)
 
         // Informational commands.
     case CMD_DISPLAY_CHARACTER_STATUS: display_char_status();          break;
-    case CMD_DISPLAY_COMMANDS:         list_commands(0, true);         break;
+    case CMD_DISPLAY_COMMANDS:         list_commands(0); clrscr(); redraw_screen(); break;
     case CMD_DISPLAY_INVENTORY:        display_inventory();            break;
     case CMD_DISPLAY_KNOWN_OBJECTS: check_item_knowledge(); redraw_screen(); break;
     case CMD_DISPLAY_MUTATIONS: display_mutations(); redraw_screen();  break;

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -1760,7 +1760,7 @@ int MenuHighlighter::entry_colour(const MenuEntry *entry) const
 // column_composer
 
 column_composer::column_composer(int cols, ...)
-    : pagesize(0), columns()
+    : columns()
 {
     ASSERT(cols > 0);
 
@@ -1781,11 +1781,6 @@ column_composer::column_composer(int cols, ...)
     va_end(args);
 }
 
-void column_composer::set_pagesize(int ps)
-{
-    pagesize = ps;
-}
-
 void column_composer::clear()
 {
     flines.clear();
@@ -1804,8 +1799,7 @@ void column_composer::add_formatted(int ncol,
     vector<formatted_string> newlines;
     // Add a blank line if necessary. Blank lines will not
     // be added at page boundaries.
-    if (add_separator && col.lines && !segs.empty()
-        && (!pagesize || col.lines % pagesize))
+    if (add_separator && col.lines && !segs.empty())
     {
         newlines.emplace_back();
     }

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -377,7 +377,7 @@ void MenuDisplayTile::set_num_columns(int columns)
 }
 #endif
 
-Menu::Menu(int _flags, const string& tagname, bool text_only)
+Menu::Menu(int _flags, const string& tagname)
   : f_selitem(nullptr), f_keyfilter(nullptr),
     action_cycle(CYCLE_NONE), menu_action(ACT_EXAMINE), title(nullptr),
     title2(nullptr), flags(_flags), tag(tagname),
@@ -386,13 +386,7 @@ Menu::Menu(int _flags, const string& tagname, bool text_only)
     alive(false), last_selected(-1)
 {
 #ifdef USE_TILE_LOCAL
-    if (text_only)
-    {
-        ASSERT(!(flags & MF_USE_TWO_COLUMNS));
-        mdisplay = new MenuDisplayText(this);
-    }
-    else
-        mdisplay = new MenuDisplayTile(this);
+    mdisplay = new MenuDisplayTile(this);
 #else
     mdisplay = new MenuDisplayText(this);
 #endif
@@ -2002,6 +1996,10 @@ void column_composer::compose_formatted_column(
 
 formatted_scroller::formatted_scroller() : Menu(MF_NOSELECT)
 {
+#ifdef USE_TILE_LOCAL
+    delete mdisplay;
+    mdisplay = new MenuDisplayText(this);
+#endif
     set_highlighter(nullptr);
 }
 

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -166,7 +166,7 @@ void MenuDisplayTile::set_num_columns(int columns)
 #endif
 
 Menu::Menu(int _flags, const string& tagname, bool text_only)
-  : f_selitem(nullptr), f_drawitem(nullptr), f_keyfilter(nullptr),
+  : f_selitem(nullptr), f_keyfilter(nullptr),
     action_cycle(CYCLE_NONE), menu_action(ACT_EXAMINE), title(nullptr),
     title2(nullptr), flags(_flags), tag(tagname), first_entry(0), y_offset(0),
     pagesize(0), max_pagesize(0), more("-more-", true), items(), sel(),
@@ -1415,10 +1415,7 @@ void Menu::draw_index_item(int index, const MenuEntry *me) const
     if (crawl_state.doing_prev_cmd_again)
         return;
 
-    if (f_drawitem)
-        (*f_drawitem)(index, me);
-    else
-        draw_stock_item(index, me);
+    draw_stock_item(index, me);
 }
 
 void Menu::draw_stock_item(int index, const MenuEntry *me) const

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -97,15 +97,185 @@ int Popup::pop()
 }
 #endif
 
-int MenuDisplayText::get_maxpagesize()
+class MenuDisplay
 {
-    return get_number_of_lines();
+public:
+    MenuDisplay(Menu *menu) : m_menu(menu) {};
+    virtual ~MenuDisplay() {}
+    virtual void draw_stock_item(int index, const MenuEntry *me) = 0;
+    virtual void draw_items() = 0;
+    virtual bool item_in_page(int index) = 0;
+    virtual void set_offset(int lines) = 0;
+    virtual void draw_more() = 0;
+    virtual void set_num_columns(int columns) = 0;
+    virtual bool scroll_page(int delta) = 0;
+    virtual bool scroll_to_item(int index) = 0;
+    virtual void get_visible_items_range(int &first, int &last) = 0;
+protected:
+    Menu *m_menu;
+};
+
+class MenuDisplayText : public MenuDisplay
+{
+public:
+    MenuDisplayText(Menu *menu) : MenuDisplay(menu), m_first_entry(0) {};
+    virtual void draw_stock_item(int index, const MenuEntry *me) override;
+    virtual void draw_items() override;
+    virtual bool item_in_page(int index) override;
+    virtual void draw_more() override;
+    virtual void set_offset(int lines) override { m_offset = lines; }
+    virtual void set_num_columns(int columns) override {}
+    virtual bool scroll_page(int delta) override;
+    virtual bool scroll_to_item(int index) override;
+    virtual void get_visible_items_range(int &first, int &last) override;
+
+    bool jump_to_item(int index);
+    bool scroll_line(int delta);
+    void cgotoxy_for_index(int index);
+protected:
+    int m_pagesize;
+    int m_offset;
+    int m_first_entry;
+    int m_last_entry;
+
+    int recalculate_page_size();
+};
+
+class MenuDisplayTile : public MenuDisplay
+{
+public:
+    MenuDisplayTile(Menu *menu) : MenuDisplay(menu) {};
+    virtual void draw_stock_item(int index, const MenuEntry *me) override;
+    virtual void draw_items() override;
+    virtual bool item_in_page(int index) override;
+    virtual void set_offset(int lines) override;
+    virtual void draw_more() override;
+    virtual void set_num_columns(int columns) override;
+    virtual bool scroll_page(int delta) override;
+    virtual bool scroll_to_item(int index) override;
+    virtual void get_visible_items_range(int &first, int &last) override;
+};
+
+static bool menu_entries_have_dup_hotkeys(vector<MenuEntry*>& items)
+{
+    bool used_hotkeys[52] = {0};
+    for (MenuEntry *entry : items)
+    {
+        if (entry->level != MEL_ITEM)
+            continue;
+        for (int key : entry->hotkeys)
+        {
+            if (!(key >= 'A' && key <= 'Z') && !(key >= 'a' && key <= 'z'))
+                continue;
+            int idx = key - (key >= 'a' ? ('a'-26) : 'A');
+            ASSERT_RANGE(idx, 0, 52);
+            if (used_hotkeys[idx])
+                return true;
+            used_hotkeys[idx] = true;
+        }
+    }
+    return false;
+}
+
+int MenuDisplayText::recalculate_page_size()
+{
+    m_pagesize = get_number_of_lines() - m_menu->title_height() - 1;
+    if (menu_entries_have_dup_hotkeys(m_menu->items))
+        m_pagesize = min(52, m_pagesize);
+
+    int end = min(m_first_entry + m_pagesize, (int)m_menu->items.size());
+    int i;
+    for (i = m_first_entry; i < end; ++i)
+    {
+        if (m_menu->items[i]->level == MEL_END_OF_SECTION)
+            break;
+    }
+    m_last_entry = i-1;
+
+    return m_pagesize;
+}
+
+void MenuDisplayText::draw_items()
+{
+    recalculate_page_size();
+
+    for (int i = m_first_entry; i <= m_last_entry; ++i)
+        m_menu->draw_item(i);
+
+    // Update the paging info so we can set the title correctly
+    m_menu->num_pages = m_menu->items.empty() ? 1 : ((m_menu->items.size()-1) / m_pagesize + 1);
+    m_menu->cur_page = m_first_entry / m_pagesize + 1;
+}
+
+bool MenuDisplayText::item_in_page(int index)
+{
+    return index >= m_first_entry && index < m_first_entry + m_pagesize;
+}
+
+bool MenuDisplayText::scroll_page(int delta)
+{
+    return scroll_to_item(m_first_entry + m_pagesize*delta);
+}
+
+bool MenuDisplayText::scroll_line(int delta)
+{
+    return scroll_to_item(m_first_entry + delta);
+}
+
+// XXX: This is a nasty but at least localized hack...
+void MenuDisplayText::cgotoxy_for_index(int index)
+{
+    cgotoxy(1, m_offset + index - m_first_entry);
+}
+
+bool MenuDisplayText::scroll_to_item(int index)
+{
+    // XXX: why was this needed
+    if (m_menu->items.empty())
+        return false;
+
+    int old_first = m_first_entry;
+    recalculate_page_size();
+
+    int dir = index < m_first_entry ? -1 : 1;
+
+    // Find leading edge of page area, and check for MEL_END_OF_SECTIONs
+    for (int i = dir == -1 ? m_first_entry : m_last_entry; ; i += dir, m_first_entry += dir)
+    {
+        if (m_first_entry == index)
+            break;
+        if (i+dir < 0 || i+dir >= (int)m_menu->items.size())
+            break;
+        if (m_menu->items[i+dir]->level == MEL_END_OF_SECTION)
+            break;
+    }
+
+    return old_first != m_first_entry;
+}
+
+bool MenuDisplayText::jump_to_item(int index)
+{
+    int old_first = m_first_entry;
+    recalculate_page_size();
+
+    const int breakpoint = m_menu->items.size() - m_pagesize;
+    m_first_entry = max(0, min(index, breakpoint));
+
+    return old_first != m_first_entry;
+}
+
+void MenuDisplayText::get_visible_items_range(int &first, int &last)
+{
+    first = m_first_entry;
+    last = m_last_entry;
 }
 
 void MenuDisplayText::draw_stock_item(int index, const MenuEntry *me)
 {
     if (crawl_state.doing_prev_cmd_again)
         return;
+
+    cgotoxy(1, m_offset + index - m_first_entry);
 
     const int col = m_menu->item_colour(index, me);
     textcolour(col);
@@ -128,16 +298,73 @@ void MenuDisplayText::draw_stock_item(int index, const MenuEntry *me)
 
 void MenuDisplayText::draw_more()
 {
-    cgotoxy(1, m_menu->get_y_offset() + m_menu->get_pagesize() -
+    cgotoxy(1, m_offset + m_pagesize -
             count_linebreaks(m_menu->get_more()));
     textcolour(LIGHTGREY);
     m_menu->get_more().display();
 }
 
 #ifdef USE_TILE_LOCAL
-int MenuDisplayTile::get_maxpagesize()
+void MenuDisplayTile::draw_items()
 {
-    return tiles.get_menu()->maxpagesize();
+    if (crawl_state.doing_prev_cmd_again)
+        return;
+
+    for (unsigned int i = 0; i < m_menu->items.size(); ++i)
+    {
+        // Only formatted_scrollers have these, and they use the text renderer
+        ASSERT(m_menu->items[i]->level != MEL_END_OF_SECTION);
+        draw_stock_item(i, m_menu->items[i]);
+    }
+
+    // XXX: This is ugly and could be improved upon. We do:
+    // 1) Tell renderer which page needs to be drawn
+    // 2) Layout and draw
+    // 3) Fetch the resulting page info from the renderer
+    tiles.get_menu()->cur_page = m_menu->cur_page;
+    tiles.get_menu()->place_entries();
+    m_menu->cur_page = tiles.get_menu()->cur_page;
+    m_menu->num_pages = tiles.get_menu()->num_pages;
+}
+
+bool MenuDisplayTile::scroll_page(int delta)
+{
+    int old_page = m_menu->cur_page;
+    m_menu->cur_page = max(1, min(m_menu->num_pages, old_page+delta));
+    return m_menu->cur_page != old_page;
+}
+
+bool MenuDisplayTile::item_in_page(int index)
+{
+    int a, b;
+    get_visible_items_range(a, b);
+    return a <= index && index <= b;
+}
+
+bool MenuDisplayTile::scroll_to_item(int index)
+{
+    index = min(index, ((int)m_menu->items.size()-1));
+
+    // XXX: we require valid layout info, but currently that's entangled
+    // with rendering. This should also re-layout only if it's dirty
+    draw_items();
+
+    // Go to the page with the item
+    for (int page = 1; page <= m_menu->num_pages; ++page)
+    {
+        tiles.get_menu()->cur_page = page;
+        if (item_in_page(index))
+        {
+            m_menu->cur_page = page;
+            return true;
+        }
+    }
+    return false;
+}
+
+void MenuDisplayTile::get_visible_items_range(int &first, int &last)
+{
+    tiles.get_menu()->get_visible_items_range(first, last);
 }
 
 void MenuDisplayTile::draw_stock_item(int index, const MenuEntry *me)
@@ -157,6 +384,7 @@ void MenuDisplayTile::set_offset(int lines)
 void MenuDisplayTile::draw_more()
 {
     tiles.get_menu()->set_more(m_menu->get_more());
+    tiles.get_menu()->place_entries(); // XXX: needed to repack the font buffer (ugh)
 }
 
 void MenuDisplayTile::set_num_columns(int columns)
@@ -168,20 +396,22 @@ void MenuDisplayTile::set_num_columns(int columns)
 Menu::Menu(int _flags, const string& tagname, bool text_only)
   : f_selitem(nullptr), f_keyfilter(nullptr),
     action_cycle(CYCLE_NONE), menu_action(ACT_EXAMINE), title(nullptr),
-    title2(nullptr), flags(_flags), tag(tagname), first_entry(0), y_offset(0),
-    pagesize(0), max_pagesize(0), more("-more-", true), items(), sel(),
+    title2(nullptr), flags(_flags), tag(tagname),
+    cur_page(1), more("-more-", true), items(), sel(),
     select_filter(), highlighter(new MenuHighlighter), num(-1), lastch(0),
     alive(false), last_selected(-1)
 {
 #ifdef USE_TILE_LOCAL
     if (text_only)
+    {
+        ASSERT(!(flags & MF_USE_TWO_COLUMNS));
         mdisplay = new MenuDisplayText(this);
+    }
     else
         mdisplay = new MenuDisplayTile(this);
 #else
     mdisplay = new MenuDisplayText(this);
 #endif
-    mdisplay->set_num_columns(1);
     set_flags(flags);
 
 #ifdef USE_TILE_WEB
@@ -249,13 +479,12 @@ void Menu::set_flags(int new_flags, bool use_options)
     if (use_options && Options.easy_exit_menu)
         flags |= MF_EASY_EXIT;
 
+    mdisplay->set_num_columns((flags & MF_USE_TWO_COLUMNS) ? 2 : 1);
+
 #ifdef DEBUG
     int sel_flag = flags & (MF_NOSELECT | MF_SINGLESELECT | MF_MULTISELECT);
     ASSERT(sel_flag == MF_NOSELECT || sel_flag == MF_SINGLESELECT || sel_flag == MF_MULTISELECT);
 #endif
-
-    if (flags & MF_NOSELECT)
-        max_pagesize = 52;
 }
 
 void Menu::set_more(const formatted_string &fs)
@@ -310,7 +539,7 @@ void Menu::add_entry(MenuEntry *entry)
 
 void Menu::reset()
 {
-    first_entry = 0;
+    mdisplay->scroll_to_item(0);
 }
 
 vector<MenuEntry *> Menu::show(bool reuse_selections)
@@ -331,10 +560,8 @@ vector<MenuEntry *> Menu::show(bool reuse_selections)
     // Reset offset to default.
     mdisplay->set_offset(1 + title_height());
 
-    recalculate_page_sizes();
-
     if (is_set(MF_START_AT_END))
-        first_entry = max((int)items.size() - pagesize, 0);
+        mdisplay->scroll_to_item(INT_MAX);
 
     do_menu();
 
@@ -469,10 +696,7 @@ bool Menu::process_key(int keyin)
         nav = true;
         repaint = page_down();
         if (!repaint && !is_set(MF_EASY_EXIT) && !is_set(MF_NOWRAP))
-        {
-            repaint = (first_entry != 0);
-            first_entry = 0;
-        }
+            repaint = mdisplay->scroll_to_item(0);
         break;
     case CK_PGUP: case '<': case ';':
         nav = true;
@@ -488,20 +712,12 @@ bool Menu::process_key(int keyin)
         break;
     case CK_HOME:
         nav = true;
-        repaint = (first_entry != 0);
-        first_entry = 0;
+        repaint = mdisplay->scroll_to_item(0);
         break;
     case CK_END:
-    {
         nav = true;
-        const int breakpoint = items.size() - pagesize;
-        if (first_entry < breakpoint)
-        {
-            first_entry = breakpoint;
-            repaint = true;
-        }
+        repaint = mdisplay->scroll_to_item(INT_MAX);
         break;
-    }
     case CONTROL('F'):
     {
         if (!(flags & MF_ALLOW_FILTER))
@@ -551,12 +767,12 @@ bool Menu::process_key(int keyin)
                 draw_select_count(sel.size());
                 if (get_cursor() < next)
                 {
-                    first_entry = 0;
+                    mdisplay->scroll_to_item(0);
                     nav = true;
                 }
             }
 
-            if (!nav && (first_entry + pagesize - last_selected) == 1)
+            if (!nav && !in_page(last_selected))
             {
                 page_down();
                 nav = true;
@@ -586,11 +802,11 @@ bool Menu::process_key(int keyin)
             {
                 if (next_cursor < last_selected)
                 {
-                    first_entry = 0;
+                    mdisplay->scroll_to_item(0);
                     nav = true;
                     repaint = true;
                 }
-                else if ((first_entry + pagesize - last_selected) == 1)
+                else if (!in_page(last_selected))
                 {
                     page_down();
                     nav = true;
@@ -814,15 +1030,17 @@ void Menu::deselect_all(bool update_view)
     }
 }
 
+int Menu::get_first_visible() const
+{
+    int a, b;
+    mdisplay->get_visible_items_range(a, b);
+    return a;
+}
+
 bool Menu::is_hotkey(int i, int key)
 {
-    int end = first_entry + pagesize;
-    if (end > static_cast<int>(items.size())) end = items.size();
-
     bool ishotkey = items[i]->is_hotkey(key);
-
-    return !is_set(MF_SELECT_BY_PAGE) ? ishotkey
-                                      : ishotkey && i >= first_entry && i < end;
+    return ishotkey && (!is_set(MF_SELECT_BY_PAGE) || in_page(i));
 }
 
 void Menu::select_items(int key, int qty)
@@ -837,7 +1055,7 @@ void Menu::select_items(int key, int qty)
         select_index(-1, 0);
     else
     {
-        int final = items.size();
+        int first_entry = get_first_visible(), final = items.size();
         bool selected = false;
 
         // Process all items, in case user hits hotkey for an
@@ -1223,7 +1441,10 @@ void Menu::select_item_index(int idx, int qty, bool draw_cursor)
 
 void Menu::select_index(int index, int qty)
 {
-    int si = index == -1 ? first_entry : index;
+    int first_vis, last_vis;
+    mdisplay->get_visible_items_range(first_vis, last_vis);
+
+    int si = index == -1 ? first_vis : index;
 
     if (index == -1)
     {
@@ -1279,46 +1500,24 @@ int Menu::get_entry_index(const MenuEntry *e) const
     return -1;
 }
 
-void Menu::recalculate_page_sizes()
-{
-    int mps = max_pagesize > 0 ? max_pagesize : INT_MAX;
-    mps = min(mps, mdisplay->get_maxpagesize());
-
-    // Lose lines for the title + room for -more- line.
-#ifdef USE_TILE_LOCAL
-    pagesize = mps - title_height() - 1;
-#else
-    pagesize = get_number_of_lines() - title_height() - 1;
-    if (mps > 0 && pagesize > mps)
-        pagesize = mps;
-#endif
-}
-
 void Menu::draw_menu()
 {
     if (crawl_state.doing_prev_cmd_again)
         return;
 
     clrscr();
+    mdisplay->set_offset(1 + title_height());
 
-    recalculate_page_sizes();
+    mdisplay->draw_items();
+
     draw_title();
     draw_select_count(sel.size());
-    y_offset = 1 + title_height();
 
-    mdisplay->set_offset(y_offset);
-
-    int end = first_entry + pagesize;
-    if (end > (int) items.size()) end = items.size();
-
-    for (int i = first_entry; i < end; ++i)
-    {
-        if (items[i]->level == MEL_END_OF_SECTION)
-            break;
-        draw_item(i);
-    }
-
-    if (end < (int) items.size() || is_set(MF_ALWAYS_SHOW_MORE))
+    int a, b;
+    mdisplay->get_visible_items_range(a, b);
+    if ((a > 0 && items[a-1]->level != MEL_END_OF_SECTION)
+        || (b < (int)items.size()-1 && items[b+1]->level != MEL_END_OF_SECTION)
+        || is_set(MF_ALWAYS_SHOW_MORE))
         mdisplay->draw_more();
 }
 
@@ -1370,11 +1569,10 @@ void Menu::write_title()
         // page a bit less so. To make sense, we hack it so that your
         // current page is based on the first line you're seeing, *unless*
         // you're seeing the last item.
-        int numpages = items.empty() ? 1 : ((items.size()-1) / pagesize + 1);
-        int curpage = first_entry / pagesize + 1;
+
         if (in_page(items.size() - 1))
-            curpage = numpages;
-        fs.cprintf(" (page %d of %d)", curpage, numpages);
+            cur_page = num_pages;
+        fs.cprintf(" (page %d of %d)", cur_page, num_pages);
     }
     fs.display();
 
@@ -1397,15 +1595,13 @@ int Menu::title_height() const
 
 bool Menu::in_page(int index) const
 {
-    return index >= first_entry && index < first_entry + pagesize;
+    return mdisplay->item_in_page(index);
 }
 
 void Menu::draw_item(int index) const
 {
     if (!in_page(index) || crawl_state.doing_prev_cmd_again)
         return;
-
-    cgotoxy(1, y_offset + index - first_entry);
 
     draw_index_item(index, items[index]);
 }
@@ -1415,63 +1611,29 @@ void Menu::draw_index_item(int index, const MenuEntry *me) const
     if (crawl_state.doing_prev_cmd_again)
         return;
 
-    draw_stock_item(index, me);
-}
-
-void Menu::draw_stock_item(int index, const MenuEntry *me) const
-{
     mdisplay->draw_stock_item(index, me);
 }
 
 bool Menu::page_down()
 {
-    int old_first = first_entry;
-
-    if ((int) items.size() > first_entry + pagesize)
-    {
-        first_entry += pagesize;
-        //if (first_entry + pagesize > (int) items.size())
-        //    first_entry = items.size() - pagesize;
-
-        if (old_first != first_entry)
-            return true;
-    }
-    return false;
+    return mdisplay->scroll_page(1);
 }
 
 bool Menu::page_up()
 {
-    int old_first = first_entry;
-
-    if (first_entry > 0)
-    {
-        if ((first_entry -= pagesize) < 0)
-            first_entry = 0;
-
-        if (old_first != first_entry)
-            return true;
-    }
-    return false;
+    return mdisplay->scroll_page(-1);
 }
 
 bool Menu::line_down()
 {
-    if (first_entry + pagesize < (int) items.size())
-    {
-        ++first_entry;
-        return true;
-    }
-    return false;
+    MenuDisplayText *text_display = dynamic_cast<MenuDisplayText*>(mdisplay);
+    return text_display && text_display->scroll_line(1);
 }
 
 bool Menu::line_up()
 {
-    if (first_entry > 0)
-    {
-        --first_entry;
-        return true;
-    }
-    return false;
+    MenuDisplayText *text_display = dynamic_cast<MenuDisplayText*>(mdisplay);
+    return text_display && text_display->scroll_line(-1);
 }
 
 #ifdef USE_TILE_WEB
@@ -1507,6 +1669,7 @@ void Menu::webtiles_write_menu(bool replace) const
     tiles.json_write_int("total_items", count);
     tiles.json_write_int("chunk_start", start - webtiles_section_start());
 
+    int first_entry = get_first_visible();
     if (first_entry != 0 && !is_set(MF_START_AT_END))
         tiles.json_write_int("jump_to", first_entry - webtiles_section_start());
 
@@ -1525,9 +1688,8 @@ void Menu::webtiles_scroll(int first)
     if (first >= (int) items.size()) first = (int) items.size() - 1;
     if (first < 0) first = 0;
 
-    if (first_entry != first)
+    if (mdisplay->scroll_to_item(first))
     {
-        first_entry = first;
         draw_menu();
         update_screen();
         webtiles_update_scroll_pos();
@@ -1630,7 +1792,7 @@ void Menu::webtiles_update_scroll_pos() const
 {
     tiles.json_open_object();
     tiles.json_write_string("msg", "menu_scroll");
-    tiles.json_write_int("first", first_entry);
+    tiles.json_write_int("first", get_first_visible());
     tiles.json_close_object();
     tiles.finish_message();
 }
@@ -1711,6 +1873,7 @@ void Menu::webtiles_write_item(int index, const MenuEntry* me) const
 
 void Menu::webtiles_update_section_boundaries()
 {
+    int first_entry = get_first_visible();
     if (first_entry < webtiles_section_start()
         || webtiles_section_end() <= first_entry)
     {
@@ -1873,7 +2036,6 @@ void formatted_scroller::set_flags(int new_flags, bool use_options)
     if (!(new_flags & MF_SINGLESELECT))
         new_flags |= MF_NOSELECT;
     Menu::set_flags(new_flags);
-    max_pagesize = 0;
 }
 
 void formatted_scroller::add_text(const string& s, bool new_line, int wrap_col)
@@ -1945,7 +2107,10 @@ void formatted_scroller::draw_index_item(int index, const MenuEntry *me) const
     if (me->data == nullptr)
         Menu::draw_index_item(index, me);
     else
+    {
+        static_cast<MenuDisplayText*>(mdisplay)->cgotoxy_for_index(index);
         static_cast<formatted_string*>(me->data)->display();
+    }
 }
 
 #ifdef USE_TILE_WEB
@@ -2000,13 +2165,17 @@ string get_linebreak_string(const string& s, int maxcol)
     return r;
 }
 
-bool formatted_scroller::jump_to(int i)
+bool formatted_scroller::jump_to(int i, bool no_scroll)
 {
-    if (i == first_entry)
+    MenuDisplayText *display = static_cast<MenuDisplayText*>(mdisplay);
+    if (no_scroll && !display->jump_to_item(i))
+        return false;
+    if (!no_scroll && !display->scroll_to_item(i))
         return false;
 
-    first_entry = i;
-
+    // jump_to() is used to jump between sections of a formatted_scroller
+    // we only want to re-show the menu when we jump between sections, which
+    // is why this code doesn't belong in MenuDisplayText::scroll_to_item()
 #ifdef USE_TILE_WEB
     webtiles_update_section_boundaries();
     if (tiles.is_in_menu(this))
@@ -2019,91 +2188,11 @@ bool formatted_scroller::jump_to(int i)
     return true;
 }
 
-// Don't scroll past MEL_END_OF_SECTION entries
-bool formatted_scroller::page_down()
-{
-    const int old_first = first_entry;
-
-    if ((int) items.size() <= first_entry + pagesize)
-        return false;
-
-    int target;
-    // First, search for a MEL_END_OF_SECTION in the current page
-    for (target = first_entry; target < first_entry + pagesize; ++target)
-    {
-        if (items[target]->level == MEL_END_OF_SECTION)
-            return false;
-    }
-    // If, when scrolling forward, we encounter a MEL_END_OF_SECTION
-    // somewhere in the newly displayed page, stop scrolling
-    // just before it becomes visible
-    for (target = first_entry; target < first_entry + pagesize; ++target)
-    {
-        const int offset = target + pagesize;
-        if (offset < (int)items.size() && items[offset]->level == MEL_END_OF_SECTION)
-            break;
-    }
-    first_entry = target;
-    return old_first != first_entry;
-}
-
-bool formatted_scroller::page_up()
-{
-    if (items.empty())
-        return false;
-
-    const int old_first = first_entry;
-
-    // If, when scrolling backward, we encounter a MEL_END_OF_SECTION
-    // somewhere in the newly displayed page, stop scrolling
-    // just before it becomes visible
-
-    if (items[first_entry]->level == MEL_END_OF_SECTION)
-        return false;
-
-    for (int i = 0; i < pagesize; ++i)
-    {
-        if (first_entry == 0 || items[first_entry-1]->level == MEL_END_OF_SECTION)
-            break;
-
-        --first_entry;
-    }
-
-    return old_first != first_entry;
-}
-
-bool formatted_scroller::line_down()
-{
-    if ((int) items.size() <= first_entry + pagesize)
-        return false;
-
-    // Search [first, first+pagesize] inclusive for a MEL_END_OF_SECTION
-    for (int target = first_entry; target <= first_entry + pagesize; ++target)
-    {
-        if (items[target]->level == MEL_END_OF_SECTION)
-            return false;
-    }
-    ++first_entry;
-    return true;
-}
-
-bool formatted_scroller::line_up()
-{
-    if (first_entry > 0 && items[first_entry-1]->level != MEL_END_OF_SECTION
-        && items[first_entry]->level != MEL_END_OF_SECTION)
-    {
-        --first_entry;
-        return true;
-    }
-    return false;
-}
-
 bool formatted_scroller::jump_to_hotkey(int keyin)
 {
     for (unsigned int i = 0; i < items.size(); ++i)
         if (items[i]->is_hotkey(keyin))
-            return jump_to(i);
-
+            return jump_to(i, true);
     return false;
 }
 
@@ -2162,12 +2251,8 @@ bool formatted_scroller::process_key(int keyin)
         repaint = jump_to(0);
         break;
     case CK_END:
-    {
-        const int breakpoint = items.size() - pagesize;
-        if (first_entry < breakpoint)
-            repaint = jump_to(breakpoint);
+        repaint = jump_to(INT_MAX);
         break;
-    }
     default:
         moved = false;
         if (is_set(MF_SINGLESELECT))

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -249,6 +249,11 @@ void Menu::set_flags(int new_flags, bool use_options)
     if (use_options && Options.easy_exit_menu)
         flags |= MF_EASY_EXIT;
 
+#ifdef DEBUG
+    int sel_flag = flags & (MF_NOSELECT | MF_SINGLESELECT | MF_MULTISELECT);
+    ASSERT(sel_flag == MF_NOSELECT || sel_flag == MF_SINGLESELECT || sel_flag == MF_MULTISELECT);
+#endif
+
     if (flags & MF_NOSELECT)
         max_pagesize = 52;
 }
@@ -1859,16 +1864,25 @@ void column_composer::compose_formatted_column(
     }
 }
 
-formatted_scroller::formatted_scroller() : Menu()
+formatted_scroller::formatted_scroller() : Menu(MF_NOSELECT)
 {
     set_highlighter(nullptr);
 }
 
-formatted_scroller::formatted_scroller(int _flags, const string& s) :
-    Menu(_flags)
+formatted_scroller::formatted_scroller(int _flags, const string& s) : Menu()
 {
+    set_flags(_flags);
     set_highlighter(nullptr);
     add_text(s);
+}
+
+void formatted_scroller::set_flags(int new_flags, bool use_options)
+{
+    ASSERT(!(new_flags & MF_MULTISELECT));
+    if (!(new_flags & MF_SINGLESELECT))
+        new_flags |= MF_NOSELECT;
+    Menu::set_flags(new_flags);
+    max_pagesize = 0;
 }
 
 void formatted_scroller::add_text(const string& s, bool new_line, int wrap_col)

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -243,16 +243,14 @@ void Menu::clear()
     last_selected = -1;
 }
 
-void Menu::set_maxpagesize(int max)
-{
-    max_pagesize = max;
-}
-
 void Menu::set_flags(int new_flags, bool use_options)
 {
     flags = new_flags;
     if (use_options && Options.easy_exit_menu)
         flags |= MF_EASY_EXIT;
+
+    if (flags & MF_NOSELECT)
+        max_pagesize = 52;
 }
 
 void Menu::set_more(const formatted_string &fs)

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -360,7 +360,6 @@ public:
     void get_selected(vector<MenuEntry*> *sel) const;
     virtual int get_cursor() const;
 
-    void set_maxpagesize(int max);
     int maxpagesize() const { return max_pagesize; }
 
     void set_select_filter(vector<text_pattern> filter)

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -383,11 +383,9 @@ public:
     int get_pagesize() const { return pagesize; }
 
     typedef string (*selitem_tfn)(const vector<MenuEntry*> *sel);
-    typedef void (*drawitem_tfn)(int index, const MenuEntry *me);
     typedef int (*keyfilter_tfn)(int keyin);
 
     selitem_tfn      f_selitem;
-    drawitem_tfn     f_drawitem;
     keyfilter_tfn    f_keyfilter;
 
     enum cycle  { CYCLE_NONE, CYCLE_TOGGLE, CYCLE_CYCLE } action_cycle;

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -293,8 +293,7 @@ class Menu
     friend class MenuDisplayText;
     friend class MenuDisplayTile;
 public:
-    Menu(int flags = MF_MULTISELECT, const string& tagname = "",
-         bool text_only = true);
+    Menu(int flags = MF_MULTISELECT, const string& tagname = "");
 
     virtual ~Menu();
 
@@ -466,8 +465,8 @@ protected:
 class ToggleableMenu : public Menu
 {
 public:
-    ToggleableMenu(int _flags = MF_MULTISELECT, bool text_only = true)
-        : Menu(_flags, "", text_only) {}
+    ToggleableMenu(int _flags = MF_MULTISELECT)
+        : Menu(_flags) {}
     void add_toggle_key(int newkey) { toggle_keys.push_back(newkey); }
 protected:
     virtual int pre_process(int key) override;

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -335,7 +335,7 @@ public:
 
     // Sets menu flags to new_flags. If use_options is true, game options may
     // override options.
-    void set_flags(int new_flags, bool use_options = true);
+    virtual void set_flags(int new_flags, bool use_options = true);
     int  get_flags() const        { return flags; }
     virtual bool is_set(int flag) const;
     void set_tag(const string& t) { tag = t; }
@@ -564,6 +564,7 @@ class formatted_scroller : public Menu
 public:
     formatted_scroller();
     formatted_scroller(int flags, const string& s);
+    virtual void set_flags(int new_flags, bool use_options = true) override;
     virtual void add_item_formatted_string(const formatted_string& s,
                                            int hotkey = 0);
     virtual void wrap_formatted_string(const formatted_string& s,

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -527,8 +527,6 @@ public:
 
     vector<formatted_string> formatted_lines() const;
 
-    void set_pagesize(int pagesize);
-
 private:
     struct column;
     void compose_formatted_column(
@@ -546,7 +544,6 @@ private:
         column(int marg = 1) : margin(marg), lines(0) { }
     };
 
-    int pagesize;
     vector<column> columns;
     vector<formatted_string> flines;
 };

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -292,6 +292,9 @@ class Menu
 {
     friend class MenuDisplayText;
     friend class MenuDisplayTile;
+#ifdef USE_TILE_LOCAL
+    friend class menu_filter_line_reader;
+#endif
 public:
     Menu(int flags = MF_MULTISELECT, const string& tagname = "");
 
@@ -306,10 +309,6 @@ public:
     int  get_flags() const        { return flags; }
     virtual bool is_set(int flag) const;
     void set_tag(const string& t) { tag = t; }
-
-    bool draw_title_suffix(const string &s, bool titlefirst = true);
-    bool draw_title_suffix(const formatted_string &fs, bool titlefirst = true);
-    void update_title();
 
     // Sets a replacement for the default -more- string.
     void set_more(const formatted_string &more);
@@ -388,6 +387,10 @@ protected:
 
     int last_selected;
 
+#ifdef USE_TILE_LOCAL
+    char* m_filter_text; // nullptr == not in filter mode
+#endif
+
     MenuDisplay *mdisplay;
 
 protected:
@@ -395,13 +398,11 @@ protected:
                                   string &line, bool check_eol);
     void do_menu();
     virtual string get_select_count_string(int count) const;
-    virtual void draw_select_count(int count, bool force = false);
     virtual void draw_item(int index) const;
     virtual void draw_index_item(int index, const MenuEntry *me) const;
 
 #ifdef USE_TILE_WEB
     void webtiles_set_title(const formatted_string title);
-    void webtiles_set_suffix(const formatted_string title);
 
     void webtiles_write_tiles(const MenuEntry& me) const;
     void webtiles_update_items(int start, int end) const;
@@ -419,7 +420,6 @@ protected:
 
     bool _webtiles_title_changed;
     formatted_string _webtiles_title;
-    formatted_string _webtiles_suffix;
 
     inline int webtiles_section_start() const
     {
@@ -432,7 +432,7 @@ protected:
 #endif
 
     virtual void draw_title();
-    virtual void write_title();
+    virtual formatted_string calc_title();
     virtual int title_height() const;
     virtual void draw_menu();
     virtual bool page_down();

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -1273,7 +1273,7 @@ static void _prompt_choice(int choice_type, newgame_def& ng, newgame_def& ng_cho
 
                 return _prompt_choice(choice_type, ng, ng_choice, defaults);
             case M_APTITUDES:
-                list_commands('%', false, _highlight_pattern(ng));
+                list_commands('%', _highlight_pattern(ng));
                 return _prompt_choice(choice_type, ng, ng_choice, defaults);
             case M_VIABLE:
                 if (choice_type == C_JOB)
@@ -1608,7 +1608,7 @@ static bool _prompt_weapon(const newgame_def& ng, newgame_def& ng_choice,
         case M_ABORT:
             return false;
         case M_APTITUDES:
-            list_commands('%', false, _highlight_pattern(ng));
+            list_commands('%', _highlight_pattern(ng));
             return _prompt_weapon(ng, ng_choice, defaults, weapons);
         case M_HELP:
             list_commands('?');
@@ -2032,7 +2032,7 @@ static void _prompt_gamemode_map(newgame_def& ng, newgame_def& ng_choice,
             // TODO: fix
             return;
         case M_APTITUDES:
-            list_commands('%', false, _highlight_pattern(ng));
+            list_commands('%', _highlight_pattern(ng));
             return _prompt_gamemode_map(ng, ng_choice, defaults, maps);
         case M_HELP:
             list_commands('?');

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2159,13 +2159,7 @@ void ShoppingList::gold_changed(int old_amount, int new_amount)
 class ShoppingListMenu : public Menu
 {
 public:
-    ShoppingListMenu()
-#ifdef USE_TILE_LOCAL
-        : Menu(MF_MULTISELECT,"",false)
-#else
-        : Menu()
-#endif
-    { }
+    ShoppingListMenu() : Menu() {}
 
 protected:
     void draw_title();

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2280,13 +2280,6 @@ void ShoppingList::display()
     MenuEntry *mtitle = new MenuEntry(title, MEL_TITLE);
     shopmenu.set_title(mtitle);
 
-    // Don't make a menu so tall that we recycle hotkeys on the same page.
-    if (list->size() > 52
-        && (shopmenu.maxpagesize() > 52 || shopmenu.maxpagesize() == 0))
-    {
-        shopmenu.set_maxpagesize(52);
-    }
-
     string more_str = make_stringf("<yellow>You have %d gp</yellow>", you.gold);
     shopmenu.set_more(formatted_string::parse_string(more_str));
 

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2159,48 +2159,41 @@ void ShoppingList::gold_changed(int old_amount, int new_amount)
 class ShoppingListMenu : public Menu
 {
 public:
-    ShoppingListMenu() : Menu() {}
+    ShoppingListMenu() : Menu(MF_MULTISELECT | MF_ALLOW_FORMATTING) {}
 
 protected:
-    void draw_title();
+    virtual formatted_string calc_title() override;
 };
 
-void ShoppingListMenu::draw_title()
+formatted_string ShoppingListMenu::calc_title()
 {
-    if (title)
+    formatted_string fs;
+    const int total_cost = you.props[SHOPPING_LIST_COST_KEY];
+
+    fs.textcolour(title->colour);
+    fs.cprintf("%d %s%s, total %d gold",
+                title->quantity, title->text.c_str(),
+                title->quantity > 1? "s" : "",
+                total_cost);
+
+    string s = "<lightgrey>  [<w>a-z</w>] ";
+
+    switch (menu_action)
     {
-        const int total_cost = you.props[SHOPPING_LIST_COST_KEY];
-
-        cgotoxy(1, 1);
-        formatted_string fs = formatted_string(title->colour);
-        fs.cprintf("%d %s%s, total %d gold",
-                   title->quantity, title->text.c_str(),
-                   title->quantity > 1? "s" : "",
-                   total_cost);
-        fs.display();
-
-#ifdef USE_TILE_WEB
-        webtiles_set_title(fs);
-#endif
-        string s = "<lightgrey>  [<w>a-z</w>] ";
-
-        switch (menu_action)
-        {
-        case ACT_EXECUTE:
-            s += "<w>travel</w>|examine|delete";
-            break;
-        case ACT_EXAMINE:
-            s += "travel|<w>examine</w>|delete";
-            break;
-        default:
-            s += "travel|examine|<w>delete</w>";
-            break;
-        }
-
-        s += "  [<w>?</w>/<w>!</w>] change action</lightgrey>";
-
-        draw_title_suffix(formatted_string::parse_string(s), false);
+    case ACT_EXECUTE:
+        s += "<w>travel</w>|examine|delete";
+        break;
+    case ACT_EXAMINE:
+        s += "travel|<w>examine</w>|delete";
+        break;
+    default:
+        s += "travel|examine|<w>delete</w>";
+        break;
     }
+
+    s += "  [<w>?</w>/<w>!</w>] change action</lightgrey>";
+    fs += formatted_string::parse_string(s);
+    return fs;
 }
 
 /**

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -605,15 +605,8 @@ static spell_type _choose_mem_spell(spell_list &spells,
 {
     sort(spells.begin(), spells.end(), _sort_mem_spells);
 
-#ifdef USE_TILE_LOCAL
-    const bool text_only = false;
-#else
-    const bool text_only = true;
-#endif
-
     ToggleableMenu spell_menu(MF_SINGLESELECT | MF_ANYPRINTABLE
-                    | MF_ALWAYS_SHOW_MORE | MF_ALLOW_FORMATTING,
-                    text_only);
+                    | MF_ALWAYS_SHOW_MORE | MF_ALLOW_FORMATTING);
 #ifdef USE_TILE_LOCAL
     // [enne] Hack. Use a separate title, so the column headers are aligned.
     spell_menu.set_title(

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -671,13 +671,6 @@ static spell_type _choose_mem_spell(spell_list &spells,
 
     spell_menu.set_more(formatted_string::parse_string(more_str));
 
-    // Don't make a menu so tall that we recycle hotkeys on the same page.
-    if (spells.size() > 52
-        && (spell_menu.maxpagesize() > 52 || spell_menu.maxpagesize() == 0))
-    {
-        spell_menu.set_maxpagesize(52);
-    }
-
     for (unsigned int i = 0; i < spells.size(); i++)
     {
         const spell_type spell = spells[i];

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -162,15 +162,8 @@ int list_spells(bool toggle_with_I, bool viewing, bool allow_preselect,
     if (toggle_with_I && get_spell_by_letter('I') != SPELL_NO_SPELL)
         toggle_with_I = false;
 
-#ifdef USE_TILE_LOCAL
-    const bool text_only = false;
-#else
-    const bool text_only = true;
-#endif
-
     ToggleableMenu spell_menu(MF_SINGLESELECT | MF_ANYPRINTABLE
-                              | MF_ALWAYS_SHOW_MORE | MF_ALLOW_FORMATTING,
-                              text_only);
+                              | MF_ALWAYS_SHOW_MORE | MF_ALLOW_FORMATTING);
     string titlestring = make_stringf("%-25.25s", title.c_str());
 #ifdef USE_TILE_LOCAL
     {

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1688,13 +1688,6 @@ bool StashTracker::display_search_results(
     mtitle->quantity = results->size();
     stashmenu.set_title(mtitle);
 
-    // Don't make a menu so tall that we recycle hotkeys on the same page.
-    if (results->size() > 52
-        && (stashmenu.maxpagesize() > 52 || stashmenu.maxpagesize() == 0))
-    {
-        stashmenu.set_maxpagesize(52);
-    }
-
     menu_letter hotkey;
     for (stash_search_result &res : *results)
     {

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1565,7 +1565,7 @@ class StashSearchMenu : public Menu
 {
 public:
     StashSearchMenu(const char* sort_style_,const char* filtered_)
-        : Menu(),
+        : Menu(MF_MULTISELECT | MF_ALLOW_FORMATTING),
           request_toggle_sort_method(false),
           request_toggle_filter_useless(false),
           sort_style(sort_style_),
@@ -1580,42 +1580,35 @@ public:
 
 protected:
     bool process_key(int key) override;
-    void draw_title() override;
+    virtual formatted_string calc_title() override;
 };
 
-void StashSearchMenu::draw_title()
+formatted_string StashSearchMenu::calc_title()
 {
-    if (title)
+    formatted_string fs;
+    fs.textcolour(title->colour);
+    fs.cprintf("%d %s%s",
+                title->quantity, title->text.c_str(),
+                title->quantity == 1 ? "" : "es");
+    if (title->quantity == 0 && filtered)
     {
-        cgotoxy(1, 1);
-        formatted_string fs = formatted_string(title->colour);
-        fs.cprintf("%d %s%s",
-                   title->quantity, title->text.c_str(),
-                   title->quantity == 1 ? "" : "es");
-        fs.display();
-
-#ifdef USE_TILE_WEB
-        webtiles_set_title(fs);
-#endif
-        if (title->quantity == 0 && filtered)
-        {
-            // TODO: it might be better to just force filtered=false in the
-            // display loop if only useless items are found.
-            draw_title_suffix(formatted_string::parse_string(
-                "<lightgrey>"
-                ": only useless items found; press <w>=</w> to show."
-                "</lightgrey>"), false);
-        } else {
-            draw_title_suffix(formatted_string::parse_string(make_stringf(
-                "<lightgrey>"
-                ": <w>%s</w> [toggle: <w>!</w>],"
-                " by <w>%s</w> [<w>/</w>],"
-                " <w>%s</w> useless & duplicates [<w>=</w>]"
-                "</lightgrey>",
-                menu_action == ACT_EXECUTE ? "travel" : "view  ",
-                sort_style, filtered)), false);
-        }
+        // TODO: it might be better to just force filtered=false in the
+        // display loop if only useless items are found.
+        fs += formatted_string::parse_string(
+            "<lightgrey>"
+            ": only useless items found; press <w>=</w> to show."
+            "</lightgrey>");
+    } else {
+        fs += formatted_string::parse_string(make_stringf(
+            "<lightgrey>"
+            ": <w>%s</w> [toggle: <w>!</w>],"
+            " by <w>%s</w> [<w>/</w>],"
+            " <w>%s</w> useless & duplicates [<w>=</w>]"
+            "</lightgrey>",
+            menu_action == ACT_EXECUTE ? "travel" : "view  ",
+            sort_style, filtered));
     }
+    return fs;
 }
 
 bool StashSearchMenu::process_key(int key)

--- a/crawl-ref/source/tilereg-menu.cc
+++ b/crawl-ref/source/tilereg-menu.cc
@@ -150,7 +150,7 @@ static bool _has_hotkey_prefix(const string &s)
 void MenuRegion::_place_entries()
 {
     const int tile_indent     = 20;
-    const int text_indent     = (Options.tile_menu_icons ? 58 : 20);
+    const int text_indent     = _draw_tiles() ? 58 : 20;
     const VColour selected_colour(50, 50, 10, 255);
 
     int more_height = (count_linebreaks(m_more)+1) * m_font_entry->char_height();
@@ -228,14 +228,15 @@ void MenuRegion::_do_layout(const int left_offset, const int top_offset,
     m_layout_dirty = false;
     m_buffer_dirty = true;
 
+    const bool draw_tiles = _draw_tiles();
     const int heading_indent  = 10;
     const int tile_indent     = 20;
-    const int text_indent     = (Options.tile_menu_icons ? 58 : 20);
-    const int max_tile_height = (Options.tile_menu_icons ? 32 : 0);
+    const int text_indent     = draw_tiles ? 58 : 20;
+    const int max_tile_height = draw_tiles ? 32 : 0;
     const int entry_buffer    = 1;
 
     int column = -1; // an initial increment makes this 0
-    if (!Options.tile_menu_icons)
+    if (!draw_tiles)
         set_num_columns(1);
     const int max_columns  = min(2, m_max_columns);
     const int column_width = menu_width / max_columns;
@@ -275,7 +276,7 @@ void MenuRegion::_do_layout(const int left_offset, const int top_offset,
             entry.ey = entry.sy + text_height;
 
             // wrap titles to two lines if they don't fit
-            if (Options.tile_menu_icons && entry.ex > entry.sx + menu_width)
+            if (draw_tiles && entry.ex > entry.sx + menu_width)
             {
                 int w = menu_width;
                 int h = m_font_entry->char_height() * 2;
@@ -304,7 +305,7 @@ void MenuRegion::_do_layout(const int left_offset, const int top_offset,
             text_sy += (entry_height - m_font_entry->char_height()) / 2;
             // Split menu entries that don't fit into a single line into
             // two lines.
-            if (Options.tile_menu_icons && text_sx + text_width > entry_start + column_width - tile_indent)
+            if (draw_tiles && text_sx + text_width > entry_start + column_width - tile_indent)
             {
                 formatted_string text;
                 if (_has_hotkey_prefix(entry.text.tostring()))
@@ -525,6 +526,16 @@ void MenuRegion::set_more(const formatted_string &more)
     m_more.clear();
     m_more += more;
     m_layout_dirty = true;
+}
+
+bool MenuRegion::_draw_tiles() const
+{
+    if (!Options.tile_menu_icons)
+        return false;
+    for (const auto& entry : m_entries)
+        if (entry.valid && !entry.heading && !entry.tiles.empty())
+            return true;
+    return false;
 }
 
 #endif

--- a/crawl-ref/source/tilereg-menu.cc
+++ b/crawl-ref/source/tilereg-menu.cc
@@ -172,7 +172,12 @@ void MenuRegion::_place_entries()
         {
             const int w = entry.ex - entry.sx, h = entry.ey - entry.sy;
             formatted_string split = m_font_entry->split(entry.text, w, h);
-            m_font_buf.add(split, entry.sx, entry.sy+scroll_y);
+            // +5 and +8 give: top margin of 5px, line-text sep of 3px, bottom margin of 2px
+            if (index < (int)m_entries.size()-1 && m_entries[index+1].valid
+                    && !m_entries[index+1].heading)
+                m_div_line_buf.add(entry.sx, entry.sy+scroll_y+5,
+                        mx-entry.sx, entry.sy+scroll_y+5, VColour(0, 64, 255, 70));
+            m_font_buf.add(split, entry.sx, entry.sy+scroll_y+8);
         }
         else
         {
@@ -275,7 +280,8 @@ void MenuRegion::_do_layout(const int left_offset, const int top_offset,
             entry.sx = heading_indent + left_offset;
             entry.ex = entry.sx + text_width + left_offset;
             entry.sy = height;
-            entry.ey = entry.sy + text_height;
+            // 10px extra used for divider line and padding
+            entry.ey = entry.sy + text_height + 10;
 
             // wrap titles to two lines if they don't fit
             if (draw_tiles && entry.ex > entry.sx + menu_width)
@@ -446,6 +452,7 @@ void MenuRegion::render()
     set_transform();
     m_shape_buf.draw();
     m_line_buf.draw();
+    m_div_line_buf.draw();
     for (int i = 0; i < TEX_MAX; i++)
         m_tile_buf[i].draw();
     m_font_buf.draw();
@@ -455,6 +462,7 @@ void MenuRegion::_clear_buffers()
 {
     m_shape_buf.clear();
     m_line_buf.clear();
+    m_div_line_buf.clear();
     for (int i = 0; i < TEX_MAX; i++)
         m_tile_buf[i].clear();
     m_font_buf.clear();

--- a/crawl-ref/source/tilereg-menu.h
+++ b/crawl-ref/source/tilereg-menu.h
@@ -5,10 +5,9 @@
 
 #include "fixedvector.h"
 #include "format.h"
+#include "menu.h"
 #include "tilebuf.h"
 #include "tilereg.h"
-
-class MenuEntry;
 
 class MenuRegion : public ControlRegion
 {
@@ -19,22 +18,29 @@ public:
     virtual void render() override;
     virtual void clear() override;
 
-    int maxpagesize() const;
     void set_entry(int index, const string &s, int colour, const MenuEntry *me,
                    bool mark_selected = true);
     void set_offset(int lines);
     void set_more(const formatted_string &more);
     void set_num_columns(int columns);
+
+    void get_visible_items_range(int &first, int &last);
+
+    int cur_page;
+    int num_pages;
+
+    virtual void place_entries();
 protected:
     virtual void on_resize() override;
-    virtual void place_entries();
     int mouse_entry(int x, int y);
+    int vis_item_first, vis_item_last;
 
     struct MenuRegionEntry
     {
         formatted_string text;
         int colour; // keep it separate from text
         int sx, ex, sy, ey;
+        int page;
         bool selected;
         bool heading;
         char key;

--- a/crawl-ref/source/tilereg-menu.h
+++ b/crawl-ref/source/tilereg-menu.h
@@ -25,8 +25,13 @@ public:
     void set_num_columns(int columns);
 
     void get_visible_items_range(int &first, int &last);
+    void get_page_info(int &first, int &last);
+    void set_menu_display(void *);
+    bool scroll_to_item(int index);
+    bool scroll_page(int delta);
+    bool scroll_line(int delta);
 
-    int cur_page;
+    int first_entry;
     int num_pages;
 
     virtual void place_entries();
@@ -34,6 +39,7 @@ protected:
     virtual void on_resize() override;
     int mouse_entry(int x, int y);
     int vis_item_first, vis_item_last;
+    void *m_menu_display;
 
     struct MenuRegionEntry
     {
@@ -53,13 +59,15 @@ protected:
     formatted_string m_more;
     int m_mouse_idx;
     int m_max_columns;
-    bool m_dirty;
+    bool m_buffer_dirty, m_layout_dirty;
 #ifdef TOUCH_UI
     int m_more_region_start;
 #endif
+    int m_end_height;
 
     virtual void run() override {};
-    void _place_entries(const int left_offset, const int top_offset,
+    void _place_entries();
+    void _do_layout(const int left_offset, const int top_offset,
                         const int menu_width);
     void _clear_buffers();
 

--- a/crawl-ref/source/tilereg-menu.h
+++ b/crawl-ref/source/tilereg-menu.h
@@ -40,6 +40,7 @@ protected:
     int mouse_entry(int x, int y);
     int vis_item_first, vis_item_last;
     void *m_menu_display;
+    bool _draw_tiles() const;
 
     struct MenuRegionEntry
     {

--- a/crawl-ref/source/tilereg-menu.h
+++ b/crawl-ref/source/tilereg-menu.h
@@ -20,7 +20,7 @@ public:
 
     void set_entry(int index, const string &s, int colour, const MenuEntry *me,
                    bool mark_selected = true);
-    void set_offset(int lines);
+    void set_title(const formatted_string &more);
     void set_more(const formatted_string &more);
     void set_num_columns(int columns);
 
@@ -41,6 +41,7 @@ protected:
     int vis_item_first, vis_item_last;
     void *m_menu_display;
     bool _draw_tiles() const;
+    virtual int _get_layout_scroll_y() const;
 
     struct MenuRegionEntry
     {
@@ -57,6 +58,7 @@ protected:
 
     ImageManager *m_image;
     FontWrapper *m_font_entry;
+    formatted_string m_title;
     formatted_string m_more;
     int m_mouse_idx;
     int m_max_columns;

--- a/crawl-ref/source/tilereg-menu.h
+++ b/crawl-ref/source/tilereg-menu.h
@@ -79,6 +79,7 @@ protected:
     // TODO enne - remove this?
     ShapeBuffer m_shape_buf;
     LineBuffer m_line_buf;
+    LineBuffer m_div_line_buf;
     FontBuffer m_font_buf;
     FixedVector<TileBuffer, TEX_MAX> m_tile_buf;
 };

--- a/crawl-ref/source/tilereg-popup.cc
+++ b/crawl-ref/source/tilereg-popup.cc
@@ -30,8 +30,7 @@ void PopupRegion::render()
 #ifdef DEBUG_TILES_REDRAW
     cprintf("rendering PopupRegion\n");
 #endif
-    if (m_dirty)
-        place_entries();
+    place_entries();
 
     MenuRegion::set_transform();
     m_shape_buf.draw();
@@ -43,6 +42,12 @@ void PopupRegion::render()
 
 void PopupRegion::place_entries()
 {
+    _do_layout(ex / 4, ey / 4, ex / 2);
+    if (vis_item_first == -1)
+        scroll_to_item(0);
+    if (!m_buffer_dirty)
+        return;
+
     _clear_buffers();
     const VColour bgcolour(0, 0, 0, 63);
     const VColour border(255, 255, 255, 255);
@@ -51,7 +56,7 @@ void PopupRegion::place_entries()
     m_shape_buf.add(ex / 4 - 2, ey / 4 - 2,
                     ex * 3 / 4 + 2, ey * 3 / 4 + 2, border);
     m_shape_buf.add(ex / 4, ey / 4, ex * 3 / 4, ey * 3 / 4, panel);
-    _place_entries(ex / 4, ey / 4, ex / 2);
+    _place_entries();
 }
 
 void PopupRegion::run()

--- a/crawl-ref/source/tilereg-popup.h
+++ b/crawl-ref/source/tilereg-popup.h
@@ -18,5 +18,6 @@ public:
 
 protected:
     int m_retval;
+    virtual int _get_layout_scroll_y() const override { return 0; }
 };
 #endif

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -372,8 +372,8 @@ int TilesFramework::draw_popup(Popup *popup)
     int col = 0;
     while (MenuEntry *me = popup->next_entry())
     {
-        col++;
         reg.set_entry(col, me->get_text(true), me->colour, me, false);
+        col++;
     }
     // fetch a return value
     use_control_region(&reg, false);

--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -427,12 +427,6 @@ function ($, comm, client, enums, dungeon_renderer, cr, util, options) {
     {
         $("#menu_title").html(util.formatted_string_to_html(menu.title.text));
         $("#menu_title").css("padding-left", menu_title_indent()+"px");
-
-        if (menu.title.suffix)
-        {
-            $("#menu_title").append(" <span id='menu_suffix'>"
-                + util.formatted_string_to_html(menu.title.suffix) + "</span>");
-        }
     }
 
     function pattern_select()

--- a/crawl-ref/source/wizard.cc
+++ b/crawl-ref/source/wizard.cc
@@ -406,9 +406,6 @@ int list_wizard_commands(bool do_redraw_screen)
 {
     // 2 columns
     column_composer cols(2, 44);
-    // Page size is number of lines - one line for --more-- prompt.
-    cols.set_pagesize(get_number_of_lines());
-
     cols.add_formatted(0,
                        "<yellow>Player stats</yellow>\n"
                        "<w>A</w>      set all skills to level\n"


### PR DESCRIPTION
Changes include:
- removal of some unused interfaces
- consolidating rendering code: all menu rendering on local tiles is done in `tilereg-menu.cc`
- ?/ menu can now show the entire set of results (e.g. ?/M .* for all monsters): duplicated hotkeys are handled by never showing >52 items at once.
- two-column menus now wrap horizontally, and have separator lines between categories. This makes scrolling large menus (e.g. ?/m .*) much more intuitive, as the two columns move in tandem. Unfortunately it also makes scanning the menu slightly slower, especially when looking at the inventory menu, as the eye must move horizontally to look at all items of a particular type. To mitigate this, only one column will be used if there is sufficient screen space, which is usually the case on commonly used menus that show a subset of the inventory (e, r, P, W, etc.).
![out4](https://user-images.githubusercontent.com/10691965/35341866-a83bbb1e-0161-11e8-9f31-9dce239ed664.png)
