### PR TITLE
Fix zot traps casting friendly malign gateways (0011042)

### DIFF
--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -3022,7 +3022,7 @@ void MiscastEffect::_zot()
             }
             break;
         case 8:
-            if (!_malign_gateway(target->is_player()))
+            if (!_malign_gateway(true))
                 goto reroll_1;
             break;
         }


### PR DESCRIPTION
Previously zot traps would cast a friendly malign gateway when a non-player triggered the trap. This has been changed to always cast a hostile malign gateway.

Mantis issue: https://crawl.develz.org/mantis/view.php?id=11042