### PR TITLE
Add an option to dump the player's options file.

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -121,7 +121,7 @@ The contents of this text are:
 4-b     Items and Kills.
                 kill_map, dump_kill_places, dump_kill_breakdowns,
                 dump_item_origins, dump_item_origin_price, dump_message_count,
-                dump_order, dump_book_spells
+                dump_order, dump_book_spells, dump_options
 4-c     Notes.
                 user_note_prefix, note_items, note_monsters, note_hp_percent,
                 note_skill_levels, note_all_skill_levels, note_skill_max,

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2231,6 +2231,10 @@ dump_book_spells = true
         spells listed in the dump. If this option is set to true, spells will
         also be dumped for non-randart spellbooks.
 
+dump_options = false
+        Setting this option to true will list the contents of the options file
+        in the character dump.
+
 4-c     Notes.
 --------------
 

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -1402,14 +1402,19 @@ static void _sdump_mutations(dump_params &par)
 
 static void _sdump_rc_file(dump_params &par)
 {
-    par.text += "Options file contents\n";
-    par.text += "---------------------\n\n";
+    if (Options.dump_options)
+    {
+        par.text += "\n";
+        par.text += "---------------------\n";
+        par.text += "Options file contents\n";
+        par.text += "---------------------\n\n";
 
-    par.text += Options.file_contents;
+        par.text += Options.file_contents;
 
-    par.text += "-------------------\n";
-    par.text += "End of options file\n";
-    par.text += "-------------------\n\n";
+        par.text += "-------------------\n";
+        par.text += "End of options file\n";
+        par.text += "-------------------\n\n";
+    }
 }
 
 // Must match the order of hunger_state_t enums

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -85,6 +85,7 @@ static void _sdump_vault_list(dump_params &);
 static void _sdump_skill_gains(dump_params &);
 static void _sdump_action_counts(dump_params &);
 static void _sdump_separator(dump_params &);
+static void _sdump_rc_file(dump_params &);
 #ifdef CLUA_BINDINGS
 static void _sdump_lua(dump_params &);
 #endif
@@ -142,6 +143,7 @@ static dump_section_handler dump_handlers[] =
     { "spell_usage",    _sdump_action_counts }, // compat
     { "action_counts",  _sdump_action_counts },
     { "skill_gains",    _sdump_skill_gains   },
+    { "options",        _sdump_rc_file       },
 
     // Conveniences for the .crawlrc artist.
     { "",               _sdump_newline       },
@@ -1396,6 +1398,18 @@ static void _sdump_mutations(dump_params &par)
         text += (formatted_string::parse_string(describe_mutations(false)));
         text += "\n\n";
     }
+}
+
+static void _sdump_rc_file(dump_params &par)
+{
+    par.text += "Options file contents\n";
+    par.text += "---------------------\n\n";
+
+    par.text += Options.file_contents;
+
+    par.text += "-------------------\n";
+    par.text += "End of options file\n";
+    par.text += "-------------------\n\n";
 }
 
 // Must match the order of hunger_state_t enums

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -216,6 +216,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(default_manual_training), false),
         new BoolGameOption(SIMPLE_NAME(one_SDL_sound_channel), false),
         new BoolGameOption(SIMPLE_NAME(sounds_on), true),
+        new BoolGameOption(SIMPLE_NAME(dump_options), false),
         new ColourGameOption(SIMPLE_NAME(tc_reachable), BLUE),
         new ColourGameOption(SIMPLE_NAME(tc_excluded), LIGHTMAGENTA),
         new ColourGameOption(SIMPLE_NAME(tc_exclude_circle), RED),

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1584,13 +1584,17 @@ void read_init_file(bool runscript)
     UNUSED(lua_builtins);
     UNUSED(config_defaults);
 #endif
+    // Clear Options.file_contents here to avoid duplication in dump
+    Options.file_contents.clear();
 
     // Load early binding extra options from the command line BEFORE init.txt.
     Options.filename     = "extra opts first";
     Options.basefilename = "extra opts first";
     Options.line_num     = 0;
+
     for (const string &extra : SysEnv.extra_opts_first)
     {
+        Options.file_contents += extra + "\n";  // Add extra options to dump
         Options.line_num++;
         Options.read_option_line(extra, true);
     }
