### PR TITLE
Fix Spellbook </magenta>

### DIFF
--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -2827,7 +2827,7 @@ string hints_memorise_info()
     {
         m += "\n\nA spell that isn't <darkgray>grayed out</darkgray> or "
              "<lightred>forbidden</lightred> can be "
-             "memorised right away by selecting it at at this menu.";
+             "memorised right away by selecting it at this menu.";
     }
     else
     {
@@ -2859,7 +2859,6 @@ string hints_memorise_info()
     text << m;
     if (you.spell_no)
         text << _hints_target_mode(true);
-    text << "</" << colour_to_str(channel_to_colour(MSGCH_TUTORIAL)) << ">";
 
     return text.str();
 }


### PR DESCRIPTION
Due to the way strings are formatted after being read from this function, this
</magenta> tag was being treated as extra text. It's not needed, so remove it.

Doing it the reverse way doesn't work.

http://self.organizing.systems/x/dcss1.png .

Fix a grammar oopsie.