### PR TITLE
Tileschat mute

### DIFF
--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -183,6 +183,7 @@ Thumbs.db
 
 # Webtiles stuff
 passwd.db3
+user_settings.db3
 *.ttyrec
 /source/rcs
 

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -23,6 +23,7 @@ logging_config = {
 }
 
 password_db = "./webserver/passwd.db3"
+settings_db = "./webserver/user_settings.db3"
 
 static_path = "./webserver/static"
 template_path = "./webserver/templates/"

--- a/crawl-ref/source/webserver/process_handler.py
+++ b/crawl-ref/source/webserver/process_handler.py
@@ -322,6 +322,7 @@ class CrawlProcessHandlerBase(object):
                             "Spectator '%s' has now been muted." % target)
         self.muted |= {target}
         self.save_mutelist(source)
+        self.update_watcher_description()
         return True
 
     def unmute(self, source, target):
@@ -341,6 +342,7 @@ class CrawlProcessHandlerBase(object):
             self.handle_notification(source, "You have cleared your mute list.")
             self.muted = set()
             self.save_mutelist(source)
+            self.update_watcher_description()
             return True
 
         if not target in self.muted:
@@ -351,6 +353,7 @@ class CrawlProcessHandlerBase(object):
         self.handle_notification(source, "You have unmuted '%s'." % target)
         self.muted -= {target}
         self.save_mutelist(source)
+        self.update_watcher_description()
         return True
 
     def show_mute_list(self, source):
@@ -378,11 +381,12 @@ class CrawlProcessHandlerBase(object):
                 class_type = 'player'
             else:
                 class_type = 'watcher'
+            n = watcher
+            if (watcher in self.muted):
+                n += " (muted)"
             if player_url is None:
-                return "<span class='{0}'>{1}</span>".format(class_type,
-                                                             watcher)
-            username = "<a href='{0}' target='_blank' class='{1}'>{2}</a>".format(config.player_url, class_type, watcher)
-            username = username.replace('%s', watcher.lower())
+                return "<span class='{0}'>{1}</span>".format(class_type, n)
+            username = "<a href='{0}' target='_blank' class='{1}'>{2}</a>".format(config.player_url, class_type, n)
             return username
 
         player_name, watchers = self.get_watchers(True)

--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -13,6 +13,7 @@ from util import *
 from ws_handler import *
 from game_data_handler import GameDataHandler
 import process_handler
+import userdb
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
@@ -214,7 +215,8 @@ if __name__ == "__main__":
     shed_privileges()
 
     if dgl_mode:
-        ensure_user_db_exists()
+        userdb.ensure_user_db_exists()
+    userdb.ensure_settings_db_exists()
 
     ioloop = tornado.ioloop.IOLoop.instance()
     ioloop.set_blocking_log_threshold(0.5)

