### PR TITLE
Handle Skill Targets with Potion of Experience

### DIFF
--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -814,6 +814,7 @@ void SkillMenu::finish_experience(bool experience_change)
         }
         m_skill_backup.restore_training();
         m_skill_backup = skill_state();
+        check_training_targets();
     }
 }
 

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -2226,7 +2226,10 @@ void skill_state::restore_training()
     for (skill_type sk = SK_FIRST_SKILL; sk < NUM_SKILLS; ++sk)
     {
         if (you.skills[sk] < MAX_SKILL_LEVEL)
+        {
             you.train[sk] = train[sk];
+            you.training_targets[sk] = training_targets[sk];
+        }
     }
 
     you.can_train                   = can_train;


### PR DESCRIPTION
https://crawl.develz.org/mantis/view.php?id=11352

Restore/disable met targets after quaffing a potion of experience