### PR TITLE
Highlight summoners when the cursor is over a summon in targeting mode

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -25,6 +25,7 @@
 #include "describe.h"
 #include "dungeon.h"
 #include "english.h"
+#include "externs.h" // INVALID_COORD
 #include "fight.h" // melee_confuse_chance
 #include "food.h"
 #include "god-abil.h"
@@ -516,6 +517,8 @@ direction_chooser::direction_chooser(dist& moves_,
     hitfunc(args.hitfunc),
     default_place(args.default_place),
     unrestricted(args.unrestricted),
+    summ_loc(INVALID_COORD),
+    highlight_on_beam(false),
     needs_path(args.needs_path)
 {
     if (!behaviour)
@@ -529,7 +532,7 @@ direction_chooser::direction_chooser(dist& moves_,
         needs_path = true;
 
     show_beam = !just_looking && needs_path;
-    need_beam_redraw = show_beam;
+    need_viewport_redraw = show_beam;
     have_beam = false;
 
     need_text_redraw = true;
@@ -1120,17 +1123,12 @@ static void _draw_ray_cell(coord_def p, coord_def target, aff_type aff)
 #endif
 }
 
-void direction_chooser::draw_beam_if_needed()
+void direction_chooser::draw_beam()
 {
-    if (!need_beam_redraw)
-        return;
-
-    need_beam_redraw = false;
-
     if (!show_beam)
     {
         viewwindow(
-#ifndef USE_TILE_LOCAL
+#ifndef USE_TILE
             false
 #endif
             );
@@ -1154,7 +1152,12 @@ void direction_chooser::draw_beam_if_needed()
                                             ? LOS_NONE : LOS_DEFAULT;
         for (radius_iterator ri(you.pos(), los); ri; ++ri)
             if (aff_type aff = hitfunc->is_affected(*ri))
+            {
                 _draw_ray_cell(*ri, target(), aff);
+
+                if (summ_loc == *ri)
+                    highlight_on_beam = true;
+            }
 
 #ifdef USE_TILE
         viewwindow(true, true);
@@ -1187,6 +1190,9 @@ void direction_chooser::draw_beam_if_needed()
 
         if (p == you.pos())
             continue;
+
+        if (summ_loc == p)
+            highlight_on_beam = true;
 
         const bool inrange = in_range(p);
 #ifdef USE_TILE
@@ -1591,7 +1597,7 @@ void direction_chooser::toggle_beam()
     }
 
     show_beam = !show_beam;
-    need_beam_redraw = true;
+    need_viewport_redraw = true;
 
     if (show_beam)
     {
@@ -1671,7 +1677,7 @@ void direction_chooser::handle_wizard_command(command_type key_command,
         show_beam = true;
         have_beam = find_ray(you.pos(), target(), beam,
                              opc_solid_see, you.current_vision, show_beam);
-        need_beam_redraw = true;
+        need_viewport_redraw = true;
         return;
 
     case CMD_TARGET_WIZARD_DEBUG_PORTAL:
@@ -1698,7 +1704,7 @@ void direction_chooser::handle_wizard_command(command_type key_command,
         if (target() != you.pos())
         {
             wizard_create_feature(target());
-            need_beam_redraw = true;
+            need_viewport_redraw = true;
         }
         return;
 
@@ -1780,13 +1786,23 @@ void direction_chooser::do_redraws()
 
     if (need_all_redraw)
     {
-        need_beam_redraw = true;
+        need_viewport_redraw = true;
         need_text_redraw = true;
         need_cursor_redraw = true;
         need_all_redraw = false;
     }
 
-    draw_beam_if_needed();
+    if (need_viewport_redraw)
+    {
+        highlight_on_beam = false;
+        find_summoner();
+        draw_beam();
+        // draw_beam calls viewwindow(true) at least one in tiles mode, and
+        // viewwindow(false) at least once in console, so the old highlight and
+        // the old beam are both gone here.
+        highlight_summoner();
+        need_viewport_redraw = false;
+    }
 
     if (need_text_redraw)
     {
@@ -1807,6 +1823,53 @@ void direction_chooser::do_redraws()
 #endif
         need_cursor_redraw = false;
     }
+}
+
+void direction_chooser::find_summoner()
+{
+    const monster* mon = monster_at(target());
+
+    if (!mon)
+    {
+        summ_loc = INVALID_COORD;
+        return;
+    }
+
+    const monster *summ = monster_by_mid(mon -> summoner);
+
+    if (!summ)
+        summ_loc = INVALID_COORD;
+    else
+        summ_loc = summ -> pos();
+}
+
+void direction_chooser::highlight_summoner()
+{
+    if (summ_loc == INVALID_COORD)
+        return;
+
+#ifdef USE_TILE
+    monster_info* summ_info = env.map_knowledge(summ_loc).monsterinfo();
+
+    if (!summ_info)  // Can happen, e. g. if the summoner is invisible
+        return;
+
+    summ_info->mb.set(MB_HIGHLIGHT);
+
+    // The first argument must be false, because otherwise viewwindow would
+    // wipe any beams we might have drawn, and also reset the monster_info we
+    // just altered, before it draws anything.
+    viewwindow(false, true);
+#else
+    char32_t glych  = get_cell_glyph(summ_loc).ch;
+    int col = highlight_on_beam ? RED : CYAN;
+    col |= COLFLAG_REVERSE;
+
+    const coord_def vp = grid2view(summ_loc);
+    cgotoxy(vp.x, vp.y, GOTO_DNGN);
+    textcolour(real_colour(col));
+    putwch(glych);
+#endif
 }
 
 bool direction_chooser::tiles_update_target()
@@ -1886,8 +1949,7 @@ bool direction_chooser::do_main_loop()
         {
             const bool was_excluded = is_exclude_root(target());
             cycle_exclude_radius(target());
-            // XXX: abusing need_beam_redraw to force viewwindow call.
-            need_beam_redraw   = true;
+            need_viewport_redraw   = true;
             const bool is_excluded = is_exclude_root(target());
             if (!was_excluded && is_excluded)
                 mpr("Placed new exclusion.");
@@ -1985,7 +2047,7 @@ bool direction_chooser::do_main_loop()
         have_beam = show_beam && find_ray(you.pos(), target(), beam,
                                           opc_solid_see, you.current_vision);
         need_text_redraw   = true;
-        need_beam_redraw   = true;
+        need_viewport_redraw   = true;
         need_cursor_redraw = true;
     }
     do_redraws();
@@ -2034,10 +2096,10 @@ bool direction_chooser::choose_direction()
     {
         have_beam = find_ray(you.pos(), target(), beam,
                              opc_solid_see, you.current_vision);
-        need_beam_redraw = have_beam;
+        need_viewport_redraw = have_beam;
     }
     if (hitfunc)
-        need_beam_redraw = true;
+        need_viewport_redraw = true;
 
     clear_messages();
     msgwin_set_temporary(true);

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -227,8 +227,11 @@ private:
     void toggle_beam();
 
     void finalize_moves();
-    void draw_beam_if_needed();
     void do_redraws();
+
+    void draw_beam();
+    void highlight_summoner();
+    void find_summoner();
 
     // Whether the current target is you.
     bool looking_at_you() const;
@@ -265,7 +268,7 @@ private:
                                 // position?
 
     // What we need to redraw.
-    bool need_beam_redraw;
+    bool need_viewport_redraw;
     bool need_cursor_redraw;
     bool need_text_redraw;
     bool need_all_redraw;       // All of the above.
@@ -276,6 +279,9 @@ private:
     static targeting_behaviour stock_behaviour;
 
     bool unrestricted;
+
+    coord_def summ_loc;
+    bool highlight_on_beam;
 
 public:
     // TODO: fix the weird behavior that led to this hack

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -174,6 +174,7 @@ enum monster_info_flags
     MB_SLOWLY_DYING,
     MB_PINNED,
     MB_VILE_CLUTCH,
+    MB_HIGHLIGHT,
     NUM_MB_FLAGS
 };
 

--- a/crawl-ref/source/tilecell.cc
+++ b/crawl-ref/source/tilecell.cc
@@ -24,6 +24,7 @@ void packed_cell::clear()
     flv.feat = 0;
     flv.special = 0;
 
+    is_highlighted   = false;
     is_bloody        = false;
     is_silenced      = false;
     halo             = HALO_NONE;

--- a/crawl-ref/source/tilecell.h
+++ b/crawl-ref/source/tilecell.h
@@ -21,6 +21,7 @@ struct packed_cell
     tile_flavour flv;
     tileidx_t cloud;
 
+    bool is_highlighted;
     bool is_bloody;
     bool is_silenced;
     char halo;

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -329,6 +329,9 @@ void DungeonCellBuffer::pack_background(int x, int y, const packed_cell &cell)
                     m_buf_feat.add(TILE_HALO_GD_NEUTRAL, x, y);
                 else if (att_flag == TILE_FLAG_NEUTRAL)
                     m_buf_feat.add(TILE_HALO_NEUTRAL, x, y);
+
+                if (cell.is_highlighted)
+                    m_buf_feat.add(TILE_HALO_FRIENDLY, x, y);
             }
 
             // Apply the travel exclusion under the foreground if the cell is

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -1408,6 +1408,9 @@ void tile_apply_properties(const coord_def &gc, packed_cell &cell)
     else
         cell.halo = HALO_NONE;
 
+    if (mc.monsterinfo() && mc.monsterinfo()->is(MB_HIGHLIGHT))
+        cell.is_highlighted = true;
+
     if (mc.flags & MAP_LIQUEFIED)
         cell.is_liquefied = true;
     else if (print_blood && (_suppress_blood(mc)

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1189,6 +1189,9 @@ void TilesFramework::_send_cell(const coord_def &gc,
         if (next_pc.halo != current_pc.halo)
             json_write_int("halo", next_pc.halo);
 
+        if (next_pc.is_highlighted != current_pc.is_highlighted)
+            json_write_bool("highlighted", next_pc.is_highlighted);
+
         if (next_pc.is_moldy != current_pc.is_moldy)
             json_write_bool("moldy", next_pc.is_moldy);
 

--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -692,6 +692,9 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
                             this.draw_dngn(dngn.HALO_GD_NEUTRAL, x, y);
                         else if (fg.NEUTRAL)
                             this.draw_dngn(dngn.HALO_NEUTRAL, x, y);
+
+                        if (cell.highlighted)
+                            this.draw_dngn(dngn.HALO_NEUTRAL, x, y);
                     }
 
 


### PR DESCRIPTION
Not a particularly excellent implementation: it adds a flag to monster_info that tracks the state of the viewport rather than the state of the monster, and the code I added in directn.cc is very dependent on viewwindow() being called this often in this order with these arguments.

But no other implementation I've thought about seems better to me, and this does work.

I did not add tiles for this; currently webtiles paints a neutral halo under the monster and tiles paints a friendly halo under it. (In other words, this is not really mergeable as is.) If you like the code, I can probably add tiles also.

I don't know if this does anything bad to ttyrecs, but I'm guessing not.