### PR TITLE
Allow naming randart fiery weapons after Dithmenos

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -169,12 +169,6 @@ static bool _god_fits_artefact(const god_type which_god, const item_def &item,
         break;
 
     case GOD_DITHMENOS:
-        // No fiery weapons.
-        if (item.base_type == OBJ_WEAPONS
-            && brand == SPWPN_FLAMING)
-        {
-            return false;
-        }
         // No reducing stealth.
         if (artefact_property(item, ARTP_STEALTH) < 0)
             return false;


### PR DESCRIPTION
Because Dithmenos doesn't have an anti-fire conduct any more, it is
no longer necessary to veto names like "...of Dithmenos's Generosity"
for randart flaming weapons.