### PR TITLE
Fix bug 11478: Movement-key actions and Wu Jian

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -3273,6 +3273,8 @@ static void _move_player(coord_def move)
         && feat_is_closed_door(targ_grid))
     {
         _open_door(move);
+        move.reset();
+        return;
     }
     else if (!targ_pass && grd(targ) == DNGN_MALIGN_GATEWAY
              && !attacking && !you.is_stationary())


### PR DESCRIPTION
In _move_player, the easy-open door let control flow continue through
the function to behaviors that should only trigger upon moving. The most
noticable is the Wu Jian processing, leading to the bug.

The function could use some further simplifications, it's a bit
spaghetti.