### PR TITLE
Do not force "more" prompts for (most) of the desolation of salt messages.

### DIFF
--- a/crawl-ref/source/dat/defaults/messages.txt
+++ b/crawl-ref/source/dat/defaults/messages.txt
@@ -117,7 +117,7 @@ force_more_message += hiss of flowing sand
 force_more_message += sound of rushing water
 force_more_message += oppressive heat about you
 force_more_message += crackle of arcane power
-force_more_message += distant wind
+force_more_message += hear a distant wind
 
 # Religion
 force_more_message += press .* to convert to Beogh


### PR DESCRIPTION
Timed portals have a default force more prompt for their initial
announcement message. The following messages do not cause additional
more prompts by default.

This commit makes the Desolation of Salt messages also behave like that.
Before this commit, the force_more was defined just as "distant wind".
Since "distant" is also used in many of the followup messages to
describe how far away the player is from the portal, this caused a lot
of additional "more" prompts for the player.