### PR TITLE
Fix Injury Bond description

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -729,8 +729,8 @@ effect when the caster's magic is depleted.
 %%%%
 Injury Bond spell
 
-Binds the caster to a nearby ally, redirecting half of any damage the target
-suffers to the caster.
+Binds the caster to nearby allies, redirecting half of any damage they suffer
+to the caster.
 %%%%
 Injury Mirror spell
 


### PR DESCRIPTION
Injury Bond affects all allies in LOS, not just one.