### PR TITLE
Display (Immune) instead of chance to defeat MR in monster descriptions when the player is intrinsically immune to a hex

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -508,11 +508,20 @@ static void _describe_book(const spellbook_contents &book,
 #endif
             && (get_spell_flags(spell) & SPFLAG_MR_CHECK))
         {
-            int chance = hex_chance(spell, hd);
-            int ch_len = to_string(chance).length();
-            description.cprintf("%c - (%d%%) %s",
-                            spell_letter, chance,
-                            chop_string(spell_title(spell), 25-ch_len).c_str());
+            if (you.immune_to_hex(spell))
+            {
+                description.cprintf("%c - (Immune) %s",
+                                spell_letter,
+                                chop_string(spell_title(spell), 20).c_str());
+            }
+            else
+            {
+                int chance = hex_chance(spell, hd);
+                int ch_len = to_string(chance).length();
+                description.cprintf("%c - (%d%%) %s",
+                    spell_letter, chance,
+                    chop_string(spell_title(spell), 25-ch_len).c_str());
+            }
         }
         else
         {

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3150,9 +3150,13 @@ static bool _get_spell_description(const spell_type spell,
             if (you.wizard)
                 wiz_info += make_stringf(" (pow %d)", _hex_pow(spell, hd));
 #endif
-            description += make_stringf("Chance to beat your MR: %d%%%s\n",
-                                        hex_chance(spell, hd),
-                                        wiz_info.c_str());
+            description += you.immune_to_hex(spell)
+                ? make_stringf("You cannot be affected by this "
+                               "spell right now. %s\n",
+                               wiz_info.c_str())
+                : make_stringf("Chance to beat your MR: %d%%%s\n",
+                               hex_chance(spell, hd),
+                               wiz_info.c_str());
         }
 
     }

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -822,6 +822,17 @@ static int _you_have_rune(lua_State *ls)
     return 1;
 }
 
+/*** Are you intrinsically immune to this particular hex spell?
+ * @treturn boolean
+ * @function you_immune_to_hex
+ */
+static int you_immune_to_hex(lua_State *ls)
+{
+    spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
+    lua_pushboolean(ls, you.immune_to_hex(spell));
+    return 1;
+}
+
 /*** How many runes do you have?
  * @treturn int
  * @function num_runes
@@ -1195,6 +1206,7 @@ static const struct luaL_reg you_clib[] =
     { "antimagic",    you_antimagic },
 #endif
     { "status",       you_status },
+    { "immune_to_hex", you_immune_to_hex },
 
     { "can_consume_corpses",      you_can_consume_corpses },
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -8202,3 +8202,44 @@ void refresh_weapon_protection()
     you.increase_duration(DUR_SPWPN_PROTECTION, 3 + random2(2), 5);
     you.redraw_armour_class = true;
 }
+
+// Is the player immune to a particular hex because of their
+// intrinsic properties?
+bool player::immune_to_hex(const spell_type hex) const
+{
+    switch (hex)
+    {
+    case SPELL_PARALYSIS_GAZE:
+    case SPELL_PARALYSE:
+    case SPELL_SLOW:
+        return stasis();
+    case SPELL_CONFUSE:
+    case SPELL_CONFUSION_GAZE:
+    case SPELL_MASS_CONFUSION:
+        return clarity() || you.duration[DUR_DIVINE_STAMINA] > 0;
+    case SPELL_TELEPORT_OTHER:
+    case SPELL_BLINK_OTHER:
+    case SPELL_BLINK_OTHER_CLOSE:
+        return no_tele();
+    case SPELL_MESMERISE:
+    case SPELL_AVATAR_SONG:
+    case SPELL_SIREN_SONG:
+        return clarity() || berserk();
+    case SPELL_CAUSE_FEAR:
+        return clarity() || !(holiness() & MH_NATURAL) || berserk();
+    case SPELL_PETRIFY:
+        return res_petrify();
+    case SPELL_PORKALATOR:
+        return is_lifeless_undead();
+    case SPELL_VIRULENCE:
+        return res_poison() == 3;
+    // don't include the hidden "sleep immunity" duration
+    case SPELL_SLEEP:
+    case SPELL_DREAM_DUST:
+        return !actor::can_sleep();
+    case SPELL_HIBERNATION:
+        return !can_hibernate();
+    default:
+        return false;
+    }
+}

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -791,6 +791,7 @@ public:
     {
         return actor::incapacitated() || duration[DUR_CLUMSY];
     }
+    bool immune_to_hex(const spell_type hex) const;
 
     bool asleep() const override;
     void put_to_sleep(actor *, int power = 0, bool hibernate = false) override;


### PR DESCRIPTION
When a player is intrinsically immune to a particular hex, through
innate abilities, equipment, god abilities or transformations, make the
chance to defeat MR indicator next to the spell on the monster
description screen read "(Immune)" instead. It is misleading to imply
that these abilities can succeed on the player through printing the
chance to defeat MR, as was the case previously.

This applies to:
 - Paralysis and slowing as a formicid,
 - Confusion with clarity or under Zin's vitalisation,
 - Petrification as a gargoyle, in statue form or under Zin's
   vitalisation,
 - Sleep and fear as undead or nonliving, with clarity or while berserk,
 - Virulence when immune to poison,
 - Porkalator when unable to transform,
 - Teleport and blink as a formicid or with -Tele equipment, and
 - Mesmerisation with clarity or while berserk.

This commit creates a new member function in the player class,
immune_to_hex. This method also returns true for hex-like spells that do
not have an MR check, such as paralysis gaze and blink other, however
these spells do not have the MR indicator and as such also do not have
the immunity indicator.

(If the only reason the player cannot be affected by a hex is because
they have sufficient MR to resist it always, the MR indicator will still
read "(0%)", to maintain the distinction between MR and intrinsic
immunity.)

Please make me aware of any hex immunity cases that I have missed, or any code style issues you have, and I will aim to fix them.