### PR TITLE
Randomise the placement of the rune in dis_grunt

### DIFF
--- a/crawl-ref/source/dat/des/branches/dis.des
+++ b/crawl-ref/source/dat/des/branches/dis.des
@@ -823,21 +823,24 @@ MAP
 ............................7.........7.............................
 ENDMAP
 
-NAME:   dis_grunt
-MONS:   patrolling Dispater, Hell Sentinel, iron dragon / iron giant w:5
-MONS:   rust devil / iron imp w:20
-MONS:   iron troll, quicksilver dragon, cacodemon
-NSUBST: G = 4:8 / *:G
-TILE:   G = dngn_statue_iron_golem
-COLOUR: G = cyan
-KMONS:  8 = iron golem
-KMONS:  9 = war gargoyle
-ITEM:   plate armour good_item / crystal plate armour good_item w:3
-ITEM:   acquire weapon
-KMONS:  F = Hell Sentinel
-KITEM:  F = |
-KMONS:  E = Hell Sentinel
-KITEM:  E = $
+NAME:    dis_grunt
+MONS:    patrolling Dispater, Hell Sentinel, iron dragon / iron giant w:5
+MONS:    rust devil / iron imp w:20
+MONS:    iron troll, quicksilver dragon, cacodemon
+SHUFFLE: AP / BQ / CR / DS / ET
+SUBST:   A = 1, B = 2, C = 2, D = 7, E = 7
+SUBST:   P = O, Q = ., R = ., S = ., T = .
+NSUBST:  G = 4:8 / *:G
+TILE:    G = dngn_statue_iron_golem
+COLOUR:  G = cyan
+KMONS:   8 = iron golem
+KMONS:   9 = war gargoyle
+ITEM:    plate armour good_item / crystal plate armour good_item w:3
+ITEM:    acquire weapon
+KMONS:   K = Hell Sentinel
+KITEM:   K = |
+KMONS:   J = Hell Sentinel
+KITEM:   J = $
 : serpent_of_hell_setup(_G)
 : dis_castle(_G)
 : dis_statues(_G)
@@ -845,9 +848,9 @@ MAP
 ....................................................................
 ....................................................................
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
-.............vvvvvvvvvvvvvvv.....+$$$v||v.......vvvvvvvvvv.......v..
-...........vvv.............v.4.5.+$$$vF|v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$E$v$$v..7.....vvvvvvvv.....2..v..
+.............vvvvvvvvvvvvvvv.....+$$$v||vP......vvvvvvvvvv......Qv..
+...........vvv.............v.4.5.+$$$vK|v........vvvvvvvv........v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$J$v$$v..A.....vvvvvvvv.....B..v..
 ......vvvvvvvv.............+...4.v|||v$$v........vvvvvvvv........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......9v.5.4.+....5...4....vvvvvvv...v45v.........vvvvvv.........v..
@@ -856,8 +859,8 @@ MAP
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvv9..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvvv..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvv9..
-..+....+.....v..4....2...5.+.....D...+....2...+...+.d..+...vvvvvvv..
-..+....+.....v..5..9.....4.+.....2...+........+...+..e.+...vvvvvv9..
+..+....+.....v..4....2...5.+.....D...+....2...+...+.dT.+...vvvvvvv..
+..+....+.....v..5..9.....4.+.....2...+........+...+.Ee.+...vvvvvv9..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvvv..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvv9..
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvvv..
@@ -866,9 +869,9 @@ MAP
 ......9v.5.4.+....4...5....vvvvvvv...v54v.........vvvvvv.........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......vvvvvvvv.............+...4.v$$$v$$v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..1.....vvvvvvvv.....7..v..
-...........vvv.............v.4.5.+$E$vF|v........vvvvvvvv........v..
-.............vvvvvvvvvvvvvvv.....+|||v||vO......vvvvvvvvvv.......v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..D.....vvvvvvvv.....C..v..
+...........vvv.............v.4.5.+$J$vK|v........vvvvvvvv........v..
+.............vvvvvvvvvvvvvvv.....+|||v||vS......vvvvvvvvvv......Rv..
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
 ....................................................................
 ....................................................................

--- a/crawl-ref/source/dat/des/branches/dis.des
+++ b/crawl-ref/source/dat/des/branches/dis.des
@@ -827,19 +827,6 @@ NAME:   dis_grunt
 MONS:   patrolling Dispater, Hell Sentinel, iron dragon / iron giant w:5
 MONS:   rust devil / iron imp w:20
 MONS:   iron troll, quicksilver dragon, cacodemon
