### PR TITLE
Fix Stomp description

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -755,8 +755,8 @@ Accepting a sacrifice will reset the timer to the standard length.
 Stomp ability
 
 Stomps down in time with the rhythm of the dance, sending a shockwave through
-all adjacent creatures. The shockwave damages each creature by a percentage of
-its maximum health, with the percentage increasing with Invocations skill.
+all adjacent creatures. The shockwave damages each creature by a sixth of its
+current health, plus extra damage increasing with Invocations skill.
 %%%%
 Line Pass ability
 


### PR DESCRIPTION
Stomp's description is totally wrong; the damage it deals is based on a percentage of current HP, not max. The percentage also does not increase with Invocations skill; it is always 1/6, with the added component independent of max HP rising with skill (from 2d2 to 2d15.5). I'm not sure if this is a problem with the description or the implementation, since looking back the two have conflicted since Uskayaw was first added, but the unambiguous comment in _get_stomped() indicates the description is in the wrong.