### PR TITLE
Improve Ashenzari's warnings for wands

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -1630,18 +1630,20 @@ bool is_offensive_wand(const item_def& item)
     switch (item.sub_type)
     {
     // Monsters don't use those, so no need to warn the player about them.
-    case WAND_ENSLAVEMENT:
+    case WAND_CLOUDS:
+    case WAND_ICEBLAST:
     case WAND_RANDOM_EFFECTS:
+    case WAND_SCATTERSHOT:
+    // Monsters use it, but it's not an offensive wand
     case WAND_DIGGING:
         return false;
 
+    case WAND_ENSLAVEMENT:
     case WAND_FLAME:
     case WAND_PARALYSIS:
-    case WAND_ICEBLAST:
     case WAND_POLYMORPH:
     case WAND_ACID:
     case WAND_DISINTEGRATION:
-    case WAND_CLOUDS:
         return true;
     }
     return false;


### PR DESCRIPTION
Two fixes:
* Ash was giving warning messages for wands of clouds and iceblast
  even though monsters don't use them.
* Ash wasn't warning the player about monsters carrying a wand of
  enslavement, which can be used to confuse the player.

Also add missing wand of scattershot.