### PR TITLE
Update descriptions of forms

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -63,7 +63,7 @@ Transforms the user into a swift-moving vampire bat, increasing evasion but
 substantially weakening melee attacks.
 
 While tranformed, any equipped weapons, armour and rings are melded, and the
-user becomes unable to evoke wands or to cast spells.
+user becomes unable to cast spells.
 %%%%
 Fly ability
 

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -130,8 +130,8 @@ Blade Hands spell
 Causes long, scythe-shaped blades to grow from the caster's hands, increasing
 melee damage significantly.
 
-While transformed, any equipped weapons are melded. The caster also becomes
-unable to evoke wands, and casting spells becomes somewhat more difficult.
+While transformed, any equipped weapons are melded, and casting spells becomes
+somewhat more difficult.
 %%%%
 Blink Allies Away spell
 
@@ -684,9 +684,8 @@ gnashing teeth are instantly devoured, reinvigorating the caster in their
 reptilian rampage. The caster gains innate armour and increased health, and
 becomes resistant to poison.
 
-While transformed, any equipped weapons and armour are melded, and wands cannot
-be evoked. The form's number of heads is fixed upon casting the spell, and
-increases with power.
+While transformed, any equipped weapons and armour are melded. The form's
+number of heads is fixed upon casting the spell, and increases with power.
 %%%%
 Iceblast spell
 
@@ -699,8 +698,7 @@ Transforms the caster into a frozen ice-creature, light enough to float on
 water. The caster gains a freezing melee attack, and becomes incredibly
 resistant to cold and resistant to poison, but vulnerable to fire.
 
-While transformed, any equipped weapons and armour are melded, and wands cannot
-be evoked.
+While transformed, any equipped weapons and armour are melded.
 %%%%
 Ignite Poison spell
 
@@ -1025,8 +1023,8 @@ shape-changing creatures.
 %%%%
 Porkalator spell
 
-Transforms the target into a pig. The target moves swiftly but cannot evoke
-wands or cast spells. The caster's demise will cause the transformation to end.
+Transforms the target into a pig. The target moves swiftly but cannot cast
+spells. The caster's demise will cause the transformation to end.
 %%%%
 Portal Projectile spell
 
@@ -1238,9 +1236,8 @@ Spider Form spell
 Transforms the caster into a venomous, spider-like creature. The caster becomes
 highly evasive and gains a poisonous bite, but gains vulnerability to poison.
 
-While transformed, any equipped weapons and armour are melded. The caster also
-becomes unable to evoke wands, and casting spells becomes slightly more
-difficult.
+While transformed, any equipped weapons and armour are melded, and casting
+spells becomes slightly more difficult.
 %%%%
 Spit Acid spell
 

--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -518,16 +518,16 @@ Spider status
 You have been transformed into a venomous, spider-like creature. You become
 highly evasive and gain a poisonous bite, but gain vulnerability to poison.
 
-Any equipped weapons and armour are melded. Your success rate with spells is
-slightly reduced, and you are unable to evoke wands.
+Any equipped weapons and armour are melded, and your success rate with spells
+is slightly reduced.
 %%%%
 Blade status
 
 Long, scythe-shaped blades have grown from your hands, increasing your melee
 damage significantly.
 
-Any equipped weapons are melded. Your success rate with spells is somewhat
-reduced, and you are unable to evoke wands.
+Any equipped weapons are melded, and your success rate with spells is somewhat
+reduced.
 %%%%
 Statue status
 
@@ -544,7 +544,7 @@ You have been transformed into a frozen ice-creature, light enough to float on
 water. You gain a freezing melee attack, and are incredibly resistant to cold
 and resistant to poison, but vulnerable to fire.
 
-Any equipped weapons and armour are melded, and you are unable to evoke wands.
+Any equipped weapons and armour are melded.
 %%%%
 Dragon status
 
@@ -596,8 +596,8 @@ Bat status
 You have been transformed into a swift-moving bat, increasing your evasion but
 substantially weakening your melee attacks.
 
-Any equipped weapons, armour and rings are melded, and you are unable to evoke
-wands or cast spells. {{
+Any equipped weapons, armour and rings are melded, and you are unable to cast
+spells. {{
     if you.race() ~= "Vampire" then
         return "The effectiveness of your melee attacks while " ..
                "in this form is based on experience level instead of on " ..
@@ -610,9 +610,9 @@ Pig status
 You have been transformed into a pig. You move quickly but are less effective
 in melee.
 
-Any equipped weapons, armour and rings are melded, and you are unable to evoke
-wands or cast spells. The effectiveness of your melee attacks while in this
-form is based on experience level instead of on Unarmed Combat skill.
+Any equipped weapons, armour and rings are melded, and you are unable to cast
+spells. The effectiveness of your melee attacks while in this form is based on
+experience level instead of on Unarmed Combat skill.
 %%%%
 App status
 
@@ -642,8 +642,8 @@ to fire, cold, electricity and acid, and immune to poison, rotting and
 negative energy.
 
 Any equipped weapons, armour and jewellery are melded, and you are unable to
-evoke wands or cast spells. The effectiveness of your melee attacks while in
-this form is based on experience level instead of on Unarmed Combat skill.
+cast spells. The effectiveness of your melee attacks while in this form is based
+on experience level instead of on Unarmed Combat skill.
 %%%%
 Fungus status
 
@@ -652,10 +652,9 @@ can release spores to cause confusion when attacking in melee, but are unable
 to move when hostile creatures are present. You are resistant to poison and
 immune to negative energy.
 
-Any equipped cloak, gloves, boots, shield, body armour and weapons are melded,
-and you are unable to evoke wands or cast spells. The effectiveness of your
-melee attacks while in this form is based on experience level instead of on
-Unarmed Combat skill.
+Any equipped weapons and armour are melded, and you are unable to cast spells.
+The effectiveness of your melee attacks while in this form is based on
+experience level instead of on Unarmed Combat skill.
 %%%%
 Shadow status
 
@@ -673,7 +672,7 @@ heads strike in all directions when attacking, and edible foes that are slain
 are instantly consumed for nutrition and health. You are naturally robust, and
 resistant to poison.
 
-Any equipped weapons and armour are melded, and you are unable to evoke wands.
+Any equipped weapons and armour are melded.
 %%%%
 Orb status
 


### PR DESCRIPTION
This commit updates descriptions of all forms that can use wands since
7d43e34acb. It also fixes Fungus form's description: players in that
form can't wear hats or helmets (commit 7346924bb0).