### PR TITLE
Fix item ego cloud immunity message with Qazlal (0011500)

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -920,7 +920,8 @@ static void _equip_armour_effect(item_def& arm, bool unmeld,
             break;
 
         case SPARM_CLOUD_IMMUNE:
-            mpr("You feel immune to the effects of clouds.");
+            if (!have_passive(passive_t::cloud_immunity))
+                mpr("You feel immune to the effects of clouds.");
             break;
         }
     }
@@ -1086,7 +1087,8 @@ static void _unequip_armour_effect(item_def& item, bool meld,
         break;
 
     case SPARM_CLOUD_IMMUNE:
-        mpr("You feel vulnerable to the effects of clouds.");
+        if (!you.cloud_immune())
+            mpr("You feel vulnerable to the effects of clouds.");
         break;
 
     default:


### PR DESCRIPTION
Made it so "You feel vulnerable to the effects of clouds." and "You feel immune to the effects of clouds" messages from unequiping/equiping cloud immunity items don't appear when you have Qazlal cloud immunity.

Mantis Issue: https://crawl.develz.org/mantis/view.php?id=11500