### PR TITLE
Add a prompt for attacking living things while under divine protection

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -905,6 +905,13 @@ bool bad_attack(const monster *mon, string& adj, string& suffix,
     if (check_landing_only)
         return bad_landing;
 
+    if (you.duration[DUR_LIFESAVING]
+        && mon->holiness() & (MH_NATURAL | MH_PLANT))
+    {
+        suffix = " while asking for your life to be spared";
+        would_cause_penance = true;
+    }
+
     if (you_worship(GOD_JIYVA) && mons_is_slime(*mon)
         && !(mon->is_shapeshifter() && (mon->flags & MF_KNOWN_SHIFTER)))
     {


### PR DESCRIPTION
Killing natural monsters while under Elyvilon's divine protection causes
penance. However, there is no prompt for this, and it seems natural
for the player to invoke divine protection when low on HP so they don't
die, then heal up, and once they've healed, try to fight the enemy
causing them trouble. It was easy for players to accidentally cause
penance by killing enemies while under divine protection in this way.

Hence, add a prompt for attacking natural monsters while divine
protection is active. Penance will not actually trigger until the
monster is killed, but it's better to be safe than sorry.

One thing: attacks like this do not necessarily cause penance; they only do so if the monster is killed by the attack. Is it therefore appropriate to display the line "This attack would place you under penance!" in the prompt? For now, I have assumed that it is, even though it is not guaranteed.