### PR TITLE
Use LoS features in autoexclude

### DIFF
--- a/crawl-ref/source/exclude.cc
+++ b/crawl-ref/source/exclude.cc
@@ -128,9 +128,19 @@ void remove_auto_exclude(const monster* mon, bool sleepy)
 travel_exclude::travel_exclude(const coord_def &p, int r,
                                bool autoexcl, string dsc, bool vaultexcl)
     : pos(p), radius(r),
-      los(los_def(p, opc_excl, circle_def(r, C_SQUARE))),
       uptodate(false), autoex(autoexcl), desc(dsc), vault(vaultexcl)
 {
+    //If the monster can't move, and doesn't do anything to
+    //you behind transparent walls, don't exclude beyond them.
+    const monster* m = monster_at(p);
+    if (m) {
+        if (m->is_stationary())
+            los = los_def(p, opc_solid_see, circle_def(r, C_SQUARE));     
+        else
+            los = los_def(p, opc_excl, circle_def(r, C_SQUARE));
+    }
+    else 
+        los = los_def(p, opc_excl, circle_def(r, C_SQUARE));
     set_los();
 }
 


### PR DESCRIPTION
https://crawl.develz.org/mantis/view.php?id=11658

As of right now, the same LoS type (unbiased, i.e. include
all visible tiles) is used for all autoexclude cases.

This solution fixes the bug, but doesn't fully solve the problem,
which is that this function set is unfinished.

Sprint 2 is a great area to test and fix these issues.

Added some cloud code that probably doesn't do anything meaningful
(at least in Sprint 2), as the doors block the vision of a generator function
that spawns clouds, and the spread beyond the doors was not true cloud drift.

Correct way to do it is to find some way to pass the cloud generator data
to autoexclude, which there is currently absolutely no code for.
