### PR TITLE
Alcon cleave bugfix

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -751,7 +751,7 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
     while (attacker.alive() && !targets.empty())
     {
         actor* def = targets.front();
-        if (def && def->alive() && !_dont_harm(attacker, *def))
+        if (def && def->alive() && !_dont_harm(attacker, *def) && cleave_target_adjacent(attacker, def))
         {
             melee_attack attck(&attacker, def, attack_number,
                                ++effective_attack_number, true);
@@ -761,6 +761,37 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
         }
         targets.pop_front();
     }
+}
+
+/**
+ * Determines adjacency of a cleave target.
+ *
+ * @param attacker                 The attacking creature.
+ * @param target                   The target to cleave.
+ */
+bool cleave_target_adjacent(actor &attacker, actor &target)
+{
+	coord_def apos = attacker.pos();
+	coord_def tpos = target.pos();
+
+	int dx = abs(apos.x - tpos.x);
+	int dy = abs(apos.y - tpos.y);
+
+	//  Maximum cleave range is 1
+	//  Note:  this is an assumption; if the max cleave range ever changes,
+	//  then more code will need to be put into place here.
+	int max_cleave_range = 1;
+
+	if((dx <= max_cleave_range) && (dy <= max_cleave_range))
+	{
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -15,6 +15,7 @@
 
 #include "art-enum.h"
 #include "cloud.h"
+#include "coord.h"
 #include "coordit.h"
 #include "delay.h"
 #include "english.h"
@@ -751,7 +752,8 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
     while (attacker.alive() && !targets.empty())
     {
         actor* def = targets.front();
-        if (def && def->alive() && !_dont_harm(attacker, *def) && cleave_target_adjacent(attacker, *def))
+        bool def_adjacent = adjacent(attacker.pos(), def->pos());
+        if (def && def->alive() && !_dont_harm(attacker, *def) && def_adjacent)
         {
             melee_attack attck(&attacker, def, attack_number,
                                ++effective_attack_number, true);
@@ -761,37 +763,6 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
         }
         targets.pop_front();
     }
-}
-
-/**
- * Determines adjacency of a cleave target.
- *
- * @param attacker                 The attacking creature.
- * @param target                   The target to cleave.
- */
-bool cleave_target_adjacent(actor &attacker, actor &target)
-{
-	coord_def apos = attacker.pos();
-	coord_def tpos = target.pos();
-
-	int dx = abs(apos.x - tpos.x);
-	int dy = abs(apos.y - tpos.y);
-
-	//  Maximum cleave range is 1
-	//  Note:  this is an assumption; if the max cleave range ever changes,
-	//  then more code will need to be put into place here.
-	int max_cleave_range = 1;
-
-	if((dx <= max_cleave_range) && (dy <= max_cleave_range))
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
-
-	return true;
 }
 
 /**

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -751,7 +751,7 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
     while (attacker.alive() && !targets.empty())
     {
         actor* def = targets.front();
-        if (def && def->alive() && !_dont_harm(attacker, *def) && cleave_target_adjacent(attacker, def))
+        if (def && def->alive() && !_dont_harm(attacker, *def) && cleave_target_adjacent(attacker, *def))
         {
             melee_attack attck(&attacker, def, attack_number,
                                ++effective_attack_number, true);

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -752,8 +752,8 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
     while (attacker.alive() && !targets.empty())
     {
         actor* def = targets.front();
-        bool def_adjacent = adjacent(attacker.pos(), def->pos());
-        if (def && def->alive() && !_dont_harm(attacker, *def) && def_adjacent)
+
+        if (def && def->alive() && !_dont_harm(attacker, *def) && adjacent(attacker.pos(), def->pos()))
         {
             melee_attack attck(&attacker, def, attack_number,
                                ++effective_attack_number, true);

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -51,7 +51,6 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
                            int effective_attack_number = 0,
                            wu_jian_attack_type wu_jian_attack
                                = WU_JIAN_ATTACK_NONE);
-bool cleave_target_adjacent(actor &attacker, actor &target);
 
 int weapon_min_delay_skill(const item_def &weapon);
 int weapon_min_delay(const item_def &weapon, bool check_speed = true);

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -51,6 +51,7 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
                            int effective_attack_number = 0,
                            wu_jian_attack_type wu_jian_attack
                                = WU_JIAN_ATTACK_NONE);
+bool cleave_target_adjacent(actor &attacker, actor &target);
 
 int weapon_min_delay_skill(const item_def &weapon);
 int weapon_min_delay(const item_def &weapon, bool check_speed = true);


### PR DESCRIPTION
Hello; this is my first pull request for an open-source project.  Forgive me if I am a little green...

So... the conditions which trigger this bug in the master branch of the main game:  
1.  You need multiple critters allied to the main character.
2.  You need a hostile monster with a cleaving weapon.
3.  You need the main character to be attacking with a 'long sword of distortion'.

The probability of producing the bug is quite low on the main branch, given that the riposte probability is 33%, and given that the probability of triggering a blink or a teleport with a distortion weapon is 25%.  I found that I needed to create a separate branch where these probabilities are 100% each.
