### PR TITLE
Vampires tooth buff

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -232,9 +232,9 @@ TILE_EQ: wucad_mu
 VALUE:   1000
 
 NAME:    Vampire's Tooth
-OBJ:     OBJ_WEAPONS/WPN_DAGGER
+OBJ:     OBJ_WEAPONS/WPN_QUICK_BLADE
 # it's a dagger made from a tooth -> no TYPE
-PLUS:    +4
+PLUS:    +12
 COLOUR:  ETC_BONE
 TILE:    spwpn_vampires_tooth
 TILE_EQ: vampires_tooth

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -130,7 +130,7 @@ protected:
     virtual bool handle_phase_end();
 
     /* Combat Calculations */
-    virtual bool using_weapon() = 0;
+    virtual bool using_weapon() const = 0;
     virtual int weapon_damage() = 0;
     virtual int get_weapon_plus();
     virtual int calc_base_unarmed_damage();

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3485,7 +3485,7 @@ int melee_attack::calc_your_to_hit_unarmed(int uattack)
     return your_to_hit;
 }
 
-bool melee_attack::using_weapon()
+bool melee_attack::using_weapon() const
 {
     return weapon && is_melee_weapon(*weapon);
 }

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -62,7 +62,7 @@ private:
     bool handle_phase_end() override;
 
     /* Combat Calculations */
-    bool using_weapon() override;
+    bool using_weapon() const override;
     int weapon_damage() override;
     int calc_mon_to_hit_base() override;
     int apply_damage_modifiers(int damage, int damage_max) override;

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -326,7 +326,7 @@ bool ranged_attack::handle_phase_hit()
     return true;
 }
 
-bool ranged_attack::using_weapon()
+bool ranged_attack::using_weapon() const
 {
     return weapon && (launch_type == launch_retval::LAUNCHED
                      || launch_type == launch_retval::BUGGY // not initialized

--- a/crawl-ref/source/ranged-attack.h
+++ b/crawl-ref/source/ranged-attack.h
@@ -28,7 +28,7 @@ private:
     bool ignores_shield(bool verbose) override;
 
     /* Combat Calculations */
-    bool using_weapon() override;
+    bool using_weapon() const override;
     int weapon_damage() override;
     int calc_base_unarmed_damage() override;
     int calc_mon_to_hit_base() override;


### PR DESCRIPTION
Constify some attack code, and then:

Buff Vampire's tooth (gammafunk)

The gimmick (100% of damage comes as vampiric heal) only works on a
weapon that's able to do some damage. This patch changes it from a +4
dagger to a +12 quickblade. The quick attack and slaying give it an
average damage less than a +4 electric brand quick blade, but enough
healing to be similar to a spellpower 100 vampiric draining cast against
targets that aren't too heavily armoured.