### PR TITLE
Add option to disable gzip in webtiles

### DIFF
--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -118,6 +118,8 @@ ssl_port = 8081
 connection_timeout = 600
 max_idle_time = 5 * 60 * 60
 
+use_gzip = True
+
 # Seconds until stale HTTP connections are closed
 # This needs a patch currently not in mainline tornado.
 http_connection_timeout = None

--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -121,7 +121,7 @@ def bind_server():
             (r"/", MainHandler),
             (r"/socket", CrawlWebSocket),
             (r"/gamedata/(.*)/(.*)", GameDataHandler)
-            ], gzip=use_gzip, **settings)
+            ], gzip=getattr(config,"use_gzip",True), **settings)
 
     kwargs = {}
     if http_connection_timeout is not None:

--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -121,7 +121,7 @@ def bind_server():
             (r"/", MainHandler),
             (r"/socket", CrawlWebSocket),
             (r"/gamedata/(.*)/(.*)", GameDataHandler)
-            ], gzip=True, **settings)
+            ], gzip=use_gzip, **settings)
 
     kwargs = {}
     if http_connection_timeout is not None:


### PR DESCRIPTION
This change allows for configuring tornado to disable gzip compression.