### PR TITLE
Add player LUA callback skill_training_needed

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 
 #include "ability.h"
+#include "clua.h"
 #include "describe-god.h"
 #include "evoke.h"
 #include "exercise.h"
@@ -732,6 +733,13 @@ bool check_selected_skills()
 
     if (trainable_skill)
     {
+        // Calling a user lua function here to allow enabling skills without user
+        // prompt (much like the callback auto_experience for the case of potion of experience).
+        if (clua.callbooleanfn(false, "skill_training_needed", nullptr))
+        {
+            return true;
+        }
+
         mpr("You need to enable at least one skill for training.");
         // Training will be fixed up on load if this ASSERT triggers.
         ASSERT(you.species != SP_GNOLL);

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -708,7 +708,7 @@ void init_training()
 
 // Make sure at least one skill is selected.
 // If not, go to the skill menu and return true.
-bool check_selected_skills()
+bool check_selected_skills(bool do_lua_callback)
 {
     bool trainable_skill = false;
     bool could_train = false;
@@ -735,9 +735,11 @@ bool check_selected_skills()
     {
         // Calling a user lua function here to allow enabling skills without user
         // prompt (much like the callback auto_experience for the case of potion of experience).
-        if (clua.callbooleanfn(false, "skill_training_needed", nullptr))
+        // If the callback does not set skill training, we nevertheless show the skill menu.
+        if (do_lua_callback)
         {
-            return true;
+            clua.callmaybefn("skill_training_needed", nullptr);
+            return check_selected_skills(false);
         }
 
         mpr("You need to enable at least one skill for training.");

--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -54,7 +54,7 @@ void check_skill_cost_change();
 
 bool training_restricted(skill_type sk);
 void reassess_starting_skills();
-bool check_selected_skills();
+bool check_selected_skills(bool do_lua_callback = true);
 void init_train();
 void init_can_train();
 void init_training();


### PR DESCRIPTION
The new skill target mechanism and its lua bindings
are a very nice way of implementing automated skill
advancement logic. However, when the last skill target is met
while gaining experience the skill menu is opened
and needs user interaction. The patch introduces a
callback `skill_training_needed` in this case. If it
returns true, the skill menu is not opened.