### PR TITLE
MSVC 2017 Compatability

### DIFF
--- a/crawl-ref/INSTALL.txt
+++ b/crawl-ref/INSTALL.txt
@@ -378,12 +378,54 @@ Building on Windows 10 (Linux Subsystem)
 Building on Windows (MSVC)
 --------------------------
 
-* Building on MSVC is not currently supported and was last maintained in 2012,
-  so it will not work straightforwardly except in Visual Studio 2012 and versions
-  of crawl from around then. See the source distribution for approximately dcss
-  0.12 for more details on how this build used to work. It is known not to work
-  on current versions. If you get it to work on a more recent version, please
-  let us know and submit a patch!
+* This build process is currently supported with glue and duct-tape and is unlikely to be
+  straightforward in versions of MSVC besides those explicitly mentioned
+  here. Support pending (possibly).
+
+* This build is tested on Visual Studio 2017 on Windows 8.1 and 10. 
+  Win32 Release-Tiles should work without any issues. Debug and x64 do not work as-is 
+  (errors stem from compatability with FreeType).
+
+* You'll need a perl environment, there are links to several Windows binaries
+  you can choose from at http://www.perl.org/get.html
+
+* In the Crawl source, run gen-all.cmd which is in source/util/. This step must
+  be executed any time you update to a new version of the source (or if you
+  have modified tile data or unrandarts).
+
+* The first time you compile, you need to build the Contribs solution. This
+  compiles various libraries which Crawl itself needs to build. This only needs
+  to be performed the first time you build, or if the contribs are ever updated
+  (extremely rare). To do this open and compile Contribs.sln in source/contrib.
+  Make sure to set Release and 32-Bit as the project types.
+
+* Open crawl-ref.sln in Visual Studio, this is in source/MSVC/.
+
+* You can now select Debug or Release from the drop-down build configurations
+  menu on the main toolbar (it should be next to "Local Windows Debugger");
+  crawl.exe can them be compiled by selecting "Build Solution" in the BUILD
+  menu. You can quickly run it by selecting "Start without Debugging" in the
+  debug menu (or debug with "Start Debugging"). Note: the Release build can 
+  still be debugged using the Visual Studio debugger. (Note as of writing this 
+  that debug does not compile).
+ 
+* Quirks: dll output duplicated for libpng in the main directory (one for tilegen
+  and 16-16 for crawl).
+  
+* Building the webserver and Lua (for the dat project) is untested as of now.
+
+* Better support for Python (for the webserver project) and Lua (for the dat
+  project) can be installed with these extensions:
+
+  Python Tools for Visual Studio
+  http://pytools.codeplex.com/releases
+
+  Ports of VsLua to Visual Studio 2012
+  http://www.dbfinteractive.com/forum/index.php?topic=5873.0
+  http://pouet.net/topic.php?which=9087
+
+  Try at your own risk, but the first one has been tested and found to be
+  effective.
 
 *****************************************************************************
 

--- a/crawl-ref/source/AppHdr.cc
+++ b/crawl-ref/source/AppHdr.cc
@@ -12,8 +12,8 @@
     #pragma comment (lib, "sqlite.lib")
         #ifdef USE_TILE_LOCAL
             #pragma comment (lib, "freetype.lib")
-            #pragma comment (lib, "SDL.lib")
-            #pragma comment (lib, "SDL_image.lib")
+            #pragma comment (lib, "SDL2.lib")
+            #pragma comment (lib, "SDL2_image.lib")
             #pragma comment (lib, "libpng.lib")
             #pragma comment (lib, "zlib.lib")
             #pragma comment (lib, "dxguid.lib")

--- a/crawl-ref/source/MSVC/PropertySheet.props
+++ b/crawl-ref/source/MSVC/PropertySheet.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+  <ItemGroup />
+</Project>

--- a/crawl-ref/source/MSVC/Tiles.props
+++ b/crawl-ref/source/MSVC/Tiles.props
@@ -8,11 +8,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\freetype\include;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\freetype\include;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>USE_TILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;SDLmain.lib;libpng.lib;zlib.lib;freetype.lib;opengl32.lib;glu32.lib;winmm.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2main.lib;libpng.lib;zlib.lib;freetype.lib;opengl32.lib;glu32.lib;winmm.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\contrib\bin\8.0\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/crawl-ref/source/MSVC/Tiles.vsprops
+++ b/crawl-ref/source/MSVC/Tiles.vsprops
@@ -11,7 +11,7 @@
 	/>
 	<Tool
 		Name="VCLinkerTool"
-		AdditionalDependencies="SDL.lib SDL_image.lib SDLmain.lib libpng.lib zlib.lib freetype.lib opengl32.lib glu32.lib winmm.lib dxguid.lib"
+		AdditionalDependencies="SDL2.lib SDL2_image.lib SDLmain.lib libpng.lib zlib.lib freetype.lib opengl32.lib glu32.lib winmm.lib dxguid.lib"
 		AdditionalLibraryDirectories="&quot;$(SolutionDir)\..\contrib\bin\8.0\$(PlatformName)&quot;"
 	/>
 </VisualStudioPropertySheet>

--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug Tiles|Win32">
       <Configuration>Debug Tiles</Configuration>
@@ -22,29 +22,30 @@
     <ProjectGuid>{3189AF12-90EF-4D3E-BFEC-4AB90D7D32DA}</ProjectGuid>
     <RootNamespace>crawlref</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
@@ -106,7 +107,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;FULLDEBUG;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -116,9 +117,10 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
       <TreatWarningAsError>false</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -138,7 +140,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;FULLDEBUG;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -149,7 +151,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -165,7 +167,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
 </Command>
     </PreBuildEvent>
     <ClCompile>
-      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./include;../sdl2;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>AppHdr.h</PrecompiledHeaderFile>
@@ -174,9 +176,10 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;msvcrt.lib;vcruntime.lib;ucrt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -197,7 +200,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>AppHdr.h</PrecompiledHeaderFile>
@@ -206,7 +209,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;lua.lib;pcre.lib;sqlite.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -285,6 +288,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\dgn-event.cc" />
     <ClCompile Include="..\directn.cc" />
     <ClCompile Include="..\dlua.cc" />
+    <ClCompile Include="..\domino.cc" />
     <ClCompile Include="..\dungeon.cc" />
     <ClCompile Include="..\end.cc" />
     <ClCompile Include="..\english.cc" />
@@ -327,6 +331,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\jobs.cc" />
     <ClCompile Include="..\json.cc" />
     <ClCompile Include="..\kills.cc" />
+    <ClCompile Include="..\l-wiz.cc" />
     <ClCompile Include="..\lang-fake.cc" />
     <ClCompile Include="..\losglobal.cc" />
     <ClCompile Include="..\l-colour.cc" />
@@ -361,6 +366,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\melee-attack.cc" />
     <ClCompile Include="..\mon-death.cc" />
     <ClCompile Include="..\mon-ench.cc" />
+    <ClCompile Include="..\movement.cc" />
     <ClCompile Include="..\ng-setup.cc" />
     <ClCompile Include="..\ng-wanderer.cc" />
     <ClCompile Include="..\orb.cc" />
@@ -457,9 +463,13 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\ranged-attack.cc" />
     <ClCompile Include="..\ray.cc" />
     <ClCompile Include="..\religion.cc" />
+    <ClCompile Include="..\rltiles\tiledef-dngn.cc" />
     <ClCompile Include="..\rltiles\tiledef-feat.cc" />
     <ClCompile Include="..\rltiles\tiledef-floor.cc" />
+    <ClCompile Include="..\rltiles\tiledef-gui.cc" />
     <ClCompile Include="..\rltiles\tiledef-icons.cc" />
+    <ClCompile Include="..\rltiles\tiledef-main.cc" />
+    <ClCompile Include="..\rltiles\tiledef-player.cc" />
     <ClCompile Include="..\rltiles\tiledef-wall.cc" />
     <ClCompile Include="..\rot.cc" />
     <ClCompile Include="..\scroller.cc" />
@@ -505,46 +515,6 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\timed-effects.cc" />
     <ClCompile Include="..\throw.cc" />
     <ClCompile Include="..\tilebuf.cc" />
-    <ClCompile Include="..\rltiles\tiledef-dngn.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="..\rltiles\tiledef-gui.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="..\rltiles\tiledef-main.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="..\rltiles\tiledef-player.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-    </ClCompile>
     <ClCompile Include="..\rltiles\tiledef-unrand.cc">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
       </PrecompiledHeader>
@@ -571,16 +541,13 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\tilereg-inv.cc" />
     <ClCompile Include="..\tilereg-map.cc" />
     <ClCompile Include="..\tilereg-mem.cc" />
-    <ClCompile Include="..\tilereg-menu.cc" />
     <ClCompile Include="..\tilereg-mon.cc" />
     <ClCompile Include="..\tilereg-msg.cc" />
-    <ClCompile Include="..\tilereg-popup.cc" />
     <ClCompile Include="..\tilereg-skl.cc" />
     <ClCompile Include="..\tilereg-spl.cc" />
     <ClCompile Include="..\tilereg-stat.cc" />
     <ClCompile Include="..\tilereg-tab.cc" />
     <ClCompile Include="..\tilereg-text.cc" />
-    <ClCompile Include="..\tilereg-title.cc" />
     <ClCompile Include="..\tilereg.cc" />
     <ClCompile Include="..\tilesdl.cc" />
     <ClCompile Include="..\tiletex.cc" />
@@ -610,7 +577,6 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClCompile Include="..\wizard.cc" />
     <ClCompile Include="..\worley.cc" />
     <ClCompile Include="..\xom.cc" />
-    <ClCompile Include="..\zotdef.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ability-type.h" />
@@ -702,6 +668,8 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\directn.h" />
     <ClInclude Include="..\disable-type.h" />
     <ClInclude Include="..\dlua.h" />
+    <ClInclude Include="..\domino-data.h" />
+    <ClInclude Include="..\domino.h" />
     <ClInclude Include="..\dungeon-char-type.h" />
     <ClInclude Include="..\dungeon-feature-type.h" />
     <ClInclude Include="..\dungeon.h" />
@@ -738,6 +706,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\format.h" />
     <ClInclude Include="..\fprop.h" />
     <ClInclude Include="..\game-chapter.h" />
+    <ClInclude Include="..\game-exit-type.h" />
     <ClInclude Include="..\game-options.h" />
     <ClInclude Include="..\game-type.h" />
     <ClInclude Include="..\gender-type.h" />
@@ -770,6 +739,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\item-type-id-state-type.h" />
     <ClInclude Include="..\item-use.h" />
     <ClInclude Include="..\items.h" />
+    <ClInclude Include="..\job-data.h" />
     <ClInclude Include="..\job-type.h" />
     <ClInclude Include="..\jobs.h" />
     <ClInclude Include="..\json-wrapper.h" />
@@ -848,6 +818,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\monster-type.h" />
     <ClInclude Include="..\monster.h" />
     <ClInclude Include="..\montravel-target-type.h" />
+    <ClInclude Include="..\movement.h" />
     <ClInclude Include="..\mpr.h" />
     <ClInclude Include="..\msvc.h" />
     <ClInclude Include="..\mutant-beast.h" />
@@ -1002,16 +973,13 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\tilereg-inv.h" />
     <ClInclude Include="..\tilereg-map.h" />
     <ClInclude Include="..\tilereg-mem.h" />
