### PR TITLE
Fixup artp tweaks and revise some unrand blades.

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -286,7 +286,10 @@ bool actor::reflection(bool calc_unid, bool items) const
 
 bool actor::extra_harm(bool calc_unid, bool items) const
 {
-    return items && wearing(EQ_AMULET, AMU_HARM, calc_unid);
+    const item_def *wp = primary_weapon();
+    return items &&
+           (wearing(EQ_AMULET, AMU_HARM, calc_unid)
+            || wp && is_unrandom_artefact(*wp, UNRAND_MORG));
 }
 
 bool actor::rmut_from_item(bool calc_unid) const

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -572,14 +572,13 @@ BOOL:    poison, no_upgrade
 
 NAME:     Spriggan's Knife
 OBJ:      OBJ_WEAPONS/WPN_DAGGER
+INSCRIP:  stab,
 TYPE:     knife
 PLUS:     +7
 COLOUR:   LIGHTCYAN
 TILE:     urand_spriggans_knife
 TILE_EQ:  spriggans_knife
 EV:       4
-DEX:      4
-MAGIC:    1
 STEALTH:  1
 
 NAME:    plutonium sword

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -377,13 +377,13 @@ BOOL:    poison, skip_ego, nogen
 
 NAME:     dagger "Morg"
 OBJ:      OBJ_WEAPONS/WPN_DAGGER
+INSCRIP:  biting pain, Harm
 PLUS:     +4
 COLOUR:   LIGHTRED
 TILE:     urand_morg
 TILE_EQ:  morg
 BRAND:    SPWPN_PAIN
-INT:      5
-MAGIC:    1
+BOOL:     drain, skip_ego
 
 NAME:    scythe "Finisher"
 OBJ:     OBJ_WEAPONS/WPN_SCYTHE

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -545,8 +545,13 @@ void attack::pain_affects_defender()
     actor* user = _pain_weapon_user(attacker);
     if (!one_chance_in(user->skill_rdiv(SK_NECROMANCY) + 1))
     {
+        int effective_skill = 0;
+        if (using_weapon() && is_unrandom_artefact(*weapon, UNRAND_MORG))
+            effective_skill = user->skill_rdiv(SK_NECROMANCY, 3, 2);
+        else
+            effective_skill = user->skill_rdiv(SK_NECROMANCY);
         special_damage += resist_adjust_damage(defender, BEAM_NEG,
-                              random2(1 + user->skill_rdiv(SK_NECROMANCY)));
+                              random2(1 + effective_skill));
 
         if (special_damage && defender_visible)
         {

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1795,7 +1795,15 @@ void attack::player_stab_check()
         return;
     }
 
-    const stab_type st = find_stab_type(&you, *defender);
+    stab_type st = find_stab_type(&you, *defender);
+    // Find stab type is also used for displaying information about monsters,
+    // so we need to upgrade the stab type for the Spriggan's Knife here
+    if (using_weapon()
+        && is_unrandom_artefact(*weapon, UNRAND_SPRIGGANS_KNIFE)
+        && st != STAB_NO_STAB)
+    {
+        st = STAB_SLEEPING;
+    }
     stab_attempt = st != STAB_NO_STAB;
     stab_bonus = stab_bonus_denom(st);
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -237,9 +237,8 @@ harder it will be to find a worthy opponent.
 %%%%
 Spriggan's Knife
 
-A dainty little knife which was made by Spriggans, or for Spriggans, or
-possibly from Spriggans. Anyway, it's in some way associated with those fey
-folk.
+A dainty little knife which was made by Spriggans. It carves into the world of
+dreams, and stabs any unaware enemy as if it were asleep.
 %%%%
 plutonium sword
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -124,8 +124,10 @@ slowing down their movement somewhat.
 %%%%
 dagger "Morg"
 
-An ugly rusty dagger. Many years ago it was the property of a powerful mage
-called Boris. He got lost in the Dungeon while seeking the Orb.
+An ugly rusty dagger. Many years ago it was crafted a powerful mage called
+Boris in search of the secrets of life and death. He got lost in the Dungeon
+while seeking the Orb. The wounds it inflicts are exceptionally painful to
+living creatures. It increases damage dealt and taken.
 %%%%
 scythe "Finisher"
 

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -754,13 +754,7 @@ void sonic_damage(bool scream)
         int hurt = (random2(2) + 1) * (random2(2) + 1) * (random2(3) + 1)
                  + (random2(3) + 1) + 1;
         if (scream)
