### PR TITLE
Refactor elemental colours and recolour awoken forests in console.

### DIFF
--- a/crawl-ref/source/colour.cc
+++ b/crawl-ref/source/colour.cc
@@ -31,7 +31,11 @@ struct random_element_colour_calc : public element_colour_calc
                                vector< pair<int, int> > _rand_vals)
         : element_colour_calc(_type, _name, (element_colour_calculator)_randomized_element_colour),
           rand_vals(_rand_vals)
-        {};
+    {
+        rand_max = 0;
+        for (const auto &pair : rand_vals)
+            rand_max += pair.first;
+    };
 
     virtual int get(const coord_def& loc = coord_def(),
                     bool non_random = false) override;
@@ -42,7 +46,7 @@ protected:
 
 int element_colour_calc::rand(bool non_random)
 {
-    return non_random ? 0 : ui_random(120);
+    return non_random ? 0 : ui_random(rand_max);
 }
 
 int element_colour_calc::get(const coord_def& loc, bool non_random)

--- a/crawl-ref/source/colour.cc
+++ b/crawl-ref/source/colour.cc
@@ -633,8 +633,8 @@ void init_element_colours()
 #endif
     add_element_colour(new random_element_colour_calc(
                             ETC_AWOKEN_FOREST, "awoken_forest",
-                            { {40, GREEN},
-                              {40, LIGHTGREEN},
+                            { {40, RED},
+                              {20, LIGHTRED},
                             }));
     add_element_colour(new random_element_colour_calc(
                             ETC_WU_JIAN, "wu_jian",

--- a/crawl-ref/source/colour.h
+++ b/crawl-ref/source/colour.h
@@ -88,6 +88,7 @@ struct element_colour_calc
     virtual ~element_colour_calc() {};
 
 protected:
+    int rand_max {120};
     int rand(bool non_random);
 
     element_colour_calculator calc;


### PR DESCRIPTION
Make awoken forests an animated RED/LIGHTRED (angry trees) so that the
effect stands out to the player.

Old behavior is awoken forests are an animated GREEN/LIGHTGREEN
alternation. This sticks out a bit in swamp, where trees are
GREEN/BROWN, but is still not as dramatic as the berserk faces now in
tiles. It is also much less noticable outside of the swamp (some lair
ends in particular) where trees are GREEN/LIGHTGREEN to begin with.