### PR TITLE
 Have butchering always leave a skeleton.

### DIFF
--- a/crawl-ref/source/butcher.cc
+++ b/crawl-ref/source/butcher.cc
@@ -377,35 +377,25 @@ void turn_corpse_into_chunks(item_def &item, bool bloodspatter)
     init_perishable_stack(item, item.freshness * ROT_TIME_FACTOR);
 }
 
-static void _turn_corpse_into_skeleton_and_chunks(item_def &item, bool prefer_chunks)
+static void _turn_corpse_into_skeleton_and_chunks(item_def &item)
 {
     item_def copy = item;
 
-    // Complicated logic, but unless we use the original, both could fail if
-    // mitm[] is overstuffed.
-    if (prefer_chunks)
-    {
-        turn_corpse_into_chunks(item);
-        turn_corpse_into_skeleton(copy);
-    }
-    else
-    {
-        turn_corpse_into_chunks(copy);
-        turn_corpse_into_skeleton(item);
-    }
+    turn_corpse_into_chunks(item);
+    turn_corpse_into_skeleton(copy);
 
     copy_item_to_grid(copy, item_pos(item));
 }
 
-void butcher_corpse(item_def &item, maybe_bool skeleton, bool chunks)
+void butcher_corpse(item_def &item, bool skeleton, bool chunks)
 {
     item_was_destroyed(item);
     if (!mons_skeleton(item.mon_type))
-        skeleton = MB_FALSE;
-    if (skeleton == MB_TRUE || skeleton == MB_MAYBE && one_chance_in(3))
+        skeleton = false;
+    if (skeleton)
     {
         if (chunks)
-            _turn_corpse_into_skeleton_and_chunks(item, skeleton != MB_TRUE);
+            _turn_corpse_into_skeleton_and_chunks(item);
         else
         {
             _bleed_monster_corpse(item);

--- a/crawl-ref/source/butcher.h
+++ b/crawl-ref/source/butcher.h
@@ -13,7 +13,7 @@ void finish_butchering(item_def& corpse, bool bottling);
 void maybe_drop_monster_hide(const item_def &corpse);
 bool turn_corpse_into_skeleton(item_def &item);
 void turn_corpse_into_chunks(item_def &item, bool bloodspatter = true);
-void butcher_corpse(item_def &item, maybe_bool skeleton = MB_MAYBE,
+void butcher_corpse(item_def &item, bool skeleton = true,
                     bool chunks = true);
 bool can_bottle_blood_from_corpse(monster_type mons_class);
 int num_blood_potions_from_corpse(monster_type mons_class);

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -11,7 +11,6 @@
 
 #include "areas.h"
 #include "art-enum.h"
-#include "butcher.h" // butcher_corpse
 #include "coordit.h" // radius_iterator
 #include "god-conduct.h"
 #include "god-passive.h"

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1863,7 +1863,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
             && mons_skeleton(si->mon_type)
             && mons_class_can_be_zombified(si->mon_type))
         {
-            butcher_corpse(*si, MB_TRUE);
+            butcher_corpse(*si, true);
             mpr("Before your eyes, flesh is ripped from the corpse!");
             request_autopickup();
             // Only convert the top one.
@@ -1957,7 +1957,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
             mprf("The headless hydra simulacr%s immediately collapse%s into snow!",
                  how_many == 1 ? "um" : "a", how_many == 1 ? "s" : "");
             if (!turn_corpse_into_skeleton(corpse))
-                butcher_corpse(corpse, MB_FALSE, false);
+                butcher_corpse(corpse, false, false);
             return SPRET_SUCCESS;
         }
         mg.props[MGEN_NUM_HEADS] = corpse.props[CORPSE_HEADS].get_short();
@@ -1976,7 +1976,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
     if (!count)
         canned_msg(MSG_NOTHING_HAPPENS);
     else if (!turn_corpse_into_skeleton(corpse))
-        butcher_corpse(corpse, MB_FALSE, false);
+        butcher_corpse(corpse, false, false);
 
     return SPRET_SUCCESS;
 }


### PR DESCRIPTION
Currently, if you cast animate skeleton, you get a skeleton and chunks.

However, if you forget that you have animate skeleton (or have
auto-butcher on or whatever), you have a one_chance_in(3) chance of
being left with a skeleton to animate.

This behavior gives Animate Dead an extra hidden nutritional trade-off,
in exchange for an interface screw.

This commit changes the behavior of butchering to always leave a
skeleton, so that butchering and casting animate skeleton commute.

A consequence is that Animate Dead becomes *slightly* stronger, as a
player could now butcher every corpse for nutrition and then animate the
skeleton, at the expense of a few HD for the undead minions. This isn't
actually a buff, though, because said hypothetical player can already walk to
each corpse and cast animate skeleton for an almost identical effect
(slightly different MP cost).
8f96055