### PR TITLE
Add auto_hide_spells option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -572,7 +572,6 @@ auto_hide_spells = false
         When set to true, spells added to the library will automatically be
         hidden.
 
-
 3-b     Passive Sightings (detected or remembered entities).
 ------------------------------------------------------------
 

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -24,7 +24,8 @@ The contents of this text are:
 3-  Interface.
 3-a     Dropping and Picking up.
                 autopickup, autopickup_exceptions, default_autopickup,
-                pickup_thrown, assign_item_slot, pickup_menu_limit, drop_filter
+                pickup_thrown, assign_item_slot, pickup_menu_limit,
+                drop_filter, auto_hide_spells,
 3-b     Passive Sightings (detected and remembered entities).
                 detected_monster_colour, detected_item_colour,
                 remembered_monster_colour
@@ -566,6 +567,11 @@ drop_filter += <regex>, <regex>, ...
         When a drop_filter is set, using the select/deselect keys will
         set/clear selection of items that match the filter
         expression(s).
+
+auto_hide_spells = false
+        When set to true, spells added to the library will automatically be
+        hidden.
+
 
 3-b     Passive Sightings (detected or remembered entities).
 ------------------------------------------------------------

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -156,6 +156,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(enable_recast_spell), true),
         new BoolGameOption(SIMPLE_NAME(easy_eat_chunks), false),
         new BoolGameOption(SIMPLE_NAME(auto_eat_chunks), true),
+        new BoolGameOption(SIMPLE_NAME(auto_hide_spells), false),
         new BoolGameOption(SIMPLE_NAME(blink_brightens_background), false),
         new BoolGameOption(SIMPLE_NAME(bold_brightens_foreground), false),
         new BoolGameOption(SIMPLE_NAME(best_effort_brighten_background), false),

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1827,7 +1827,7 @@ bool move_item_to_inv(int obj, int quant_got, bool quiet)
     return keep_going;
 }
 
-static void _get_book(const item_def& it, bool quiet)
+static void _get_book(const item_def& it, bool quiet, bool allow_auto_hide)
 {
     vector<string> spellnames;
     if (!quiet)
@@ -1840,6 +1840,8 @@ static void _get_book(const item_def& it, bool quiet)
             if (you_can_memorise(st))
                 spellnames.push_back(spell_title(st));
             else
+                you.hidden_spells.set(st, true);
+            if (Options.auto_hide_spells && allow_auto_hide)
                 you.hidden_spells.set(st, true);
         }
     }
@@ -1866,7 +1868,7 @@ void add_held_books_to_library()
     {
         if (it.base_type == OBJ_BOOKS && it.sub_type != BOOK_MANUAL)
         {
-            _get_book(it, true);
+            _get_book(it, true, false);
             destroy_item(it);
         }
     }
@@ -2176,7 +2178,7 @@ static bool _merge_items_into_inv(item_def &it, int quant_got,
     }
     if (it.base_type == OBJ_BOOKS && it.sub_type != BOOK_MANUAL)
     {
-        _get_book(it, quiet);
+        _get_book(it, quiet, true);
         return true;
     }
     // Runes are also massless.

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -233,6 +233,7 @@ public:
     bool        easy_eat_chunks; // make 'e' auto-eat the oldest safe chunk
     bool        auto_eat_chunks; // allow eating chunks while resting or travelling
     skill_focus_mode skill_focus; // is the focus skills available
+    bool        auto_hide_spells; // hide new spells
 
     bool        note_all_skill_levels;  // take note for all skill levels (1-27)
     bool        note_skill_max;   // take note when skills reach new max


### PR DESCRIPTION
A friend was bugging me to make the library work nicely in reverse, so here's an option to do that. Off by default, it hides spells from spellbooks you find on the ground so you can go into the list and unhide the ones you want to eventually learn, as opposed to hiding all of the many spells you don't care about.

Because you usually want most of the spells in your background, it won't hide spells from that.