### PR TITLE
Remove hair/beard layer from Ba and Gn tiles.

### DIFF
--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -673,15 +673,6 @@ void tilep_race_default(int sp, int level, dolls_data *doll)
         case SP_DEEP_ELF:
             hair = TILEP_HAIR_ELF_WHITE;
             break;
-        case SP_HILL_ORC:
-            hair = 0;
-            break;
-        case SP_KOBOLD:
-            hair = 0;
-            break;
-        case SP_MUMMY:
-            hair = 0;
-            break;
         case SP_TROLL:
             hair = TILEP_HAIR_TROLL;
             break;
@@ -699,15 +690,6 @@ void tilep_race_default(int sp, int level, dolls_data *doll)
             hair   = 0;
             break;
         }
-        case SP_MINOTAUR:
-            hair = 0;
-            break;
-        case SP_DEMONSPAWN:
-            hair = 0;
-            break;
-        case SP_GHOUL:
-            hair = 0;
-            break;
         case SP_MERFOLK:
             result = you.fishtail ? TILEP_BASE_MERFOLK_WATER
                                   : TILEP_BASE_MERFOLK;
@@ -727,7 +709,17 @@ void tilep_race_default(int sp, int level, dolls_data *doll)
             hair = 0;
             beard = TILEP_BEARD_MEDIUM_GREEN;
             break;
+        case SP_MINOTAUR:
+        case SP_DEMONSPAWN:
+        case SP_GHOUL:
+        case SP_HILL_ORC:
+        case SP_KOBOLD:
+        case SP_MUMMY:
         case SP_FORMICID:
+        case SP_BARACHI:
+        case SP_GNOLL:
+        case SP_GARGOYLE:
+        case SP_VINE_STALKER:
             hair = 0;
             break;
         default:
@@ -1032,14 +1024,6 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
         flag[TILEP_PART_SHADOW]= TILEP_FLAG_HIDE;
         flag[TILEP_PART_DRCWING]=TILEP_FLAG_HIDE;
         flag[TILEP_PART_DRCHEAD]=TILEP_FLAG_HIDE;
-    }
-    else if (is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_BARACHI)
-             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GNOLL)
-             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GARGOYLE)
-             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_VINE_STALKER))
-    {
-        flag[TILEP_PART_HAIR]  = TILEP_FLAG_HIDE;
-        flag[TILEP_PART_BEARD] = TILEP_FLAG_HIDE;
     }
 
     if (doll.parts[TILEP_PART_ARM] == TILEP_ARM_OCTOPODE_SPIKE

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -1033,6 +1033,12 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
         flag[TILEP_PART_DRCWING]=TILEP_FLAG_HIDE;
         flag[TILEP_PART_DRCHEAD]=TILEP_FLAG_HIDE;
     }
+    else if (is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_BARACHI)
+             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GNOLL))
+    {
+        flag[TILEP_PART_HAIR]  = TILEP_FLAG_HIDE;
+        flag[TILEP_PART_BEARD] = TILEP_FLAG_HIDE;
+    }
 
     if (doll.parts[TILEP_PART_ARM] == TILEP_ARM_OCTOPODE_SPIKE
         && !is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_OCTOPODE))

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -1034,7 +1034,9 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
         flag[TILEP_PART_DRCHEAD]=TILEP_FLAG_HIDE;
     }
     else if (is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_BARACHI)
-             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GNOLL))
+             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GNOLL)
+             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_GARGOYLE)
+             || is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_VINE_STALKER))
     {
         flag[TILEP_PART_HAIR]  = TILEP_FLAG_HIDE;
         flag[TILEP_PART_BEARD] = TILEP_FLAG_HIDE;


### PR DESCRIPTION
Displaying hair on these tiles was unintentional.

Ba for example is drawn to have 4 eyes, but the default hair covers up
the top two. This, and considering the fact that frogs aren't hairy IRL
makes it pretty clear that displaying hair was an accident, not a
deliberate artistic decision.