### PR TITLE
Make the estimate of XLs to mindelay more accurate (0011490)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2744,10 +2744,20 @@ int xp_to_level_diff(int xp, int scale)
         level++;
     if (scale > 1)
     {
+        //variables for calculating the remainder after the last level
         unsigned int remainder = adjusted_xp - (int) exp_needed(level);
         unsigned int denom = exp_needed(level + 1) - (int) exp_needed(level);
-        return (level - you.experience_level) * scale +
-                    (remainder * scale / denom);
+
+        //variables for calculating the experience needed to hit the first level
+        unsigned int exp_to_first_level =
+                    (int) exp_needed(you.experience_level + 1) - you.experience;
+        unsigned int total_exp_for_first_level =
+                    (int) exp_needed(you.experience_level + 1)
+                    - (int) exp_needed(you.experience_level);
+
+        return (level - you.experience_level - 1) * scale
+                + (exp_to_first_level * scale / total_exp_for_first_level)
+                + (remainder * scale / denom);
     } else
         return level - you.experience_level;
 }


### PR DESCRIPTION
Previously the estimated XLs to mindelay in the item description of shields and weapons didn't take the progress toward the next level into account. No matter how much progress you had made toward the next level it counted that as a whole level. With this change it only adds how much exp need to get to the next level to the estimate and matches the desired behavior outlined in the bug report.