### PR TITLE
Make swamp worms patrol swamp entries

### DIFF
--- a/crawl-ref/source/dat/des/branches/swamp.des
+++ b/crawl-ref/source/dat/des/branches/swamp.des
@@ -128,7 +128,7 @@ ENDMAP
 NAME:   minmay_swamp_entry_worms
 TAGS:   swamp_entry
 SUBST:  T = tww
-KMONS:  w = patrolling swamp worm / tyrant leech / nothing w:89
+KMONS:  w = swamp worm / tyrant leech / nothing w:89
 KFEAT:  w = w / W
 KFEAT:  O = enter_swamp
 MARKER: O = lua:fog_machine { \
@@ -166,14 +166,14 @@ MAP
 ENDMAP
 
 NAME: nicolae_swamp_entry_splash_gauntlet
-TAGS: swamp_entry
+TAGS: swamp_entry patrolling
 KFEAT: O = enter_swamp
 MARKER: O = lua:fog_machine { pow_min = 8, pow_max = 12, delay = 25, \
    size = 2, walk_dist = 1, spread_rate = 33 }
 SUBST: D = twww
 NSUBST: E = tt. / ., F = tt. / ., H = tt. / ., J = tt. / ., K = tt. / .
 NSUBST: L = tt. / .
-KMONS: 1 = patrolling swamp worm / nothing w:5
+KMONS: 1 = swamp worm / bog body / nothing
 KMONS: 2 = electric eel
 KFEAT: 12 = w
 MAP

--- a/crawl-ref/source/dat/des/branches/swamp.des
+++ b/crawl-ref/source/dat/des/branches/swamp.des
@@ -128,7 +128,7 @@ ENDMAP
 NAME:   minmay_swamp_entry_worms
 TAGS:   swamp_entry
 SUBST:  T = tww
-KMONS:  w = swamp worm / tyrant leech / nothing w:89
+KMONS:  w = patrolling swamp worm / tyrant leech / nothing w:89
 KFEAT:  w = w / W
 KFEAT:  O = enter_swamp
 MARKER: O = lua:fog_machine { \
@@ -173,7 +173,7 @@ MARKER: O = lua:fog_machine { pow_min = 8, pow_max = 12, delay = 25, \
 SUBST: D = twww
 NSUBST: E = tt. / ., F = tt. / ., H = tt. / ., J = tt. / ., K = tt. / .
 NSUBST: L = tt. / .
-KMONS: 1 = swamp worm / nothing w:5
+KMONS: 1 = patrolling swamp worm / nothing w:5
 KMONS: 2 = electric eel
 KFEAT: 12 = w
 MAP


### PR DESCRIPTION
Now that swamp worms can cross land they have a tendancy to wander away
from swamp entry vaults. While harpoon shot is dangerous without water
nearby, running into one halfway across the map is a bit odd.

nicolae_swamp_entry_spanish_gauntlet especially suffers if the worms
wander off.

minmay_swamp_worms could go either way