### PR TITLE
Fix HP+ artefacts causing HP-scaling transmutations to overscale the player's HP (11728) (take 2)

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -45,7 +45,7 @@ static void _mark_unseen_monsters();
  */
 static void _calc_hp_artefact()
 {
-    recalc_and_scale_hp();
+    recalc_and_scale_hp(true);
     if (you.hp_max <= 0) // Borgnjor's abusers...
         ouch(0, KILLED_BY_DRAINING);
 }

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1048,9 +1048,9 @@ bool player_has_feet(bool temp = true, bool include_mutations = true);
 bool enough_hp(int minimum, bool suppress_msg, bool abort_macros = true);
 bool enough_mp(int minimum, bool suppress_msg, bool abort_macros = true);
 
-void calc_hp();
+void calc_hp(bool ignore_transformations = false);
 void calc_mp();
-void recalc_and_scale_hp();
+void recalc_and_scale_hp(bool ignore_transformations = false);
 
 void dec_hp(int hp_loss, bool fatal, const char *aux = nullptr);
 void dec_mp(int mp_loss, bool silent = false);
@@ -1071,7 +1071,8 @@ void dec_max_hp(int hp_loss);
 void deflate_hp(int new_level, bool floor);
 void set_hp(int new_amount);
 
-int get_real_hp(bool trans, bool rotted = false);
+int get_real_hp(bool temp_effects, bool rotted = false,
+                bool ignore_forms = false);
 int get_real_mp(bool include_items);
 
 int get_contamination_level();

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1959,6 +1959,24 @@ void untransform(bool skip_move)
     if (dex_mod)
         notify_stat_change(STAT_DEX, -dex_mod, true);
 
+    if (hp_downscale != 10 && you.hp != you.hp_max)
+    {
+        int hp = you.hp * 10 / hp_downscale;
+        if (hp < 1)
+            hp = 1;
+        else if (hp > you.hp_max)
+            hp = you.hp_max;
+        set_hp(hp);
+    }
+    calc_hp();
+
+    if (you.hp <= 0)
+    {
+        ouch(0, KILLED_BY_FRAILTY, MID_NOBODY,
+             make_stringf("losing the %s form",
+                          transform_name(old_form)).c_str());
+    }
+
     _unmeld_equipment(melded);
 
     if (!skip_move)
@@ -2003,24 +2021,6 @@ void untransform(bool skip_move)
         const item_def *armour = you.slot_item(EQ_BODY_ARMOUR, false);
         mprf(MSGCH_DURATION, "%s cracks your icy armour.",
              armour->name(DESC_YOUR).c_str());
-    }
-
-    if (hp_downscale != 10 && you.hp != you.hp_max)
-    {
-        int hp = you.hp * 10 / hp_downscale;
-        if (hp < 1)
-            hp = 1;
-        else if (hp > you.hp_max)
-            hp = you.hp_max;
-        set_hp(hp);
-    }
-    calc_hp();
-
-    if (you.hp <= 0)
-    {
-        ouch(0, KILLED_BY_FRAILTY, MID_NOBODY,
-             make_stringf("losing the %s form",
-                          transform_name(old_form)).c_str());
     }
 
     // Stop being constricted if we are now too large.


### PR DESCRIPTION
The previous attempt at fixing this issue, 82e9058 from PR #870,
caused problems with forcibly unwielding equipment instead of melding
equipment, because _remove_equipment was being called before the
transformation took effect. The second part of this original commit was
fine and is retained in this commit; that is, downscaling HP before
unmelding equipment in untransform.

To fix the double-scaling of HP when transforming, add a new parameter
to the functions recalc_and_scale_hp, calc_hp and get_real_hp, called
ignore_transformations, with a single purpose: when recalc_and_scale_hp
is called from _calc_hp_artefact, don't include any the effects of any
current transformations in the max HP calculated in get_real_hp.

Additionally, the get_real_hp function is confusing, so add a properly
formatted docstring, and rename the parameter trans to external_effects.
This parameter was incorrectly described as only affecting whether to
include berserk/transformation HP bonuses, when it also includes
equipment bonuses.

**This PR is simply a basic patch for bug 11728. Stenella and I worked together in understanding this code and he has produced a more comprehensive rewrite of the HP code in PR #877. If that PR goes ahead, this PR will become redundant, but I will leave it open until that happens.** (Of course this PR can be merged first, to fix the bug, and then the other PR merged afterwards, if you would prefer to do it that way.)