### PR TITLE
Fix the spell targeter for Gell's Gravitas

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1172,8 +1172,8 @@ static unique_ptr<targeter> _spell_targeter(spell_type spell, int pow,
                                              range);
     case SPELL_GRAVITAS:
         return make_unique<targeter_smite>(&you, range,
-                                           pow >= 80 ? 3 : 2,
-                                           pow >= 80 ? 3 : 2,
+                                           gravitas_range(pow),
+                                           gravitas_range(pow),
                                            false,
                                            [](const coord_def& p) -> bool {
                                               return you.pos() != p; });

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1172,8 +1172,11 @@ static unique_ptr<targeter> _spell_targeter(spell_type spell, int pow,
                                              range);
     case SPELL_GRAVITAS:
         return make_unique<targeter_smite>(&you, range,
-                                           gravitas_range(pow, 2),
-                                           gravitas_range(pow));
+                                           pow >= 80 ? 3 : 2,
+                                           pow >= 80 ? 3 : 2,
+                                           false,
+                                           [](const coord_def& p) -> bool {
+                                              return you.pos() != p; });
     case SPELL_VIOLENT_UNRAVELLING:
         return make_unique<targeter_unravelling>(&you, range, pow);
     case SPELL_RANDOM_BOLT:

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1007,11 +1007,6 @@ spret_type cast_dispersal(int pow, bool fail)
     return SPRET_SUCCESS;
 }
 
-int gravitas_range(int pow, int strength)
-{
-    return max(0, min(LOS_RADIUS, (int)isqrt((pow/10 + 1) / strength)));
-}
-
 #define GRAVITY "by gravitational forces"
 
 static void _attract_actor(const actor* agent, actor* victim,

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1007,6 +1007,12 @@ spret_type cast_dispersal(int pow, bool fail)
     return SPRET_SUCCESS;
 }
 
+int gravitas_range(int pow)
+{
+    return pow >= 80 ? 3 : 2;
+}
+
+
 #define GRAVITY "by gravitational forces"
 
 static void _attract_actor(const actor* agent, actor* victim,
@@ -1077,10 +1083,10 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
             continue;
 
         const int range = (pos - ai->pos()).rdist();
-        const int strength =
-            min(LOS_RADIUS, ((pow + 100) / 20) / (range*range));
-        if (strength <= 0)
+        if (range > gravitas_range(pow))
             continue;
+
+        const int strength = ((pow + 100) / 20) / (range*range);
 
         affected = true;
         _attract_actor(agent, *ai, pos, pow, strength);

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -25,7 +25,6 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail);
 
 spret_type cast_dispersal(int pow, bool fail);
 
-int gravitas_range(int pow, int strength = 1);
 bool fatal_attraction(const coord_def& pos, const actor *agent, int pow);
 spret_type cast_gravitas(int pow, const coord_def& where, bool fail);
 

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -25,6 +25,7 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail);
 
 spret_type cast_dispersal(int pow, bool fail);
 
+int gravitas_range(int pow);
 bool fatal_attraction(const coord_def& pos, const actor *agent, int pow);
 spret_type cast_gravitas(int pow, const coord_def& where, bool fail);
 


### PR DESCRIPTION
This is inspired by the Tavern post made by Doesnt outlining the targeter's problems, which can be found here: https://crawl.develz.org/tavern/viewtopic.php?f=17&t=25497&p=329839&hilit=gell%27s#p329839

Previously, the formula used to calculate the targeted area was
completely different to that which the spell itself used, resulting in
the targeter blatantly lying to the player about the tiles which could
and could not be affected.

The current behaviour of Gell's Gravitas is entirely predictable based
on spell power, with no randomness involved, therefore the new targeter
is entirely in the darker yellow colour to indicate the certainty. The
power breakpoints are:
\>0 power: at radius 1 from the centre, the monster is pulled 1 tile;
\>0 power: at radius 2, the monster is pulled 1 tile;
\>60 power: at radius 2, the monster is pulled 2 tiles; and
\>80 power: at radius 3, the monster is pulled 1 tile.

The previous spell targeter suggested that, at low power levels,
monsters at radius 2 could never be affected, and that at exceptionally
high power levels, targets at radius 4 could be affected, both of which
are incorrect. Hence, this commit changes the targeter to reflect the
fact that monsters at radius 2 are always affected and monsters at
radius 3 are always affected when, and only when, above 80 power.

An argument could be made for having the targeted tile (the centre of
the "gravitational reorientation") not appear coloured, given that this
tile is not affected, however this would require significantly more
work.

This commit removes the gravitas_range function, which was previously
only used for making the targeter, because it is no longer required.
Additionally, this commit removes the player's tile being highlighted,
given the player is never affected.

Note: the new targeter does not change at 60 power, because the radius that is affected does not change. An argument could be made for having tiles at radius 2 be pale yellow to indicate that enemies are not dragged right to the centre when below 60 piety (and similarly for tiles at radius 3 above 80 piety). Please let me know if you would prefer this behaviour.