### PR TITLE
Properly explode Wooden doors

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2104,7 +2104,7 @@ bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
     case DNGN_METAL_WALL:
         if (what)
             *what = "metal wall";
-        // fall through
+        // fall-through
     case DNGN_GRATE:
         if (what && *what == nullptr)
             *what = "iron grate";
@@ -2121,13 +2121,13 @@ bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
         beam.damage.num = 4;
         break;
 
-    // Stone doors and arches
+    // Stone arches and doors
     case DNGN_OPEN_DOOR:
     case DNGN_CLOSED_DOOR:
     case DNGN_RUNED_DOOR:
     case DNGN_SEALED_DOOR:
         if (what)
-            *what = "door";
+            *what = "stone door frame";
         // fall-through
     case DNGN_STONE_ARCH:
         if (what && *what == nullptr)


### PR DESCRIPTION
Fixes https://crawl.develz.org/mantis/view.php?id=11695

There are currently no stone doors in the game.

Damage unchanged.