### PR TITLE
Fix some floor tiles in pf_slime_end_temple

### DIFF
--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -3237,7 +3237,7 @@ SUBST:     " : " .:3,  " = .c, ' : ' .:3,  ' = .S
 SUBST:     - = --.
 LFLOORCOL: green
 COLOUR:    - = lightgray
-FTILE:     .J = floor_slime
+FTILE:     .JB = floor_slime
 : set_feature_name("stone_wall", "rune-carved stone wall")
 MAP
 SSSSSSSSSSSSSSSSSSSSSSSSSSSS


### PR DESCRIPTION
Previously this would place erroneous floor tiles on some altars, because it was missing B in the FTILE assignment. This can be seen here:
![image](https://user-images.githubusercontent.com/37064413/41374530-4a1335be-6f4b-11e8-8cb0-530fd81f86a1.png)