-# Randomise placement of Dispater and rune, where 0.2 chance to place
-# in the centre, 0.4 in the near corner and 0.4 in the far corner
-: local rnd = crawl.random2(5)
-: if rnd == 0 then                        
-SUBST: A = 2, B = 7, C = 2, D = 7, E = 1
-SUBST: P = ., Q = ., T = O
-: elseif rnd == 1 or rnd == 2 then
-SUBST: A = 7, B = 1, C = 7, D = 2, E = 2  
-SUBST: P = ., Q = O, T = .
-: else
-SUBST: A = 1, B = 7, C = 2, D = 7, E = 2  
-SUBST: P = O, Q = ., T = .
-: end
 NSUBST: G = 4:8 / *:G
 TILE:   G = dngn_statue_iron_golem
 COLOUR: G = cyan
@@ -847,10 +834,10 @@ KMONS:  8 = iron golem
 KMONS:  9 = war gargoyle
 ITEM:   plate armour good_item / crystal plate armour good_item w:3
 ITEM:   acquire weapon
-KMONS:  K = Hell Sentinel
-KITEM:  K = |
-KMONS:  J = Hell Sentinel
-KITEM:  J = $
+KMONS:  F = Hell Sentinel
+KITEM:  F = |
+KMONS:  E = Hell Sentinel
+KITEM:  E = $
 : serpent_of_hell_setup(_G)
 : dis_castle(_G)
 : dis_statues(_G)
@@ -858,9 +845,9 @@ MAP
 ....................................................................
 ....................................................................
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
-.............vvvvvvvvvvvvvvv.....+$$$v||vP......vvvvvvvvvv......Qv..
-...........vvv.............v.4.5.+$$$vK|v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$J$v$$v..A.....vvvvvvvv.....B..v..
+.............vvvvvvvvvvvvvvv.....+$$$v||v.......vvvvvvvvvv.......v..
+...........vvv.............v.4.5.+$$$vF|v........vvvvvvvv........v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$E$v$$v..7.....vvvvvvvv.....2..v..
 ......vvvvvvvv.............+...4.v|||v$$v........vvvvvvvv........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......9v.5.4.+....5...4....vvvvvvv...v45v.........vvvvvv.........v..
@@ -869,8 +856,8 @@ MAP
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvv9..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvvv..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvv9..
-..+....+.....v..4....2...5.+.....D...+....2...+...+.dT.+...vvvvvvv..
-..+....+.....v..5..9.....4.+.....2...+........+...+.Ee.+...vvvvvv9..
+..+....+.....v..4....2...5.+.....D...+....2...+...+.d..+...vvvvvvv..
+..+....+.....v..5..9.....4.+.....2...+........+...+..e.+...vvvvvv9..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvvv..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvv9..
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvvv..
@@ -879,9 +866,9 @@ MAP
 ......9v.5.4.+....4...5....vvvvvvv...v54v.........vvvvvv.........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......vvvvvvvv.............+...4.v$$$v$$v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..D.....vvvvvvvv.....C..v..
-...........vvv.............v.4.5.+$J$vK|v........vvvvvvvv........v..
-.............vvvvvvvvvvvvvvv.....+|||v||v.......vvvvvvvvvv.......v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..1.....vvvvvvvv.....7..v..
+...........vvv.............v.4.5.+$E$vF|v........vvvvvvvv........v..
+.............vvvvvvvvvvvvvvv.....+|||v||vO......vvvvvvvvvv.......v..
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
 ....................................................................
 ....................................................................

--- a/crawl-ref/source/dat/des/branches/dis.des
+++ b/crawl-ref/source/dat/des/branches/dis.des
@@ -827,6 +827,19 @@ NAME:   dis_grunt
 MONS:   patrolling Dispater, Hell Sentinel, iron dragon / iron giant w:5
 MONS:   rust devil / iron imp w:20
 MONS:   iron troll, quicksilver dragon, cacodemon
+# Randomise placement of Dispater and rune, where 0.2 chance to place
+# in the centre, 0.4 in the near corner and 0.4 in the far corner
+: local rnd = crawl.random2(5)
+: if rnd == 0 then                        
+SUBST: A = 2, B = 7, C = 2, D = 7, E = 1
+SUBST: P = ., Q = ., T = O
+: elseif rnd == 1 or rnd == 2 then
+SUBST: A = 7, B = 1, C = 7, D = 2, E = 2  
+SUBST: P = ., Q = O, T = .
+: else
+SUBST: A = 1, B = 7, C = 2, D = 7, E = 2  
+SUBST: P = O, Q = ., T = .
+: end
 NSUBST: G = 4:8 / *:G
 TILE:   G = dngn_statue_iron_golem
 COLOUR: G = cyan
@@ -834,10 +847,10 @@ KMONS:  8 = iron golem
 KMONS:  9 = war gargoyle
 ITEM:   plate armour good_item / crystal plate armour good_item w:3
 ITEM:   acquire weapon
