### PR TITLE
Ghost vaultsmithing functions + 6 early D appropriate ghost vaults

### DIFF
--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -192,3 +192,24 @@ nnn===nnn
 .........
 .........
 ENDMAP
+
+NAME:   ebering_vaults_ghost_inner_flame
+TAGS:   vaults_orient_w
+KPROP:  xn'O = w:5 bloody / nothing
+KMONS:  O = player_ghost
+KITEM:  O = scroll of immolation ident:all
+NSUBST: ' = |* / |*$ / 998 / dF / 3=d. / F. / .
+MARKER: F = lua:fog_machine { cloud_type = "black smoke", \
+            pow_min = 10000, pow_max = 10000, delay = 1, \
+            size = 1, walk_dist = 0, start_clouds = 1 }
+: dgn.delayed_decay(_G, "d", "chunk")
+: vaults_ghost_setup(_G)
+MAP
+..x....
+..x''..
+..n'''.
+..='O'.
+..n'''.
+..x''..
+..x....
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -232,3 +232,27 @@ xn=nx
 .....
 .....
 ENDMAP
+
+NAME:   ebering_vaults_ghost_disaster_area
+TAGS:   vaults_orient_s
+KMONS:  O = player ghost
+NSUBST: ' = d / e / 8=wWlr / -
+: if you.depth() < dgn.br_depth(you.branch()) then
+KFEAT:  r = known shaft trap
+: else
+SUBST:  r = wWl
+: end
+SUBST:  P = GTV
+KITEM:  O = superb_item / star_item
+SUBST:  de = |*
+: vaults_ghost_setup(_G)
+MAP
+..........
+.'xx'x'x'.
+.x''O''x'.
+.'x'''''x.
+.''P'x''x.
+.x'''''''.
+xxnn==nnxx
+....@@....
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -213,3 +213,22 @@ MAP
 ..x''..
 ..x....
 ENDMAP
+
+NAME:   ebering_vaults_ghost_reflecting_pool
+TAGS:   vaults_orient_s no_pool_fixup
+KMONS:  O = player_ghost
+KFEAT:  O = shallow_water
+KITEM:  O = superb_item / star_item
+SUBST:  de = |*
+: vaults_ghost_setup(_G)
+MAP
+.....
+.dOe.
+.-w-.
+.-w-.
+.-w-.
+.-W-.
+xn=nx
+.....
+.....
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -111,6 +111,22 @@ function setup_armoury_orcs(e)
             "| large shield randart w:1")
 end
 
+-- Determine the number of gold piles placed for the Gozag ghost
+-- Linearly interpolates between 3-9 on D:3 and 12-18 on D:15, with
+-- Lair and Orc getting 8-14 and everything else getting 12-18.
+-- ebering_gozag_ghost
+function setup_gozag_gold(e)
+    if you.in_branch("D") then
+        pile_mean = math.floor(3/4 * you.depth() + 3.75)
+    elseif you.in_branch("Lair") or you.in_branch("Orc") then
+        pile_mean = 11
+    else
+        pile_mean = 15
+    end
+    pile_count = crawl.random_range(pile_mean - 3, pile_mean + 3)
+    e.nsubst("' = " .. pile_count .. "=$ / -")
+end
+
 -- Basic loot scale for extra loot for lone ghosts
 -- takes none_glyph to use when it would like no item
 -- adds depth appropriate items to de
@@ -384,40 +400,39 @@ ORIENT: float
 # If ghost selectors ever happen this should be a gozag ghost
 KMONS: O = player_ghost
 KFEAT: O = abandoned_shop
-# Scale up to acquire gold by depth
-# D:3 Min: 66 Max: 1656 Mean: 365 Dev: 274
-# D:7 Min: 154 Max: 3864 Mean: 851 Dev: 638
-# D:10- acquire gold
-{{
-  if you.in_branch("D") and you.depth() < 10 then
-    gold_qty = you.depth() * (20
-                             + crawl.roll_dice(1, 20)
-                             + (crawl.roll_dice(1, 8)
-                                * crawl.roll_dice(1, 8)
-                                * crawl.roll_dice(1, 8)))
-    item("gold q:" .. gold_qty)
-  else
-    item("acquire gold")
-  end
-}}
-NSUBST: ' = d / 2=998 / $
-KFEAT: Z = altar_gozag
-SUBST: _ = GZ
+KFEAT: _ = altar_gozag
+: if you.absdepth() < 10 then
+NSUBST: M = 2=998 / G
+: else
+NSUBST: M = 2=998 / 2=0 / 2=0G
+: end
+: if you.absdepth() >= 14 then
+:   if you.in_branch("Lair") then
+MONS: oklob plant
+:   else
+MONS: obsidian statue
+:   end
+SUBST: S = GG1
+: else
+SUBST: S = G
+: end
+: setup_gozag_gold(_G)
 TILE: G = dngn_golden_statue
-FTILE: -d$89OGZ = floor_limestone
+FTILE: -$0189OGZS = floor_limestone
 RTILE: c = wall_sandstone
 COLOUR: cG = yellow
 : set_feature_name("granite_statue", "golden statue")
 : set_feature_name("stone_wall", "golden wall")
 : ghost_setup(_G)
 MAP
-  ccc
- ccOcc
-cc'''cc
-c'-_-'c
-cc---cc
- cn=nc
-  .@.
+ ccccccc
+ccMcOcMcc
+cM'''''Mc
+cc''S''cc
+cM''_''Mc
+cc'''''cc
+ nn===nn
+ ...@...
 ENDMAP
 
 NAME: ebering_ghost_rock_garden

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -378,6 +378,33 @@ MAP
  ccccc
 ENDMAP
 
