### PR TITLE
Remove flame clouds from inner flame vault (jboons)

### DIFF
--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -342,7 +342,7 @@ KPROP: cn'O = w:5 bloody / nothing
 KMONS: O = player_ghost
 KITEM: O = scroll of immolation ident:all
 NSUBST: ' = |* / |*$ / 998 / dF / 3=d. / F. / .
-MARKER: F = lua:fog_machine { cloud_type = "flame", \
+MARKER: F = lua:fog_machine { cloud_type = "black smoke", \
             pow_min = 10000, pow_max = 10000, delay = 1, \
             size = 1, walk_dist = 0, start_clouds = 1 }
 : dgn.delayed_decay(_G, "d", "chunk")


### PR DESCRIPTION
Ghosts and monsters were dying to them. Replaced with black smoke, which
gives similar flavor but without the monster deaths.