### PR TITLE
Fix a couple of wall jump inconsistencies (11687, 11690)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1623,6 +1623,42 @@ static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
         }
         return true;
 
+    case ABIL_WU_JIAN_WALLJUMP:
+    {
+        // TODO: Add check for whether there is any valid landing spot
+        if (you.is_nervous())
+        {
+            if (!quiet)
+                mpr("You are too terrified to wall jump!");
+            return false;
+        }
+        if (you.attribute[ATTR_HELD])
+        {
+            if (!quiet)
+            {
+                mprf("You cannot wall jump while caught in a %s.",
+                     get_trapping_net(you.pos()) == NON_ITEM ? "web" : "net");
+            }
+            return false;
+        }
+        // Is there a valid place to wall jump?
+        bool has_targets = false;
+        for (adjacent_iterator ai(you.pos()); ai; ++ai)
+            if (feat_can_wall_jump_against(grd(*ai)))
+            {
+                has_targets = true;
+                break;
+            }
+
+        if (!has_targets)
+        {
+            if (!quiet)
+                mpr("There is nothing to wall jump against here.");
+            return false;
+        }
+        return true;
+    }
+
     default:
         return true;
     }

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1162,21 +1162,11 @@ void no_ability_msg()
 
 bool activate_ability()
 {
-    if (you.berserk())
-    {
-        canned_msg(MSG_TOO_BERSERK);
-        crawl_state.zero_turns_taken();
-        return false;
-    }
+    vector<talent> talents = your_talents(false);
 
-    const bool confused = you.confused();
-    vector<talent> talents = your_talents(confused);
     if (talents.empty())
     {
-        if (confused)
-            canned_msg(MSG_TOO_CONFUSED);
-        else
-            no_ability_msg();
+        no_ability_msg();
         crawl_state.zero_turns_taken();
         return false;
     }

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -114,6 +114,7 @@ enum class abflag
     sacrifice           = 0x00200000, // sacrifice (Ru)
     hostile             = 0x00400000, // failure summons a hostile (Makhleb)
     starve_ok           = 0x00800000, // can use even if starving
+    berserk_ok          = 0x01000000, // can use even if berserk
 };
 DEF_BITFIELD(ability_flags, abflag);
 
@@ -641,9 +642,10 @@ static const ability_def Ability_List[] =
         0, 0, 0, 20, {fail_basis::invo, piety_breakpoint(5), 0, 1}, abflag::none },
     // Lunge and Whirlwind abilities aren't menu abilities but currently need
     // to exist for action counting, hence need enums/entries.
-    { ABIL_WU_JIAN_LUNGE, "Lunge", 0, 0, 0, 0, {}, abflag::none },
-    { ABIL_WU_JIAN_WHIRLWIND, "Whirlwind", 0, 0, 0, 0, {}, abflag::none },
-    { ABIL_WU_JIAN_WALLJUMP, "Wall Jump", 0, 0, 0, 0, {}, abflag::starve_ok },
+    { ABIL_WU_JIAN_LUNGE, "Lunge", 0, 0, 0, 0, {}, abflag::berserk_ok },
+    { ABIL_WU_JIAN_WHIRLWIND, "Whirlwind", 0, 0, 0, 0, {}, abflag::berserk_ok },
+    { ABIL_WU_JIAN_WALLJUMP, "Wall Jump",
+        0, 0, 0, 0, {}, abflag::starve_ok | abflag::berserk_ok },
 
     { ABIL_STOP_RECALL, "Stop Recall", 0, 0, 0, 0, {fail_basis::invo}, abflag::starve_ok },
     { ABIL_RENOUNCE_RELIGION, "Renounce Religion",
@@ -1251,7 +1253,7 @@ static bool _can_hop(bool quiet)
 // TODO: Many more cases need to be added!
 static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
 {
-    if (you.berserk())
+    if (you.berserk() && !testbits(abil.flags, abflag::berserk_ok))
     {
         if (!quiet)
             canned_msg(MSG_TOO_BERSERK);

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -7222,6 +7222,13 @@ bool wu_jian_wall_jump_ability()
         return false;
     }
 
+    if (you.attribute[ATTR_HELD])
+    {
+        mprf("You cannot wall jump while caught in a %s.",
+             get_trapping_net(you.pos()) == NON_ITEM ? "web" : "net");
+        return false;
+    }
+
     // query for location:
     dist beam;
 


### PR DESCRIPTION
Firstly, allow wall jumping via the ability whilst berserk. Previously, the ability menu simply would not open whilst berserk. (11687)

Secondly, disallow wall jumping while stuck in nets or webs - previously this was impossible via movement but the ability method was successful. (the second issue reported in 11690)

I am working on fixing the first issue in https://crawl.develz.org/mantis/view.php?id=11690, and may have a fix for that soon. For this issue, it seems logical that the player gets their attacks when landing in a web, so the only actual issue that needs fixing is the message order. This is more complicated than it looks though.

For now I thought I would post these two fixes, since these can be merged anyway. If there are any code style issues, feel free to post them and I can fix them. I have tested both of these commits and they seem to work fine for me.