### PR TITLE
Halve the max MP contribution from evocations

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3988,7 +3988,7 @@ int get_real_mp(bool include_items)
 
     int spell_extra = spellcasting; // 100%
     int invoc_extra = you.skill(SK_INVOCATIONS, 1 * scale, true) / 2; // 50%
-    int evoc_extra = you.skill(SK_EVOCATIONS, 1 * scale, true) / 2; // 50%
+    int evoc_extra = you.skill(SK_EVOCATIONS, 1 * scale, true) / 4; // 25%
     int highest_skill = max(spell_extra, max(invoc_extra, evoc_extra));
     enp += highest_skill + min(8 * scale, min(highest_skill, scaled_xl)) / 2;
 


### PR DESCRIPTION
About 1 MP every 4 levels of evocations.

Over time, fewer evocable abilities have required MP. The ones that
remain now are: blink, flight (1 MP), invisibility (2 MP), and the
unrand abilities fog and ratskin (3 MP).

A lot of characters train evocations for MP to use for other purposes.
Most notably, MP for guardian spirit or for DD Heal Wounds ability.
Arguably, this makes evocations a little too good, so reduce the amount
of MP one can theoretically get from the skill.