### PR TITLE
Abyss Recall

### DIFF
--- a/crawl-ref/source/god-companions.cc
+++ b/crawl-ref/source/god-companions.cc
@@ -184,9 +184,12 @@ bool companion_is_elsewhere(mid_t mid, bool must_exist)
     if (companion_list.count(mid))
     {
         return companion_list[mid].level != level_id::current()
-               || (player_in_branch(BRANCH_PANDEMONIUM)
-                   && companion_list[mid].level.branch == BRANCH_PANDEMONIUM
-                   && !monster_by_mid(mid));
+            || (player_in_branch(BRANCH_PANDEMONIUM)
+                && companion_list[mid].level.branch == BRANCH_PANDEMONIUM
+                && !monster_by_mid(mid))
+            || (player_in_branch(BRANCH_ABYSS)
+                && companion_list[mid].level.branch == BRANCH_ABYSS
+                && !monster_by_mid(mid));
     }
 
     return !must_exist;


### PR DESCRIPTION
Upon further inspection, this appears to be a design choice.
https://github.com/crawl/crawl/blob/master/crawl-ref/source/god-companions.cc#L116

Discussion required?

Regardless, this should not be merged, as the solution would be to remove the above-linked lines, or add an exception for Hep's ancestor.

--
Bug description:

Leaving the Abyss without the Ancestor, then re-entering makes
it impossible to recall the Ancestor for a short period of time,
failing silently. This fixes the check that causes it to fail.