### PR TITLE
Abort Vampiric Draining at full health

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -767,6 +767,12 @@ void sonic_damage(bool scream)
 
 spret_type vampiric_drain(int pow, monster* mons, bool fail)
 {
+    if (you.hp == you.hp_max)
+    {
+        canned_msg(MSG_FULL_HEALTH);
+        return SPRET_ABORT;
+    }
+
     if (mons == nullptr || mons->submerged())
     {
         fail_check();


### PR DESCRIPTION
The spell will have no effect so don't waste a turn and mp casting it.