### PR TITLE
Fix for hi-score sometimes highlighting wrong entry. 

### DIFF
--- a/crawl-ref/source/end.cc
+++ b/crawl-ref/source/end.cc
@@ -16,7 +16,9 @@
 #include "database.h"
 #include "describe.h"
 #include "dungeon.h"
+#include "files.h"
 #include "god-passive.h"
+#include "ghost.h"
 #include "hints.h"
 #include "invent.h"
 #include "item-prop.h"
@@ -275,8 +277,38 @@ static string _exit_type_to_string(game_exit e)
     return "BUGGY EXIT TYPE";
 }
 
-NORETURN void end_game(scorefile_entry &se, int hiscore_index)
+NORETURN void end_game(scorefile_entry &se)
 {
+    //Update states
+    crawl_state.need_save       = false;
+    crawl_state.updating_scores = true;
+
+    const kill_method_type death_type = (kill_method_type) se.get_death_type();
+
+    const bool non_death = death_type == KILLED_BY_QUITTING
+                        || death_type == KILLED_BY_WINNING
+                        || death_type == KILLED_BY_LEAVING;
+
+    int hiscore_index = -1;
+#ifndef SCORE_WIZARD_CHARACTERS
+    if (!you.wizard && !you.explore)
+#endif
+    {
+        // Add this highscore to the score file.
+        hiscore_index = hiscores_new_entry(se);
+        logfile_new_entry(se);
+    }
+#ifndef SCORE_WIZARD_CHARACTERS
+    else 
+    {
+        hiscores_read_to_memory();
+    }
+#endif
+
+    // Never generate bones files of wizard or tutorial characters -- bwr
+    if (!non_death && !crawl_state.game_is_tutorial() && !you.wizard)
+        save_ghosts(ghost_demon::find_ghosts());
+
     for (auto &item : you.inv)
         if (item.defined() && item_type_unknown(item))
             add_inscription(item, "unknown");
@@ -285,11 +317,8 @@ NORETURN void end_game(scorefile_entry &se, int hiscore_index)
 
     _delete_files();
 
-    kill_method_type death_type = (kill_method_type) se.get_death_type();
-
     // death message
-    if (death_type != KILLED_BY_LEAVING && death_type != KILLED_BY_QUITTING
-        && death_type != KILLED_BY_WINNING)
+    if (!non_death)
     {
         canned_msg(MSG_YOU_DIE);
         xom_death_message(death_type);
@@ -414,7 +443,7 @@ NORETURN void end_game(scorefile_entry &se, int hiscore_index)
 
     string hiscore = hiscores_format_single_long(se, true);
 
-    const int lines = count_occurrences(hiscore, "\n") + 1;
+    const int desc_lines = count_occurrences(hiscore, "\n") + 1;
 
     cprintf("%s", hiscore.c_str());
 
@@ -422,7 +451,7 @@ NORETURN void end_game(scorefile_entry &se, int hiscore_index)
             crawl_state.game_type_name().c_str());
 
     // "- 5" gives us an extra line in case the description wraps on a line.
-    hiscores_print_list(get_number_of_lines() - lines - 5, SCORE_TERSE,
+    hiscores_print_list(get_number_of_lines() - desc_lines - 5, SCORE_TERSE,
                         hiscore_index);
 
 #ifndef DGAMELAUNCH

--- a/crawl-ref/source/end.h
+++ b/crawl-ref/source/end.h
@@ -12,7 +12,7 @@
 bool crawl_should_restart(game_exit exit);
 
 NORETURN void end(int exit_code, bool print_err = false, PRINTF(2, = nullptr));
-NORETURN void end_game(scorefile_entry &se, int hiscore_index = -1);
+NORETURN void end_game(scorefile_entry &se);
 NORETURN void game_ended(game_exit exit, const string &message = "");
 NORETURN void game_ended_with_error(const string &message);
 NORETURN void screen_end_game(string text);

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -61,6 +61,8 @@
 
 // enough memory allocated to snarf in the scorefile entries
 static unique_ptr<scorefile_entry> hs_list[SCORE_FILE_ENTRIES];
+static int hs_list_size = 0;
+static bool hs_list_initalized = false;
 
 static FILE *_hs_open(const char *mode, const string &filename);
 static void  _hs_close(FILE *handle, const string &filename);
@@ -96,7 +98,7 @@ int hiscores_new_entry(const scorefile_entry &ne)
     unwind_bool score_update(crawl_state.updating_scores, true);
 
     FILE *scores;
-    int i, total_entries;
+    int i;
     bool inserted = false;
     int newest_entry = -1;
 
@@ -146,14 +148,15 @@ int hiscores_new_entry(const scorefile_entry &ne)
         i++;
     }
 
+    hs_list_size = i;
+    hs_list_initalized = true;
+
     // If we've still not inserted it, it's not a highscore.
     if (!inserted)
     {
         _hs_close(scores, _score_file_name());
         return -1;
     }
-
-    total_entries = i;
 
     // The old code closed and reopened the score file, leading to a
     // race condition where one Crawl process could overwrite the
@@ -165,10 +168,13 @@ int hiscores_new_entry(const scorefile_entry &ne)
     rewind(scores);
 
     // write scorefile entries.
-    for (i = 0; i < total_entries; i++)
+    for (i = 0; i < hs_list_size; i++)
     {
         _hs_write(scores, *hs_list[i]);
-        hs_list[i].reset(nullptr);
+
+        // Leave in memory.  Does this anyway if !inserted.  
+        // Can write cleanup function if nessicary??
+        // hs_list[i].reset(nullptr);
     }
 
     // close scorefile.
@@ -218,6 +224,32 @@ static void _hiscores_print_entry(const scorefile_entry &se,
     pf("%s", entry.c_str());
 }
 
+// Reads hiscores file to memory
+void hiscores_read_to_memory()
+{
+    FILE *scores;
+    int i;
+
+    // open highscore file (reading)
+    scores = _hs_open("r", _score_file_name());
+    if (scores == nullptr)
+        return;
+
+    // read highscore file
+    for (i = 0; i < SCORE_FILE_ENTRIES; i++)
+    {
+        hs_list[i].reset(new scorefile_entry);
+        if (_hs_read(scores, *hs_list[i]) == false)
+            break;
+    }
+
+    hs_list_size = i;
+    hs_list_initalized = true;
+
+    //close off
+    _hs_close(scores, _score_file_name());
+}
+
 // Writes all entries in the scorefile to stdout in human-readable form.
 void hiscores_print_all(int display_count, int format)
 {
@@ -252,28 +284,17 @@ void hiscores_print_list(int display_count, int format, int newest_entry)
 {
     unwind_bool scorefile_display(crawl_state.updating_scores, true);
 
-    FILE *scores;
+    //Additional check to preserve previous functionality
+    if(!hs_list_initalized){
+        hiscores_read_to_memory();
+    }
+
     int i, total_entries;
 
     if (display_count <= 0)
         return;
 
-    // open highscore file (reading)
-    scores = _hs_open("r", _score_file_name());
-    if (scores == nullptr)
-        return;
-
-    // read highscore file
-    for (i = 0; i < SCORE_FILE_ENTRIES; i++)
-    {
-        hs_list[i].reset(new scorefile_entry);
-        if (_hs_read(scores, *hs_list[i]) == false)
-            break;
-    }
-    total_entries = i;
-
-    // close off
-    _hs_close(scores, _score_file_name());
+    total_entries = hs_list_size;
 
     textcolour(LIGHTGREY);
 
@@ -295,6 +316,7 @@ void hiscores_print_list(int display_count, int format, int newest_entry)
 
         _hiscores_print_entry(*hs_list[i], i, format, cprintf);
 
+        // return to normal color for next entry
         if (i == newest_entry)
             textcolour(LIGHTGREY);
     }

--- a/crawl-ref/source/hiscores.h
+++ b/crawl-ref/source/hiscores.h
@@ -14,6 +14,8 @@ int hiscores_new_entry(const scorefile_entry &se);
 
 void logfile_new_entry(const scorefile_entry &se);
 
+void hiscores_read_to_memory();
+
 void hiscores_print_list(int display_count = -1, int format = SCORE_TERSE,
                          int newest_entry = -1);
 void hiscores_print_all(int display_count = -1, int format = SCORE_TERSE);

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -34,7 +34,6 @@
 #include "fight.h"
 #include "files.h"
 #include "fineff.h"
-#include "ghost.h"
 #include "god-abil.h"
 #include "god-conduct.h"
 #include "god-passive.h"
@@ -1088,28 +1087,10 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
         return;
     }
 
-    // The game's over.
-    crawl_state.need_save       = false;
-    crawl_state.updating_scores = true;
-
     // Prevent bogus notes.
     activate_notes(false);
 
-    int hiscore_index = -1;
-#ifndef SCORE_WIZARD_CHARACTERS
-    if (!you.wizard && !you.explore)
-#endif
-    {
-        // Add this highscore to the score file.
-        hiscore_index = hiscores_new_entry(se);
-        logfile_new_entry(se);
-    }
-
-    // Never generate bones files of wizard or tutorial characters -- bwr
-    if (!non_death && !crawl_state.game_is_tutorial() && !you.wizard)
-        save_ghosts(ghost_demon::find_ghosts());
-
-    end_game(se, hiscore_index);
+    end_game(se);
 }
 
 string morgue_name(string char_name, time_t when_crawl_got_even)


### PR DESCRIPTION
Decouple hi-score logic from ouch.

Bugfix for issue #11431.
Update to print logic to pull from the hi-scores already in memory.
All entries are added to memory from the read when attempting
to add the entry.