### PR TITLE
Make items for the cloak slot be equally common as other auxiliary armour slots again

### DIFF
--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1048,19 +1048,19 @@ static armour_type _get_random_armour_type(int item_level)
     // Secondary armours.
     if (one_chance_in(5))
     {
-        // Total weight is 30, each slot has a weight of 6
-        armtype = random_choose_weighted(6, ARM_BOOTS,
-                                         6, ARM_GLOVES,
+        // Total weight is 60, each slot has a weight of 12
+        armtype = random_choose_weighted(12, ARM_BOOTS,
+                                         12, ARM_GLOVES,
                                          // Cloak slot
-                                         3, ARM_CLOAK,
-                                         1, ARM_SCARF,
+                                         9, ARM_CLOAK,
+                                         3, ARM_SCARF,
                                          // Head slot
-                                         5, ARM_HELMET,
-                                         1, ARM_HAT,
+                                         10, ARM_HELMET,
+                                         2, ARM_HAT,
                                          // Shield slot
-                                         2, ARM_SHIELD,
-                                         3, ARM_BUCKLER,
-                                         1, ARM_LARGE_SHIELD);
+                                         4, ARM_SHIELD,
+                                         6, ARM_BUCKLER,
+                                         2, ARM_LARGE_SHIELD);
     }
     else if (x_chance_in_y(11 + item_level, 10000))
     {


### PR DESCRIPTION
In commit 651d724, scarves were increased from being 1/6 to 1/4 of items generated for the cloak slot, however the actual increase in spawn rate for scarves was minimal, from 1/30 to 1/28 of all auxiliary slot armours generated, because what this commit actually did was reduce the spawn rate of cloaks from 5/30 to 3/28 by reducing the weight of cloaks.

It seems like an accident that this meant the total weight for this random_choose_weighted was not the 30 that a comment implied, and that the cloak slot items (cloaks and scarves combined) were made 2/3 as common as other auxiliary slot armours.

As a result, this commit buffs the spawn rate of cloaks and scarves to bring the overall spawn rate in line with that of other auxiliary armours, whilst maintaining the same 3:1 ratio of cloaks:scarves.

If breaking `git blame` by increasing the total weight from 30 to 60 is an issue, then we would have to change the ratio of cloaks to scarves as well, which is something I have tried to avoid.