### PR TITLE
Add functionality to search items by handedness.

### DIFF
--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -9,6 +9,7 @@
 -- {artefact} for artefacts.
 -- {ego} for identified branded items.
 -- { <skill> } - the relevant weapon skill for weapons.
+-- { <num>-handed } - the handedness of the weapon for weapons.
 -- { <class> } - item class: gold, weapon, missile, wand, carrion, food,
 --               scroll, jewellery, potion, book, magical staff, orb, misc,
 --               <armourtype> armour
@@ -51,7 +52,17 @@ function ch_stash_search_annotate_item(it)
 
   local skill = it.weap_skill
   if skill then
+    local hands = it.hands
+    local hands_adj
+    if hands == 2 then
+      hands_adj = "two-handed"
+    else
+      hands_adj = "one-handed"
+    end
     annot = annot .. "{" .. skill .. "} "
+    if skill ~= "Throwing" then
+      annot = annot .. "{" .. hands_adj .. "} "
+    end
   end
 
   if it.ego_type_terse ~= "" and it.ego_type_terse ~= "unknown" then

--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -52,6 +52,7 @@ function ch_stash_search_annotate_item(it)
 
   local skill = it.weap_skill
   if skill then
+    annot = annot .. "{" .. skill .. "} "
     local hands = it.hands
     local hands_adj
     if hands == 2 then
@@ -59,7 +60,6 @@ function ch_stash_search_annotate_item(it)
     else
       hands_adj = "one-handed"
     end
-    annot = annot .. "{" .. skill .. "} "
     if skill ~= "Throwing" then
       annot = annot .. "{" .. hands_adj .. "} "
     end


### PR DESCRIPTION
When a player has a good shield and has trained a lot of shield skill,
it would be nice to filter out two-handed weapons. Likewise, later in
the game once a player is committed to two-handed weapons, it can would
be nice to filter out one-handed weapons. However, no stash search
prefix has previously existed so it was impossible to search for a
particular handedness.

Hence, add a stash search prefix for handedness. There is no check in
the hands function defined in l-item.cc that the item searched for is
actually a weapon, so we check that the item is a weapon first.
Additionally, filter out throwing weapons because they don't occupy the
weapon slot, therefore their handedness is not useful to search for and
will instead clutter up the search results list.

Re throwing, if you would rather include throwing weapons under the one-handed prefix, I can do that.