-            hurt = max(hurt * 2, 16);
-        int cap = scream ? mi->max_hit_points / 2 : mi->max_hit_points * 3 / 10;
-        hurt = min(hurt, max(cap, 1));
-        // not so much damage if you're a n00b
-        hurt = div_rand_round(hurt * you.experience_level, 27);
-        // scale by time taken, so multiple quick actions don't hurt more
-        hurt = div_rand_round(hurt * you.time_taken, BASELINE_DELAY);
+            hurt = hurt * 2;
         /* per dpeg:
          * damage is universal (well, only to those who can hear, but not sure
            we can determine that in-game), i.e. smiting, no resists

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -64,6 +64,7 @@ my %field_type = (
     RND_TELE => "bool",
     SEEINV   => "bool",
     SKIP_EGO => "bool",
+    SH       => "num",
     SLAY     => "num",
     SPECIAL  => "bool",
     SLOW     => "bool",
@@ -490,7 +491,7 @@ my @art_order = (
     "MUTATE", "unused", "SLAY", "CURSE", "STEALTH", "MP", "\n",
     "BASE_DELAY", "HP", "CLARITY", "BASE_ACC", "BASE_DAM", "\n",
     "RMSL", "FOG", "REGEN", "unused", "NO_UPGRADE", "RCORR", "\n",
-    "RMUT", "unused", "CORRODE", "DRAIN", "SLOW", "FRAGILE", "\n",
+    "RMUT", "unused", "CORRODE", "DRAIN", "SLOW", "FRAGILE", "SH", "\n",
     "}",
 
     "equip_func", "unequip_func", "world_reacts_func", "melee_effects_func",

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -271,11 +271,13 @@ static void _tweak_randart(item_def &item)
         char buf[80];
 
         if (choice_num < 26)
-            choice = 'A' + choice_num;
-        else if (choice_num < 'A' - '0' + 26)
+            choice = 'a' + choice_num;
+        else if (choice_num < 52)
+            choice = 'A' + choice_num - 26;
+        else if (choice_num < 'A' - '0' + 52)
         {
             // 0-9 then :;<=>?@ . Any higher would collide with letters.
-            choice = '0' + choice_num - 26;
+            choice = '0' + choice_num - 52;
         }
         else
             choice = '-'; // Too many choices!
@@ -290,17 +292,19 @@ static void _tweak_randart(item_def &item)
 
         choice_num++;
     }
-    mprf(MSGCH_PROMPT, "%s", prompt.c_str());
+    mprf_nocap(MSGCH_PROMPT, "%s", prompt.c_str());
 
     mprf(MSGCH_PROMPT, "Change which field? ");
 
-    int keyin = toalower(get_ch());
+    int keyin = get_ch();
     unsigned int  choice;
 
-    if (isaalpha(keyin))
+    if (isaalpha(keyin) && islower(keyin))
         choice = keyin - 'a';
+    else if (isaalpha(keyin) && isupper(keyin))
+        choice = keyin - 'A' + 26;
     else if (keyin >= '0' && keyin < 'A')
-        choice = keyin - '0' + 26;
+        choice = keyin - '0' + 52;
     else
     {
         canned_msg(MSG_OK);


### PR DESCRIPTION
SHIELDING (giving SH) is now a possible Artefact property, but it was not possible to assign this in art-data.txt, nor was it possible to add it using &t in wizard mode. Fix that first.

Then, three unrandart blade revisions based on irc conversations with mikee and gammafunk:

- Give Morg 1.5 * Necromancy skill for pain damage, as well as Harm and *Drain. The Harm part was met with some controversy but I think it poses an interesting choice, as elaborated on in the commit message. Another possibility would be to make it a necro enhancer, though that is less interesting. Remove the Int+5 and MR+.

- Make the Spriggan's knife always stab at Tier 1, remove Dex+4 and MR+. This makes it very very good at hitting things that can be stabbed, but still bad otherwise in melee.

- Make the Singing Sword not depend on tension, instead give the damaging noise effect on hits (with a chance). Simplify and buff the damage formula.