### PR TITLE
Don't corrode or appear to damage acid immune enemies with Punk or acidic bite (11746)

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4370,6 +4370,10 @@ bool monster::corrode_equipment(const char* corrosion_source, int degree)
 void monster::splash_with_acid(const actor* evildoer, int /*acid_strength*/,
                                bool /*allow_corrosion*/, const char* /*hurt_msg*/)
 {
+    // Splashing with acid shouldn't do anything to immune targets
+    if (res_acid() == 3)
+        return;
+
     const int dam = roll_dice(2, 4);
     const int post_res_dam = resist_adjust_damage(this, BEAM_ACID, dam);
 


### PR DESCRIPTION
Acidic attacks, from the acidic bite mutation and Punk, previously
displayed the "[Enemy] is splashed with acid" line against all targets,
which suggested to the player that acid immune targets still took extra
damage from these attacks even though any damage was in fact resisted.
Additionally, this was able to corrode acid immune enemies, which does
not seem thematically correct.

Therefore, in `monster::splash_with_acid`, add a check at the start of the
method for acid immunity, which if true, return early from without any
opportunity to damage or corrode the monster.

Acid resistant enemies correctly take half-damage from acid splash and
resist corrosion half of the time both before and after this change.