--- a/crawl-ref/source/webserver/static/scripts/chat.js
+++ b/crawl-ref/source/webserver/static/scripts/chat.js
@@ -8,6 +8,7 @@ define(["jquery", "comm", "linkify"], function ($, comm, linkify) {
     var message_history = [];
     var unsent_message = "";
     var history_pos = -1;
+    var chat_hidden = false;
 
     function update_spectators(data)
     {
@@ -135,8 +136,59 @@ define(["jquery", "comm", "linkify"], function ($, comm, linkify) {
         }
     }
 
+    function toggle_entire_chat()
+    {
+        if ($("#chat").css("display") === "none")
+        {
+            chat_hidden = false;
+            // slide looks odd if the chat box is already 1 line
+            if ($("#chat_body").css("display") === "none")
+                $("#chat").show();
+            else
+                $("#chat").slideDown(200);
+        }
+        else
+        {
+            chat_hidden = true;
+            $(document.activeElement).blur();
+            // slide looks odd if the chat box is already 1 line
+            if ($("#chat_body").css("display") === "none")
+                $("#chat").hide();
+            else
+                $("#chat").slideUp(200);
+        }
+        $("#chat_hidden").toggle(chat_hidden);
+    }
+
+    function super_hide_chat()
+    {
+        // this hides chat and deletes the + div, so needs a reload or logout
+        // to get back the chat window.
+        if ($("#chat").css("display") != "none")
+            toggle_entire_chat();
+        $("#chat_hidden").remove();
+    }
+
+    function reset_visibility(in_game)
+    {
+        if (!in_game)
+        {
+            $("#chat").hide()
+            $("#chat_hidden").hide()
+        }
+        else
+        {
+            $("#chat").toggle(!chat_hidden);
+            $("#chat_hidden").toggle(chat_hidden);
+        }
+    }
+
     function focus()
     {
+        if (!$("#chat_hidden").length)
+            return;
+        if ($("#chat_hidden").css("display") != "none")
+            toggle_entire_chat();
         if ($("#chat_body").css("display") === "none")
             toggle();
 
@@ -157,17 +209,22 @@ define(["jquery", "comm", "linkify"], function ($, comm, linkify) {
     $(document).ready(function () {
         $("#chat_input").bind("keydown", chat_message_send);
         $("#chat_caption").bind("click", toggle);
+        $("#chat_hide_button").bind("click", toggle_entire_chat);
+        $("#chat_hidden").bind("click", toggle_entire_chat);
     });
 
     comm.register_handlers({
         "dump": handle_dump,
         "chat": receive_message,
-        "update_spectators": update_spectators
+        "update_spectators": update_spectators,
+        "toggle_chat": toggle_entire_chat,
+        "super_hide_chat": super_hide_chat
     });
 
     return {
         spectators: spectators,
         clear: clear,
         focus: focus,
+        reset_visibility: reset_visibility,
     }
 });

--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -182,7 +182,7 @@ function (exports, $, key_conversion, chat, comm) {
         });
         current_layer = layer;
 
-        $("#chat").toggle(in_game());
+        chat.reset_visibility(in_game());
     }
 
     function register_layer(name)
@@ -432,6 +432,7 @@ function (exports, $, key_conversion, chat, comm) {
         $("#reg_link").hide();
         $("#logout_link").show();
 
+        chat.reset_visibility(true);
         $("#chat_input").show();
         $("#chat_login_text").hide();
 
@@ -697,7 +698,7 @@ function (exports, $, key_conversion, chat, comm) {
         var msg = data.reason;
         set_layer("crt");
         hide_dialog();
-        $("#chat").hide();
+        chat.reset_visibility(false);
         $("#crt").html(msg + "<br><br>");
         showing_close_message = true;
         return true;

--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -977,6 +977,7 @@ function (exports, $, key_conversion, chat, comm) {
         playing = true;
         watching = false;
     }
+
     function crawl_ended(data)
     {
         playing = false;

--- a/crawl-ref/source/webserver/static/style.css
+++ b/crawl-ref/source/webserver/static/style.css
@@ -176,9 +176,33 @@ body {
     z-index: 3000;
 }
 
+#chat_hidden {
+    background: rgba(0, 0, 0, 0.85);
+    width: 1em;
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+
+    color: #A2A2A2;
+
+    font-size: small;
+    text-align: center;
+
+    padding: 5px;
+    border: 1px solid #626262;
+
+    z-index: 3000;
+}
+
 #chat a {
     color: inherit;
     font-weight: inherit;
+}
+
+#chat_hidden a {
+    color: inherit;
+    font-weight: inherit;
+    text-decoration: none;
 }
 
 #chat_caption {
@@ -200,6 +224,12 @@ body {
 }
 
 #message_count {
+    float: right;
+}
+#chat_hide_button_span {
+    text-align: center;
+    padding-left: 5px;
+    padding-right: 3px;
     float: right;
 }
 #message_count.has_new {

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -175,7 +175,12 @@
 
     <div id="overlay"></div>
 
+    <div id="chat_hidden" style="display: none;"><span><a href="javascript:">+</a></span></div>
+
     <div id="chat" style="display: none;">
+      <a href="javascript:" id="chat_hide_button">
+        <span id="chat_hide_button_span">(-)</span>
+      </a>
       <a href="javascript:" id="chat_caption">
         <span id="spectator_count">0 spectators</span>
         <span id="message_count">0 new messages</span>

--- a/crawl-ref/source/webserver/userdb.py
+++ b/crawl-ref/source/webserver/userdb.py
@@ -5,8 +5,66 @@ import os.path
 import logging
 import random
 
