### PR TITLE
Leave Dual-Wielders Alone

### DIFF
--- a/crawl-ref/source/tilemcache.cc
+++ b/crawl-ref/source/tilemcache.cc
@@ -1242,8 +1242,14 @@ bool mcache_monster::valid(const monster_info& mon)
     bool have_shield_offs = (mon.type == MONS_PLAYER
                              && Options.tile_shield_offsets.first != INT_MAX)
         || get_shield_offset(mon_tile, &ox, &oy);
+    //Return true if the tile has a weapon offset and has a weapon,
+    //a shield offset and a shield, or is a dual-wielder and has a 
+    //shield offset and an off-hand weapon (a valid edge case)
     return (mon.inv[MSLOT_WEAPON] && have_weapon_offs)
-        || (mon.inv[MSLOT_SHIELD] && have_shield_offs);
+            || ((mon.inv[MSLOT_SHIELD]
+                    || (mon.inv[MSLOT_ALT_WEAPON]
+                            && mons_class_wields_two_weapons(mon.type)))
+                 && have_shield_offs);
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #858

If a dual-wielder's primary weapon was removed by Tukima's
(determined by a coin-flip in monster::weapon()) , their mcache
entry would be invalided by this check, which didn't consider the
valid option of an alt-hand-wielded weapon.