### PR TITLE
Lrd tree bug pr

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6017,8 +6017,11 @@ void bolt::determine_affected_cells(explosion_map& m, const coord_def& delta,
 
     bool at_wall = false;
 
-    // Check to see if we're blocked by a wall.
-    if (feat_is_wall(dngn_feat)
+    // Check to see if we're blocked by a wall or a tree.
+    // Can't use feat_is_solid here, since that includes statues which
+    // are a separate check, nor feat_is_opaque, since that excludes
+    // transparent walls, which we want.
+    if (feat_is_wall(dngn_feat) || feat_is_tree(dngn_feat)
         || feat_is_closed_door(dngn_feat))
     {
         // Special case: explosion originates from rock/statue

--- a/crawl-ref/source/losparam.cc
+++ b/crawl-ref/source/losparam.cc
@@ -112,8 +112,7 @@ opacity_type opacity_no_actor::operator()(const coord_def& p) const
 
 static opacity_type _feat_opacity(dungeon_feature_type feat)
 {
-    return feat_is_opaque(feat) ? OPC_OPAQUE
-         : feat_is_tree(feat)   ? OPC_HALF : OPC_CLEAR;
+    return feat_is_opaque(feat) ? OPC_OPAQUE : OPC_CLEAR;
 }
 
 opacity_type opacity_excl::operator()(const coord_def& p) const


### PR DESCRIPTION
Chase down some edge case behavior with trees being opaque these days.

Removes one instance of trees getting OPC_HALF opacity, and modifies beam explosions to be blocked by them in a fashion consistent with how they modify LOS.