### PR TITLE
Draw higher XL players deeper into the abyss

### DIFF
--- a/crawl-ref/source/dat/descript/branches.txt
+++ b/crawl-ref/source/dat/descript/branches.txt
@@ -139,7 +139,8 @@ Portals to the Abyss are found abundantly in the Depths.
 The Abyss consists of five infinite levels. The abyssal rune of Zot can be
 found from the third level onwards, and is more common at greater depths.
 Portals back to the dungeon are scattered throughout the Abyss, and are found
-more commonly at greater depths or while carrying the abyssal rune. Killing
+more commonly at greater depths or while carrying the abyssal rune. Adventurers
+who linger in the Abyss will find themselves drawn irresistibly deeper. Killing
 monsters will warp the substance of the Abyss, eventually generating a gateway
 out. Further persistence will wear holes in the Abyss, allowing descent into
 deeper layers.


### PR DESCRIPTION
Currently, outside of the abyss, as dungeon threat level goes up, the
average banishment depth goes up also. However, if a high XL player
enters the abyss voluntarily, they can hang out on A:1 forever.

This patch gives a chance that an abyss teleport drives the player
deeper into the abyss. The chance scales up with XL and down with depth,
and doesn't kick in until XL > depth +13. This has two effects: it
increases the lethaltiy of the abyss for higher XL players, and speeds
their progress through it.