### PR TITLE
Add stab messages for blobs

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -1574,6 +1574,19 @@ void melee_attack::set_attack_verb(int damage)
                 attack_verb = "attack";
                 verb_degree = "'s weak point";
             }
+            else if (get_mon_shape(defender_genus) == MON_SHAPE_BLOB
+                     && one_chance_in(3))
+            {
+                static const char * const pierce_desc[][2] =
+                {
+                    {"prod", "like stale pudding"},
+                    {"plough into", "like fruit mash"},
+                    {"turn over", "like a beet garden"}
+                };
+                const int choice = random2(ARRAYSZ(pierce_desc));
+                attack_verb = pierce_desc[choice][0];
+                verb_degree = pierce_desc[choice][1];
+            }
             else
             {
                 static const char * const pierce_desc[][2] =


### PR DESCRIPTION
I spend a lot of time in crawl stabbing things and felt like an opportunity had been wasted to implement yet another food-related stab message.

I find that stale pudding is a good approximation/compromise between the various blobs, which range from viscuous ooze to jiggly jello. Perhaps not stale in the sense that it has completely lost its fresh pudding qualities, but something between those two extremes.

Chance is one in three in accordance with the turkey attack message in another damage type.