### PR TITLE
Fix a hints mode memorise menu message from extending horizontally

### DIFF
--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -2853,12 +2853,12 @@ string hints_memorise_info()
         cmd.push_back(CMD_CAST_SPELL);
     }
 
+    if (you.spell_no)
+        m += _hints_target_mode(true);
     linebreak_string(m, _get_hints_cols());
     if (!cmd.empty())
         insert_commands(m, cmd);
     text << m;
-    if (you.spell_no)
-        text << _hints_target_mode(true);
 
     return text.str();
 }


### PR DESCRIPTION
The text from hints_target_mode was not properly broken up. See the image in a comment below for the original issue. (I'd rather not post it multiple times).

As stenellad mentions, there are still issues with how it's rendered, but after this simple fix it will no longer go a long way off the right of the screen. These issues may be fixed in a later PR, which is probably best done by adding this information to the dat/descript/ folder so that lines are wrapped at their normal place automatically.

I found this while trying (and failing) to fix an issue posted in ##crawl-dev concerned with the presence of the `</magenta>` tag at the end of this description in tutorial/hints modes. See http://self.organizing.systems/x/dcss1.png [Now fixed in PR #896.]