### PR TITLE
Adding a variety of new arrival vaults

### DIFF
--- a/crawl-ref/source/dat/des/arrival/large.des
+++ b/crawl-ref/source/dat/des/arrival/large.des
@@ -1013,3 +1013,40 @@ xttttwwwwwwwwwwwwwwwwwwW
 xtwwwwwwwwwwwwwwwwwwwwwW
 xWWWWWWWWWWWWWWWWWWWWWWW
 ENDMAP
+
+################################################################################
+NAME:       psy_arrival_wood_between_worlds
+TAGS:       arrival no_monster_gen no_trap_gen no_pool_fixup
+WEIGHT:     3
+ORIENT:     float
+FTILE:      t.qG^P{ = floor_grass
+KMONS:      P = plant / bush
+KFEAT:      ^ = known teleport trap
+KFEAT:      p = W
+KMONS:      p = plant
+NSUBST:     p = 10:p / *:W, q = 10:P / *:.
+MAP
+ xxxxxxxxx+++xxxxxxxxx 
+xxtttttttx...xtttttttxx
+xttpW.qttx...xttq.Wpttx
+xtGWW^...........^WWGtx
+xttpW.qtqqq.qqqtq.Wpttx
+xxttttttttq.qttttttttxx
+xxtttqPtttq.qtttPqtttxx
+xttpW.qtqqq.qqqtq.Wpttx
+xtGWW^...........^WWGtx
+xttpW.qt.......tq.Wpttx
+xxtttttt.......ttttttxx
+xxtttttt...{...ttttttxx
+xttpW.qt.......tq.Wpttx
+xtGWW^...........^WWGtx
+xttpW.qt.......tq.Wpttx
+xxtttqPtt.ttt.ttPqtttxx
+ xxxttttP.PtP.Pttttxxx 
+   xxxxt.^.t.^.txxxx   
+      xtWWWtWWWtx      
+      xtpWptpWptx      
+      xttGtttGttx      
+      xxtttxtttxx      
+       xxxxxxxxx       
+ENDMAP

--- a/crawl-ref/source/dat/des/arrival/large.des
+++ b/crawl-ref/source/dat/des/arrival/large.des
@@ -1026,7 +1026,7 @@ KFEAT:      p = W
 KMONS:      p = plant
 NSUBST:     p = 10:p / *:W, q = 10:P / *:.
 MAP
- xxxxxxxxx+++xxxxxxxxx 
+ xxxxxxxxx@@@xxxxxxxxx 
 xxtttttttx...xtttttttxx
 xttpW.qttx...xttq.Wpttx
 xtGWW^...........^WWGtx

--- a/crawl-ref/source/dat/des/arrival/simple.des
+++ b/crawl-ref/source/dat/des/arrival/simple.des
@@ -2206,3 +2206,172 @@ MAP
    .xxxxxxxxxx.
    ............
 ENDMAP
+
+################################################################################
+NAME:       psy_arrival_basics
+TAGS:       arrival
+ORIENT:     float
+MAP
+xxxxxxxxxxxxm@
+x............@
+x.xxxxx...xxG@
+x.xxxx.....xx 
+x.xxxxx.{.xxx 
+x.xxxx.....xx 
+x.xxxxx...xxG@
+x............@
+xxxxxxxxxxxxm@
+ENDMAP
+
+NAME:       psy_arrival_conway
+TAGS:       arrival no_monster_gen no_pool_fixup
+ORIENT:     float
+KMONS:      P = plant / bush
+KFEAT:      P = W
+MAP
+xxxxxxxxxxxxxx
+xWPW.........x
+xWWPxx.xxx.{.x
+xPPPxx.xxx...x
+x.xxPWPxxxxx.x
+x.xxWPPxxxxx.x
+x...WPWxxxxx.x
+x.xxxxxWWP...x
+x.xxxxxPWPxx.x
+x.xxxxxWPPxx.x
+x...xxx.xxPWWx
+@...xxx.xxWPPx
+x.........PPWx
+xx@xxxxxxxxxxx
+ENDMAP
+
+NAME:       psy_arrival_dodecagon
+TAGS:       arrival no_monster_gen transparent
+ORIENT:     float
+SUBST:      p:Wmvb
+SUBST:      q:..xlm
+MAP
+           .           
+          .x.          
+         .x.x.         
+   ......x...x......   
+   .xxxxxxx.xxxxxxx.   
+   .xppx.......xppx.   
+   .xpx.........xpx.   
+   .xx...........xx.   
+   .x.............x.   
+  .xx.............xx.  
+ .xqx.............xqx. 
+.xqqq......{......qqqx.
+ .xqx.............xqx. 
+  .xx.............xx.  
+   .x.............x.   
+   .xx...........xx.   
+   .xpx.........xpx.   
+   .xppx.......xppx.   
+   .xxxxxxxqxxxxxxx.   
+   ......xqqqx......   
+         .xqx.         
+          .x.          
+           .           
+ENDMAP
+
+NAME:       psy_arrival_heroes
+TAGS:       arrival no_monster_gen
+WEIGHT:     5
+ORIENT:     float
+SUBST:      p : c@
+MAP
+        ppp                  
+        cGc                  
+        c.c                  
+      ccc.ccc                
+    ccc.....ccc              
+    c.........c cccccccccccc 
+   cc.........cccGccGccGccGc 
+   c........................@
+pccc........................@
+pG.......{..................@
+pccc........................@
+   c........................@
+   cc.........cccGccGccGccGc 
+    c.........c cccccccccccc 
+    ccc.....ccc              
+      ccc.ccc                
+        c.c                  
+        cGc                  
+        ppp                  
+ENDMAP
+
+NAME:       psy_arrival_radial01
+TAGS:       arrival no_monster_gen
+ORIENT:     float
+SHUFFLE:    pqr
+SUBST:      p:x, q:x, r:@
+MAP
+pxxxqqq rrxxxxxpp
+p..xx.xxx.x...x.x
+xx.x..x...x.x...x
+x..x.xx.xxx.xxxxx
+x.xx.x....x....xq
+x......xx.x.xx..q
+xxxxxxxx..x..xxxq
+r..x...x.xxx...x 
+rx.x.x..{..x.x.xr
+ x...xxx.x...x..r
+qxxx..x..xxxxxxxx
+q..xx.x.xx......x
+qx....x....x.xx.x
+xxxxx.xxx.xx.x..x
+x...x.x...x..x.xx
+x.x...x.xxx.xx..p
+ppxxxxxrr qqqxxxp
+ENDMAP
+
+NAME:       psy_arrival_radial02
+TAGS:       arrival no_monster_gen no_pool_fixup
+ORIENT:     float
+SHUFFLE:    JKLM
+SUBST:      JKL:x, M:@, p:llWWmvbx
+MAP
+pJxKxxxLxxxxMpppppppp
+p.x.x...x....p......J
+p.x.x.xxx.pppp.xxxxxx
+p.x.x.x...p.........K
+p.x.x.x.ppp.xxxxxxxxx
+p.x.x...p...........x
+p...x.ppp.ppppp.xxx.x
+ppp.x.p...p...p...x.L
+M.p.x.p.ppp.p.ppp.xxx
+x.p...p.....p...p...x
+x.ppp.ppp.{.ppp.ppp.x
+x...p...p.....p...p.x
+xxx.ppp.p.ppp.p.x.p.M
+L.x...p...p...p.x.ppp
+x.xxx.ppppp.ppp.x...p
+x...........p...x.x.p
+xxxxxxxxx.ppp.x.x.x.p
+K.........p...x.x.x.p
+xxxxxx.pppp.xxx.x.x.p
+J......p....x...x.x.p
+ppppppppMxxxxLxxxKxJp
+ENDMAP
+
+NAME:       psy_arrival_whirlpool
+TAGS:       arrival
+ORIENT:     float
+MAP
+ xxxxxxxxxx@ 
+xxWWWWWWWW.G@
+xWW.....WWW.x
+xW..WWW..WW.x
+x..WWWWW..W.x
+x.WW...WW.W.+
++.W..W{W..W.+
++.W.WW...WW.x
+x.W..WWWWW..x
+x.WW..WWW..Wx
+x.WWW.....WWx
+@G.WWWWWWWWxx
+ @xxxxxxxxxx 
+ENDMAP

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -3208,3 +3208,197 @@ xx'...--.......'xx
     xxaataaaataxx
      xxxxxxxxxxx
 ENDMAP
+
+################################################################################
+NAME:       psy_arrival_batcave
+TAGS:       arrival no_monster_gen
+WEIGHT:     5
+ORIENT:     float
+KFEAT:      2 = w
+KFEAT:      1 = W
+KMONS:      12 = bat
+MAP
+      xxx          
+ xxxxxx.@    xxxx  
+xx...xx+x   xxW1xx 
+x.....x.xxxxx...Wx 
+x..{.......+.....x 
+x.....x.x.xxx....x 
+xx...xx+x.xxxx..xx 
+ xxxxx..x.xxxxxxx  
+ xxxx..xx.xxxxxxxxx
+ xx....xx..+...WW+@
+ xW.....x.xxx..Wxxx
+ xWW...Wx+xx..WWwxx
+ xx1WWWxx.x..WWW2wx
+  xxxxxx..xWWWWwwwx
+       @@xxx1W2wwxx
+           xxwwwxx 
+            xxxxx  
+ENDMAP
+
+NAME:       psy_arrival_crosshairs
+TAGS:       arrival no_monster_gen
+WEIGHT:     5
+ORIENT:     float
+SUBST:      p : xxwWlcbvm
+SUBST:      q : xxwWlcbvm
+SUBST:      r : xxwWlcbvm
+SUBST:      s : xxwWlcbvm
+MAP
+rrrrrrrr@rrrrrrrr
+r...............r
+r.qqqqqq.qqqqqq.r
+r.q...........q.r
+r.q.ssss.ssss.q.r
+r.q.s.......s.q.r
+r.q.s.pp.pp.s.q.r
+r.q.s.p...p.s.q.r
+@.......{.......@
+r.q.s.p...p.s.q.r
+r.q.s.pp.pp.s.q.r
+r.q.s.......s.q.r
+r.q.ssss.ssss.q.r
+r.q...........q.r
+r.qqqqqq.qqqqqq.r
+r...............r
+rrrrrrrr@rrrrrrrr
+ENDMAP
+
+NAME:       psy_arrival_fountain
+TAGS:       arrival no_monster_gen
+ORIENT:     float
+FTILE:      t.qpP{T = floor_grass
+SHUFFLE:    pq
+SUBST:      p = .P, q : .
+KMONS:      P = plant
+MAP
+xxxxxxxxxxxxx
+xtttttttttttx
+xt{.........+
+xt...tttttqtx
+xt....PtPtqtx
+xt.t....qtqtx
+xt.tt.T...qtx
+xt.tP....tttx
+xt.ttP.pttttx
+xt.ttt.tttttx
+xt.pppptttttx
+xt.tttttttttx
+xx+xxxxxxxxxx
+ENDMAP
+
+NAME:       psy_arrival_solomon
+TAGS:       arrival no_monster_gen no_rotate no_item_gen no_pool_fixup
+ORIENT:     float
+SUBST:      p : tvGGd, q : wwlx'''
+KFEAT:      '" = .
+FTILE:      ' = floor_pebble_darkgray
+COLOUR:     ' : darkgrey
+ITEM:       stone
+MAP
+    x+xxxxx+x    
+  xxx...q...xxx  
+ xx.p..q.q..p.xx 
+xx....q...q....xx
+xqqqqqqqqqqqqqqqx
++.q..q.....q..q.+
+x..q.q.....q.q..x
+x..qq.......qq..x
+xp..q...{...q..px
+x..qq.......qq..x
+x..q.q.....q.q..x
++.q..q.....q..q.+
+xqqqqqqqqqqqqqqqx
+xx....q...q....xx
+ xx.p..q.q..p.xx 
+  xxx...q...xxx  
+    x+xxxxx+x    
+ENDMAP
+
+NAME:       psy_arrival_spokes
+TAGS:       arrival no_monster_gen
+WEIGHT:     3
+ORIENT:     float
+: if crawl.coinflip() then
+SUBST:      q : @, r : x, p : .
+:end
+CLEAR:      pqr
+MAP
+     rqx@@@xqr     
+     rpx...xpr     
+     rpx...xpr     
+     rpx...xpr     
+     rpx...xpr     
+     rpx...xpr     
+     rpx...xpr     
+    rrpx...xprr    
+   rrpxx.{.xxprr   
+  rrpxx.....xxprr  
+ rrpxx..}.G..xxprr 
+rrpxx.........xxprr
+rpxx.....x.....xxpr
+qxx.....xxx.....xxq
+xx.....xxpxx.....xx
+x.....xxprpxx.....x
+@@...xxprrrpxx...@@
+ @@.xxprr rrpxx.@@ 
+  @xxqrr   rrqxx@  
+ENDMAP
+
+NAME:       psy_arrival_statuary
+TAGS:       arrival no_monster_gen
+ORIENT:     float
+FTILE:      'qrp{ = floor_pebble_darkgray
+FTILE:      . = floor_pebble_cyan
+COLOUR:     'qrp{ = darkgrey
+COLOUR:     . = cyan
+SHUFFLE:    pqr
+SUBST:      p : GGU, qr : .
+SUBST:      s : Gxxxb
+MAP
+xxxxxxx@xxxxxxx
+xxxxxxx+xxxxxxx
+xxq'..'''..'qxx
+xx''..'r'..''xx
+xx..p'...'p..xx
+xx..''...''..xx
+xx''..'''..''xx
+xs'r..'{'..r'sx
+xx''..'''..''xx
+xx..''...''..xx
+xx..p'...'p..xx
+xx''..'r'..''xx
+xxq'..'''..'qxx
+xxxxxxx+xxxxxxx
+xxxxxxx@xxxxxxx
+ENDMAP
+
+NAME:       psy_arrival_terrarium
+TAGS:       arrival
+ORIENT:     float
+FTILE:      Pqr' = floor_grass
+KMONS:      p = plant
+KMONS:      P = plant / bush
+KFEAT:      p = W
+KMASK:      WpPqr' = no_item_gen
+KMASK:      WpPqr' = no_monster_gen
+KPROP:      WpPqr' = no_tele_into
+SUBST:      q = P', r = P''
+MAP
+   xxxx+xxxx   
+  xxppm.mPPxx  
+ xxpWWm.mqqPxx 
+xxpWWWm.mrrqPxx
+xpWWWWm.m''rqPx
+xpWWWWm.m''rqPx
+xmmmmmm.mmmmmmx
++......{......+
+xmmmmmm.mmmmmmx
+xPqr''m.mWWWWpx
+xPqr''m.mWWWWpx
+xxPqrrm.mWWWpxx
+ xxPqqm.mWWpxx 
+  xxPPm.mppxx  
+   xxxx+xxxx   
+ENDMAP

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -3237,34 +3237,6 @@ xx...xx+x.xxxx..xx
             xxxxx  
 ENDMAP
 
-NAME:       psy_arrival_crosshairs
-TAGS:       arrival no_monster_gen
-WEIGHT:     5
-ORIENT:     float
-SUBST:      p : xxwWlcbvm
-SUBST:      q : xxwWlcbvm
-SUBST:      r : xxwWlcbvm
-SUBST:      s : xxwWlcbvm
-MAP
-rrrrrrrr@rrrrrrrr
-r...............r
-r.qqqqqq.qqqqqq.r
-r.q...........q.r
-r.q.ssss.ssss.q.r
-r.q.s.......s.q.r
-r.q.s.pp.pp.s.q.r
-r.q.s.p...p.s.q.r
-@.......{.......@
-r.q.s.p...p.s.q.r
-r.q.s.pp.pp.s.q.r
-r.q.s.......s.q.r
-r.q.ssss.ssss.q.r
-r.q...........q.r
-r.qqqqqq.qqqqqq.r
-r...............r
-rrrrrrrr@rrrrrrrr
-ENDMAP
-
 NAME:       psy_arrival_fountain
 TAGS:       arrival no_monster_gen
 ORIENT:     float
@@ -3348,6 +3320,7 @@ ENDMAP
 
 NAME:       psy_arrival_statuary
 TAGS:       arrival no_monster_gen
+WEIGHT:     5
 ORIENT:     float
 FTILE:      'qrp{ = floor_pebble_darkgray
 FTILE:      . = floor_pebble_cyan


### PR DESCRIPTION
First time vault submission, edits/feedback welcome if anything looks nonstandard. I've been working on a Tiled (.tmx) utility to make generation a little more visual and am hoping to submit more vaults for other areas in the future.

### simple:
 - psy_arrival_basics - two exits and kite route
 - psy_arrival_conway - features a plant glider pattern
 - psy_arrival_dodecagon - floating star, can generate with 1 or 12 sides open to leave
 - psy_arrival_heroes - statue hall
 - psy_arrival_radial - two variable maps with radial symmetry
 - psy_arrival_whirlpool - shallow water paths

### small:
 - psy_arrival_batcave - a cave, with bats in it... batcave
 - psy_arrival_fountain - grove with a spring, half blocked off by plants
 - psy_arrival_solomon - variable map based on the seal of Solomon design, can generate as transparent or three separate rooms
 - psy_arrival_spokes - open 3-fork vault, some stuff in middle as it's vulnerable
 - psy_arrival_statuary - statues/fountains on a checkered floor design
 - psy_arrival_terrarium - some closed areas with water/plants

### large:
 - psy_arrival_wood_between_worlds - low-weight greenery vault with some id'd tele traps