+NAME: ebering_ghost_gozag
+WEIGHT: 2 (D:3-7), 5 (D:8-11)
+ORIENT: float
+# If ghost selectors ever happen this should be a gozag ghost
+KMONS: O = player_ghost
+KFEAT: O = abandoned_shop
+ITEM: acquire gold
+NSUBST: ' = d / 2=998 / $
+KFEAT: Z = altar_gozag
+SUBST: _ = GZ
+TILE: G = dngn_golden_statue
+FTILE: -d$89OGZ = floor_limestone
+RTILE: c = wall_sandstone
+COLOUR: cG = yellow
+: set_feature_name("granite_statue", "golden statue")
+: set_feature_name("stone_wall", "golden wall")
+: ghost_setup(_G)
+MAP
+  ccc
+ ccOcc
+cc'''cc
+c'-_-'c
+cc---cc
+ cn=nc
+  .@.
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -384,7 +384,22 @@ ORIENT: float
 # If ghost selectors ever happen this should be a gozag ghost
 KMONS: O = player_ghost
 KFEAT: O = abandoned_shop
-ITEM: acquire gold
+# Scale up to acquire gold by depth
+# D:3 Min: 66 Max: 1656 Mean: 365 Dev: 274
+# D:7 Min: 154 Max: 3864 Mean: 851 Dev: 638
+# D:10- acquire gold
+{{
+  if you.in_branch("D") and you.depth() < 10 then
+    gold_qty = you.depth() * (20
+                             + crawl.roll_dice(1, 20)
+                             + (crawl.roll_dice(1, 8)
+                                * crawl.roll_dice(1, 8)
+                                * crawl.roll_dice(1, 8)))
+    item("gold q:" .. gold_qty)
+  else
+    item("acquire gold")
+  end
+}}
 NSUBST: ' = d / 2=998 / $
 KFEAT: Z = altar_gozag
 SUBST: _ = GZ

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -549,6 +549,7 @@ KFEAT:  r = known shaft trap
 : else
 SUBST:  r = wWl
 : end
+SUBST: P = GTV
 : lone_ghost_guarded_loot(_G, "O")
 : lone_ghost_extra_loot(_G, "-")
 : ghost_setup(_G)
@@ -557,7 +558,7 @@ cccccccccc
 cccc'c'ccc
 cc''O''c'c
 c'c'''''cc