-    <ClInclude Include="..\tilereg-menu.h" />
     <ClInclude Include="..\tilereg-mon.h" />
     <ClInclude Include="..\tilereg-msg.h" />
-    <ClInclude Include="..\tilereg-popup.h" />
     <ClInclude Include="..\tilereg-skl.h" />
     <ClInclude Include="..\tilereg-spl.h" />
     <ClInclude Include="..\tilereg-stat.h" />
     <ClInclude Include="..\tilereg-tab.h" />
     <ClInclude Include="..\tilereg-text.h" />
-    <ClInclude Include="..\tilereg-title.h" />
     <ClInclude Include="..\tilereg.h" />
     <ClInclude Include="..\tiles.h" />
     <ClInclude Include="..\tiles-build-specific.h" />
@@ -1054,11 +1022,11 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\wizard.h" />
     <ClInclude Include="..\wizard-option-type.h" />
     <ClInclude Include="..\worley.h" />
+    <ClInclude Include="..\wu-jian-attack-type.h" />
     <ClInclude Include="..\xom.h" />
     <ClInclude Include="..\xp-tracking-type.h" />
     <ClInclude Include="..\zap-data.h" />
     <ClInclude Include="..\zap-type.h" />
-    <ClInclude Include="..\zotdef.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="tilegen.vcxproj">

