### PR TITLE
Allow Trog to berserk all species

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -941,7 +941,6 @@ ability_type fixup_ability(ability_type ability)
         return ability;
 
     case ABIL_EVOKE_BERSERK:
-    case ABIL_TROG_BERSERK:
         if (you.is_lifeless_undead(false)
             || you.species == SP_FORMICID)
         {
@@ -1294,12 +1293,11 @@ static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
         }
     }
 
-    if ((abil.ability == ABIL_EVOKE_BERSERK
-         || abil.ability == ABIL_TROG_BERSERK)
-        && !you.can_go_berserk(true, false, quiet))
-    {
-        return false;
-    }
+    if (abil.ability == ABIL_EVOKE_BERSERK)
+        return you.can_go_berserk(true, false, quiet);
+
+    if (abil.ability == ABIL_TROG_BERSERK)
+        return you.can_go_berserk(true, false, quiet, nullptr, true, true);
 
     if ((abil.ability == ABIL_EVOKE_FLIGHT
          || abil.ability == ABIL_TRAN_BAT
@@ -1566,11 +1564,6 @@ static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
              mpr(no_tele_reason);
         return false;
     }
-
-    case ABIL_EVOKE_BERSERK:
-    case ABIL_TROG_BERSERK:
-        return you.can_go_berserk(true, false, true)
-               && (quiet || berserk_check_wielded_weapon());
 
     case ABIL_EVOKE_FOG:
         if (cloud_at(you.pos()))
@@ -2444,7 +2437,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_TROG_BERSERK:
         fail_check();
         // Trog abilities don't use or train invocations.
-        you.go_berserk(true);
+        you.go_berserk(true, false, true);
         break;
 
     case ABIL_TROG_REGEN_MR:

--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -168,7 +168,8 @@ public:
     }
     virtual void attacking(actor *other, bool ranged = false) = 0;
     virtual bool can_go_berserk() const = 0;
-    virtual bool go_berserk(bool intentional, bool potion = false) = 0;
+    virtual bool go_berserk(bool intentional, bool potion = false,
+                            bool divine = false) = 0;
     virtual bool berserk() const = 0;
     virtual bool can_see_invisible(bool calc_unid = true) const = 0;
     virtual bool invisible() const = 0;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2763,7 +2763,7 @@ bool monster::go_frenzy(actor *source)
     return true;
 }
 
-bool monster::go_berserk(bool intentional, bool /* potion */)
+bool monster::go_berserk(bool intentional, bool /* potion */, bool /* divine */)
 {
     if (!can_go_berserk())
         return false;

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -343,7 +343,8 @@ public:
     void attacking(actor *other, bool ranged) override;
     bool can_go_frenzy() const;
     bool can_go_berserk() const override;
-    bool go_berserk(bool intentional, bool potion = false) override;
+    bool go_berserk(bool intentional, bool potion = false,
+                    bool divine = false) override;
     bool go_frenzy(actor *source);
     bool berserk() const override;
     bool berserk_or_insane() const;

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -675,8 +675,9 @@ public:
     bool can_go_berserk() const override;
     bool can_go_berserk(bool intentional, bool potion = false,
                         bool quiet = false, string *reason = nullptr,
-                        bool temp = true) const;
-    bool go_berserk(bool intentional, bool potion = false) override;
+                        bool temp = true, bool divine = false) const;
+    bool go_berserk(bool intentional, bool potion = false,
+                    bool divine = false) override;
     bool berserk() const override;
     bool can_mutate() const override;
     bool can_safely_mutate(bool temp = true) const override;


### PR DESCRIPTION
Currently formicids and the undead cannot go berserk (except Full+
vampires) from any means. This commit allows Trog's divine rage to
stir anger into the heart of even these species.

Most god abilities override species restrictions, for example Trog's
Hand, Bend Space, and Potion Petition working where the player might not
expect them to. There are cases where god abilities do not override
species restrictions, for example Jiyva not mutation the undead, and
Nemelex cards respecting various species restrictions.

In future, it might be worth looking at these two approaches to the
species restriction vs divine ability priority and deciding if there
should be more consistency in how they are resolved (either changing all
cases to one or the other approach, or defining an inutitive test to
tell whether an ability should override restrictions or not).