### PR TITLE
Clean up uses of unique_ptrs

### DIFF
--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -729,8 +729,8 @@ static void _abyss_wipe_square_at(coord_def p, bool saveMonsters=false)
     remove_markers_and_listeners_at(p);
 
     env.map_knowledge(p).clear();
-    if (env.map_forgotten.get())
-        (*env.map_forgotten.get())(p).clear();
+    if (env.map_forgotten)
+        (*env.map_forgotten)(p).clear();
     env.map_seen.set(p, false);
 #ifdef USE_TILE
     tile_forget_map(p);

--- a/crawl-ref/source/colour.cc
+++ b/crawl-ref/source/colour.cc
@@ -159,7 +159,7 @@ static int _etc_waves(int, const coord_def& loc)
 {
     // Shouldn't have this outside of Shoals, but it can happen.
     // See !lg lakren crash 8 .
-    if (!env.heightmap.get())
+    if (!env.heightmap)
         return CYAN;
     short height = dgn_height_at(loc);
     int cycle_point = you.num_turns % 20;

--- a/crawl-ref/source/dbg-maps.cc
+++ b/crawl-ref/source/dbg-maps.cc
@@ -192,7 +192,7 @@ static void _dungeon_places()
         for (int depth = 1; depth <= brdepth[it->id]; ++depth)
         {
             level_id l(it->id, depth);
-            if (SysEnv.map_gen_range.get() && !SysEnv.map_gen_range->is_usable_in(l))
+            if (SysEnv.map_gen_range && !SysEnv.map_gen_range->is_usable_in(l))
                 continue;
             generated_levels.push_back(l);
             if (new_branch)
@@ -346,7 +346,7 @@ static void _write_map_stats()
         for (int dep = 1; dep <= brdepth[it->id]; ++dep)
         {
             const level_id lid(it->id, dep);
-            if (SysEnv.map_gen_range.get()
+            if (SysEnv.map_gen_range
                 && !SysEnv.map_gen_range->is_usable_in(lid))
             {
                 continue;
@@ -406,7 +406,7 @@ static void _write_map_stats()
             fprintf(outf, "%3d) %s\n", i->first, i->second.c_str());
     }
 
-    if (!unused_maps.empty() && !SysEnv.map_gen_range.get())
+    if (!unused_maps.empty() && !SysEnv.map_gen_range)
     {
         fprintf(outf, "\n\nUnused maps:\n\n");
         for (int i = 0, size = unused_maps.size(); i < size; ++i)

--- a/crawl-ref/source/dbg-objstat.cc
+++ b/crawl-ref/source/dbg-objstat.cc
@@ -1129,8 +1129,8 @@ static void _write_stat_info()
     string all_desc;
     if (num_branches > 1)
     {
-        if (SysEnv.map_gen_range.get())
-            all_desc = SysEnv.map_gen_range.get()->describe();
+        if (SysEnv.map_gen_range)
+            all_desc = SysEnv.map_gen_range->describe();
         else
             all_desc = "All Levels";
         all_desc = "Levels included in AllLevels: " + all_desc + "\n";
@@ -1205,7 +1205,7 @@ void objstat_generate_stats()
         for (int dep = 1; dep <= brdepth[br]; ++dep)
         {
             const level_id lid(br, dep);
-            if (SysEnv.map_gen_range.get()
+            if (SysEnv.map_gen_range
                 && !SysEnv.map_gen_range->is_usable_in(lid))
             {
                 continue;

--- a/crawl-ref/source/dgn-height.cc
+++ b/crawl-ref/source/dgn-height.cc
@@ -20,7 +20,7 @@ void dgn_initialise_heightmap(int height)
 
 void dgn_height_set_at(const coord_def &c, int height)
 {
-    if (env.heightmap.get())
+    if (env.heightmap)
         dgn_height_at(c) = height;
 }
 

--- a/crawl-ref/source/dgn-shoals.cc
+++ b/crawl-ref/source/dgn-shoals.cc
@@ -670,7 +670,7 @@ void dgn_build_shoals_level()
 // in the vault to reasonable levels.
 void shoals_postprocess_level()
 {
-    if (!player_in_branch(BRANCH_SHOALS) || !env.heightmap.get())
+    if (!player_in_branch(BRANCH_SHOALS) || !env.heightmap)
         return;
 
     for (rectangle_iterator ri(1); ri; ++ri)
@@ -1008,7 +1008,7 @@ void shoals_apply_tides(int turns_elapsed, bool force, bool incremental_tide)
 {
     if (!player_in_branch(BRANCH_SHOALS)
         || (!turns_elapsed && !force)
-        || !env.heightmap.get())
+        || !env.heightmap)
     {
         return;
     }
@@ -1104,7 +1104,7 @@ static void _shoals_force_tide(CrawlHashTable &props, int increment)
 
 void wizard_mod_tide()
 {
-    if (!player_in_branch(BRANCH_SHOALS) || !env.heightmap.get())
+    if (!player_in_branch(BRANCH_SHOALS) || !env.heightmap)
     {
         mprf(MSGCH_WARN, "Not in Shoals or no heightmap; tide not available.");
         return;

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3448,7 +3448,7 @@ static void _debug_describe_feature_at(const coord_def &where)
     }
     const string traveldest = _stair_destination_description(where);
     string height_desc;
-    if (env.heightmap.get())
+    if (env.heightmap)
         height_desc = make_stringf(" (height: %d)", (*env.heightmap)(where));
     const dungeon_feature_type feat = grd(where);
 

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -654,7 +654,7 @@ static void _dgn_load_colour_grid()
 
 static void _dgn_map_colour_fixup()
 {
-    if (!dgn_colour_grid.get())
+    if (!dgn_colour_grid)
         return;
 
     // If the original coloured feature has been changed, reset the colour.
@@ -677,7 +677,7 @@ void dgn_set_grid_colour_at(const coord_def &c, int colour)
     if (colour != BLACK)
     {
         env.grid_colours(c) = colour;
-        if (!dgn_colour_grid.get())
+        if (!dgn_colour_grid)
             dgn_colour_grid.reset(new dungeon_colour_grid);
 
         (*dgn_colour_grid)(c) = coloured_feature(grd(c), colour);
@@ -4968,11 +4968,11 @@ dungeon_feature_type map_feature_at(map_def *map, const coord_def &c,
     if (mapsp)
     {
         feature_spec f = mapsp->get_feat();
-        if (f.trap.get())
+        if (f.trap)
         {
             // f.feat == 1 means trap is generated known.
             if (f.feat == 1)
-                return trap_category(static_cast<trap_type>(f.trap.get()->tr_type));
+                return trap_category(static_cast<trap_type>(f.trap->tr_type));
             else
                 return DNGN_UNDISCOVERED_TRAP;
         }
@@ -4980,7 +4980,7 @@ dungeon_feature_type map_feature_at(map_def *map, const coord_def &c,
             return static_cast<dungeon_feature_type>(f.feat);
         else if (f.glyph >= 0)
             return map_feature_at(nullptr, c, f.glyph);
-        else if (f.shop.get())
+        else if (f.shop)
             return DNGN_ENTER_SHOP;
 
         return DNGN_FLOOR;
@@ -4993,24 +4993,18 @@ static void _vault_grid_mapspec(vault_placement &place, const coord_def &where,
                                 keyed_mapspec& mapsp)
 {
     const feature_spec f = mapsp.get_feat();
-    if (f.trap.get())
+    if (f.trap)
     {
         // f.feat == 1 means trap is generated known.
         const bool known = f.feat == 1;
-        trap_spec* spec = f.trap.get();
-        if (spec)
-            _place_specific_trap(where, spec, 0, known);
+        _place_specific_trap(where, f.trap.get(), 0, known);
     }
     else if (f.feat >= 0)
         grd(where) = static_cast<dungeon_feature_type>(f.feat);
     else if (f.glyph >= 0)
         _vault_grid_glyph(place, where, f.glyph);
-    else if (f.shop.get())
-    {
-        shop_spec *spec = f.shop.get();
-        ASSERT(spec);
-        place_spec_shop(where, *spec);
-    }
+    else if (f.shop)
+        place_spec_shop(where, *f.shop);
     else
         grd(where) = DNGN_FLOOR;
 
@@ -6893,17 +6887,13 @@ static dungeon_feature_type _vault_inspect_mapspec(vault_placement &place,
 {
     dungeon_feature_type found = NUM_FEATURES;
     const feature_spec f = mapsp.get_feat();
-    if (f.trap.get())
-    {
-        trap_spec* spec = f.trap.get();
-        if (spec)
-            found = trap_category(spec->tr_type);
-    }
+    if (f.trap)
+        found = trap_category(f.trap->tr_type);
     else if (f.feat >= 0)
         found = static_cast<dungeon_feature_type>(f.feat);
     else if (f.glyph >= 0)
         found = _vault_inspect_glyph(place, f.glyph);
-    else if (f.shop.get())
+    else if (f.shop)
         found = DNGN_ENTER_SHOP;
     else
         found = DNGN_FLOOR;

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -693,7 +693,7 @@ void ghost_demon::find_transiting_ghosts(
             if (i->mons.type == MONS_PLAYER_GHOST)
             {
                 const monster& m = i->mons;
-                if (m.ghost.get())
+                if (m.ghost)
                 {
                     announce_ghost(*m.ghost);
                     gs.push_back(*m.ghost);
@@ -714,7 +714,7 @@ void ghost_demon::find_extra_ghosts(vector<ghost_demon> &gs)
 {
     for (monster_iterator mi; mi; ++mi)
     {
-        if (mi->type == MONS_PLAYER_GHOST && mi->ghost.get())
+        if (mi->type == MONS_PLAYER_GHOST && mi->ghost)
         {
             // Bingo!
             announce_ghost(*(mi->ghost));

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4447,13 +4447,11 @@ static void _gozag_place_shop(int index)
     ASSERT(grd(you.pos()) == DNGN_FLOOR);
     keyed_mapspec kmspec;
     kmspec.set_feat(_gozag_shop_spec(index), false);
-    if (!kmspec.get_feat().shop.get())
+    if (!kmspec.get_feat().shop)
         die("Invalid shop spec?");
 
     feature_spec feat = kmspec.get_feat();
-    shop_spec *spec = feat.shop.get();
-    ASSERT(spec);
-    place_spec_shop(you.pos(), *spec, you.experience_level);
+    place_spec_shop(you.pos(), *feat.shop, you.experience_level);
 
     link_items();
     env.markers.add(new map_feature_marker(you.pos(), DNGN_ABANDONED_SHOP));

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -754,10 +754,10 @@ actor* scorefile_entry::killer() const
 
 xlog_fields scorefile_entry::get_fields() const
 {
-    if (!fields.get())
+    if (!fields)
         return xlog_fields();
     else
-        return *fields.get();
+        return *fields;
 }
 
 bool scorefile_entry::parse(const string &line)
@@ -793,7 +793,7 @@ string scorefile_entry::raw_string() const
 
     set_score_fields();
 
-    if (!fields.get())
+    if (!fields)
         return "";
 
     return fields->xlog_line() + "\n";
@@ -1049,7 +1049,7 @@ void scorefile_entry::init_with_fields()
 
 void scorefile_entry::set_base_xlog_fields() const
 {
-    if (!fields.get())
+    if (!fields)
         fields.reset(new xlog_fields);
 
     string score_version = SCORE_VERSION;
@@ -1147,7 +1147,7 @@ void scorefile_entry::set_score_fields() const
 {
     fields.reset(new xlog_fields);
 
-    if (!fields.get())
+    if (!fields)
         return;
 
     set_base_xlog_fields();

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -191,7 +191,7 @@ subvault_place::subvault_place(const coord_def &_tl,
 
 subvault_place::subvault_place(const subvault_place &place)
     : tl(place.tl), br(place.br),
-      subvault(place.subvault.get() ? new map_def(*place.subvault) : nullptr)
+      subvault(place.subvault ? new map_def(*place.subvault) : nullptr)
 {
 }
 
@@ -199,7 +199,7 @@ subvault_place &subvault_place::operator = (const subvault_place &place)
 {
     tl = place.tl;
     br = place.br;
-    subvault.reset(place.subvault.get() ? new map_def(*place.subvault)
+    subvault.reset(place.subvault ? new map_def(*place.subvault)
                                         : nullptr);
     return *this;
 }
@@ -570,7 +570,7 @@ void map_lines::apply_markers(const coord_def &c)
 
 void map_lines::apply_grid_overlay(const coord_def &c, bool is_layout)
 {
-    if (!overlay.get())
+    if (!overlay)
         return;
 
     for (int y = height() - 1; y >= 0; --y)
@@ -594,7 +594,7 @@ void map_lines::apply_grid_overlay(const coord_def &c, bool is_layout)
             const int fheight = (*overlay)(x, y).height;
             if (fheight != INVALID_HEIGHT)
             {
-                if (!env.heightmap.get())
+                if (!env.heightmap)
                     dgn_initialise_heightmap();
                 dgn_height_at(gc) = fheight;
             }
@@ -1050,7 +1050,7 @@ void map_lines::extend(int min_width, int min_height, char fill)
     normalise(fill);
 
     // Extend overlay matrix as well.
-    if (overlay.get())
+    if (overlay)
     {
         auto new_overlay = make_unique<overlay_matrix>(width(), height());
 
@@ -1157,7 +1157,7 @@ void map_lines::subst(subst_spec &spec)
 
 void map_lines::bind_overlay()
 {
-    if (!overlay.get())
+    if (!overlay)
         overlay.reset(new overlay_matrix(width(), height()));
 }
 
@@ -1226,7 +1226,7 @@ map_corner_t map_lines::merge_subvault(const coord_def &mtl,
     vbr.x -= (width_diff - ox);
     vbr.y -= (height_diff - oy);
 
-    if (!overlay.get())
+    if (!overlay)
         overlay.reset(new overlay_matrix(width(), height()));
 
     // Clear any markers in the vault's grid
@@ -1392,7 +1392,7 @@ map_corner_t map_lines::merge_subvault(const coord_def &mtl,
             (*this)(x, y) = SUBVAULT_GLYPH;
 
             // Merge overlays
-            if (vlines.overlay.get())
+            if (vlines.overlay)
                 (*overlay)(x, y) = (*vlines.overlay)(vx, vy);
             else
             {
@@ -1409,7 +1409,7 @@ map_corner_t map_lines::merge_subvault(const coord_def &mtl,
 
 void map_lines::overlay_tiles(tile_spec &spec)
 {
-    if (!overlay.get())
+    if (!overlay)
         overlay.reset(new overlay_matrix(width(), height()));
 
     for (int y = 0, ysize = lines.size(); y < ysize; ++y)
@@ -1560,7 +1560,7 @@ void map_lines::rotate(bool clockwise)
         newlines.push_back(line);
     }
 
-    if (overlay.get())
+    if (overlay)
     {
         auto new_overlay = make_unique<overlay_matrix>(lines.size(), map_width);
         for (int i = xs, y = 0; i != xe; i += xi, ++y)
@@ -1629,7 +1629,7 @@ void map_lines::vmirror()
         lines[vsize - 1 - i] = temp;
     }
 
-    if (overlay.get())
+    if (overlay)
     {
         for (int i = 0; i < midpoint; ++i)
             for (int j = 0, wide = width(); j < wide; ++j)
@@ -1647,7 +1647,7 @@ void map_lines::hmirror()
         for (int j = 0; j < midpoint; ++j)
             swap(s[j], s[map_width - 1 - j]);
 
-    if (overlay.get())
+    if (overlay)
     {
         for (int i = 0, vsize = lines.size(); i < vsize; ++i)
             for (int j = 0; j < midpoint; ++j)
@@ -1675,8 +1675,8 @@ keyed_mapspec *map_lines::mapspec_at(const coord_def &c)
     if (key == SUBVAULT_GLYPH)
     {
         // Any subvault should create the overlay.
-        ASSERT(overlay.get());
-        if (!overlay.get())
+        ASSERT(overlay);
+        if (!overlay)
             return nullptr;
 
         key = (*overlay)(c.x, c.y).keyspec_idx;
@@ -1695,8 +1695,8 @@ const keyed_mapspec *map_lines::mapspec_at(const coord_def &c) const
     if (key == SUBVAULT_GLYPH)
     {
         // Any subvault should create the overlay and set the keyspec idx.
-        ASSERT(overlay.get());
-        if (!overlay.get())
+        ASSERT(overlay);
+        if (!overlay)
             return nullptr;
 
         key = (*overlay)(c.x, c.y).keyspec_idx;
@@ -5794,8 +5794,8 @@ string map_marker_spec::apply_transform(map_lines &map)
 
 map_marker *map_marker_spec::create_marker()
 {
-    return lua_fn.get()
-        ? new map_lua_marker(*lua_fn.get())
+    return lua_fn
+        ? new map_lua_marker(*lua_fn)
         : map_marker::parse_marker(marker);
 }
 
@@ -6165,12 +6165,12 @@ void feature_spec::init_with(const feature_spec& other)
     mimic = other.mimic;
     no_mimic = other.no_mimic;
 
-    if (other.trap.get())
+    if (other.trap)
         trap.reset(new trap_spec(*other.trap));
     else
         trap.reset(nullptr);
 
-    if (other.shop.get())
+    if (other.shop)
         shop.reset(new shop_spec(*other.shop));
     else
         shop.reset(nullptr);

--- a/crawl-ref/source/mapmark.cc
+++ b/crawl-ref/source/mapmark.cc
@@ -236,7 +236,7 @@ void map_lua_marker::check_register_table()
 
 bool map_lua_marker::get_table() const
 {
-    if (marker_table.get())
+    if (marker_table)
     {
         marker_table->push();
         return lua_istable(dlua, -1);

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -133,7 +133,7 @@ static bool _fill_out_corpse(const monster& mons, item_def& corpse)
     if (col == COLOUR_UNDEF)
     {
         // XXX hack to avoid crashing in wiz mode.
-        if (mons_is_ghost_demon(mons.type) && !mons.ghost.get())
+        if (mons_is_ghost_demon(mons.type) && !mons.ghost)
             col = LIGHTRED;
         else
         {

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -638,7 +638,7 @@ monster_info::monster_info(const monster* m, int milev)
 
     if (mons_is_pghost(type))
     {
-        ASSERT(m->ghost.get());
+        ASSERT(m->ghost);
         ghost_demon& ghost = *m->ghost;
         i_ghost.species = ghost.species;
         if (species_is_draconian(i_ghost.species) && ghost.xl < 7)
@@ -818,7 +818,7 @@ static string _mutant_beast_facet(int facet)
 
 string monster_info::db_name() const
 {
-    if (type == MONS_DANCING_WEAPON && inv[MSLOT_WEAPON].get())
+    if (type == MONS_DANCING_WEAPON && inv[MSLOT_WEAPON])
     {
         iflags_t ignore_flags = ISFLAG_KNOW_CURSE | ISFLAG_KNOW_PLUSES;
         bool     use_inscrip  = false;
@@ -886,7 +886,7 @@ string monster_info::_core_name() const
 
         case MONS_DANCING_WEAPON:
         case MONS_SPECTRAL_WEAPON:
-            if (inv[MSLOT_WEAPON].get())
+            if (inv[MSLOT_WEAPON])
             {
                 iflags_t ignore_flags = ISFLAG_KNOW_CURSE | ISFLAG_KNOW_PLUSES;
                 bool     use_inscrip  = true;

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -245,7 +245,7 @@ struct monster_info : public monster_info_base
     {
         for (unsigned i = 0; i <= MSLOT_LAST_VISIBLE_SLOT; ++i)
         {
-            if (mi.inv[i].get())
+            if (mi.inv[i])
                 inv[i].reset(new item_def(*mi.inv[i]));
         }
     }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3248,7 +3248,7 @@ mon_energy_usage mons_class_energy(monster_type mc)
 mon_energy_usage mons_energy(const monster& mon)
 {
     mon_energy_usage meu = mons_class_energy(mons_base_type(mon));
-    if (mon.ghost.get())
+    if (mon.ghost)
         meu.move = meu.swim = mon.ghost->move_energy;
     return meu;
 }
@@ -3269,7 +3269,7 @@ int mons_class_zombie_base_speed(monster_type zombie_base_mc)
  */
 int mons_base_speed(const monster& mon, bool known)
 {
-    if (mon.ghost.get())
+    if (mon.ghost)
         return mon.ghost->speed;
 
     if (mon.props.exists(MON_SPEED_KEY)

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -201,7 +201,7 @@ void monster::init_with(const monster& mon)
     damage_total      = mon.damage_total;
     xp_tracking       = mon.xp_tracking;
 
-    if (mon.ghost.get())
+    if (mon.ghost)
         ghost.reset(new ghost_demon(*mon.ghost));
     else
         ghost.reset(nullptr);
@@ -2204,7 +2204,7 @@ bool monster::has_base_name() const
 {
     // Any non-ghost, non-Pandemonium demon that has an explicitly set
     // name has a base name.
-    return !mname.empty() && !ghost.get();
+    return !mname.empty() && !ghost;
 }
 
 static string _invalid_monster_str(monster_type type)
@@ -4130,7 +4130,7 @@ bool monster::airborne() const
 {
     // For dancing weapons, this function can get called before their
     // ghost_demon is created, so check for a nullptr ghost. -cao
-    return mons_is_ghost_demon(type) && ghost.get() && ghost->flies
+    return mons_is_ghost_demon(type) && ghost && ghost->flies
            // check both so spectral humans and zombified dragons both fly
            || mons_class_flag(mons_base_type(*this), M_FLIES)
            || mons_class_flag(type, M_FLIES)
@@ -4924,7 +4924,7 @@ void monster::set_transit(const level_id &dest)
 
 void monster::load_ghost_spells()
 {
-    if (!ghost.get())
+    if (!ghost)
     {
         spells.clear();
         return;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2393,8 +2393,8 @@ void forget_map(bool rot)
             continue;
 
         env.map_knowledge(p).clear();
-        if (env.map_forgotten.get())
-            (*env.map_forgotten.get())(p).clear();
+        if (env.map_forgotten)
+            (*env.map_forgotten)(p).clear();
         StashTrack.update_stash(p);
 #ifdef USE_TILE
         tile_forget_map(p);

--- a/crawl-ref/source/sqldbm.cc
+++ b/crawl-ref/source/sqldbm.cc
@@ -423,8 +423,8 @@ sql_datum dbm_fetch(SQL_DBM *db, const sql_datum &key)
 static sql_datum dbm_key(SQL_DBM *db, unique_ptr<string> (SQL_DBM::*key)())
 {
     unique_ptr<string> res = (db->*key)();
-    if (res.get())
-        return sql_datum(*res.get());
+    if (res)
+        return sql_datum(*res);
     else
     {
         sql_datum dummy;

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -4244,8 +4244,8 @@ static void tag_construct_level(writer &th)
             marshallInt(th, env.pgrid[count_x][count_y].flags);
         }
 
-    marshallBoolean(th, !!env.map_forgotten.get());
-    if (env.map_forgotten.get())
+    marshallBoolean(th, !!env.map_forgotten);
+    if (env.map_forgotten)
         for (int x = 0; x < GXM; x++)
             for (int y = 0; y < GYM; y++)
                 marshallMapCell(th, (*env.map_forgotten)[x][y]);
@@ -4292,8 +4292,8 @@ static void tag_construct_level(writer &th)
     marshallInt(th, you.dactions.size());
 
     // Save heightmap, if present.
-    marshallByte(th, !!env.heightmap.get());
-    if (env.heightmap.get())
+    marshallByte(th, !!env.heightmap);
+    if (env.heightmap)
     {
         grid_heightmap &heightmap(*env.heightmap);
         for (rectangle_iterator ri(0); ri; ++ri)
@@ -5192,7 +5192,7 @@ void marshallMonster(writer &th, const monster& m)
     if (parts & MP_GHOST_DEMON)
     {
         // *Must* have ghost field set.
-        ASSERT(m.ghost.get());
+        ASSERT(m.ghost);
         marshallGhost(th, *m.ghost);
     }
 
@@ -5259,10 +5259,10 @@ void marshallMonsterInfo(writer &th, const monster_info& mi)
         _marshall_mi_attack(th, mi.attack[i]);
     for (unsigned int i = 0; i <= MSLOT_LAST_VISIBLE_SLOT; ++i)
     {
-        if (mi.inv[i].get())
+        if (mi.inv[i])
         {
             marshallBoolean(th, true);
-            marshallItem(th, *mi.inv[i].get(), true);
+            marshallItem(th, *mi.inv[i], true);
         }
         else
             marshallBoolean(th, false);
@@ -5516,7 +5516,7 @@ void unmarshallMonsterInfo(reader &th, monster_info& mi)
         if (unmarshallBoolean(th))
         {
             mi.inv[i].reset(new item_def());
-            unmarshallItem(th, *mi.inv[i].get());
+            unmarshallItem(th, *mi.inv[i]);
         }
     }
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -770,7 +770,7 @@ static unique_ptr<map_mask_boolean> _slime_wall_precomputed_neighbour_mask;
 
 static void _precompute_slime_wall_neighbours()
 {
-    map_mask_boolean &mask(*_slime_wall_precomputed_neighbour_mask.get());
+    map_mask_boolean &mask(*_slime_wall_precomputed_neighbour_mask);
     for (rectangle_iterator ri(1); ri; ++ri)
     {
         if (grd(*ri) == DNGN_SLIMY_WALL)
@@ -787,7 +787,7 @@ unwind_slime_wall_precomputer::unwind_slime_wall_precomputer(bool docompute)
     if (!(env.level_state & LSTATE_SLIMY_WALL))
         return;
 
-    if (docompute && !_slime_wall_precomputed_neighbour_mask.get())
+    if (docompute && !_slime_wall_precomputed_neighbour_mask)
     {
         did_compute_mask = true;
         _slime_wall_precomputed_neighbour_mask.reset(
@@ -807,7 +807,7 @@ bool slime_wall_neighbour(const coord_def& c)
     if (!(env.level_state & LSTATE_SLIMY_WALL))
         return false;
 
-    if (_slime_wall_precomputed_neighbour_mask.get())
+    if (_slime_wall_precomputed_neighbour_mask)
         return (*_slime_wall_precomputed_neighbour_mask)(c);
 
     // Not using count_adjacent_slime_walls because the early return might

--- a/crawl-ref/source/tilemcache.cc
+++ b/crawl-ref/source/tilemcache.cc
@@ -1242,8 +1242,8 @@ bool mcache_monster::valid(const monster_info& mon)
     bool have_shield_offs = (mon.type == MONS_PLAYER
                              && Options.tile_shield_offsets.first != INT_MAX)
         || get_shield_offset(mon_tile, &ox, &oy);
-    return (mon.inv[MSLOT_WEAPON].get() != nullptr && have_weapon_offs)
-        || (mon.inv[MSLOT_SHIELD].get() != nullptr && have_shield_offs);
+    return (mon.inv[MSLOT_WEAPON] && have_weapon_offs)
+        || (mon.inv[MSLOT_SHIELD] && have_shield_offs);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1359,7 +1359,7 @@ static tileidx_t _tileidx_monster_zombified(const monster_info& mon)
 // for when they have a bow.
 static bool _bow_offset(const monster_info& mon)
 {
-    if (!mon.inv[MSLOT_WEAPON].get())
+    if (!mon.inv[MSLOT_WEAPON])
         return true;
 
     switch (mon.inv[MSLOT_WEAPON]->sub_type)
@@ -1694,7 +1694,7 @@ static tileidx_t _tileidx_monster_no_props(const monster_info& mon)
             return base + (_bow_offset(mon) ? 1 : 0);
 
         case MONS_CEREBOV:
-            return base + (mon.inv[MSLOT_WEAPON].get() == nullptr ? 1 : 0);
+            return base + (mon.inv[MSLOT_WEAPON] ? 1 : 0);
 
         case MONS_SLAVE:
             return base + (mon.mname == "freed slave" ? 1 : 0);
@@ -1712,7 +1712,7 @@ static tileidx_t _tileidx_monster_no_props(const monster_info& mon)
             // but will use a regular stance if she picks up a shield
             // (enhancer staves are compatible with those).
             const item_def* weapon = mon.inv[MSLOT_WEAPON].get();
-            if (!mon.inv[MSLOT_SHIELD].get() && weapon
+            if (!mon.inv[MSLOT_SHIELD] && weapon
                 && (weapon->is_type(OBJ_STAVES, STAFF_POISON)
                     || is_unrandom_artefact(*weapon, UNRAND_OLGREB)))
             {
@@ -1760,7 +1760,7 @@ static tileidx_t _tileidx_monster_no_props(const monster_info& mon)
 
         case MONS_SPECTRAL_WEAPON:
         {
-            if (!mon.inv[MSLOT_WEAPON].get())
+            if (!mon.inv[MSLOT_WEAPON])
                 return TILEP_MONS_SPECTRAL_SBL;
 
             // Tiles exist for each class of weapon.

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -1014,7 +1014,7 @@ bool DungeonRegion::update_tip_text(string &tip)
             tip += make_stringf("GC(%d, %d) EP(%d, %d)\n",
                                 gc.x, gc.y, ep.x, ep.y);
 
-            if (env.heightmap.get())
+            if (env.heightmap)
                 tip += make_stringf("HEIGHT(%d)\n", dgn_height_at(gc));
 
             tip += "\n";
@@ -1023,7 +1023,7 @@ bool DungeonRegion::update_tip_text(string &tip)
         else
         {
             tip += make_stringf("GC(%d, %d) [out of sight]\n", gc.x, gc.y);
-            if (env.heightmap.get())
+            if (env.heightmap)
                 tip += make_stringf("HEIGHT(%d)\n", dgn_height_at(gc));
             tip += "\n";
         }

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -378,7 +378,7 @@ private:
 public:
     precompute_travel_safety_grid() : did_compute(false)
     {
-        if (!_travel_safe_grid.get())
+        if (!_travel_safe_grid)
         {
             did_compute = true;
             auto tsgrid = make_unique<travel_safe_grid>();
@@ -418,7 +418,7 @@ static bool _is_travelsafe_square(const coord_def& c, bool ignore_hostile,
     if (!in_bounds(c))
         return false;
 
-    if (_travel_safe_grid.get())
+    if (_travel_safe_grid)
     {
         const cell_travel_safety &cell((*_travel_safe_grid)(c));
         return ignore_hostile? cell.safe_if_ignoring_hostile_terrain

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -570,8 +570,8 @@ static level_pos _stair_dest(const coord_def& p, command_type dir)
 
 static void _unforget_map()
 {
-    ASSERT(env.map_forgotten.get());
-    MapKnowledge &old(*env.map_forgotten.get());
+    ASSERT(env.map_forgotten);
+    MapKnowledge &old(*env.map_forgotten);
 
     for (rectangle_iterator ri(0); ri; ++ri)
         if (!env.map_knowledge(*ri).seen() && old(*ri).seen())
@@ -881,7 +881,7 @@ bool show_map(level_pos &lpos,
             case CMD_MAP_FORGET:
                 {
                     // Merge it with already forgotten data first.
-                    if (env.map_forgotten.get())
+                    if (env.map_forgotten)
                         _unforget_map();
                     MapKnowledge *old = new MapKnowledge(env.map_knowledge);
                     _forget_map();
@@ -891,7 +891,7 @@ bool show_map(level_pos &lpos,
                 break;
 
             case CMD_MAP_UNFORGET:
-                if (env.map_forgotten.get())
+                if (env.map_forgotten)
                 {
                     _unforget_map();
                     env.map_forgotten.reset();

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -565,7 +565,7 @@ void debug_stethoscope(int mon)
 
     if (mons_is_ghost_demon(mons.type))
     {
-        ASSERT(mons.ghost.get());
+        ASSERT(mons.ghost);
         const ghost_demon &ghost = *mons.ghost;
         mprf(MSGCH_DIAGNOSTICS, "Ghost damage: %d; brand: %d; att_type: %d; "
                                 "att_flav: %d",


### PR DESCRIPTION
operator bool and operator* allow a lot of superflous .get() calls to be
removed, as well as a few ASSERTs that will never trigger and some
braces.