### PR TITLE
Fix box_level_dp loot

### DIFF
--- a/crawl-ref/source/dat/des/branches/depths_encompass.des
+++ b/crawl-ref/source/dat/des/branches/depths_encompass.des
@@ -236,8 +236,8 @@ NSUBST:  C = 1:+ / *:b, D = 1:+ / *:b
 NSUBST:  E = 1:+ / *:x, N = 1:= / *:n
 SUBST:   ' : ''l. , ' = l.
 SUBST:   " : ""W. , " = Ww..
-NSUBST:  * = 1:f / *:*
-SUBST:   * = * % % $ $ e
+NSUBST:  * = 1:e / *:*
+SUBST:   * = * % % $ $ d
 SUBST:   ; = 9 0
 SUBST:   ! = %$, & = *%
 KITEM:   V = *


### PR DESCRIPTION
This vault was originally supposed to put one ring of teleportation in the metal room, a random quantity of scrolls of teleportation around the perimeter of the giant box, and a single amulet of reflection. Commit cefc067 removed the rings of teleportation from this vault without updating the letters used for the other two, causing the vault to place one scroll of teleportation nowhere, a random quantity of amulets of reflection, and a single nothing. This PR restores the old and less bizarre behavior.