### PR TITLE
Give the mace of Variability chain chaos

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -186,12 +186,13 @@ BRAND:   SPWPN_ANTIMAGIC
 
 NAME:    mace of Variability
 OBJ:     OBJ_WEAPONS/WPN_GREAT_MACE
-PLUS:    +0   # Set on generation
+INSCRIP: chain chaos
+PLUS:    +10
 COLOUR:  ETC_RANDOM
 TILE:    spwpn_mace_of_variability
 TILE_EQ: mace_of_variability
 VALUE:   600
-BOOL:    special, no_upgrade
+BOOL:    skip_ego
 BRAND:   SPWPN_CHAOS
 
 NAME:    glaive of Prune

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -491,12 +491,17 @@ static void _VAMPIRES_TOOTH_equip(item_def *item, bool *show_msgs, bool unmeld)
 
 ///////////////////////////////////////////////////
 
-// XXX: Pluses at creation time are hardcoded in make_item_unrandart()
-
-static void _VARIABILITY_world_reacts(item_def *item)
+static void _VARIABILITY_melee_effects(item_def* weapon, actor* attacker,
+                                       actor* defender, bool mondied,
+                                       int dam)
 {
-    item->plus += random_choose(0, 0, 0, +1, -1);
-    item->plus = max((short)-4, min((short)16, item->plus));
+    if (!mondied && one_chance_in(5))
+    {
+        const int pow = 75 + random2avg(75, 2);
+        if (you.can_see(*attacker))
+            mpr("The mace of Variability scintillates.");
+        cast_chain_spell(SPELL_CHAIN_OF_CHAOS, pow, attacker);
+    }
 }
 
 ///////////////////////////////////////////////////

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -1767,9 +1767,7 @@ bool make_item_unrandart(item_def &item, int unrand_index)
 
     _set_unique_item_status(unrand_index, UNIQ_EXISTS);
 
-    if (unrand_index == UNRAND_VARIABILITY)
-        item.plus = random_range(-4, 16);
-    else if (unrand_index == UNRAND_FAERIE)
+    if (unrand_index == UNRAND_FAERIE)
         _make_faerie_armour(item);
     else if (unrand_index == UNRAND_OCTOPUS_KING_RING)
         _make_octoring(item);

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -541,35 +541,29 @@ bool bolt::can_affect_actor(const actor *act) const
 static beam_type _chaos_beam_flavour(bolt* beam)
 {
     beam_type flavour;
-    do
-    {
-        flavour = random_choose_weighted(
-            10, BEAM_FIRE,
-            10, BEAM_COLD,
-            10, BEAM_ELECTRICITY,
-            10, BEAM_POISON,
-            10, BEAM_NEG,
-            10, BEAM_ACID,
-            10, BEAM_DAMNATION,
-            10, BEAM_STICKY_FLAME,
-            10, BEAM_SLOW,
-            10, BEAM_HASTE,
-            10, BEAM_MIGHT,
-            10, BEAM_BERSERK,
-            10, BEAM_HEALING,
-            10, BEAM_PARALYSIS,
-            10, BEAM_CONFUSION,
-            10, BEAM_INVISIBILITY,
-            10, BEAM_POLYMORPH,
-            10, BEAM_BANISH,
-            10, BEAM_DISINTEGRATION,
-            10, BEAM_PETRIFY,
-            10, BEAM_AGILITY,
-             2, BEAM_ENSNARE);
-    }
-    while (beam->origin_spell == SPELL_CHAIN_OF_CHAOS
-           && (flavour == BEAM_BANISH
-               || flavour == BEAM_POLYMORPH));
+    flavour = random_choose_weighted(
+        10, BEAM_FIRE,
+        10, BEAM_COLD,
+        10, BEAM_ELECTRICITY,
+        10, BEAM_POISON,
+        10, BEAM_NEG,
+        10, BEAM_ACID,
+        10, BEAM_DAMNATION,
+        10, BEAM_STICKY_FLAME,
+        10, BEAM_SLOW,
+        10, BEAM_HASTE,
+        10, BEAM_MIGHT,
+        10, BEAM_BERSERK,
+        10, BEAM_HEALING,
+        10, BEAM_PARALYSIS,
+        10, BEAM_CONFUSION,
+        10, BEAM_INVISIBILITY,
+        10, BEAM_POLYMORPH,
+        10, BEAM_BANISH,
+        10, BEAM_DISINTEGRATION,
+        10, BEAM_PETRIFY,
+        10, BEAM_AGILITY,
+         2, BEAM_ENSNARE);
 
     return flavour;
 }

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -256,7 +256,7 @@ caster's line of sight will end the effect.
 Chain of Chaos spell
 
 Creates an arc of pure chaos, striking nearby creatures with unpredictable
-effects.
+effects. The arc can touch upon the caster without harming them.
 %%%%
 Chain Lightning spell
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -22,7 +22,8 @@ mace of Variability
 
 A weapon with a peculiar reputation — said to be at times peerless in quality,
 and other times virtually useless. No one knows exactly who would have made
-such a weapon, or why, but Xom is probably to blame somehow.
+such a weapon, or why, but Xom is probably to blame somehow. Striking an enemy
+with it will occasionally unleash a chain of chaos.
 %%%%
 glaive of Prune
 

--- a/crawl-ref/source/dat/dlua/ghost.lua
+++ b/crawl-ref/source/dat/dlua/ghost.lua
@@ -313,6 +313,8 @@ function setup_xom_dancing_weapon(e)
         quality = crawl.coinflip() and "good_item"
                   or crawl.coinflip() and "randart"
                   or ""
+        variability = not you.unrands("mace of Variability")
+                      and crawl.one_chance_in(100) and "mace of Variability"
     end
 
     -- Make one weapons table with each weapon getting weight by class.
@@ -328,7 +330,8 @@ function setup_xom_dancing_weapon(e)
     end
 
     -- Generate a dancing weapon based on the table that always has chaos ego.
-    weapon_def = random_item_def(weapons, {["chaos"] = 1}, quality, "|")
+    weapon_def = variability
+                 or random_item_def(weapons, {["chaos"] = 1}, quality, "|")
     e.mons("dancing weapon; " .. weapon_def)
 end
 

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -317,6 +317,14 @@ spret_type cast_chain_spell(spell_type spell_cast, int pow,
         // Be kinder to the caster.
         if (target == caster->pos())
         {
+            if (spell_cast == SPELL_CHAIN_OF_CHAOS)
+            {
+                // This should not hit the caster, too scary as a player effect
+                // and too kind to the player as a monster effect.
+                // Mnoleg and Chaos Champions should not paralyse themselves.
+                beam.real_flavour = BEAM_VISUAL;
+                beam.flavour      = BEAM_VISUAL;
+            }
             if (!(beam.damage.num /= 2))
                 beam.damage.num = 1;
             if ((beam.damage.size /= 2) < 3)


### PR DESCRIPTION
From discussions on irc. The current moV's gimmick (enchants on a random walk from -4 to +16) isn't good, it encourages the player to wait to fight until its + is up. Worse, the change only happens when wielded, so the player can't swap when the moV is not in the mood.

This PR:

- Removes self harm from the Chain of Chaos spell.
- Gives the moV a fixed plus and a chance to cast Chain of Chaos on hit.
- Gives the moV a chance of spawning in ebering_ghost_xom as a dancing weapon.