@@ -1635,7 +1639,7 @@ void read_init_file(bool runscript)
     if (f.error())
         return;
     string option_file_contents = Options.read_options(f, runscript);
-    Options.file_contents = option_file_contents;
+    Options.file_contents += option_file_contents;
 
     if (Options.read_persist_options)
     {
@@ -1653,6 +1657,7 @@ void read_init_file(bool runscript)
     Options.line_num     = 0;
     for (const string &extra : SysEnv.extra_opts_last)
     {
+        Options.file_contents += extra + "\n";  // Add extra options to dump
         Options.line_num++;
         Options.read_option_line(extra, true);
     }

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1625,6 +1625,8 @@ void read_init_file(bool runscript)
     }
 #endif
 
+    FileLineInput f(init_file_name.c_str());
+
     Options.filename = init_file_name;
     Options.line_num = 0;
 #ifdef UNIX
@@ -1633,18 +1635,10 @@ void read_init_file(bool runscript)
     Options.basefilename = "init.txt";
 #endif
 
-    // Read in the options file
-    FILE *f = fopen_u(init_file_name.c_str(), "r");
-
-    unsigned long size = file_size(f);
-
-    char *options_contents = new char[size];
-
-    fread(options_contents, 1, size, f);
-    fclose(f);
-
-    read_options(options_contents, runscript);
-    Options.file_contents += options_contents;
+    if (f.error())
+        return;
+    string option_file_contents = Options.read_options(f, runscript);
+    Options.file_contents += "\n" + option_file_contents + "\n\n";
 
     if (Options.read_persist_options)
     {
@@ -1775,7 +1769,7 @@ game_options::~game_options()
     deleteAll(option_behaviour);
 }
 
