### PR TITLE
Kung Fu with swordchucks (11402)

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -741,11 +741,16 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
                            int attack_number, int effective_attack_number,
                            wu_jian_attack_type wu_jian_attack)
 {
-    if (wu_jian_attack == WU_JIAN_ATTACK_WHIRLWIND
-        || wu_jian_attack == WU_JIAN_ATTACK_WALL_JUMP
-        || wu_jian_attack == WU_JIAN_ATTACK_TRIGGERED_AUX)
+    const item_def* weap = attacker.weapon(attack_number);
+
+    if ((wu_jian_attack == WU_JIAN_ATTACK_WHIRLWIND
+         || wu_jian_attack == WU_JIAN_ATTACK_WALL_JUMP
+         || wu_jian_attack == WU_JIAN_ATTACK_TRIGGERED_AUX)
+        && !(weap && is_unrandom_artefact(*weap, UNRAND_GYRE)))
     {
-        return; // WJC AOE attacks don't cleave.
+        return; // WJC AOE attacks don't cleave, but G&G use cleaving
+        // XXX: If a player under Xom wrath gets cleaving while using G&G and
+        // worshiping Wu they'll be able to cleave their Wu attacks.
     }
 
     while (attacker.alive() && !targets.empty())


### PR DESCRIPTION
Allow Gyre and Gimble to double-attack in Wu Jian martial attacks.

(Implementation introduces the behavior that a player who gets the
Cleave status from Xom wrath while worshipping Wu and using G&G will be
able to cleave their Wu attacks. Handling this edge case correctly would
be a huge pain.)