### PR TITLE
Fix polymorph/frenzy bug (0011504)

### DIFF
--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -314,6 +314,13 @@ void change_monster_type(monster* mons, monster_type targetc)
             mons->props["old_heads"].get_int() = mons->num_heads;
     }
 
+    //if monster was frenzied before it was polymorphed reset attitude
+    if (mons->props.exists("old_attitude"))
+    {
+        mons->attitude = static_cast<mon_attitude_type>(mons->props["old_attitude"].get_short());
+        mons_att_changed(mons);
+    }
+
     mon_enchant abj       = mons->get_ench(ENCH_ABJ);
     mon_enchant fabj      = mons->get_ench(ENCH_FAKE_ABJURATION);
     mon_enchant charm     = mons->get_ench(ENCH_CHARM);


### PR DESCRIPTION
This issue is due to frenzy setting the attitude and storing the old
attitude in the props map and it never gets set back when polymorphed as
it simply clears the enchantment map. The old attitude usually gets
restored when remove enchantment is called after the duration times out
but since that isn't called it keeps the indifferent attitude.

This is mostly a band-aid fix to just fix this one instance because
other enchantments don't seem to have similar issues. A more long term
fix would be adding a function that calls remove enchantment function
for each enchantment. I wasn't sure the best way to do this so I have
submitted this simple fix.

https://crawl.develz.org/mantis/view.php?id=11504