### PR TITLE
Grant Qazlal cloud immunity to allies

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -918,6 +918,12 @@ bool actor_cloud_immune(const actor &act, const cloud_struct &cloud)
         return true;
     }
 
+    if (!player && have_passive(passive_t::cloud_immunity)
+        && (act.as_monster()->friendly() || act.as_monster()->neutral()))
+	{
+        return true;
+    }
+
     return false;
 }
 

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -920,7 +920,7 @@ bool actor_cloud_immune(const actor &act, const cloud_struct &cloud)
 
     if (!player && have_passive(passive_t::cloud_immunity)
         && (act.as_monster()->friendly() || act.as_monster()->neutral()))
-	{
+    {
         return true;
     }
 

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -372,7 +372,7 @@ static const vector<god_passive> god_passives[] =
 
     // Qazlal
     {
-        {  0, passive_t::cloud_immunity, "are ADV immune to clouds" },
+        {  0, passive_t::cloud_immunity, "and your allies are ADV immune to clouds" },
         {  1, passive_t::storm_shield,
               "generate elemental clouds to protect yourself" },
         {  4, passive_t::upgraded_storm_shield,

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -282,7 +282,7 @@ const vector<god_power> god_powers[NUM_GODS] =
 
     // Qazlal
     {
-      { 0, "Qazlal grants you immunity to clouds." },
+      { 0, "Qazlal grants you and your allies immunity to clouds." },
       { 1, "You are surrounded by a storm.", "Your storm dissipates completely." },
       { 2, ABIL_QAZLAL_UPHEAVAL, "call upon nature to destroy your foes" },
       { 3, ABIL_QAZLAL_ELEMENTAL_FORCE, "give life to nearby clouds" },


### PR DESCRIPTION
This fixes the non-combo circumstance where your own clouds kill your Qazlal Elementals. Furthermore, Qazlal's noise is already a sufficient penalty and denying most summons is an unnecessary limitation on tactical and build choices.