-void game_options::read_options(LineInput &il, bool runscript,
+string game_options::read_options(LineInput &il, bool runscript,
                                 bool clear_aliases)
 {
     unsigned int line = 0;
@@ -1791,6 +1785,7 @@ void game_options::read_options(LineInput &il, bool runscript,
 
     dlua_chunk luacond(filename);
     dlua_chunk luacode(filename);
+    string content = "";
     while (!il.eof())
     {
         line_num++;
@@ -1799,6 +1794,8 @@ void game_options::read_options(LineInput &il, bool runscript,
         line++;
 
         trim_string(str);
+
+        content += str + "\n";
 
         // This is to make some efficient comments
         if ((str.empty() || str[0] == '#') && !inscriptcond && !inscriptblock)
@@ -1943,6 +1940,7 @@ void game_options::read_options(LineInput &il, bool runscript,
             mprf(MSGCH_ERROR, "Lua error: %s", luacond.orig_error().c_str());
     }
 #endif
+    return content;
 }
 
 void game_options::fixup_options()

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1141,6 +1141,7 @@ void game_options::reset_options()
     // Currently enabled by default for testing in trunk.
     if (Version::ReleaseType == VER_ALPHA)
         new_dump_fields("xp_by_level");
+    new_dump_fields("options");
 
     use_animations = (UA_BEAM | UA_RANGE | UA_HP | UA_MONSTER_IN_SIGHT
                       | UA_PICKUP | UA_MONSTER | UA_PLAYER | UA_BRANCH_ENTRY
@@ -1632,7 +1633,8 @@ void read_init_file(bool runscript)
 
     if (f.error())
         return;
-    Options.read_options(f, runscript);
+    string option_file_contents = Options.read_options(f, runscript);
+    Options.file_contents = option_file_contents;
 
     if (Options.read_persist_options)
     {
@@ -1748,7 +1750,7 @@ void save_player_name()
 void read_options(const string &s, bool runscript, bool clear_aliases)
 {
     StringLineInput st(s);
-    Options.read_options(st, runscript, clear_aliases);
+    string test = Options.read_options(st, runscript, clear_aliases);
 }
 
 game_options::game_options()
@@ -1762,7 +1764,7 @@ game_options::~game_options()
     deleteAll(option_behaviour);
 }
 
-void game_options::read_options(LineInput &il, bool runscript,
+string game_options::read_options(LineInput &il, bool runscript,
                                 bool clear_aliases)
 {
     unsigned int line = 0;
@@ -1778,7 +1780,7 @@ void game_options::read_options(LineInput &il, bool runscript,
 
     dlua_chunk luacond(filename);
     dlua_chunk luacode(filename);
-
+    string content = "";
     while (!il.eof())
     {
         line_num++;
@@ -1787,6 +1789,9 @@ void game_options::read_options(LineInput &il, bool runscript,
         line++;
 
         trim_string(str);
+
+        content += str;
+        content += "\n";
 
         // This is to make some efficient comments
         if ((str.empty() || str[0] == '#') && !inscriptcond && !inscriptblock)
@@ -1931,6 +1936,7 @@ void game_options::read_options(LineInput &il, bool runscript,
             mprf(MSGCH_ERROR, "Lua error: %s", luacond.orig_error().c_str());
     }
 #endif
+    return content;
 }
 
 void game_options::fixup_options()

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1751,7 +1751,7 @@ void save_player_name()
 void read_options(const string &s, bool runscript, bool clear_aliases)
 {
     StringLineInput st(s);
-    string test = Options.read_options(st, runscript, clear_aliases);
+    Options.read_options(st, runscript, clear_aliases);
 }
 
 game_options::game_options()
@@ -1791,8 +1791,7 @@ string game_options::read_options(LineInput &il, bool runscript,
 
         trim_string(str);
 
-        content += str;
-        content += "\n";
+        content += str + "\n";
 
         // This is to make some efficient comments
         if ((str.empty() || str[0] == '#') && !inscriptcond && !inscriptblock)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1591,7 +1591,6 @@ void read_init_file(bool runscript)
     Options.filename     = "extra opts first";
     Options.basefilename = "extra opts first";
     Options.line_num     = 0;
-
     for (const string &extra : SysEnv.extra_opts_first)
     {
         Options.file_contents += extra + "\n";  // Add extra options to dump
@@ -1639,7 +1638,7 @@ void read_init_file(bool runscript)
     if (f.error())
         return;
     string option_file_contents = Options.read_options(f, runscript);
-    Options.file_contents += option_file_contents;
+    Options.file_contents += "\n" + option_file_contents + "\n\n";
 
     if (Options.read_persist_options)
     {

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -399,6 +399,7 @@ public:
     int         dump_item_origins;  // Show where items came from?
     int         dump_item_origin_price;
     bool        dump_book_spells;
+    bool        dump_options;       // Whether to dump the options file
 
     // Order of sections in the character dump.
     vector<string> dump_order;

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -130,7 +130,7 @@ public:
     void reset_options();
 
     void read_option_line(const string &s, bool runscripts = false);
-    void read_options(LineInput &, bool runscripts,
+    string read_options(LineInput &, bool runscripts,
                       bool clear_aliases = true);
 
     void include(const string &file, bool resolve, bool runscript);

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -130,7 +130,7 @@ public:
     void reset_options();
 
     void read_option_line(const string &s, bool runscripts = false);
-    void read_options(LineInput &, bool runscripts,
+    string read_options(LineInput &, bool runscripts,
                       bool clear_aliases = true);
 
     void include(const string &file, bool resolve, bool runscript);
@@ -151,6 +151,8 @@ public:
     string      filename;     // The name of the file containing options.
     string      basefilename; // Base (pathless) file name
     int         line_num;     // Current line number being processed.
+
+    string      file_contents; // The raw text of the options file.
 
     // View options
     map<dungeon_feature_type, feature_def> feature_colour_overrides;

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -130,7 +130,7 @@ public:
     void reset_options();
 
     void read_option_line(const string &s, bool runscripts = false);
-    string read_options(LineInput &, bool runscripts,
+    void read_options(LineInput &, bool runscripts,
                       bool clear_aliases = true);
 
     void include(const string &file, bool resolve, bool runscript);


### PR DESCRIPTION
Since last December, the speedrunning community has realised the potential for the use of multi-action macros made in-game, and lua macros constructed in the RC file, and come to the consensus that this should not be allowed in the rules of realtime speedrunning. However, there has been no way to actually check that players saying they are not using such multi-action macros are not.

This PR aims to go one step towards achieving this goal, by adding an option to dump the options file.
At some point another PR will need to be made, in order to dump a player's in-game macros into the RC file.

~~I will probably have to do a little more work on this to deal with extra options from the command line, but this isn't strictly necessary to get this option to work.~~ (Done)