### PR TITLE
Fix potential teleport closets in nooodl_elf_gasket

### DIFF
--- a/crawl-ref/source/dat/des/branches/elf.des
+++ b/crawl-ref/source/dat/des/branches/elf.des
@@ -2489,8 +2489,8 @@ xxxc$$c.............cxxxc.............c$$c
 xxxc*$ccc...........cxxxc...........ccc$*c
 xxxc*$$$cc.......cscccccccsc.......cc$$$*c
 xxxc**$ccc+ccccccc.6.....6.ccccccc+ccc$**c
-xxxc**cc..3ccxxc.............cxxcc5..cc**c
-xxxc*cc.....ccxc......3......cxcc.....cc*c
+xxxc**cc..3ccccc.............ccccc5..cc**c
+xxxc*cc.....cccc......3......cccc.....cc*c
 xxxc*c.......ccc..3.......3..ccc.......c*c
 xxxccc..5.1..cc.4...........4.cc..2.4..ccc
 xxxxcc.......t.......APA.......t.......ccx


### PR DESCRIPTION
This vault had rock walls which could be broken down by Awaken Earth entirely bounded by stone walls, so after a deep elf elementalist had cast its Awaken Earth spell, these would become teleport closets.