### PR TITLE
Don't halve the MR of magic immune creatures from AF_VULN (11754)

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -2993,6 +2993,9 @@ void melee_attack::mons_apply_attack_flavour()
             }
             else
             {
+                // Halving the MR of magic immune targets has no effect
+                if (defender->as_monster()->res_magic() == MAG_IMMUNE)
+                    break;
                 if (!defender->as_monster()->has_ench(ENCH_LOWERED_MR))
                     visible_effect = true;
                 mon_enchant lowered_mr(ENCH_LOWERED_MR, 1, attacker,


### PR DESCRIPTION
Previously phantasmal warriors were able to halve the MR of magic immune
creatures, which was announced and appeared to have an effect even
though it really had no effect whatsoever.

Hence, add a check to exit the case for AF_VULN early if the defender is
immune to hostile enchantments.