### PR TITLE
Add elemental colour support to the equip bar

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -67,12 +67,12 @@ The contents of this text are:
                 hp_warning, mp_warning, hp_colour, mp_colour, stat_colour,
                 status_caption_colour, enemy_hp_colour, clear_messages,
                 show_more, small_more, show_newturn_mark, show_game_time,
-                equip_bar, item_stack_summary_minimum, mlist_min_height,
-                mlist_allow_alternate_layout, msg_min_height, msg_max_height,
-                messages_at_top, skill_focus, msg_condense_repeats,
-                msg_condense_short, show_travel_trail, monster_list_colour,
-                view_delay, force_more_message, flash_screen_message,
-                use_animations, darken_beyond_range
+                equip_bar, animate_equip_bar, item_stack_summary_minimum,
+                mlist_min_height, mlist_allow_alternate_layout, msg_min_height,
+                msg_max_height, messages_at_top, skill_focus,
+                msg_condense_repeats, msg_condense_short, show_travel_trail,
+                monster_list_colour, view_delay, force_more_message,
+                flash_screen_message, use_animations, darken_beyond_range
 3-i     Colours (messages and menus)
                 menu_colour, message_colour
 3-j     Missiles.
@@ -1438,6 +1438,10 @@ equip_bar = false
         When set to true, this option replaces the noise bar with an
         "equipment bar" showing the glyphs of all currently equipped items,
         with gaps for available but currently unfilled equipment slots.
+
+animate_equip_bar = false
+        When set to true, any items displayed in the equipment bar that have a
+        variable colour will be animated.
 
 item_stack_summary_minimum = 4
         If you step over a stack with this number or more of items in

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -176,6 +176,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(show_newturn_mark), true),
         new BoolGameOption(SIMPLE_NAME(show_game_time), true),
         new BoolGameOption(SIMPLE_NAME(equip_bar), false),
+        new BoolGameOption(SIMPLE_NAME(animate_equip_bar), false),
         new BoolGameOption(SIMPLE_NAME(mouse_input), false),
         new BoolGameOption(SIMPLE_NAME(mlist_allow_alternate_layout), false),
         new BoolGameOption(SIMPLE_NAME(messages_at_top), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -219,6 +219,7 @@ public:
     bool        show_newturn_mark;// Show underscore prefix in messages for new turn
     bool        show_game_time; // Show game time instead of player turns.
     bool        equip_bar; // Show equip bar instead of noise bar.
+    bool        animate_equip_bar; // Animate colours in equip bar.
 
     FixedBitVector<NUM_OBJECT_CLASSES> autopickups; // items to autopickup
     bool        auto_switch;     // switch melee&ranged weapons according to enemy range

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -594,6 +594,7 @@ static void _print_stats_equip(int x, int y)
             if (you.slot_item(eqslot))
             {
                 cglyph_t g = get_item_glyph(*(you.slot_item(eqslot)));
+                g.col = element_colour(g.col, !Options.animate_equip_bar);
                 formatted_string::parse_string(glyph_to_tagstr(g)).display();
             }
             else if (!you_can_wear(eqslot, true))


### PR DESCRIPTION
This commit modifies the equip bar to process elemental colours (coming
from unrands) for equipment glyphs in the equip bar.

By default, the colours are not animated, since a goal of the equip bar
was to lower visual noise. The option "animate_equip_bar" is added to
toggle this behavior, as the other goal is to show of your cool stuff.