### PR TITLE
Let the sturdy frame mutation reduce stealth/dodging penalties (11768)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5701,7 +5701,8 @@ void player::ablate_deflection()
  * Used as the base for adjusted armour penalty calculations, as well as for
  * stealth penalty calculations.
  *
- * @return  The player's body armour's PARM_EVASION, if any.
+ * @return  The player's body armour's PARM_EVASION, if any, taking into account
+ *          the sturdy frame mutation that reduces encumbrance.
  */
 int player::unadjusted_body_armour_penalty() const
 {
@@ -5709,7 +5710,9 @@ int player::unadjusted_body_armour_penalty() const
     if (!body_armour)
         return 0;
 
-    return -property(*body_armour, PARM_EVASION) / 10;
+    // PARM_EVASION is always less than or equal to 0
+    return max(0, -property(*body_armour, PARM_EVASION) / 10
+                  - get_mutation_level(MUT_STURDY_FRAME) * 2);
 }
 
 /**
@@ -5721,9 +5724,7 @@ int player::unadjusted_body_armour_penalty() const
  */
 int player::adjusted_body_armour_penalty(int scale) const
 {
-    const int base_ev_penalty =
-        max(0, unadjusted_body_armour_penalty()
-                   - get_mutation_level(MUT_STURDY_FRAME) * 2);
+    const int base_ev_penalty = unadjusted_body_armour_penalty();
 
     // New formula for effect of str on aevp: (2/5) * evp^2 / (str+3)
     return 2 * base_ev_penalty * base_ev_penalty * (450 - skill(SK_ARMOUR, 10))


### PR DESCRIPTION
See mantis bug report 11768: https://crawl.develz.org/mantis/view.php?id=11768

Previously, the sturdy frame mutation was taken into consideration only
for the adjusted_armour_evasion_penalty method, not the
unadjusted_armour_evasion_penalty. The latter of the two methods is used
for stealth penalties, Jiyva stat shuffling, autotraining and some parts
of the dodging penalty calculations, which means these things were not
affected by the sturdy frame mutation. This meant the claimed ER-2 of
the sturdy frame mutation did not have the full effect of reducing the
ER by 2.

Hence, move the sturdy frame mutation's effect to
unadjusted_armour_evasion_penalty.