### PR TITLE
Update dream sheep description

### DIFF
--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -975,8 +975,6 @@ dream sheep
 A drowsy, fluffy ovine whose coat sparkles with motes of dream dust. It gathers
 in herds and fills the air with dream dust, overwhelming its victims and
 putting them to sleep.
-
-Its wool looks quite flammable.
 %%%%
 drowned soul
 


### PR DESCRIPTION
"Its wool looks quite flammable" was a reference to dream sheep fires, a special-cased sticky flame mechanic. Because it was removed in 1d1b1003d6 and there are no other fire-related mechanics (dream sheep are not even vulnerable to fire) that bit of flavor is now misleading.