-KMONS:  F = Hell Sentinel
-KITEM:  F = |
-KMONS:  E = Hell Sentinel
-KITEM:  E = $
+KMONS:  K = Hell Sentinel
+KITEM:  K = |
+KMONS:  J = Hell Sentinel
+KITEM:  J = $
 : serpent_of_hell_setup(_G)
 : dis_castle(_G)
 : dis_statues(_G)
@@ -845,9 +858,9 @@ MAP
 ....................................................................
 ....................................................................
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
-.............vvvvvvvvvvvvvvv.....+$$$v||v.......vvvvvvvvvv.......v..
-...........vvv.............v.4.5.+$$$vF|v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$E$v$$v..7.....vvvvvvvv.....2..v..
+.............vvvvvvvvvvvvvvv.....+$$$v||vP......vvvvvvvvvv......Qv..
+...........vvv.............v.4.5.+$$$vK|v........vvvvvvvv........v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$J$v$$v..A.....vvvvvvvv.....B..v..
 ......vvvvvvvv.............+...4.v|||v$$v........vvvvvvvv........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......9v.5.4.+....5...4....vvvvvvv...v45v.........vvvvvv.........v..
@@ -856,8 +869,8 @@ MAP
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvv9..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvvv..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvv9..
-..+....+.....v..4....2...5.+.....D...+....2...+...+.d..+...vvvvvvv..
-..+....+.....v..5..9.....4.+.....2...+........+...+..e.+...vvvvvv9..
+..+....+.....v..4....2...5.+.....D...+....2...+...+.dT.+...vvvvvvv..
+..+....+.....v..5..9.....4.+.....2...+........+...+.Ee.+...vvvvvv9..
 ..v...4v...G.v.............v..4.8....vvvvvvvvvv...vv..vv...vvvvvvv..
 .vvv++vv...3.v.G.G.....G.G.vv..G.G.G.vvvvvvvvvv....v++v....vvvvvv9..
 .vv...9v.....v.............vvv.......+..vvvvvv..............vvvvvv..
@@ -866,9 +879,9 @@ MAP
 ......9v.5.4.+....4...5....vvvvvvv...v54v.........vvvvvv.........v..
 ......vv.....+......3......+.....vvvvv++v........vvvvvvvv........v..
 ......vvvvvvvv.............+...4.v$$$v$$v........vvvvvvvv........v..
-.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..1.....vvvvvvvv.....7..v..
-...........vvv.............v.4.5.+$E$vF|v........vvvvvvvv........v..
-.............vvvvvvvvvvvvvvv.....+|||v||vO......vvvvvvvvvv.......v..
+.........vvvvv.G.G.G.G.G.G.v..3..v$$$v$$v..D.....vvvvvvvv.....C..v..
+...........vvv.............v.4.5.+$J$vK|v........vvvvvvvv........v..
+.............vvvvvvvvvvvvvvv.....+|||v||v.......vvvvvvvvvv.......v..
 ...............vv9.vv4.vv9.vvvvvvvvvvvvvvvvvvvvvv.9v.4v.9vvvvvvvvv..
 ....................................................................
 ....................................................................

--- a/crawl-ref/source/dat/des/branches/dis.des
+++ b/crawl-ref/source/dat/des/branches/dis.des
@@ -828,8 +828,8 @@ MONS:    patrolling Dispater, Hell Sentinel, iron dragon / iron giant w:5
 MONS:    rust devil / iron imp w:20
 MONS:    iron troll, quicksilver dragon, cacodemon
 SHUFFLE: AP / BQ / CR / DS / ET
-SUBST:   A = 1, B = 2, C = 2, D = 7, E = 7
-SUBST:   P = O, Q = ., R = ., S = ., T = .
+SUBST:   A = 1, BC = 2, DE = 7
+SUBST:   P = O, QRST = .
 NSUBST:  G = 4:8 / *:G
 TILE:    G = dngn_statue_iron_golem
 COLOUR:  G = cyan


### PR DESCRIPTION
Stealing runes is one of the most effective ways to do 15 runes currently, and one of the easiest runes to steal is the iron rune of dis_grunt. This PR makes that somewhat less easy to do by randomising the placement of Dispater and the iron rune, having it occasionally place in the central structure and an equal chance of placing in any one of the four corners, instead of just the two corners nearest to the entrance, as was previously the case. It also adds an extra Hell Sentinel to the vault, just to make everything symmetrical with the same number and difficulty of enemies in all the different arrangements.

(Also apparently I messed up the formatting of the commit comment, in that it should be 72-characters per line. Sorry about that, I don't know how to easily fix it.)