### PR TITLE
Fix hints mode

### DIFF
--- a/crawl-ref/source/dat/descript/hints.txt
+++ b/crawl-ref/source/dat/descript/hints.txt
@@ -154,7 +154,7 @@ You can ask other Crawl players for advice and help on the <w>##crawl</w> IRC
 dissection reminder
 
 Don't forget that you can butcher corpses with <input>$cmd[CMD_BUTCHER]</input>
-<localtiles>, or by clicking on corspes in the floor part of your inventory
+<localtiles>, or by clicking on corpses in the floor part of your inventory
 with the <input>left mouse button</input></localtiles>.
 %%%%
 HINT_CONVERT Xom

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2507,7 +2507,7 @@ bool describe_item(item_def &item, function<void (string&)> fixup_desc)
     }
 
     if (crawl_state.game_is_hints())
-        desc += hints_describe_item(item);
+        desc += "\n\n" + hints_describe_item(item);
 
     if (fixup_desc)
         fixup_desc(desc);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -1206,7 +1206,7 @@ void learned_something_new(hints_event_type seen_what, coord_def gc)
                 "<console>('<w>"
              << stringize_glyph(get_item_symbol(SHOW_ITEM_MISSILE))
              << "</w>') </console>"
-                "you've picked up. Missiles like tomahwaks and throwing nets "
+                "you've picked up. Missiles like tomahawks and throwing nets "
                 "can be thrown by hand, but other missiles like arrows and "
                 "needles require a launcher and training in using it to be "
                 "really effective. "

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -2849,9 +2849,18 @@ static string _hints_throw_stuff(const item_def &item)
 {
     string result;
 
-    result  = "To do this, type <w>%</w> to fire, then <w>";
-    result += item.slot;
-    result += "</w> for ";
+    result  = "To do this, type <w>%</w> to fire, then ";
+    if (!item.slot)
+    {
+        result += "<w>";
+        result += item.slot;
+        result += "</w> for";
+    }
+    else
+    {
+        // you don't have this/these stuff(s) at present
+        result += "select ";
+    }
     result += (item.quantity > 1 ? "these" : "this");
     result += " ";
     result += item_base_name(item);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -3645,13 +3645,13 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
             if (altar_god == GOD_SIF_MUNA
                 && !player_can_join_god(altar_god))
             {
-                ostr << "As <w>p</w>raying on the altar will tell you, "
+                ostr << "As pressing <w><<</w> or <w>></w> on the altar will tell you, "
                      << god_name(altar_god) << " only accepts worship from "
                         "those who have already dabbled in magic. You can "
                         "find out more about this god by searching the "
                         "database with <w>?/g</w>.\n"
                         "For other gods, you'll be able to join the faith "
-                        "by <w>p</w>raying at their altar.";
+                        "by pressing <w><<</w> or <w>></w> at their altar.";
             }
             else if (you_worship(GOD_NO_GOD))
             {
@@ -3662,7 +3662,7 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
                         "tributes or entertainment in return.\n"
                         "You can get information about <w>"
                      << god_name(altar_god)
-                     << "</w> by pressing <w>p</w> while standing on the "
+                     << "</w> by pressing <w><<</w> or <w>></w> while standing on the "
                         "altar. Before taking up the responding faith "
                         "you'll be asked for confirmation.";
             }
@@ -3678,7 +3678,7 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
                         "but having a look won't hurt: to get information "
                         "on <w>";
                 ostr << god_name(altar_god);
-                ostr << "</w>, press <w>p</w> while standing on the "
+                ostr << "</w>, press <w><<</w> or <w>></w> while standing on the "
                         "altar. Before taking up the responding faith (and "
                         "abandoning your current one!) you'll be asked for "
                         "confirmation."

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -995,7 +995,7 @@ static string _describe_portal(const coord_def &gc)
             "<console>another <w>"
           + stringize_glyph(get_feat_symbol(DNGN_EXIT_SEWER))
           + "</w> - but NOT the ancient stone arch you'll start "
-            "out on!</console>.";
+            "out on!</console>";
 
     return text;
 }
@@ -3087,7 +3087,7 @@ string hints_describe_item(const item_def &item)
                         "them off again with <w>%</w>"
 #ifdef USE_TILE
                         ", or, alternatively, simply click on their tiles to "
-                        "perform either action."
+                        "perform either action"
 #endif
                         ".";
                 cmd.push_back(CMD_WEAR_ARMOUR);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -625,7 +625,7 @@ static void _hints_healing_reminder()
                         "health in the first place. To use your abilities type "
                         "<w>a</w>.";
             }
-            mprf(MSGCH_TUTORIAL, "%s", text.c_str());
+            mprf(MSGCH_TUTORIAL, "%s", untag_tiles_console(text).c_str());
 
             if (is_resting())
                 stop_running();


### PR DESCRIPTION
This PR contains several fixes for hints mode.

- add newlines
- add untag function
- remove redundant periods
- fix 'OBJ_MISSILES' hints (when you don' t have it)
- fix mentions about p)ray command
- fix typo