### PR TITLE
Announce the starting items and spells for wanderers (11725), and start wanderers with a spell if they have only one level 1 spell

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -572,11 +572,10 @@ static void _wanderer_note_equipment()
                                  return item.name(DESC_A, false, true);
                              }, ", ", ", ", mem_fn(&item_def::defined));
 
-    // XXX: Currently wanderers don't start with any of their spells memorised,
-    // so this never triggers.
+    // Wanderers start with at most 1 spell memorised.
     const string spell_str =
         !you.spell_no ? "" :
-        "; and the following spells memorised: "
+        "; and the following spell memorised: "
         + comma_separated_fn(begin(you.spells), end(you.spells),
                              [] (const spell_type spell) -> string
                              {

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -560,16 +560,53 @@ static void _show_commandline_options_help()
 #endif
 }
 
-static void _wanderer_note_items()
+// Announce to the message log and make a note of the player's starting items,
+// spells and spell library
+static void _wanderer_note_equipment()
 {
     const string equip_str =
-        you.your_name + " set off with: "
+        "the following items: "
         + comma_separated_fn(begin(you.inv), end(you.inv),
                              [] (const item_def &item) -> string
                              {
                                  return item.name(DESC_A, false, true);
                              }, ", ", ", ", mem_fn(&item_def::defined));
-    take_note(Note(NOTE_MESSAGE, 0, 0, equip_str));
+
+    // XXX: Currently wanderers don't start with any of their spells memorised,
+    // so this never triggers.
+    const string spell_str =
+        !you.spell_no ? "" :
+        "; and the following spells memorised: "
+        + comma_separated_fn(begin(you.spells), end(you.spells),
+                             [] (const spell_type spell) -> string
+                             {
+                                 return spell_title(spell);
+                             },
+                             ", ", ", ",
+                             // Don't include empty spell slots
+                             [] (const spell_type spell) -> bool
+                             {
+                                 return spell != SPELL_NO_SPELL;
+                             });
+
+    auto const library = get_sorted_spell_list(true, true);
+    const string library_str =
+        !library.size() ? "" :
+        "; and the following spells available to memorise: "
+        + comma_separated_fn(library.begin(), library.end(),
+                             [] (const spell_type spell) -> string
+                             {
+                                 return spell_title(spell);
+                             }, ", ", ", ");
+
+    // Announce the starting equipment and spells, because it is otherwise
+    // not obvious if the player has any spells.
+    mprf("You begin with %s%s%s.", equip_str.c_str(),
+         spell_str.c_str(), library_str.c_str());
+
+    const string combined_str = you.your_name + " set off with "
+                                + equip_str + spell_str + library_str;
+    take_note(Note(NOTE_MESSAGE, 0, 0, combined_str));
 }
 
 /**
@@ -644,7 +681,7 @@ static void _take_starting_note()
 #endif
 
     if (you.char_class == JOB_WANDERER)
-        _wanderer_note_items();
+        _wanderer_note_equipment();
 
     notestr << "HP: " << you.hp << "/" << you.hp_max
             << " MP: " << you.magic_points << "/" << you.max_magic_points;

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -509,7 +509,7 @@ static void _setup_generic(const newgame_def& ng)
     // Must be after _give_basic_knowledge
     add_held_books_to_library();
 
-    if (you.char_class = JOB_WANDERER)
+    if (you.char_class == JOB_WANDERER)
         memorise_wanderer_spell();
 
     initialise_item_descriptions();

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -509,6 +509,9 @@ static void _setup_generic(const newgame_def& ng)
     // Must be after _give_basic_knowledge
     add_held_books_to_library();
 
+    if (you.char_class = JOB_WANDERER)
+        memorise_wanderer_spell();
+
     initialise_item_descriptions();
 
     // A first pass to link the items properly.

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -747,3 +747,24 @@ void create_wanderer()
 
     _wanderer_cover_equip_holes();
 }
+
+void memorise_wanderer_spell()
+{
+    // If the player got only one level 1 spell, memorise it. Otherwise, let the
+    // player choose which spell(s) to memorise and don't memorise any.
+    auto const available_spells = get_sorted_spell_list(true, true);
+    if (available_spells.size())
+    {
+        int num_level_one_spells;
+        spell_type which_spell;
+        for (spell_type spell : available_spells)
+            if (spell_difficulty(spell) == 1)
+            {
+                num_level_one_spells += 1;
+                which_spell = spell;
+            }
+
+        if (num_level_one_spells == 1)
+            add_spell_to_memory(which_spell);
+    }
+}

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -755,7 +755,7 @@ void memorise_wanderer_spell()
     auto const available_spells = get_sorted_spell_list(true, true);
     if (available_spells.size())
     {
-        int num_level_one_spells;
+        int num_level_one_spells = 0;
         spell_type which_spell;
         for (spell_type spell : available_spells)
             if (spell_difficulty(spell) == 1)

--- a/crawl-ref/source/ng-wanderer.h
+++ b/crawl-ref/source/ng-wanderer.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void create_wanderer();
+void memorise_wanderer_spell();


### PR DESCRIPTION
First commit:

Previously, players that did not look at their M screen would not be
aware of if they had spells in their spell library.

Therefore, print the player's inventory and spell library to the message
log at the start of the game. Also, take a note of the spell library to
include in the dump. This is done by expanding the note_wanderer_items
function and renaming it to note_wanderer_equipment (to be more
accurate).

This commit also adds support to print any spells the player begins with
memorised at the start, although this currently never happens.

Second commit:

If wanderers have more than one level 1 spell, they may not have enough
spell levels to memorise all of them, and so the player should get to
choose which spell to memorise.

If, however, wanderers have only 1 level 1 spell in their library, and
they have a spell level available, it makes sense for the player to have
that spell automatically memorised. Hence, in this case, memorise the
player's only level 1 spell.

Please feel free to give comments on either of these commits, or any comments on how the code could be improved.