### PR TITLE
Add unbrace to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_install:
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.7" CC="gcc-4.7"; fi
 env:
     - NOTHING=1
+    - UNBRACE=1
+    - CHECKWHITE=1
     - FULLDEBUG=1
     - TILES=1
     - TILES=1 FULLDEBUG=1

--- a/.travis/build.pl
+++ b/.travis/build.pl
@@ -17,6 +17,14 @@ $ENV{TRAVIS} = 1;
 $ENV{FORCE_CC} = $ENV{CC};
 $ENV{FORCE_CXX} = $ENV{CXX};
 
+if ($ENV{UNBRACE}) {
+    try("util/unbrace -n");
+}
+
+if ($ENV{CHECKWHITE}) {
+    try("util/checkwhite -an");
+}
+
 if ($ENV{CROSSCOMPILE}) {
     try("make CROSSHOST=i686-w64-mingw32 package-windows");
     exit 0;

--- a/crawl-ref/INSTALL.txt
+++ b/crawl-ref/INSTALL.txt
@@ -296,9 +296,9 @@ from within the MSYS2 Shell.
 
 * At this point on current MSYS2 versions, your development environment should
   be complete. You can test it by running:
-  
+
   gcc -v
-  
+
   If this works, you're all set. If it doesn't, you may be an an older version
   of MSYS2 and need to manually add the newly installed toolchain to your
   path. To do so, run the following line, either at the command line (for

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -327,7 +327,7 @@ struct save_version
 
     bool is_compatible() const
     {
-        return (valid() && !is_ancient() && !is_future());
+        return valid() && !is_ancient() && !is_future();
     }
 
     bool is_current() const

--- a/crawl-ref/source/util/checkwhite
+++ b/crawl-ref/source/util/checkwhite
@@ -133,4 +133,8 @@ for (@files)
     }
 }
 
-exit 1 if ($dry_run and $any_bad);
+if ($dry_run and $any_bad) {
+    print "Found unnecessary whitespace in the above files.\n";
+    print "Re-run this command (without -n) to automatically remove it.\n";
+    exit 1;
+}


### PR DESCRIPTION
Changes the output of `util/unbrace -n` so it's informative for new
contributors reading failed build output.