-from config import (max_passwd_length, nick_regex, password_db,
+from config import (max_passwd_length, nick_regex, password_db, settings_db,
                     crypt_algorithm, crypt_salt_length)
+
+def ensure_settings_db_exists():
+    if os.path.exists(settings_db):
+        return
+    logging.warn("User settings database didn't exist at '%s'; creating it now." % settings_db)
+    c = None
+    conn = None
+    try:
+        conn = sqlite3.connect(settings_db)
+        c = conn.cursor()
+        schema = ("CREATE TABLE mutesettings (username text primary key not null unique, mutelist text default '');")
+        c.execute(schema)
+        conn.commit()
+    finally:
+        if c:
+            c.close()
+        if conn:
+            conn.close()
+
+def get_mutelist(username):
+    # TODO: based on userdb; why doesn't this just keep the database open?
+    # I think sqlite can handle that...
+    try:
+        conn = sqlite3.connect(settings_db)
+        c = conn.cursor()
+        c.execute("select mutelist from mutesettings where username=? collate nocase",
+                  (username,))
+        result = c.fetchone()
+
+        if result is None:
+            return None
+        else:
+            return result[0]
+    finally:
+        if c: c.close()
+        if conn: conn.close()
+
+def set_mutelist(username, mutelist):
+    # TODO: based on userdb; why doesn't this just keep the database open?
+    # I think sqlite can handle that...
+    try:
+        conn = sqlite3.connect(settings_db)
+        c = conn.cursor()
+        if mutelist is None:
+            mutelist = ""
+
+        # n.b. the following will wipe out any columns not mentioned, if there
+        # ever are any...
+        c.execute("insert or replace into mutesettings(username, mutelist) values (?,?)",
+                  (username, mutelist))
+
+        conn.commit()
+    finally:
+        if c:
+            c.close()
+        if conn:
+            conn.close()
+
 
 def user_passwd_match(username, passwd): # Returns the correctly cased username.
     try:

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -502,7 +502,8 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                                   = 'You need to log in to send messages!')
                 return
 
-            receiver.handle_chat_message(self.username, text)
+            if not receiver.handle_chat_command(self.username, text):
+                receiver.handle_chat_message(self.username, text)
 
     def register(self, username, password, email):
         error = register_user(username, password, email)

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -14,7 +14,7 @@ import zlib
 
 import config
 import checkoutput
-from userdb import *
+import userdb
 from util import *
 
 sockets = set()
@@ -302,6 +302,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                 return
 
             self.send_message("game_started")
+            self.restore_mutelist()
 
             if config.dgl_mode:
                 if self.process.where == {}:
@@ -382,7 +383,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             self.send_game_links()
 
     def login(self, username, password):
-        real_username = user_passwd_match(username, password)
+        real_username = userdb.user_passwd_match(username, password)
         if real_username:
             self.logger.info("User %s logged in.", real_username)
             self.do_login(real_username)
@@ -424,6 +425,29 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                 del login_tokens[(token, username)]
         except ValueError:
             return
+
+    def restore_mutelist(self):
+        if not self.username:
+            return
+        receiver = None
+        if self.process:
+            receiver = self.process
+        elif self.watched_game:
+            receiver = self.watched_game
+
+        if not receiver:
+            return
+
+        db_string = userdb.get_mutelist(self.username)
+        if db_string is None:
+            db_string = ""
+        # list constructor here is for forward compatibility with python 3.
+        muted = list(filter(None, db_string.strip().split(' ')))
+        receiver.restore_mutelist(self.username, muted)
+
+    def save_mutelist(self, muted):
+        db_string = " ".join(muted).strip()
+        userdb.set_mutelist(self.username, db_string)
 
     def pong(self):
         self.received_pong = True
@@ -506,7 +530,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                 receiver.handle_chat_message(self.username, text)
 
     def register(self, username, password, email):
-        error = register_user(username, password, email)
+        error = userdb.register_user(username, password, email)
         if error is None:
             self.logger.info("Registered user %s.", username)
             self.do_login(username)

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -134,6 +134,8 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
 
         self.subprotocol = None
 
+        self.chat_hidden = False
+
         self.logger = logging.LoggerAdapter(logging.getLogger(), {})
         self.logger.process = self._process_log_msg
 
@@ -526,7 +528,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                                   = 'You need to log in to send messages!')
                 return
 
-            if not receiver.handle_chat_command(self.username, text):
+            if not receiver.handle_chat_command(self, text):
                 receiver.handle_chat_message(self.username, text)
 
     def register(self, username, password, email):


### PR DESCRIPTION
Implement some basic tileschat admin commands for the player, mainly aimed at dealing with spamming; this allows muting and unmuting, and will save mute lists on the server. This branch is ready for some review.

These changes may require a server admin to update code that's not usually updated on a new version (for the webtiles server).