### PR TITLE
Webtiles: Use X-Forwarded-Proto header for websocket protocol

### DIFF
--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -18,10 +18,7 @@ import userdb
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
         host = self.request.host
-        proto = self.request.headers.get_list('x-forwarded-proto')
-        if len(proto) > 0 : proto = proto[0]
-        else: proto = None
-        if self.request.protocol == "https" or proto == "https":
+        if self.request.protocol == "https" or self.request.headers.get("x-forwarded-proto") == "https":
             protocol = "wss://"
         else:
             protocol = "ws://"

--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -18,7 +18,10 @@ import userdb
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
         host = self.request.host
-        if self.request.protocol == "https":
+        proto = self.request.headers.get_list('x-forwarded-proto')
+        if len(proto) > 0 : proto = proto[0]
+        else: proto = None
+        if self.request.protocol == "https" or proto == "https":
             protocol = "wss://"
         else:
             protocol = "ws://"


### PR DESCRIPTION
If the webtiles server is running behind a proxy server which terminates SSL connections, and http is used between the proxy and webtiles, the X-Forwarded-Proto header can be set by the proxy to indicate to the webtiles server that the client is using a secure connection. This allows webtiles to generate the correct protocol wss:// even it sees http.

1. Client connects to proxy server with https
2. Proxy connects to webtiles with http
3. Webtiles thinks the client wants to use insecure websocket
4. Client will refuse the websocket

This PR fixes this issue and allows the proxy to inform webtiles of the protocol that is really being used by the client: https.