### PR TITLE
If there's no assert message on crash, put signal into the noun

### DIFF
--- a/crawl-ref/source/crash.cc
+++ b/crawl-ref/source/crash.cc
@@ -271,7 +271,7 @@ void init_crash_handler()
 #endif // if defined(USE_UNIX_SIGNALS)
 }
 
-void dump_crash_info(FILE* file)
+string crash_signal_info()
 {
 #if defined(UNIX)
     #ifdef TARGET_OS_FREEBSD
@@ -288,9 +288,11 @@ void dump_crash_info(FILE* file)
 
     if (name == nullptr)
         name = "INVALID";
-
-    fprintf(file, "Crash caused by signal #%d: %s\n\n", _crash_signal, name);
+    return make_stringf("Crash caused by signal #%d: %s", _crash_signal, name);
+#else
+    return "";
 #endif
+
 }
 
 #if defined(BACKTRACE_SUPPORTED)

--- a/crawl-ref/source/crash.h
+++ b/crawl-ref/source/crash.h
@@ -8,7 +8,7 @@
 #include <cstdio>
 
 void init_crash_handler();
-void dump_crash_info(FILE* file);
+string crash_signal_info();
 void write_stack_trace(FILE* file, int ignore_count);
 void call_gdb(FILE *file);
 void disable_other_crashes();


### PR DESCRIPTION
*This is a PR because of the following question: can anyone spot some unintended consequences of changing the milestone this way?*

This includes the signal information in the crash milestone if there's
no assert message; before, the milestone would just be empty (which I
guess translates to "?"). It also will give the signal info on the first
line of the crash dump in these circumstances so that any non-windows
crash dump always has a cause on the first line.