### PR TITLE
Make Iron Giants and other Throw Ally users obey Sanctuary

### DIFF
--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3622,7 +3622,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_ALLY, "Throw Ally",
     SPTYP_TRANSLOCATION,
-    SPFLAG_MONSTER | SPFLAG_NOT_SELF,
+    SPFLAG_TARGET | SPFLAG_MONSTER | SPFLAG_NOT_SELF,
     2,
     50,
     LOS_RADIUS, LOS_RADIUS,


### PR DESCRIPTION
Iron Giants can throw monsters at the player protected by Sanctuary.
They can do up to 35 damage (random2(HD*2)) per throw without angering
Zin. Originally Throw Ally was a Robin-exclusive ability, so this was
not a problem.

Normally monsters don't use abilities that can harm the player, if the
player is in sanctuary. These checks are done in
mon-cast.cc:_ms_waste_of_time(). But for spell_harms_target()
Throw Ally is not a harmful ability. This is because the ability
doesn't have a SPFLAG_TARGETING_MASK flag (either SPFLAG_DIR_OR_TARGET
or SPFLAG_TARGET). Since Throw Ally is a smite-targeted ability, the
appropriate flag for it is SPFLAG_TARGET.