### PR TITLE
Replace outdated commands in FAQ and hints

### DIFF
--- a/crawl-ref/source/dat/database/FAQ.txt
+++ b/crawl-ref/source/dat/database/FAQ.txt
@@ -222,7 +222,7 @@ Yredelemnul (for undead allies). Also, while unreliable, Xom can be a lot of
 fun.
 
 Whenever you encounter an altar, be sure to read the corresponding god's
-description (by 'p'raying on the altar) and take your time in deciding whether
+description (by praying on the altar with '>') and take your time in deciding whether
 to pick this deity or not. As a follower, you can reread your god's
 description, now more detailed via the '!' toggle, on the '^' screen.
 

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -3643,13 +3643,13 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
             if (altar_god == GOD_SIF_MUNA
                 && !player_can_join_god(altar_god))
             {
-                ostr << "As <w>p</w>raying on the altar will tell you, "
+                ostr << "As praying with <w>></w> on the altar will tell you, "
                      << god_name(altar_god) << " only accepts worship from "
                         "those who have already dabbled in magic. You can "
                         "find out more about this god by searching the "
                         "database with <w>?/g</w>.\n"
                         "For other gods, you'll be able to join the faith "
-                        "by <w>p</w>raying at their altar.";
+                        "by praying with <w>></w> at their altar.";
             }
             else if (you_worship(GOD_NO_GOD))
             {
@@ -3660,7 +3660,7 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
                         "tributes or entertainment in return.\n"
                         "You can get information about <w>"
                      << god_name(altar_god)
-                     << "</w> by pressing <w>p</w> while standing on the "
+                     << "</w> by pressing <w>></w> while standing on the "
                         "altar. Before taking up the responding faith "
                         "you'll be asked for confirmation.";
             }
@@ -3676,7 +3676,7 @@ static void _hints_describe_feature(int x, int y, ostringstream& ostr)
                         "but having a look won't hurt: to get information "
                         "on <w>";
                 ostr << god_name(altar_god);
-                ostr << "</w>, press <w>p</w> while standing on the "
+                ostr << "</w>, press <w>></w> while standing on the "
                         "altar. Before taking up the responding faith (and "
                         "abandoning your current one!) you'll be asked for "
                         "confirmation."


### PR DESCRIPTION
Multiple instances of 'p'raying still existed in FAQ and hints. These have been replaced with references to using > to pray rather than 'p'.