-c''''c''cc
+c''P'c''cc
 cc'''''''c
 ccnn==nncc
   ..@@..

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -445,6 +445,28 @@ cn=nc
  .@.
 ENDMAP
 
+NAME: ebering_ghost_xom
+ORIENT: float
+KMONS: O = player_ghost
+KFEAT: O = altar_xom
+: lone_ghost_extra_loot(_G,"-")
+{{
+  egos = {["vorpal"] = 20, ["freezing"] = 15, ["flaming"] = 15,
+          ["venom"] = 10, ["protection"] = 10, ["electrocution"] = 5,
+          ["draining"] = 5, ["antimagic"] = 2}
+  local dagger_def = random_item_def({["dagger"] = 10}, egos,
+                                     crawl.one_chance_in(7), "|")
+  mons("dancing weapon; " .. dagger_def)
+}}
+FTILE:  -|*%$O1 : floor_pebble_brown / floor_pebble_darkgray
+MAP
+ ccc
+cc1cc
+cdOec
+cn=nc
+..@..
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -405,6 +405,28 @@ cc---cc
   .@.
 ENDMAP
 
+NAME: ebering_ghost_rock_garden
+ORIENT: float
+KMONS: O = player_ghost
+: local large_rocks = crawl.random_range(3,7)
+: kitem("O = large rock q:" .. large_rocks)
+KITEM: ' = stone q:1 / large rock w:1
+NSUBST: r = O / d / e / tG / t'' / '
+: lone_ghost_extra_loot(_G, "'")
+COLOUR: -deOtG'|*%$ = yellow, c = white
+FTILE: -deOtG'|*%$ = floor_dirt
+: ghost_setup(_G)
+MAP
+ccccccccc
+c---r-r-c
+crr-----c
+c----r--c
+c--r----c
+cr----r-c
+cnn===nnc
+ ...@...
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -467,6 +467,49 @@ cn=nc
 ..@..
 ENDMAP
 
+NAME: ebering_ghost_sewer_d
+# based on sewer_entry_d
+ORIENT: float
+DEPTH: D:3-6
+KMONS: O = player_ghost
+KFEAT: O = expired_portal
+KMONS: 1 = patrolling adder
+KFEAT: 1 = W
+: lone_ghost_guarded_loot(_G, "O")
+: lone_ghost_extra_loot(_G, "W")
+COLOUR: 1W = lightgreen / cyan w:5
+FTILE: O = dngn_portal_sewer_rusted
+: ghost_setup(_G)
+MAP
+       ..
+ccccccnn.
+cdOe1WW=.
+ccccccnn.
+       ..
+ENDMAP
+
+NAME: ebering_ghost_sewer_f
+# based on sewer_entry_f
+ORIENT: float
+DEPTH: D:3-6
+KMONS: O = player_ghost
+KFEAT: O = expired_portal
+KMONS:  1 = leopard gecko / giant cockroach / nothing w:5
+NSUBST: W = 6:1 / *:W
+KFEAT: 1 = W
+: lone_ghost_guarded_loot(_G, "O")
+: lone_ghost_extra_loot(_G, "W")
+COLOUR: 1W = lightgreen / cyan w:5
+FTILE: O = dngn_portal_sewer_rusted
+: ghost_setup(_G)
+MAP
+ ccccccccccc
+.nWWWWeWWWWn.
+@=WWWWOWWWW=@
+.nWWWWdWWWWn.
+ ccccccccccc
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -427,6 +427,24 @@ cnn===nnc
  ...@...
 ENDMAP
 
+NAME: ebering_ghost_reflecting_pool
+ORIENT: float
+KMONS: O = player_ghost
+KFEAT: O = shallow_water
+: lone_ghost_guarded_loot(_G, "O")
+: lone_ghost_extra_loot(_G, "-")
+FTILE:  -|*%$O : floor_pebble_brown / floor_pebble_darkgray
+MAP
+ccccc
+cdOec
+c-w-c
+c-w-c
+c-w-c
+c-W-c
+cn=nc
+ .@.
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -540,6 +540,29 @@ MAP
  ccccccccccc
 ENDMAP
 
+NAME:   ebering_ghost_disaster_area
+ORIENT: float
+KMONS:  O = player ghost
+NSUBST: ' = d / e / 8=wWlr / -
+: if you.depth() < dgn.br_depth(you.branch()) then
+KFEAT:  r = known shaft trap
+: else
+SUBST:  r = wWl
+: end
+: lone_ghost_guarded_loot(_G, "O")
+: lone_ghost_extra_loot(_G, "-")
+: ghost_setup(_G)
+MAP
+cccccccccc
+cccc'c'ccc
+cc''O''c'c
+c'c'''''cc
+c''''c''cc
+cc'''''''c
+ccnn==nncc
+  ..@@..
+ENDMAP
+
 ###############################################################################
 #
 # <<2>> Themed ghost vaults.

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -110,6 +110,51 @@ function setup_armoury_orcs(e)
             "| shield randart w:2 | large shield good_item w:2 " ..
             "| large shield randart w:1")
 end
+
+-- Basic loot scale for extra loot for lone ghosts
+-- takes none_glyph to use when it would like no item
+-- adds depth appropriate items to de
+function lone_ghost_extra_loot(e,none_glyph)
+    if you.in_branch("D") then
+        if you.depth() < 6 then
+            e.subst("de = " .. none_glyph)
+        elseif you.depth() < 9 then
+            e.subst("d = %$" .. none_glyph .. none_glyph)
+            e.subst("e = " ..none_glyph)
+        elseif you.absdepth() < 12 then
+            e.subst("d = %$")
+            e.subst("e = " ..none_glyph)
+        else
+            e.subst("d = |*")
+            e.subst("e = *$")
+        end
+    elseif you.in_branch("Lair") then
+        e.subst("d = *%")
+        e.subst("e = %$" .. none_glyph .. none_glyph)
+    elseif you.in_branch("Orc") then
+        e.subst("d = |*")
+        e.subst("e = %$")
+    else
+        e.subst("de = |*")
+    end
+end
+
+-- Basic loot scale for ghost "guarded" loot for lone ghosts
+-- KITEMS this to ghost_glyph
+function lone_ghost_guarded_loot(e,ghost_glyph)
+    if you.in_branch("D") then
+        if you.depth() < 6 then
+            e.kitem(ghost_glyph .. " = star_item / any")
+        elseif you.depth() < 9 then
+            e.kitem(ghost_glyph .. " = star_item")
+        else
+            e.kitem(ghost_glyph .. " = superb_item / star_item")
+        end
+    else
+        e.kitem(ghost_glyph .. " = superb_item / star_item")
+    end
+end
+
 }}
 
 # Only the below levels and Vaults:1-4 place ghost vaults. A specific ghost
@@ -130,30 +175,8 @@ default-depth: D:3-, Lair, Elf, Orc, Snake, Shoals, Swamp, Spider, Depths, \
 NAME:  gammafunk_ghost_grave
 ORIENT: float
 WEIGHT: 20 (D:3-11)
-: if you.in_branch("D") then
-:     if you.depth() < 6 then
-KITEM: O = star_item / any
-SUBST: de = -
-:     elseif you.depth() < 9 then
-KITEM: O = star_item
-SUBST: d = %$--, e = -
-:     elseif you.absdepth() < 12 then
-KITEM: O = superb_item / star_item
-SUBST: d = %$, e = -
-:     else
-KITEM: O = superb_item / star_item
-SUBST: d = |*, e = *$
-:     end
-: elseif you.in_branch("Lair") then
-KITEM: O = superb_item / star_item
-SUBST: d = *%, e = %$--
-: elseif you.in_branch("Orc") then
-KITEM: O = superb_item / star_item
-SUBST: d = |*, e = %$
-: else
-KITEM: O = superb_item / star_item
-SUBST: de = |*
-: end
+: lone_ghost_guarded_loot(_G, "O")
+: lone_ghost_extra_loot(_G, "-")
 KMONS: O = player ghost
 KMONS: p = withered plant
 SUBST: t : tp

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -468,7 +468,7 @@ KFEAT: O = altar_xom
 {{
   egos = {["vorpal"] = 20, ["freezing"] = 15, ["flaming"] = 15,
           ["venom"] = 10, ["protection"] = 10, ["electrocution"] = 5,
-          ["draining"] = 5, ["antimagic"] = 2}
+          ["draining"] = 5, ["antimagic"] = 2, ["chaos"] = 1}
   local dagger_def = random_item_def({["dagger"] = 10}, egos,
                                      crawl.one_chance_in(7), "|")
   mons("dancing weapon; " .. dagger_def)

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -1181,3 +1181,35 @@ c.............c
 cnnnnn===nnnnnc
 I......@......I
 ENDMAP
+
+NAME:   ebering_ghost_davey_jones
+ORIENT: float
+TAGS:   water_ok
+DEPTH:  Shoals, !Shoals:$
+KMONS:  O = player_ghost
+KITEM:  O = any ring randart w:20 / ring of the octopus king w:1
+KFEAT:  O' = W
+KMONS:  1 = kraken / kraken simulacrum
+KFEAT:  1 = w
+SUBST:  u = wW, s=W.
+NSUBST: ' = 3=|* / *%
+{{
+dgn.delayed_decay(_G,"%","minotaur skeleton / halfling skeleton" ..
+  " / dwarf skeleton / human skeleton / kobold skeleton" ..
+  " / felid skeleton / orc skeleton / centaur skeleton")
+}}
+: ghost_setup(_G)
+MAP
+ WWWWWWWWWWWWW
+WWcccccccccccWW
+WccuwwwwwwwuccW
+WcWuwwwww'wuWcW
+WcWWW'wwwuWWWcW
+Wns%Wuw1wuWWWnW
+Wn.sWuwwwuW%snW
+Wc%sW'uOu'Ws.cW
+Wc..%sWsWWs..cW
+Wcc......%..ccW
+WWcnnn===nnncWW
+ WW....@....WW
+ENDMAP


### PR DESCRIPTION
Abstract loot scaling for single ghosts:

Creates two lua functions for placing the "guarded" and "extra" loot in
a ghost vault that places a single ghost, for consistent scaling and to
make writing single-ghost vaults easier.

ebering_ghost_gozag - lots of gold, Gozag altar or golden statue, 998
ebering_ghost_rock_garden - lone ghost, zen garden theme. floor_dirt is kinda ugly but floor_sand has misplaced stones, could use some tile love
ebering_ghost_reflecting_pool - lone ghost with a memorial pool
ebering_ghost_xom - ghost, dancing nice dagger (could maybe be made to scale with depth), Xom altar
ebering_ghost_sewer_* - two ghost vaults based on sewer entry vaults, has the ghost on a closed portal