--- a/crawl-ref/source/MSVC/crawl.vcxproj.filters
+++ b/crawl-ref/source/MSVC/crawl.vcxproj.filters
@@ -1,645 +1,2301 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\ability.cc" />
-    <ClCompile Include="..\abyss.cc" />
-    <ClCompile Include="..\acquire.cc" />
-    <ClCompile Include="..\act-iter.cc" />
-    <ClCompile Include="..\actor-los.cc" />
-    <ClCompile Include="..\actor.cc" />
-    <ClCompile Include="..\adjust.cc" />
-    <ClCompile Include="..\AppHdr.cc" />
-    <ClCompile Include="..\areas.cc" />
-    <ClCompile Include="..\arena.cc" />
-    <ClCompile Include="..\artefact.cc" />
-    <ClCompile Include="..\attack.cc" />
-    <ClCompile Include="..\attitude-change.cc" />
-    <ClCompile Include="..\beam.cc" />
-    <ClCompile Include="..\behold.cc" />
-    <ClCompile Include="..\bitary.cc" />
-    <ClCompile Include="..\branch.cc" />
-    <ClCompile Include="..\chardump.cc" />
-    <ClCompile Include="..\cio.cc" />
-    <ClCompile Include="..\cloud.cc" />
-    <ClCompile Include="..\clua.cc" />
-    <ClCompile Include="..\cluautil.cc" />
-    <ClCompile Include="..\colour.cc" />
-    <ClCompile Include="..\command.cc" />
-    <ClCompile Include="..\coord-circle.cc" />
-    <ClCompile Include="..\coord.cc" />
-    <ClCompile Include="..\coordit.cc" />
-    <ClCompile Include="..\crash.cc" />
-    <ClCompile Include="..\ctest.cc" />
-    <ClCompile Include="..\dactions.cc" />
-    <ClCompile Include="..\database.cc" />
-    <ClCompile Include="..\dbg-asrt.cc" />
-    <ClCompile Include="..\dbg-maps.cc" />
-    <ClCompile Include="..\dbg-objstat.cc" />
-    <ClCompile Include="..\dbg-scan.cc" />
-    <ClCompile Include="..\dbg-util.cc" />
-    <ClCompile Include="..\decks.cc" />
-    <ClCompile Include="..\delay.cc" />
-    <ClCompile Include="..\describe.cc" />
-    <ClCompile Include="..\describe-god.cc" />
-    <ClCompile Include="..\describe-spells.cc" />
-    <ClCompile Include="..\dgl-message.cc" />
-    <ClCompile Include="..\dgn-delve.cc" />
-    <ClCompile Include="..\dgn-height.cc" />
-    <ClCompile Include="..\dgn-labyrinth.cc" />
-    <ClCompile Include="..\dgn-layouts.cc" />
-    <ClCompile Include="..\dgn-overview.cc" />
-    <ClCompile Include="..\dgn-proclayouts.cc" />
-    <ClCompile Include="..\dgn-shoals.cc" />
-    <ClCompile Include="..\dgn-swamp.cc" />
-    <ClCompile Include="..\dgn-event.cc" />
-    <ClCompile Include="..\directn.cc" />
-    <ClCompile Include="..\dlua.cc" />
-    <ClCompile Include="..\dungeon.cc" />
-    <ClCompile Include="..\end.cc" />
-    <ClCompile Include="..\english.cc" />
-    <ClCompile Include="..\errors.cc" />
-    <ClCompile Include="..\evoke.cc" />
-    <ClCompile Include="..\exclude.cc" />
-    <ClCompile Include="..\exercise.cc" />
-    <ClCompile Include="..\fearmonger.cc" />
-    <ClCompile Include="..\feature.cc" />
-    <ClCompile Include="..\fight.cc" />
-    <ClCompile Include="..\files.cc" />
-    <ClCompile Include="..\fineff.cc" />
-    <ClCompile Include="..\fontwrapper-ft.cc" />
-    <ClCompile Include="..\food.cc" />
-    <ClCompile Include="..\format.cc" />
-    <ClCompile Include="..\fprop.cc" />
-    <ClCompile Include="..\game-options.cc" />
-    <ClCompile Include="..\geom2d.cc" />
-    <ClCompile Include="..\ghost.cc" />
-    <ClCompile Include="..\glwrapper-ogl.cc" />
-    <ClCompile Include="..\glwrapper.cc" />
-    <ClCompile Include="..\god-abil.cc" />
-    <ClCompile Include="..\god-companions.cc" />
-    <ClCompile Include="..\god-conduct.cc" />
-    <ClCompile Include="..\god-item.cc" />
-    <ClCompile Include="..\god-menu.cc" />
-    <ClCompile Include="..\god-passive.cc" />
-    <ClCompile Include="..\god-prayer.cc" />
-    <ClCompile Include="..\god-wrath.cc" />
-    <ClCompile Include="..\hints.cc" />
-    <ClCompile Include="..\hiscores.cc" />
-    <ClCompile Include="..\initfile.cc" />
-    <ClCompile Include="..\invent.cc" />
-    <ClCompile Include="..\item-use.cc" />
-    <ClCompile Include="..\item-name.cc" />
-    <ClCompile Include="..\item-prop.cc" />
-    <ClCompile Include="..\items.cc" />
-    <ClCompile Include="..\jobs.cc" />
-    <ClCompile Include="..\kills.cc" />
-    <ClCompile Include="..\lang-fake.cc" />
-    <ClCompile Include="..\losglobal.cc" />
-    <ClCompile Include="..\l-colour.cc" />
-    <ClCompile Include="..\l-crawl.cc" />
-    <ClCompile Include="..\l-debug.cc" />
-    <ClCompile Include="..\l-dgn.cc" />
-    <ClCompile Include="..\l-dgnbld.cc" />
-    <ClCompile Include="..\l-dgnevt.cc" />
-    <ClCompile Include="..\l-dgngrd.cc" />
-    <ClCompile Include="..\l-dgnit.cc" />
-    <ClCompile Include="..\l-dgnlvl.cc" />
-    <ClCompile Include="..\l-dgnmon.cc" />
-    <ClCompile Include="..\l-dgntil.cc" />
-    <ClCompile Include="..\l-feat.cc" />
-    <ClCompile Include="..\l-file.cc" />
-    <ClCompile Include="..\l-food.cc" />
-    <ClCompile Include="..\l-global.cc" />
-    <ClCompile Include="..\l-item.cc" />
-    <ClCompile Include="..\l-los.cc" />
-    <ClCompile Include="..\l-mapgrd.cc" />
-    <ClCompile Include="..\l-mapmrk.cc" />
-    <ClCompile Include="..\l-moninf.cc" />
-    <ClCompile Include="..\l-mons.cc" />
-    <ClCompile Include="..\l-option.cc" />
-    <ClCompile Include="..\l-spells.cc" />
-    <ClCompile Include="..\l-subvault.cc" />
-    <ClCompile Include="..\l-travel.cc" />
-    <ClCompile Include="..\l-view.cc" />
-    <ClCompile Include="..\l-you.cc" />
-    <ClCompile Include="..\lev-pand.cc" />
-    <ClCompile Include="..\lookup-help.cc" />
-    <ClCompile Include="..\melee-attack.cc" />
-    <ClCompile Include="..\mon-death.cc" />
-    <ClCompile Include="..\mon-ench.cc" />
-    <ClCompile Include="..\mon-stealth.cc" />
-    <ClCompile Include="..\ng-setup.cc" />
-    <ClCompile Include="..\ng-wanderer.cc" />
-    <ClCompile Include="..\orb.cc" />
-    <ClCompile Include="..\package.cc" />
-    <ClCompile Include="..\pcg.cc" />
-    <ClCompile Include="..\perlin.cc" />
-    <ClCompile Include="..\place-info.cc" />
-    <ClCompile Include="..\player-act.cc" />
-    <ClCompile Include="..\player-equip.cc" />
-    <ClCompile Include="..\player-reacts.cc" />
-    <ClCompile Include="..\player-stats.cc" />
-    <ClCompile Include="..\potion.cc" />
-    <ClCompile Include="..\prebuilt\levcomp.lex.cc" />
-    <ClCompile Include="..\prebuilt\levcomp.tab.cc" />
-    <ClCompile Include="..\prompt.cc" />
-    <ClCompile Include="..\libgui.cc" />
-    <ClCompile Include="..\libutil.cc" />
-    <ClCompile Include="..\libw32c.cc" />
-    <ClCompile Include="..\los.cc" />
-    <ClCompile Include="..\los-def.cc" />
-    <ClCompile Include="..\losparam.cc" />
-    <ClCompile Include="..\luaterp.cc" />
-    <ClCompile Include="..\macro.cc" />
-    <ClCompile Include="..\main.cc" />
-    <ClCompile Include="..\makeitem.cc" />
-    <ClCompile Include="..\map-knowledge.cc" />
-    <ClCompile Include="..\mapdef.cc" />
-    <ClCompile Include="..\mapmark.cc" />
-    <ClCompile Include="..\maps.cc" />
-    <ClCompile Include="..\menu.cc" />
-    <ClCompile Include="..\message-stream.cc" />
-    <ClCompile Include="..\message.cc" />
-    <ClCompile Include="..\misc.cc" />
-    <ClCompile Include="..\mon-abil.cc" />
-    <ClCompile Include="..\mon-act.cc" />
-    <ClCompile Include="..\mon-behv.cc" />
-    <ClCompile Include="..\mon-cast.cc" />
-    <ClCompile Include="..\mon-clone.cc" />
-    <ClCompile Include="..\mon-gear.cc" />
-    <ClCompile Include="..\mon-grow.cc" />
-    <ClCompile Include="..\mon-info.cc" />
-    <ClCompile Include="..\mon-movetarget.cc" />
-    <ClCompile Include="..\mon-pathfind.cc" />
-    <ClCompile Include="..\mon-pick.cc" />
-    <ClCompile Include="..\mon-place.cc" />
-    <ClCompile Include="..\mon-poly.cc" />
-    <ClCompile Include="..\mon-project.cc" />
-    <ClCompile Include="..\mon-speak.cc" />
-    <ClCompile Include="..\mon-tentacle.cc" />
-    <ClCompile Include="..\mon-transit.cc" />
-    <ClCompile Include="..\mon-util.cc" />
-    <ClCompile Include="..\monster.cc" />
-    <ClCompile Include="..\mutation.cc" />
-    <ClCompile Include="..\nearby-danger.cc" />
-    <ClCompile Include="..\newgame.cc" />
-    <ClCompile Include="..\ng-init.cc" />
-    <ClCompile Include="..\ng-input.cc" />
-    <ClCompile Include="..\ng-restr.cc" />
-    <ClCompile Include="..\notes.cc" />
-    <ClCompile Include="..\ouch.cc" />
-    <ClCompile Include="..\output.cc" />
-    <ClCompile Include="..\pattern.cc" />
-    <ClCompile Include="..\place.cc" />
-    <ClCompile Include="..\playable.cc" />
-    <ClCompile Include="..\player.cc" />
-    <ClCompile Include="..\quiver.cc" />
-    <ClCompile Include="..\random-var.cc" />
-    <ClCompile Include="..\random.cc" />
-    <ClCompile Include="..\ranged-attack.cc" />
-    <ClCompile Include="..\ray.cc" />
-    <ClCompile Include="..\religion.cc" />
-    <ClCompile Include="..\rltiles\tiledef-feat.cc" />
-    <ClCompile Include="..\rltiles\tiledef-floor.cc" />
-    <ClCompile Include="..\rltiles\tiledef-icons.cc" />
-    <ClCompile Include="..\rltiles\tiledef-wall.cc" />
-    <ClCompile Include="..\shopping.cc" />
-    <ClCompile Include="..\shout.cc" />
-    <ClCompile Include="..\show.cc" />
-    <ClCompile Include="..\showsymb.cc" />
-    <ClCompile Include="..\skills.cc" />
-    <ClCompile Include="..\skill-menu.cc" />
-    <ClCompile Include="..\species.cc" />
-    <ClCompile Include="..\spl-book.cc" />
-    <ClCompile Include="..\spl-cast.cc" />
-    <ClCompile Include="..\spl-clouds.cc" />
-    <ClCompile Include="..\spl-damage.cc" />
-    <ClCompile Include="..\spl-goditem.cc" />
-    <ClCompile Include="..\spl-miscast.cc" />
-    <ClCompile Include="..\spl-monench.cc" />
-    <ClCompile Include="..\spl-other.cc" />
-    <ClCompile Include="..\spl-selfench.cc" />
-    <ClCompile Include="..\spl-summoning.cc" />
-    <ClCompile Include="..\spl-tornado.cc" />
-    <ClCompile Include="..\spl-transloc.cc" />
-    <ClCompile Include="..\spl-util.cc" />
-    <ClCompile Include="..\spl-wpnench.cc" />
-    <ClCompile Include="..\spl-zap.cc" />
-    <ClCompile Include="..\sprint.cc" />
-    <ClCompile Include="..\sqldbm.cc" />
-    <ClCompile Include="..\stairs.cc" />
-    <ClCompile Include="..\startup.cc" />
-    <ClCompile Include="..\stash.cc" />
-    <ClCompile Include="..\state.cc" />
-    <ClCompile Include="..\status.cc" />
-    <ClCompile Include="..\stepdown.cc" />
-    <ClCompile Include="..\store.cc" />
-    <ClCompile Include="..\stringutil.cc" />
-    <ClCompile Include="..\syscalls.cc" />
-    <ClCompile Include="..\tags.cc" />
-    <ClCompile Include="..\target.cc" />
-    <ClCompile Include="..\teleport.cc" />
-    <ClCompile Include="..\terrain.cc" />
-    <ClCompile Include="..\throw.cc" />
-    <ClCompile Include="..\timed-effects.cc" />
-    <ClCompile Include="..\tilebuf.cc" />
-    <ClCompile Include="..\rltiles\tiledef-dngn.cc" />
-    <ClCompile Include="..\rltiles\tiledef-gui.cc" />
-    <ClCompile Include="..\rltiles\tiledef-main.cc" />
-    <ClCompile Include="..\rltiles\tiledef-player.cc" />
-    <ClCompile Include="..\rltiles\tiledef-unrand.cc" />
-    <ClCompile Include="..\tilecell.cc" />
-    <ClCompile Include="..\tiledgnbuf.cc" />
-    <ClCompile Include="..\tiledoll.cc" />
-    <ClCompile Include="..\tilefont.cc" />
-    <ClCompile Include="..\tilemcache.cc" />
-    <ClCompile Include="..\tilepick-p.cc" />
-    <ClCompile Include="..\tilepick.cc" />
-    <ClCompile Include="..\tilereg-abl.cc" />
-    <ClCompile Include="..\tilereg-cmd.cc" />
-    <ClCompile Include="..\tilereg-crt.cc" />
-    <ClCompile Include="..\tilereg-dgn.cc" />
-    <ClCompile Include="..\tilereg-doll.cc" />
-    <ClCompile Include="..\tilereg-grid.cc" />
-    <ClCompile Include="..\tilereg-inv.cc" />
-    <ClCompile Include="..\tilereg-map.cc" />
-    <ClCompile Include="..\tilereg-mem.cc" />
-    <ClCompile Include="..\tilereg-menu.cc" />
-    <ClCompile Include="..\tilereg-mon.cc" />
-    <ClCompile Include="..\tilereg-msg.cc" />
-    <ClCompile Include="..\tilereg-popup.cc" />
-    <ClCompile Include="..\tilereg-skl.cc" />
-    <ClCompile Include="..\tilereg-spl.cc" />
-    <ClCompile Include="..\tilereg-stat.cc" />
-    <ClCompile Include="..\tilereg-tab.cc" />
-    <ClCompile Include="..\tilereg-text.cc" />
-    <ClCompile Include="..\tilereg-title.cc" />
-    <ClCompile Include="..\tilereg.cc" />
-    <ClCompile Include="..\tilesdl.cc" />
-    <ClCompile Include="..\tiletex.cc" />
-    <ClCompile Include="..\tileview.cc" />
-    <ClCompile Include="..\tileweb.cc" />
-    <ClCompile Include="..\transform.cc" />
-    <ClCompile Include="..\traps.cc" />
-    <ClCompile Include="..\travel.cc" />
-    <ClCompile Include="..\tutorial.cc" />
-    <ClCompile Include="..\uncancel.cc" />
-    <ClCompile Include="..\unicode.cc" />
-    <ClCompile Include="..\version.cc" />
-    <ClCompile Include="..\view.cc" />
-    <ClCompile Include="..\viewchar.cc" />
-    <ClCompile Include="..\viewgeom.cc" />
-    <ClCompile Include="..\viewmap.cc" />
-    <ClCompile Include="..\wcwidth.cc" />
-    <ClCompile Include="..\windowmanager-sdl.cc" />
-    <ClCompile Include="..\wiz-dgn.cc" />
-    <ClCompile Include="..\wiz-dump.cc" />
-    <ClCompile Include="..\wiz-fsim.cc" />
-    <ClCompile Include="..\wiz-item.cc" />
-    <ClCompile Include="..\wiz-mon.cc" />
-    <ClCompile Include="..\wiz-you.cc" />
-    <ClCompile Include="..\worley.cc" />
-    <ClCompile Include="..\xom.cc" />
-    <ClCompile Include="..\dgn-irregular-box.cc" />
-    <ClCompile Include="..\json.cc" />
-    <ClCompile Include="..\spl-pick.cc" />
-    <ClCompile Include="..\hash.cc" />
+    <ClCompile Include="..\ability.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\abyss.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\acquire.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\act-iter.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\actor.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\actor-los.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\adjust.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\AppHdr.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\areas.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\arena.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\artefact.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\attack.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\attitude-change.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\beam.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\behold.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\bitary.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\bloodspatter.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\branch.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\butcher.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\chardump.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\cio.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\cloud.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\clua.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\cluautil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\colour.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\command.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\coord.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\coord-circle.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\coordit.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\crash.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ctest.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dactions.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\database.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dbg-asrt.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dbg-maps.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dbg-objstat.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dbg-scan.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dbg-util.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\decks.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\delay.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\describe.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\describe-god.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\describe-spells.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgl-message.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-delve.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-event.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-height.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\xom.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\worley.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-you.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-mon.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-item.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-fsim.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-dump.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wiz-dgn.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wizard.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\windowmanager-sdl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\wcwidth.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\viewmap.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\viewgeom.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\viewchar.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\view.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\version.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\unicode.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\uncancel.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ui.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tutorial.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\travel.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\traps.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\transform.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\timed-effects.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tileweb-text.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tileweb.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tileview.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tiletex.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilesdl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-text.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-tab.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-stat.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-spl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-skl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-msg.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-mon.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-mem.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-map.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-inv.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-grid.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-doll.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-dgn.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-crt.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-cmd.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg-abl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilereg.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilepick-p.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilepick.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilemcache.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilefont.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tiledoll.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tiledgnbuf.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-unrand.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilecell.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tilebuf.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\throw.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\terrain.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\teleport.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\target.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\tags.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\syscalls.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\stringutil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\store.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\stepdown.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\status.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\state.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\stash.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\startup.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\stairs.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sqldbm.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sprint.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-zap.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-wpnench.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-util.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-transloc.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-tornado.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-summoning.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-selfench.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-pick.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-other.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-monench.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-miscast.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-goditem.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-damage.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-clouds.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-cast.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\spl-book.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\species.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\sound.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\skills.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\skill-menu.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\showsymb.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\show.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\shout.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\shopping.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\scroller.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rot.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\religion.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ray.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ranged-attack.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\random-var.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\random.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\randbook.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\quiver.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\prompt.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\potion.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\player-stats.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\player-reacts.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\player-equip.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\player-act.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\player.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\playable.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\place-info.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\place.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\perlin.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pcg.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\pattern.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\package.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\output.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ouch.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\orb.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\notes.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ng-wanderer.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ng-setup.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ng-restr.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ng-input.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ng-init.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\newgame.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\nearby-danger.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mutation.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-util.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-transit.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-tentacle.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\monster.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-speak.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-project.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-poly.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-place.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-pick.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-pathfind.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-movetarget.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-info.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-grow.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-gear.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-ench.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-death.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-clone.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-cast.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-behv.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-act.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mon-abil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\misc.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\message-stream.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\message.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\menu.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\melee-attack.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\maps.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mapmark.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\map-knowledge.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\mapdef.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\makeitem.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\macro.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-you.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-view.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\luaterp.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-travel.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-subvault.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-spells.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\losparam.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\losglobal.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\los-def.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\los.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-option.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lookup-help.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-mons.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-mapmrk.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-moninf.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-mapgrd.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-los.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-item.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libw32c.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libutil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\libgui.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-global.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-food.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-file.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-feat.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lev-pand.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\prebuilt\levcomp.tab.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\prebuilt\levcomp.lex.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgntil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgnlvl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgnit.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgnmon.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgngrd.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgnbld.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgnevt.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-dgn.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-crawl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-debug.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-colour.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\lang-fake.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\kills.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\json.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\jobs.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\item-use.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\items.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\item-prop.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\item-name.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\invent.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\initfile.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hiscores.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hints.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hash.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-wrath.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-prayer.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-passive.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-menu.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-item.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-conduct.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-companions.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-blessing.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\god-abil.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\glwrapper-ogl.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\glwrapper.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\ghost.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\geom2d.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\game-options.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\fprop.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\format.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\food.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\fontwrapper-ft.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\fineff.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\files.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\fight.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\feature.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\fearmonger.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\exercise.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\exclude.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\evoke.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\errors.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\english.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\end.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dungeon.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dlua.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\directn.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-swamp.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-shoals.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-proclayouts.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-overview.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-layouts.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-labyrinth.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dgn-irregular-box.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\loading-screen.cc">
+      <Filter>h</Filter>
+    </ClCompile>
+    <ClCompile Include="..\domino.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\l-wiz.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\movement.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-gui.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-icons.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-player.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-dngn.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-feat.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-floor.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-main.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
+    <ClCompile Include="..\rltiles\tiledef-wall.cc">
+      <Filter>rtiles_generated</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\ability.h" />
-    <ClInclude Include="..\abyss.h" />
-    <ClInclude Include="..\acquire.h" />
-    <ClInclude Include="..\act-iter.h" />
-    <ClInclude Include="..\actor.h" />
-    <ClInclude Include="..\adjust.h" />
-    <ClInclude Include="..\AppHdr.h" />
-    <ClInclude Include="..\aptitudes.h" />
-    <ClInclude Include="..\areas.h" />
-    <ClInclude Include="..\arena.h" />
-    <ClInclude Include="..\art-data.h" />
-    <ClInclude Include="..\art-enum.h" />
-    <ClInclude Include="..\art-func.h" />
-    <ClInclude Include="..\artefact.h" />
-    <ClInclude Include="..\attack.h" />
-    <ClInclude Include="..\attitude-change.h" />
-    <ClInclude Include="..\beam.h" />
-    <ClInclude Include="..\bitary.h" />
-    <ClInclude Include="..\book-data.h" />
-    <ClInclude Include="..\branch-data.h" />
-    <ClInclude Include="..\branch.h" />
-    <ClInclude Include="..\build.h" />
-    <ClInclude Include="..\chardump.h" />
-    <ClInclude Include="..\cio.h" />
-    <ClInclude Include="..\cloud.h" />
-    <ClInclude Include="..\clua.h" />
-    <ClInclude Include="..\cluautil.h" />
-    <ClInclude Include="..\cmd-keys.h" />
-    <ClInclude Include="..\cmd-name.h" />
-    <ClInclude Include="..\colour.h" />
-    <ClInclude Include="..\command.h" />
-    <ClInclude Include="..\compflag.h" />
-    <ClInclude Include="..\coord-circle.h" />
-    <ClInclude Include="..\coord.h" />
-    <ClInclude Include="..\coordit.h" />
-    <ClInclude Include="..\crash.h" />
-    <ClInclude Include="..\ctest.h" />
-    <ClInclude Include="..\dactions.h" />
-    <ClInclude Include="..\database.h" />
-    <ClInclude Include="..\dbg-crsh.h" />
-    <ClInclude Include="..\dbg-maps.h" />
-    <ClInclude Include="..\dbg-objstat.h" />
-    <ClInclude Include="..\dbg-scan.h" />
-    <ClInclude Include="..\dbg-util.h" />
-    <ClInclude Include="..\debug.h" />
-    <ClInclude Include="..\decks.h" />
-    <ClInclude Include="..\defines.h" />
-    <ClInclude Include="..\delay.h" />
-    <ClInclude Include="..\describe.h" />
-    <ClInclude Include="..\describe-god.h" />
-    <ClInclude Include="..\describe-spells.h" />
-    <ClInclude Include="..\dgl-message.h" />
-    <ClInclude Include="..\dgn-delve.h" />
-    <ClInclude Include="..\dgn-height.h" />
-    <ClInclude Include="..\dgn-labyrinth.h" />
-    <ClInclude Include="..\dgn-layouts.h" />
-    <ClInclude Include="..\dgn-overview.h" />
-    <ClInclude Include="..\dgn-proclayouts.h" />
-    <ClInclude Include="..\dgn-shoals.h" />
-    <ClInclude Include="..\dgn-swamp.h" />
-    <ClInclude Include="..\dgn-event.h" />
-    <ClInclude Include="..\directn.h" />
-    <ClInclude Include="..\dlua.h" />
-    <ClInclude Include="..\dungeon.h" />
-    <ClInclude Include="..\end.h" />
-    <ClInclude Include="..\endianness.h" />
-    <ClInclude Include="..\english.h" />
-    <ClInclude Include="..\enum.h" />
-    <ClInclude Include="..\env.h" />
-    <ClInclude Include="..\errors.h" />
-    <ClInclude Include="..\evoke.h" />
-    <ClInclude Include="..\exclude.h" />
-    <ClInclude Include="..\exercise.h" />
-    <ClInclude Include="..\externs.h" />
-    <ClInclude Include="..\feature.h" />
-    <ClInclude Include="..\fight.h" />
-    <ClInclude Include="..\files.h" />
-    <ClInclude Include="..\fineff.h" />
-    <ClInclude Include="..\fixary.h" />
-    <ClInclude Include="..\fixedarray.h" />
-    <ClInclude Include="..\fixedvector.h" />
-    <ClInclude Include="..\fixvec.h" />
-    <ClInclude Include="..\flood-find.h" />
-    <ClInclude Include="..\fontwrapper-ft.h" />
-    <ClInclude Include="..\food.h" />
-    <ClInclude Include="..\form-data.h" />
-    <ClInclude Include="..\format.h" />
-    <ClInclude Include="..\fprop.h" />
-    <ClInclude Include="..\game-options.h" />
-    <ClInclude Include="..\geom2d.h" />
-    <ClInclude Include="..\ghost.h" />
-    <ClInclude Include="..\glwrapper-ogl.h" />
-    <ClInclude Include="..\glwrapper.h" />
-    <ClInclude Include="..\god-abil.h" />
-    <ClInclude Include="..\god-companions.h" />
-    <ClInclude Include="..\god-conduct.h" />
-    <ClInclude Include="..\god-item.h" />
-    <ClInclude Include="..\god-menu.h" />
-    <ClInclude Include="..\god-passive.h" />
-    <ClInclude Include="..\god-prayer.h" />
-    <ClInclude Include="..\god-wrath.h" />
-    <ClInclude Include="..\hash.h" />
-    <ClInclude Include="..\hints.h" />
-    <ClInclude Include="..\hiscores.h" />
-    <ClInclude Include="..\initfile.h" />
-    <ClInclude Include="..\invent.h" />
-    <ClInclude Include="..\item-prop-enum.h" />
-    <ClInclude Include="..\item-use.h" />
-    <ClInclude Include="..\item-name.h" />
-    <ClInclude Include="..\item-prop.h" />
-    <ClInclude Include="..\items.h" />
-    <ClInclude Include="..\jobs.h" />
-    <ClInclude Include="..\json.h" />
-    <ClInclude Include="..\json-wrapper.h" />
-    <ClInclude Include="..\kills.h" />
-    <ClInclude Include="..\lang-fake.h" />
-    <ClInclude Include="..\libconsole.h" />
-    <ClInclude Include="..\libunix.h" />
-    <ClInclude Include="..\losglobal.h" />
-    <ClInclude Include="..\l-defs.h" />
-    <ClInclude Include="..\l-libs.h" />
-    <ClInclude Include="..\l_los.h" />
-    <ClInclude Include="..\lev-pand.h" />
-    <ClInclude Include="..\lookup-help.h" />
-    <ClInclude Include="..\matrix.h" />
-    <ClInclude Include="..\melee-attack.h" />
-    <ClInclude Include="..\mi-enum.h" />
-    <ClInclude Include="..\mon-death.h" />
-    <ClInclude Include="..\mon-ench.h" />
-    <ClInclude Include="..\mon-flags.h" />
-    <ClInclude Include="..\mon-mst.h" />
-    <ClInclude Include="..\mon-pick-data.h" />
-    <ClInclude Include="..\mutant-beast.h" />
-    <ClInclude Include="..\mutation-data.h" />
-    <ClInclude Include="..\newgame-def.h" />
-    <ClInclude Include="..\ng-setup.h" />
-    <ClInclude Include="..\ng-wanderer.h" />
-    <ClInclude Include="..\noise.h" />
-    <ClInclude Include="..\options.h" />
-    <ClInclude Include="..\orb.h" />
-    <ClInclude Include="..\package.h" />
-    <ClInclude Include="..\perlin.h" />
-    <ClInclude Include="..\place-info.h" />
-    <ClInclude Include="..\platform.h" />
-    <ClInclude Include="..\player-equip.h" />
-    <ClInclude Include="..\player-reacts.h" />
-    <ClInclude Include="..\player-stats.h" />
-    <ClInclude Include="..\potion.h" />
-    <ClInclude Include="..\prebuilt\levcomp.tab.h" />
-    <ClInclude Include="..\prompt.h" />
-    <ClInclude Include="..\libgui.h" />
-    <ClInclude Include="..\libutil.h" />
-    <ClInclude Include="..\libw32c.h" />
-    <ClInclude Include="..\los.h" />
-    <ClInclude Include="..\los-def.h" />
-    <ClInclude Include="..\losparam.h" />
-    <ClInclude Include="..\luaterp.h" />
-    <ClInclude Include="..\macro.h" />
-    <ClInclude Include="..\makeitem.h" />
-    <ClInclude Include="..\map-knowledge.h" />
-    <ClInclude Include="..\mapdef.h" />
-    <ClInclude Include="..\mapmark.h" />
-    <ClInclude Include="..\maps.h" />
-    <ClInclude Include="..\menu.h" />
-    <ClInclude Include="..\message.h" />
-    <ClInclude Include="..\mgen-data.h" />
-    <ClInclude Include="..\mgen-enum.h" />
-    <ClInclude Include="..\misc.h" />
-    <ClInclude Include="..\mon-abil.h" />
-    <ClInclude Include="..\mon-act.h" />
-    <ClInclude Include="..\mon-behv.h" />
-    <ClInclude Include="..\mon-cast.h" />
-    <ClInclude Include="..\mon-clone.h" />
-    <ClInclude Include="..\mon-data.h" />
-    <ClInclude Include="..\mon-enum.h" />
-    <ClInclude Include="..\mon-gear.h" />
-    <ClInclude Include="..\mon-grow.h" />
-    <ClInclude Include="..\mon-info.h" />
-    <ClInclude Include="..\mon-movetarget.h" />
-    <ClInclude Include="..\mon-pathfind.h" />
-    <ClInclude Include="..\mon-pick.h" />
-    <ClInclude Include="..\mon-place.h" />
-    <ClInclude Include="..\mon-poly.h" />
-    <ClInclude Include="..\mon-project.h" />
-    <ClInclude Include="..\mon-speak.h" />
-    <ClInclude Include="..\mon-spell.h" />
-    <ClInclude Include="..\mon-tentacle.h" />
-    <ClInclude Include="..\mon-transit.h" />
-    <ClInclude Include="..\mon-util.h" />
-    <ClInclude Include="..\monster.h" />
-    <ClInclude Include="..\mpr.h" />
-    <ClInclude Include="..\msvc.h" />
-    <ClInclude Include="..\mutation.h" />
-    <ClInclude Include="..\newgame.h" />
-    <ClInclude Include="..\ng-init.h" />
-    <ClInclude Include="..\ng-input.h" />
-    <ClInclude Include="..\ng-restr.h" />
-    <ClInclude Include="..\notes.h" />
-    <ClInclude Include="..\ouch.h" />
-    <ClInclude Include="..\output.h" />
-    <ClInclude Include="..\pattern.h" />
-    <ClInclude Include="..\pcg.h" />
-    <ClInclude Include="..\place.h" />
-    <ClInclude Include="..\player.h" />
-    <ClInclude Include="..\playable.h" />
-    <ClInclude Include="..\process-desc.h" />
-    <ClInclude Include="..\props.h" />
-    <ClInclude Include="..\quiver.h" />
-    <ClInclude Include="..\random-var.h" />
-    <ClInclude Include="..\random.h" />
-    <ClInclude Include="..\ranged-attack.h" />
-    <ClInclude Include="..\ray.h" />
-    <ClInclude Include="..\religion-enum.h" />
-    <ClInclude Include="..\religion.h" />
-    <ClInclude Include="..\rltiles\tiledef-feat.h" />
-    <ClInclude Include="..\rltiles\tiledef-floor.h" />
-    <ClInclude Include="..\rltiles\tiledef-icons.h" />
-    <ClInclude Include="..\rltiles\tiledef-wall.h" />
-    <ClInclude Include="..\rltiles\tiledef_defines.h" />
-    <ClInclude Include="..\SDLMain.h" />
-    <ClInclude Include="..\sacrifice-data.h" />
-    <ClInclude Include="..\shopping.h" />
-    <ClInclude Include="..\shout.h" />
-    <ClInclude Include="..\show.h" />
-    <ClInclude Include="..\showsymb.h" />
-    <ClInclude Include="..\skills.h" />
-    <ClInclude Include="..\skill-menu.h" />
-    <ClInclude Include="..\species.h" />
-    <ClInclude Include="..\species-data.h" />
-    <ClInclude Include="..\species-def.h" />
-    <ClInclude Include="..\species-type.h" />
-    <ClInclude Include="..\spl-book.h" />
-    <ClInclude Include="..\spl-cast.h" />
-    <ClInclude Include="..\spl-clouds.h" />
-    <ClInclude Include="..\spl-damage.h" />
-    <ClInclude Include="..\spl-data.h" />
-    <ClInclude Include="..\spl-goditem.h" />
-    <ClInclude Include="..\spl-miscast.h" />
-    <ClInclude Include="..\spl-monench.h" />
-    <ClInclude Include="..\spl-other.h" />
-    <ClInclude Include="..\spl-selfench.h" />
-    <ClInclude Include="..\spl-summoning.h" />
-    <ClInclude Include="..\spl-transloc.h" />
-    <ClInclude Include="..\spl-util.h" />
-    <ClInclude Include="..\spl-wpnench.h" />
-    <ClInclude Include="..\spl-zap.h" />
-    <ClInclude Include="..\sprint.h" />
-    <ClInclude Include="..\sqldbm.h" />
-    <ClInclude Include="..\stairs.h" />
-    <ClInclude Include="..\startup.h" />
-    <ClInclude Include="..\stash.h" />
-    <ClInclude Include="..\state.h" />
-    <ClInclude Include="..\status.h" />
-    <ClInclude Include="..\stepdown.h" />
-    <ClInclude Include="..\store.h" />
-    <ClInclude Include="..\stringutil.h" />
-    <ClInclude Include="..\syscalls.h" />
-    <ClInclude Include="..\tag-version.h" />
-    <ClInclude Include="..\tags.h" />
-    <ClInclude Include="..\target.h" />
-    <ClInclude Include="..\teleport.h" />
-    <ClInclude Include="..\terrain.h" />
-    <ClInclude Include="..\threads.h" />
-    <ClInclude Include="..\throw.h" />
-    <ClInclude Include="..\tilebuf.h" />
-    <ClInclude Include="..\timed-effects.h" />
-    <ClInclude Include="..\rltiles\tiledef-dngn.h" />
-    <ClInclude Include="..\rltiles\tiledef-gui.h" />
-    <ClInclude Include="..\rltiles\tiledef-main.h" />
-    <ClInclude Include="..\rltiles\tiledef-player.h" />
-    <ClInclude Include="..\rltiles\tiledef-unrand.h" />
-    <ClInclude Include="..\tilecell.h" />
-    <ClInclude Include="..\tiledgnbuf.h" />
-    <ClInclude Include="..\tiledoll.h" />
-    <ClInclude Include="..\tilefont.h" />
-    <ClInclude Include="..\tilemcache.h" />
-    <ClInclude Include="..\tilepick-p.h" />
-    <ClInclude Include="..\tilepick.h" />
-    <ClInclude Include="..\tilereg-abl.h" />
-    <ClInclude Include="..\tilereg-cmd.h" />
-    <ClInclude Include="..\tilereg-crt.h" />
-    <ClInclude Include="..\tilereg-dgn.h" />
-    <ClInclude Include="..\tilereg-doll.h" />
-    <ClInclude Include="..\tilereg-grid.h" />
-    <ClInclude Include="..\tilereg-inv.h" />
-    <ClInclude Include="..\tilereg-map.h" />
-    <ClInclude Include="..\tilereg-mem.h" />
-    <ClInclude Include="..\tilereg-menu.h" />
-    <ClInclude Include="..\tilereg-mon.h" />
-    <ClInclude Include="..\tilereg-msg.h" />
-    <ClInclude Include="..\tilereg-popup.h" />
-    <ClInclude Include="..\tilereg-skl.h" />
-    <ClInclude Include="..\tilereg-spl.h" />
-    <ClInclude Include="..\tilereg-stat.h" />
-    <ClInclude Include="..\tilereg-tab.h" />
-    <ClInclude Include="..\tilereg-text.h" />
-    <ClInclude Include="..\tilereg-title.h" />
-    <ClInclude Include="..\tilereg.h" />
-    <ClInclude Include="..\tiles.h" />
-    <ClInclude Include="..\tilesdl.h" />
-    <ClInclude Include="..\tiletex.h" />
-    <ClInclude Include="..\tileview.h" />
-    <ClInclude Include="..\tileweb.h" />
-    <ClInclude Include="..\transform.h" />
-    <ClInclude Include="..\traps.h" />
-    <ClInclude Include="..\trap-def.h" />
-    <ClInclude Include="..\travel.h" />
-    <ClInclude Include="..\travel-defs.h" />
-    <ClInclude Include="..\tutorial.h" />
-    <ClInclude Include="..\uncancel.h" />
-    <ClInclude Include="..\unicode.h" />
-    <ClInclude Include="..\unrand.h" />
-    <ClInclude Include="..\unwind.h" />
-    <ClInclude Include="..\version.h" />
-    <ClInclude Include="..\view.h" />
-    <ClInclude Include="..\viewchar.h" />
-    <ClInclude Include="..\viewgeom.h" />
-    <ClInclude Include="..\viewmap.h" />
-    <ClInclude Include="..\windowmanager-sdl.h" />
-    <ClInclude Include="..\windowmanager.h" />
-    <ClInclude Include="..\winhdr.h" />
-    <ClInclude Include="..\wiz-dgn.h" />
-    <ClInclude Include="..\wiz-dump.h" />
-    <ClInclude Include="..\wiz-fsim.h" />
-    <ClInclude Include="..\wiz-item.h" />
-    <ClInclude Include="..\wiz-mon.h" />
-    <ClInclude Include="..\wiz-you.h" />
-    <ClInclude Include="..\worley.h" />
-    <ClInclude Include="..\xom.h" />
-    <ClInclude Include="..\xp-tracking-type.h" />
-    <ClInclude Include="..\zap-data.h" />
-    <ClInclude Include="..\dgn-irregular-box.h" />
-    <ClInclude Include="..\random-pick.h" />
-    <ClInclude Include="..\spl-pick.h" />
-    <ClInclude Include="..\mon-book.h" />
+    <ClInclude Include="..\ability.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ability-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\abyss.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\acquire.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\act-iter.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\activity-interrupt-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\actor.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ac-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\adjust.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\AppHdr.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\aptitudes.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\areas.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\arena.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\art-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\artefact.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\artefact-prop-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\art-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\art-func.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\attack.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\attitude-change.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\attribute-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\beam.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\beam-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\beh-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\bitary.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\bloodspatter.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\book-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\book-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\branch.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\branch-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\branch-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\build.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\butcher.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\caction-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\canned-message-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\chardump.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\char-set-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cio.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cleansing-flame-source-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cloud.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cloud-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\clua.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cluautil.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cmd-keys.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cmd-name.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\colour.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\command.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\command-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\compflag.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\conduct-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\confirm-butcher-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\confirm-level-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\confirm-prompt-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\coord.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\coord-circle.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\coordit.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\crash.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ctest.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cursor-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dactions.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\daction-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\database.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dbg-maps.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dbg-objstat.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dbg-scan.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dbg-util.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\debug.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\deck-rarity-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\decks.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\defines.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\delay.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\describe.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\describe-god.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\describe-spells.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\description-level-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgl-message.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-delve.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-event.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-height.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-irregular-box.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-labyrinth.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-layouts.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-overview.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-proclayouts.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-shoals.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dgn-swamp.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\directn.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\disable-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dlua.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dungeon.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dungeon-char-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\dungeon-feature-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\duration-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\duration-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\enchant-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\end.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\endianness.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\energy-use-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\english.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\env.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\eq-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\eq-type-flags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\equipment-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\errors.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\evoke.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\exclude.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\exercise.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\externs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\feature.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\feature-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fight.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\files.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fineff.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fixedarray.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fixedvector.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\flang-t.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\flood-find.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\flush-reason-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fontwrapper-ft.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\food.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\format.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\form-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\fprop.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\game-chapter.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\game-options.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\game-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\gender-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\geom2d.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ghost.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\glwrapper.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\glwrapper-ogl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-abil.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-blessing.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-companions.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-conduct.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-item.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-menu.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-passive.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-prayer.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\god-wrath.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hash.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hints.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hiscores.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\holy-word-source-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hunger-state-t.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ieoh-jian-attack-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\initfile.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\invent.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-name.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-prop.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-prop-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\items.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-status-flag-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-type-id-state-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\item-use.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\jobs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\job-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\json.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\json-wrapper.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\KeymapContext.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\kill-category.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\killer-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\kills.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lang-fake.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lang-t.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\l-defs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\prebuilt\levcomp.tab.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\level-state-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lev-pand.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libconsole.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libunix.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libutil.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libw32c.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\l-libs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\loading-screen.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lookup-help.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\los.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\los-def.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\losglobal.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\losparam.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\los-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\luaterp.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\macro.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\makeitem.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\map-cell.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mapdef.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\map-feature.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\map-knowledge.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mapmark.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\map-marker-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\maps.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\matrix.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\maybe-bool.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\melee-attack.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\menu.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\menu-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\message.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mgen-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mgen-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mi-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\misc.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-abil.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-act.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-attitude-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-behv.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-book.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-cast.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-clone.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-death.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-ench.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-flags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-gear.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-grow.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-holy-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-info.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-inv-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-movetarget.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-mst.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-pathfind.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-pick.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-pick-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-place.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-poly.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-project.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-speak.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-spell.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\monster.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\monster-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-tentacle.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-transit.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\montravel-target-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mon-util.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mpr.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\msvc.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mutant-beast.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mutation.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mutation-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\mutation-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\nearby-danger.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\newgame.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\newgame-def.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ng-init.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ng-input.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ng-restr.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ng-setup.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ng-wanderer.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\noise.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\notes.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\object-class-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\operation-types.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\options.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\orb.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\orb-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ouch.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\output.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\package.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\pattern.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\pcg.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\perlin.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\place.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\place-info.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\platform.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\playable.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\player.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\player-equip.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\player-reacts.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\player-save-info.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\player-stats.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\potion.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\potion-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\process-desc.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\prompt.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\pronoun-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\props.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\quiver.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\randbook.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\random.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\random-pick.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\random-var.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ranged-attack.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ray.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\reach-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\recite-eligibility.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\recite-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\religion.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\religion-enum.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rng-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rot.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sacrifice-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\score-format-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\screen-mode.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\scroller.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\SDLMain.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\seen-context-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sense-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\shopping.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\shop-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\shout.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\show.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\showsymb.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\size-part-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\size-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\skill-focus-mode.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\skill-menu.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\skill-menu-state.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\skills.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\skill-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\slot-select-mode.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sound.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\species.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\species-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\species-def.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\species-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spell-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-book.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-cast.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-clouds.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-damage.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-goditem.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-miscast.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-monench.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-other.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-pick.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-selfench.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-summoning.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-transloc.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-util.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-wpnench.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\spl-zap.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sprint.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\sqldbm.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stairs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\startup.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stash.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\state.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stat-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\status.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stepdown.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\store.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\stringutil.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\syscalls.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tag-pref.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tag-version.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\target.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\targeting-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\targ-mode-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\teleport.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\terrain.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\terrain-change-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\text-tag-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\threads.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\throw.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilebuf.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilecell.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef_defines.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-unrand.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tiledgnbuf.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tiledoll.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tile-flags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilefont.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tile-inventory-flags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilemcache.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilepick.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilepick-p.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tile-player-flag-cut.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tile-player-flags.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-abl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-cmd.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-crt.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-dgn.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-doll.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-grid.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-inv.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-map.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-mem.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-mon.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-msg.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-skl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-spl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-stat.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-tab.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilereg-text.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tiles.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tiles-build-specific.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tilesdl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tiletex.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tileview.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tileweb.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tileweb-text.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\timed-effects.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\timed-effect-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\torment-source-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\transform.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\transformation.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\trap-def.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\traps.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\trap-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\travel.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\travel-defs.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\tutorial.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ui.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\uncancel.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\uncancellable-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\undead-state-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\unicode.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\unique-item-status-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\unwind.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\version.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\view.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\viewchar.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\viewgeom.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\viewmap.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\windowmanager.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\windowmanager-sdl.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wizard.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wizard-option-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-dgn.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-dump.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-fsim.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-item.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-mon.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wiz-you.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\worley.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xom.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\xp-tracking-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\zap-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\zap-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\domino.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\domino-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\wu-jian-attack-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\movement.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\job-data.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\game-exit-type.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-dngn.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-gui.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-icons.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-player.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-feat.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-floor.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-main.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\rltiles\tiledef-wall.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="cc">
+      <UniqueIdentifier>{938d2e05-8ec4-4bc5-9e03-0b81f2c3fe9a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="h">
+      <UniqueIdentifier>{ec3d9f5c-c077-4e44-98c5-9b3f40eb1c0e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="rtiles_generated">
+      <UniqueIdentifier>{130af3a6-ee12-4d01-909c-3fe6bd58ec78}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
 </Project>

--- a/crawl-ref/source/MSVC/include/stdint.h
+++ b/crawl-ref/source/MSVC/include/stdint.h
@@ -125,7 +125,7 @@ typedef uint64_t  uintmax_t;
 
 
 // 7.18.2 Limits of specified-width integer types
-
+#define __STDC_LIMIT_MACROS
 #if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
 
 // 7.18.2.1 Limits of exact-width integer types

--- a/crawl-ref/source/MSVC/tilegen.vcproj
+++ b/crawl-ref/source/MSVC/tilegen.vcproj
@@ -43,7 +43,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
+				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -62,7 +62,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="SDL.lib SDL_image.lib libpng.lib"
+				AdditionalDependencies="SDL2.lib SDL2_image.lib libpng.lib"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories=""
 				GenerateDebugInformation="true"
@@ -122,7 +122,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
+				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
 				PreprocessorDefinitions="WIN32;_DEBUG;_CONSOLE"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -141,7 +141,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="SDL.lib SDL_image.lib libpng.lib"
+				AdditionalDependencies="SDL2.lib SDL2_image.lib libpng.lib"
 				LinkIncremental="2"
 				AdditionalLibraryDirectories=""
 				GenerateDebugInformation="true"
@@ -200,7 +200,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
+				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
@@ -217,7 +217,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="SDL.lib SDL_image.lib libpng.lib"
+				AdditionalDependencies="SDL2.lib SDL2_image.lib libpng.lib"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories=""
 				GenerateDebugInformation="true"
@@ -279,7 +279,7 @@
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
-				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
+				AdditionalIncludeDirectories="$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib"
 				PreprocessorDefinitions="WIN32;NDEBUG;_CONSOLE"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"
@@ -296,7 +296,7 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="SDL.lib SDL_image.lib libpng.lib"
+				AdditionalDependencies="SDL2.lib SDL2_image.lib libpng.lib"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories=""
 				GenerateDebugInformation="true"

--- a/crawl-ref/source/MSVC/tilegen.vcxproj
+++ b/crawl-ref/source/MSVC/tilegen.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -22,28 +22,29 @@
     <ProjectGuid>{DAE92A45-087B-445B-8E94-BA864173A73F}</ProjectGuid>
     <RootNamespace>tilegen</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -99,7 +100,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -108,7 +109,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -141,7 +142,7 @@ copy *.png ..\dat\tiles\
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -150,7 +151,7 @@ copy *.png ..\dat\tiles\
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -179,14 +180,15 @@ copy *.png ..\dat\tiles\
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;ucrt.lib;vcruntime.lib;msvcrt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -220,14 +222,14 @@ copy *.png ..\dat\tiles\
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl\include;$(SolutionDir)\..\contrib\sdl-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\contrib\sdl2\include;$(SolutionDir)\..\contrib\sdl2-image;$(SolutionDir)\..\contrib\libpng;$(SolutionDir)\..\contrib\zlib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL.lib;SDL_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;libpng.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/crawl-ref/source/contrib/Contribs.sln
+++ b/crawl-ref/source/contrib/Contribs.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2012 for Windows Desktop
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2046
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "freetype", "freetype\builds\win32\vc2012\freetype.vcxproj", "{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libpng", "libpng\projects\visualc11\libpng.vcxproj", "{69C22A64-61EF-4206-816C-6D36766652A6}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL2", "sdl2\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL", "sdl\VisualC\SDL\SDL.vcxproj", "{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL_image", "sdl-image\VisualC\SDL_image.vcxproj", "{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL2_image", "sdl2-image\VisualC\SDL_image_VS2012.vcxproj", "{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}"
+	ProjectSection(ProjectDependencies) = postProject
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68} = {81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A} = {DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lua", "lua\src\lua.vcxproj", "{A61349B6-4099-4688-AA1A-00D91397857D}"
 EndProject
@@ -17,88 +21,168 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pcre", "pcre\pcre.vcxproj",
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "zlib", "zlib\projects\visualc2012\zlib.vcxproj", "{3D9F174B-2909-4834-A3D7-892E8D442A5D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDLmain", "sdl\VisualC\SDLmain\SDLmain.vcxproj", "{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SDL2main", "sdl2\VisualC\SDLmain\SDLmain.vcxproj", "{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libpng", "libpng\projects\vstudio\libpng\libpng.vcxproj", "{D6973076-9317-4EF2-A0B8-B7A18AC0713E}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D} = {3D9F174B-2909-4834-A3D7-892E8D442A5D}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug Library|Win32 = Debug Library|Win32
+		Debug Library|x64 = Debug Library|x64
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Release Library|Win32 = Release Library|Win32
+		Release Library|x64 = Release Library|x64
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug Library|Win32.ActiveCfg = Debug Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug Library|Win32.Build.0 = Debug Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug Library|x64.ActiveCfg = Debug Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug Library|x64.Build.0 = Debug Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug|Win32.ActiveCfg = Debug Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug|Win32.Build.0 = Debug Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Debug|x64.ActiveCfg = Debug Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release Library|Win32.ActiveCfg = Release Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release Library|Win32.Build.0 = Release Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release Library|x64.ActiveCfg = Debug Multithreaded|Win32
+		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release Library|x64.Build.0 = Debug Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release|Win32.ActiveCfg = Release Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release|Win32.Build.0 = Release Multithreaded|Win32
 		{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}.Release|x64.ActiveCfg = Release Multithreaded|Win32
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Debug|Win32.ActiveCfg = LIB ASM Debug|Win32
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Debug|Win32.Build.0 = LIB ASM Debug|Win32
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Debug|x64.ActiveCfg = LIB Debug|x64
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Debug|x64.Build.0 = LIB Debug|x64
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Release|Win32.ActiveCfg = LIB ASM Release|Win32
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Release|Win32.Build.0 = LIB ASM Release|Win32
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Release|x64.ActiveCfg = LIB Release|x64
-		{69C22A64-61EF-4206-816C-6D36766652A6}.Release|x64.Build.0 = LIB Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Library|Win32.Build.0 = Debug|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Library|x64.ActiveCfg = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug Library|x64.Build.0 = Debug|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.ActiveCfg = Debug|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|Win32.Build.0 = Debug|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.ActiveCfg = Debug|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Debug|x64.Build.0 = Debug|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Library|Win32.ActiveCfg = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Library|Win32.Build.0 = Release|Win32
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Library|x64.ActiveCfg = Release|x64
+		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release Library|x64.Build.0 = Release|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.ActiveCfg = Release|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|Win32.Build.0 = Release|Win32
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.ActiveCfg = Release|x64
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug Library|Win32.Build.0 = Debug|Win32
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug Library|x64.ActiveCfg = Debug|x64
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug Library|x64.Build.0 = Debug|x64
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug|Win32.Build.0 = Debug|Win32
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug|x64.ActiveCfg = Debug|x64
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Debug|x64.Build.0 = Debug|x64
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release Library|Win32.ActiveCfg = Release|Win32
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release Library|Win32.Build.0 = Release|Win32
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release Library|x64.ActiveCfg = Release|x64
+		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release Library|x64.Build.0 = Release|x64
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release|Win32.ActiveCfg = Release|Win32
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release|Win32.Build.0 = Release|Win32
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release|x64.ActiveCfg = Release|x64
 		{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}.Release|x64.Build.0 = Release|x64
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug Library|Win32.Build.0 = Debug|Win32
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug Library|x64.ActiveCfg = Debug|x64
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug Library|x64.Build.0 = Debug|x64
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug|Win32.Build.0 = Debug|Win32
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug|x64.ActiveCfg = Debug|x64
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Debug|x64.Build.0 = Debug|x64
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Release Library|Win32.ActiveCfg = Release|Win32
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Release Library|Win32.Build.0 = Release|Win32
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Release Library|x64.ActiveCfg = Release|x64
+		{A61349B6-4099-4688-AA1A-00D91397857D}.Release Library|x64.Build.0 = Release|x64
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Release|Win32.ActiveCfg = Release|Win32
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Release|Win32.Build.0 = Release|Win32
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Release|x64.ActiveCfg = Release|x64
 		{A61349B6-4099-4688-AA1A-00D91397857D}.Release|x64.Build.0 = Release|x64
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug Library|Win32.Build.0 = Debug|Win32
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug Library|x64.ActiveCfg = Debug|x64
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug Library|x64.Build.0 = Debug|x64
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug|Win32.Build.0 = Debug|Win32
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug|x64.ActiveCfg = Debug|x64
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Debug|x64.Build.0 = Debug|x64
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release Library|Win32.ActiveCfg = Release|Win32
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release Library|Win32.Build.0 = Release|Win32
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release Library|x64.ActiveCfg = Release|x64
+		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release Library|x64.Build.0 = Release|x64
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release|Win32.ActiveCfg = Release|Win32
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release|Win32.Build.0 = Release|Win32
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release|x64.ActiveCfg = Release|x64
 		{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}.Release|x64.Build.0 = Release|x64
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug Library|Win32.Build.0 = Debug|Win32
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug Library|x64.ActiveCfg = Debug|x64
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug Library|x64.Build.0 = Debug|x64
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug|Win32.ActiveCfg = Debug|Win32
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug|Win32.Build.0 = Debug|Win32
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug|x64.ActiveCfg = Debug|x64
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Debug|x64.Build.0 = Debug|x64
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release Library|Win32.ActiveCfg = Release|Win32
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release Library|Win32.Build.0 = Release|Win32
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release Library|x64.ActiveCfg = Release|x64
+		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release Library|x64.Build.0 = Release|x64
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release|Win32.ActiveCfg = Release|Win32
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release|Win32.Build.0 = Release|Win32
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release|x64.ActiveCfg = Release|x64
 		{A0FDC72E-0BE5-4542-B381-6A482DAC2125}.Release|x64.Build.0 = Release|x64
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug Library|Win32.ActiveCfg = LIB Debug|Win32
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug Library|Win32.Build.0 = LIB Debug|Win32
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug Library|x64.ActiveCfg = LIB Release|x64
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug Library|x64.Build.0 = LIB Release|x64
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug|Win32.ActiveCfg = LIB Debug|Win32
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug|Win32.Build.0 = LIB Debug|Win32
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug|x64.ActiveCfg = LIB Debug|x64
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Debug|x64.Build.0 = LIB Debug|x64
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release Library|Win32.ActiveCfg = LIB Release|Win32
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release Library|Win32.Build.0 = LIB Release|Win32
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release Library|x64.ActiveCfg = LIB Release|x64
+		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release Library|x64.Build.0 = LIB Release|x64
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release|Win32.ActiveCfg = LIB Release|Win32
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release|Win32.Build.0 = LIB Release|Win32
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release|x64.ActiveCfg = LIB Release|x64
 		{3D9F174B-2909-4834-A3D7-892E8D442A5D}.Release|x64.Build.0 = LIB Release|x64
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug Library|Win32.ActiveCfg = Debug|Win32
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug Library|Win32.Build.0 = Debug|Win32
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug Library|x64.ActiveCfg = Debug|x64
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug Library|x64.Build.0 = Debug|x64
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug|Win32.ActiveCfg = Debug|Win32
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug|Win32.Build.0 = Debug|Win32
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug|x64.ActiveCfg = Debug|x64
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Debug|x64.Build.0 = Debug|x64
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release Library|Win32.ActiveCfg = Release|Win32
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release Library|Win32.Build.0 = Release|Win32
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release Library|x64.ActiveCfg = Release|x64
+		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release Library|x64.Build.0 = Release|x64
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release|Win32.ActiveCfg = Release|Win32
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release|Win32.Build.0 = Release|Win32
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release|x64.ActiveCfg = Release|x64
 		{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}.Release|x64.Build.0 = Release|x64
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug Library|Win32.ActiveCfg = Debug Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug Library|Win32.Build.0 = Debug Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug Library|x64.ActiveCfg = Debug Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug|Win32.Build.0 = Debug|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Debug|x64.ActiveCfg = Debug|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release Library|Win32.ActiveCfg = Release Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release Library|Win32.Build.0 = Release Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release Library|x64.ActiveCfg = Release Library|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release|Win32.ActiveCfg = Release|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release|Win32.Build.0 = Release|Win32
+		{D6973076-9317-4EF2-A0B8-B7A18AC0713E}.Release|x64.ActiveCfg = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {91B8BA13-0F79-4EE5-84B8-2CFEDA9BF05D}
 	EndGlobalSection
 EndGlobal

--- a/crawl-ref/source/contrib/zlib.props
+++ b/crawl-ref/source/contrib/zlib.props
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * zlib.props - location of zlib source
+ *
+ * libpng version 1.6.14 - October 23, 2014
+ *
+ * Copyright (c) 1998-2011 Glenn Randers-Pehrson
+ *
+ * This code is released under the libpng license.
+ * For conditions of distribution and use, see the disclaimer
+ * and license in png.h
+
+ * You must edit this file to record the location of the zlib
+ * source code.
+ -->
+
+<Project ToolsVersion="4.0"
+   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <!-- Place the name of the directory containing the source of zlib used for
+         debugging in this property.
+
+         The directory need only contain the '.c' and '.h' files from the
+         source.
+
+         If you use a relative directory name (as below) then it must be
+         relative to the project directories; these are one level deeper than
+         the directories containing this file.
+
+         If the version of zlib you use does not match that used when the
+         distribution was built you will get warnings from pngtest that the zlib
+         versions do not match. The zlib version used in this build is recorded
+         below:
+     -->
+    <ZLibSrcDir>..\..\..\..\zlib</ZLibSrcDir>
+
+    <!-- The following line allows compilation for an ARM target with Visual
+         Studio 2012. Notice that this is not supported by the Visual Studio
+         2012 IDE and that the programs that result cannot be run unless they
+         signed by Microsoft. This is therefore untested; only Microsoft can
+         test it:
+     -->
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+  </PropertyGroup>
+</Project>

--- a/crawl-ref/source/debug.h
+++ b/crawl-ref/source/debug.h
@@ -91,6 +91,7 @@ NORETURN void AssertFailed(const char *expr, const char *file, int line,
 #define ASSERT(p)                         ((void) 0)
 #define ASSERTM(p, text,...)              ((void) 0)
 #define ASSERT_RANGE(x, a, b)             ((void) 0)
+#define ASSERT_LESS(x, xmax)              ((void) 0)
 
 #endif
 

--- a/crawl-ref/source/domino.cc
+++ b/crawl-ref/source/domino.cc
@@ -23,6 +23,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  **/
+#include <AppHdr.h>
 
 #include "domino.h"
 #include "domino-data.h"

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -6017,7 +6017,7 @@ static coord_def _get_feat_dest(coord_def base_pos, dungeon_feature_type feat,
     {
         coord_def dest_pos;
 
-        if (feat_is_escape_hatch(feat) and !hatch_name.empty())
+        if (feat_is_escape_hatch(feat) && !hatch_name.empty())
             dest_pos = _find_named_hatch_dest(hatch_name);
         else
         {

--- a/crawl-ref/source/fixedvector.h
+++ b/crawl-ref/source/fixedvector.h
@@ -108,5 +108,5 @@ FixedVector<TYPE, SIZE>::FixedVector(TYPE value0, TYPE value1, ...)
 template <class TYPE, int SIZE>
 void FixedVector<TYPE, SIZE>::init(const TYPE& def)
 {
-    fill(::begin(mData), ::end(mData), def);
+    fill(std::begin(mData), std::end(mData), def);
 }

--- a/crawl-ref/source/geom2d.h
+++ b/crawl-ref/source/geom2d.h
@@ -12,13 +12,13 @@ struct vector
         : x(_x), y(_y) {}
 
     const vector& operator+=(const vector &v);
-    vector operator+(const vector &v) const PURE;
-    vector operator-() const PURE;
+    vector operator+(const vector &v) const;
+    vector operator-() const;
     const vector& operator-=(const vector &v);
-    vector operator-(const vector &v) const PURE;
+    vector operator-(const vector &v) const;
 };
 
-vector operator*(double t, const vector &v) PURE;
+vector operator*(double t, const vector &v);
 
 struct form
 {
@@ -75,7 +75,7 @@ struct lineseq
     lineseq(double a, double b, double o, double d)
         : f(a,b), offset(o), dist(d) {}
 
-    double index(const vector &v) const PURE;
+    double index(const vector &v) const;
 };
 
 struct grid

--- a/crawl-ref/source/geom2d.h
+++ b/crawl-ref/source/geom2d.h
@@ -12,13 +12,25 @@ struct vector
         : x(_x), y(_y) {}
 
     const vector& operator+=(const vector &v);
+
+#ifdef TARGET_COMPILER_VC
     vector operator+(const vector &v) const;
     vector operator-() const;
     const vector& operator-=(const vector &v);
     vector operator-(const vector &v) const;
+#else
+    vector operator+(const vector &v) const PURE;
+    vector operator-() const PURE;
+    const vector& operator-=(const vector &v);
+    vector operator-(const vector &v) const PURE;
+#endif
 };
 
+#ifdef TARGET_COMPILER_VC
 vector operator*(double t, const vector &v);
+#else
+vector operator*(double t, const vector &v) PURE;
+#endif
 
 struct form
 {
@@ -75,7 +87,12 @@ struct lineseq
     lineseq(double a, double b, double o, double d)
         : f(a,b), offset(o), dist(d) {}
 
+#ifdef TARGET_COMPILER_VC
     double index(const vector &v) const;
+#else
+    double index(const vector &v) const PURE;
+#endif
+
 };
 
 struct grid

--- a/crawl-ref/source/geom2d.h
+++ b/crawl-ref/source/geom2d.h
@@ -12,6 +12,9 @@ struct vector
         : x(_x), y(_y) {}
 
     const vector& operator+=(const vector &v);
+	
+	//TODO Figure out MSVC compatability with
+	//PURE definitions in this and hash.h
 
 #ifdef TARGET_COMPILER_VC
     vector operator+(const vector &v) const;

--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -22,7 +22,7 @@
 #   include <SDL.h>
 #   include <GLES/gl.h>
 #  else
-#   include <SDL2/SDL_opengl.h>
+#   include <SDL_opengl.h>
 #   if defined(__MACOSX__)
 #    include <OpenGL/glu.h>
 #   else

--- a/crawl-ref/source/hash.h
+++ b/crawl-ref/source/hash.h
@@ -15,5 +15,9 @@ static inline uint64_t hash3(uint64_t x, uint64_t y, uint64_t z)
     return x;
 }
 
+#ifdef TARGET_COMPILER_VC
 uint32_t hash32(const void *data, int len);
+#else
+uint32_t hash32(const void *data, int len) PURE;
+#endif
 unsigned int hash_with_seed(int x, uint32_t seed, uint32_t id = 0);

--- a/crawl-ref/source/hash.h
+++ b/crawl-ref/source/hash.h
@@ -15,5 +15,5 @@ static inline uint64_t hash3(uint64_t x, uint64_t y, uint64_t z)
     return x;
 }
 
-uint32_t hash32(const void *data, int len) PURE;
+uint32_t hash32(const void *data, int len);
 unsigned int hash_with_seed(int x, uint32_t seed, uint32_t id = 0);

--- a/crawl-ref/source/hash.h
+++ b/crawl-ref/source/hash.h
@@ -15,6 +15,9 @@ static inline uint64_t hash3(uint64_t x, uint64_t y, uint64_t z)
     return x;
 }
 
+	//TODO Figure out MSVC compatability with
+	//PURE definitions in this and geom2d.h
+
 #ifdef TARGET_COMPILER_VC
 uint32_t hash32(const void *data, int len);
 #else

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -418,7 +418,7 @@ object_class_type item_class_by_sym(char32_t c)
     case ')':
         return OBJ_WEAPONS;
     case '(':
-    case U'➹':
+    case U'\x27b9': //➹
         return OBJ_MISSILES;
     case '[':
         return OBJ_ARMOUR;
@@ -430,14 +430,14 @@ object_class_type item_class_by_sym(char32_t c)
         return OBJ_SCROLLS;
     case '"': // Make the amulet symbol equiv to ring -- bwross
     case '=':
-    case U'°':
+    case U'\xb0': //°
         return OBJ_JEWELLERY;
     case '!':
         return OBJ_POTIONS;
     case ':':
     case '+': // ??? -- was the only symbol working for tile order up to 0.10,
               // so keeping it for compat purposes (user configs).
-    case U'∞':
+    case U'\x221e': //∞
         return OBJ_BOOKS;
     case '|':
         return OBJ_STAVES;
@@ -450,9 +450,9 @@ object_class_type item_class_by_sym(char32_t c)
     case 'x':
         return OBJ_CORPSES;
     case '$':
-    case U'€':
-    case U'£':
-    case U'¥': // FR: support more currencies
+    case U'\x20ac': //€
+    case U'\xa3': //£
+    case U'\xa5': //¥ // FR: support more currencies
         return OBJ_GOLD;
 #if TAG_MAJOR_VERSION == 34
     case '\\': // Compat break: used to be staves (why not '|'?).

--- a/crawl-ref/source/libutil.h
+++ b/crawl-ref/source/libutil.h
@@ -170,12 +170,13 @@ typename M::mapped_type lookup(M &map, const typename M::key_type &key,
 }
 
 // Delete when we upgrade to C++14!
+#ifndef TARGET_COMPILER_VC
 template<typename T, typename... Args>
 unique_ptr<T> make_unique(Args&&... args)
 {
     return unique_ptr<T>(new T(forward<Args>(args)...));
 }
-
+#endif
 /** Remove from a container all elements matching a predicate.
  *
  * @tparam C the container type. Must be reorderable (not a map or set!),

--- a/crawl-ref/source/loading-screen.cc
+++ b/crawl-ref/source/loading-screen.cc
@@ -1,6 +1,7 @@
+#include "AppHdr.h"
+
 #ifdef USE_TILE_LOCAL
 
-#include "AppHdr.h"
 #include "loading-screen.h"
 #include "files.h"
 #include "options.h"

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -713,7 +713,7 @@ static void _decrement_durations()
     }
 
     if (you.duration[DUR_DISJUNCTION])
-        disjunction();
+        disjunction_spell();
 
     // Should expire before flight.
     if (you.duration[DUR_TORNADO])

--- a/crawl-ref/source/rltiles/tool/tile.cc
+++ b/crawl-ref/source/rltiles/tool/tile.cc
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <memory.h>
+#include <algorithm>
 
 #ifdef USE_TILE
  #include <png.h>
@@ -458,12 +459,15 @@ bool tile::load(const string &new_filename)
     // pixels in exactly the format tile_colour expects them in, so we
     // can just cast the tile_colour* to png_bytep and everything
     // works; but it's admittedly a bit dangerous.
-    png_bytep row_pointers[h];
+    png_bytep *row_pointers = new png_bytep[h];
+
     for (png_uint_32 i = 0; i < h; ++i)
         row_pointers[i] = ((png_bytep) m_pixels) + i * rowbytes;
 
     // and read it
     png_read_image(png_ptr, row_pointers);
+
+    delete[] row_pointers;
 
     fclose(fp);
     png_destroy_read_struct(&png_ptr, &info_ptr, nullptr);

--- a/crawl-ref/source/rltiles/tool/tile_colour.cc
+++ b/crawl-ref/source/rltiles/tool/tile_colour.cc
@@ -3,6 +3,7 @@
 #include <vector>
 #include <stdlib.h>
 #include <stdio.h>
+#include <algorithm>
 #ifdef USE_TILE
  #include <png.h>
 #endif

--- a/crawl-ref/source/rltiles/tool/tile_list_processor.cc
+++ b/crawl-ref/source/rltiles/tool/tile_list_processor.cc
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <map>
+#include <algorithm>
 
 using namespace std;
 

--- a/crawl-ref/source/rltiles/tool/tile_page.cc
+++ b/crawl-ref/source/rltiles/tool/tile_page.cc
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <cassert>
 #include "tile.h"
+#include <algorithm>
 
 tile_page::tile_page() : m_width(1024), m_height(0)
 {

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2350,10 +2350,10 @@ void ShoppingList::display(bool view_only)
             }
 
             del_thing_at_index(index);
-            mtitle->quantity = list->size();
+            mtitle->quantity = this->list->size();
             shopmenu.set_title(mtitle);
 
-            if (list->empty())
+            if (this->list->empty())
             {
                 mpr("Your shopping list is now empty.");
                 return false;

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -72,11 +72,11 @@ spret_type cast_disjunction(int pow, bool fail)
         max(you.duration[DUR_DISJUNCTION] + rand,
         30 + rand));
     contaminate_player(750 + random2(500), true);
-    disjunction();
+    disjunction_spell();
     return SPRET_SUCCESS;
 }
 
-void disjunction()
+void disjunction_spell()
 {
     int steps = you.time_taken;
     invalidate_agrid(true);

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -3,7 +3,7 @@
 #include "spl-cast.h"
 
 spret_type cast_disjunction(int pow, bool fail);
-void disjunction();
+void disjunction_spell();
 
 spret_type cast_blink(bool fail = false);
 spret_type cast_controlled_blink(bool fail = false, bool safe = true);

--- a/crawl-ref/source/viewchar.cc
+++ b/crawl-ref/source/viewchar.cc
@@ -12,28 +12,51 @@ static const char32_t dchar_table[NUM_CSET][NUM_DCHAR_TYPES] =
     // It must be limited to stuff present both in CP437 and WGL4.
     {
         // wall .. altar
-         '#', U'▓',  '*',  '.',  ',', '\'',  '+',  '^',  '>',  '<', '#',  '_',
+         '#', U'\x2593', //▓
+            '*',  '.',  ',', '\'',  '+',  '^',  '>',  '<', '#',  '_',
         // arch .. invis_exposed
-        U'∩', U'⌠', U'≈',  '8',  '{',
+         U'\x2229', //∩
+            U'\x2320', //⌠
+            U'\x2248', //≈
+            '8',  '{',
 #if defined(TARGET_OS_WINDOWS) && !defined(USE_TILE_LOCAL)
-        U'⌂', // CP437 but "optional" in WGL4
+         U'\x2302', //⌂ // CP437 but "optional" in WGL4
 #else
-        U'∆', // WGL4 and DEC
+         U'\x2206', //∆ // WGL4 and DEC
 #endif
-         '0', U'φ',  ')',  '[',  '/',  '%',  '?',  '=',  '!',  '(', ':',  '|',
+         '0', U'\x3c6', //φ
+            ')',  '[',  '/',  '%',  '?',  '=',  '!',  '(', ':',  '|',
 #if TAG_MAJOR_VERSION == 34
          '\\',
 #endif
-         '}', U'†', U'÷',  '$',  '"', U'§', U'♣',
+         '}', U'\x2020', //†
+            U'\xf7', //÷
+            '$',  '"', U'\xa7', //§
+            U'\x2663', //♣
 #if TAG_MAJOR_VERSION == 34
-        U'©',
+         U'\xa9', //©
 #endif
         // transporter .. frame_top_left
-        U'©', U'©',  ' ',  '#',  '*', U'÷',  'X',  '`',  '#', U'═', U'║', U'╔',
+         U'\xa9', //©
+            U'\xa9', //©
+            ' ',  '#',  '*', U'\xf7', //÷
+            'X',  '`',  '#', U'\x2550', //═
+            U'\x2551', //║
+            U'\x2554', //╔
         // frame_top_right .. draw_down
-        U'╗', U'╚', U'╝', U'─', U'│',  '/', '\\', U'┌', U'┐', U'└', U'┘',  'V',
+         U'\x2557', //╗
+            U'\x255a', //╚
+            U'\x255d', //╝
+            U'\x2500', //─
+            U'\x2502', //│
+            '/', '\\', U'\x250c', //┌
+            U'\x2510', //┐
+            U'\x2514', //└
+            U'\x2518', //┘
+            'V',
         // draw_up .. draw_left
-        U'Λ',  '>',  '<',
+         U'\x39b', //Λ
+            '>',  '<',
     },
     // CSET_ASCII
     {

--- a/crawl-ref/source/windowmanager-sdl.cc
+++ b/crawl-ref/source/windowmanager-sdl.cc
@@ -20,7 +20,7 @@
 # else
 #  include <SDL2/SDL.h>
 # endif
-# include <SDL2/SDL_image.h>
+# include <SDL_image.h>
 # if defined(USE_SOUND) && !defined(WINMM_PLAY_SOUNDS)
 #  include <SDL2/SDL_mixer.h>
 # endif

--- a/crawl-ref/source/wizard.cc
+++ b/crawl-ref/source/wizard.cc
@@ -2,8 +2,9 @@
  * @file
  * @brief Wizard mode command handling.
 **/
-#ifdef WIZARD
 #include "AppHdr.h"
+
+#ifdef WIZARD
 
 #include "wizard.h"
 


### PR DESCRIPTION
Changes for MSVC2017 compatability
Not included: Changes to submodule project files.

Use of all changes (and non-included submodule files) successfully builds 32-bit release tiles on MSVC2017 with no errors. Tested using Windows 8.1. Work required on freetype project files for 64-bit and debug to work.

No discussion needed:
-
Any of the project files
zlib.props (a project file)
debug.h
dungeon.cc

Discussion:
-
- AppHdr.cc

SDL2 binaries use the name SDL2. This is an MSVC file.

- MSVC/include/stdint.h

Definitions required for ratio and chrono to work properly. This might be properly defined elsewhere.

 - acquire.cc

MSVC doesn't like implicit use of && and "filter". Can probably be solved with good code. Change is a hack and shouldn't be used.

- glwrapper-ogl.cc
- windowmanager-sdl.cc

This change was required locally, I don't know if this breaks anything. If it doesn't then it should be fine.

- geom2d.h
- hash.h

If this tag isn't necessary it shouldn't be used here. Can post relevant errors if these are missed.

- domino.cc
- loading-screen.cc
- wizard.cc

Precompiled header file changed to be first line

- viewchar.cc
- initfile.cc

These are more changes here than intended. The actual changes are removal of all unicode characters from the file, in favor of their equivalent code. 

- libutil.h

Self explanatory

- player-reacts.cc
- spl-transloc.cc
- spl-transloc.h

MSVC had trouble telling the difference between this and std::disjunction. My change is a hack. Consider a different name, or a convention?

- tile.cc

Use of VLAs is strictly not supported. My change is a hack and should not be kept.

- shopping.cc

Complaints about std::list()

- tile_page.cc
- tile.cc
- tile_colour.cc
- tile_list_processor.cc
- tile_page.cc

<algorithm> included for complaints about a lack of max() and min() definitions. May not be necessarily.

- fixedvector.h

Not sure if this change is necessary

Sorry about the duplicates.