### PR TITLE
Add webtiles form to change user email address

### DIFF
--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -662,8 +662,14 @@ function (exports, $, key_conversion, chat, comm) {
         $("#register_message").html(data.reason);
     }
 
-    function start_change_email()
+    function ask_change_email()
     {
+        send_message("start_change_email");
+    }
+
+    function start_change_email(data)
+    {
+        $("#chem_current").html(data.email);
         $("#chem_message").html("");
         show_dialog("#change_email");
         $("#chem_email").focus();
@@ -690,8 +696,17 @@ function (exports, $, key_conversion, chat, comm) {
         $("#chem_message").html(data.reason);
     }
 
-    function change_email_done()
+    function change_email_done(data)
     {
+        if( data.email == "" )
+        {
+            $("#chem_confirmation_message").html("Your account is no longer associated with an email address.");
+        }
+        else
+        {
+            $("#chem_confirmation_message").html("Your email address has been set to " + data.email + ".");
+        }
+        
         show_dialog("#change_email_2");
     }
 
@@ -1273,6 +1288,7 @@ function (exports, $, key_conversion, chat, comm) {
         "login_fail": login_failed,
         "login_cookie": set_login_cookie,
         "register_fail": register_failed,
+        "start_change_email": start_change_email,
         "change_email_fail": change_email_failed,
         "change_email_done": change_email_done,
         "forgot_password_fail": forgot_password_failed,
@@ -1316,7 +1332,7 @@ function (exports, $, key_conversion, chat, comm) {
         $("#register_form").bind("submit", register);
         $("#reg_cancel").bind("click", cancel_register);
 
-        $("#chem_link").bind("click", start_change_email);
+        $("#chem_link").bind("click", ask_change_email);
         $("#chem_form").bind("submit", change_email);
         $("#chem_cancel").bind("click", cancel_change_email);
 

--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -434,6 +434,7 @@ function (exports, $, key_conversion, chat, comm) {
         $("#login_form").hide();
         $("#reg_link").hide();
         $("#forgot_link").hide();
+        $('#chem_link').show();
         $("#logout_link").show();
 
         chat.reset_visibility(true);
@@ -659,6 +660,39 @@ function (exports, $, key_conversion, chat, comm) {
     function register_failed(data)
     {
         $("#register_message").html(data.reason);
+    }
+
+    function start_change_email()
+    {
+        $("#chem_message").html("");
+        show_dialog("#change_email");
+        $("#chem_email").focus();
+    }
+
+    function cancel_change_email()
+    {
+        hide_dialog();
+    }
+
+    function change_email()
+    {
+        var email = $("#chem_email").val();
+
+        send_message("change_email", {
+            email: email
+        });
+
+        return false;
+    }
+
+    function change_email_failed(data)
+    {
+        $("#chem_message").html(data.reason);
+    }
+
+    function change_email_done()
+    {
+        show_dialog("#change_email_2");
     }
 
     function start_forgot_password()
@@ -1239,6 +1273,8 @@ function (exports, $, key_conversion, chat, comm) {
         "login_fail": login_failed,
         "login_cookie": set_login_cookie,
         "register_fail": register_failed,
+        "change_email_fail": change_email_failed,
+        "change_email_done": change_email_done,
         "forgot_password_fail": forgot_password_failed,
         "forgot_password_done": forgot_password_done,
         "reset_password_fail": reset_password_failed,
@@ -1279,6 +1315,12 @@ function (exports, $, key_conversion, chat, comm) {
         $("#reg_link").bind("click", start_register);
         $("#register_form").bind("submit", register);
         $("#reg_cancel").bind("click", cancel_register);
+
+        $("#chem_link").bind("click", start_change_email);
+        $("#chem_form").bind("submit", change_email);
+        $("#chem_cancel").bind("click", cancel_change_email);
+
+        $("#change_email_2 input").bind("click", hide_dialog);
 
         $("#forgot_link").bind("click", start_forgot_password);
         $("#forgot_form").bind("submit", forgot_password);

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -58,6 +58,7 @@
       </div>
 
       <div id="change_email" class="floating_dialog" style="display: none;">
+        <p>Your current email address is: <span id="chem_current"></span></p>
         <span id="chem_message"></span>
         <form action="#" id="chem_form">
           <label for="chem_email">Email:</label>
@@ -70,7 +71,7 @@
       </div>
 
       <div id="change_email_2" class="floating_dialog" style="display: none;">
-        <span>Your email was changed.</span>
+        <span id="chem_confirmation_message"></span>
         <input class="button" type="submit" name="submit" value="OK">
       </div>
 

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -30,6 +30,7 @@
 {% if getattr(config, "allow_password_reset", False) %}
           <a id="forgot_link" href="javascript:">Forgot Password</a>
 {% end %}
+          <a id="chem_link" href="javascript:" style="display: none;">Change Email</a>
           <a id="logout_link" href="javascript:" style="display: none;">Logout</a></span>
         </div>
       </div>
@@ -54,6 +55,23 @@
                  value="Cancel">
           <input class="button" type="submit" name="submit" id="reg_submit" value="Submit">
         </form>
+      </div>
+
+      <div id="change_email" class="floating_dialog" style="display: none;">
+        <span id="chem_message"></span>
+        <form action="#" id="chem_form">
+          <label for="chem_email">Email:</label>
+          <input class="text" type="text" name="chem_email" id="chem_email">
+          <br />
+          <p>If you do not enter an email, you can't recover your password.</p>
+          <input class="button" type="button" name="cancel" id="chem_cancel" value="Cancel">
+          <input class="button" type="submit" name="submit" id="chem_submit" value="Submit">
+        </form>
+      </div>
+
+      <div id="change_email_2" class="floating_dialog" style="display: none;">
+        <span>Your email was changed.</span>
+        <input class="button" type="submit" name="submit" value="OK">
       </div>
 
 {% if getattr(config, "allow_password_reset", False) %}

--- a/crawl-ref/source/webserver/userdb.py
+++ b/crawl-ref/source/webserver/userdb.py
@@ -81,6 +81,21 @@ def set_mutelist(username, mutelist):
         if conn:
             conn.close()
 
+def get_user_info(username): # Returns user data in a tuple (userid, email)
+    try:
+        conn = sqlite3.connect(password_db)
+        c = conn.cursor()
+        c.execute("select id,email from dglusers where username=? collate nocase",
+                  (username,))
+        result = c.fetchone()
+
+        if result is None:
+            return None
+        else:
+            return result[0], result[1]
+    finally:
+        if c: c.close()
+        if conn: conn.close()
 
 def user_passwd_match(username, passwd): # Returns the correctly cased username.
     try:
@@ -188,15 +203,15 @@ def register_user(username, passwd, email): # Returns an error message or None
         if c: c.close()
         if conn: conn.close()
 
-def change_email(username, email): # Returns an error message or None
+def change_email(user_id, email): # Returns an error message or None
     result = validate_email_address(email)
     if result: return result
     
     try:
         conn = sqlite3.connect(password_db)
         c = conn.cursor()
-        c.execute("update dglusers set email=? where username=?",
-                  (email, username))
+        c.execute("update dglusers set email=? where id=?",
+                  (email, user_id))
 
         conn.commit()
 
@@ -257,6 +272,7 @@ def update_user_password_from_token(token, passwd): # Returns a tuple where item
     return username, token_error
 
 def send_forgot_password(email): # Returns a tuple where item 1 is a truthy value when an email was sent, and item 2 is an error message or None
+    if not email: return False, "Email address can't be empty"
     email_error = validate_email_address(email)
     if email_error: return False, email_error
 

--- a/crawl-ref/source/webserver/userdb.py
+++ b/crawl-ref/source/webserver/userdb.py
@@ -188,6 +188,23 @@ def register_user(username, passwd, email): # Returns an error message or None
         if c: c.close()
         if conn: conn.close()
 
+def change_email(username, email): # Returns an error message or None
+    result = validate_email_address(email)
+    if result: return result
+    
+    try:
+        conn = sqlite3.connect(password_db)
+        c = conn.cursor()
+        c.execute("update dglusers set email=? where username=?",
+                  (email, username))
+
+        conn.commit()
+
+        return None
+    finally:
+        if c: c.close()
+        if conn: conn.close()
+
 def find_recovery_token(token): # Returns tuple (userid, username, error)
     token_hash_obj = hashlib.sha256(token)
     token_hash = token_hash_obj.hexdigest()

--- a/crawl-ref/source/webserver/util.py
+++ b/crawl-ref/source/webserver/util.py
@@ -131,8 +131,9 @@ def send_email(to_address, subject, body_plaintext, body_html):
         if email_server: email_server.quit()
 
 def validate_email_address(address): # Returns an error string describing the problem, or None
-    if not address: return "Email address can't be empty"
+    if not address: return None
     if " " in address: return "Email address can't contain a space"
     if "@" not in address: return "Expected email address to contain the @ symbol"
     if not re.match(r"[^@]+@[^@]+\.[^@]+", address): return "Invalid email address"
+    if len(address) >= 80: return "Email address can't be more than 80 characters"
     return None

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -149,6 +149,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             "watch": self.watch,
             "chat_msg": self.post_chat_message,
             "register": self.register,
+            "change_email": self.change_email,
             "forgot_password": self.forgot_password,
             "reset_password": self.reset_password,
             "go_lobby": self.go_lobby,
@@ -542,6 +543,18 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             self.logger.info("Registration attempt failed for username %s: %s",
                              username, error)
             self.send_message("register_fail", reason = error)
+
+    def change_email(self, email):
+        if self.username is None:
+            self.send_message("change_email_fail", reason = "You need to log in to change your email")
+            return
+        error = userdb.change_email(self.username, email)
+        if error is None:
+            self.logger.info("User %s changed email to %s.", self.username, email)
+            self.send_message("change_email_done")
+        else:
+            self.logger.info("Failed to change username for %s: %s", self.username, error)
+            self.send_message("change_email_fail", reason = error)
 
     def forgot_password(self, email):
         if not getattr(config, "allow_password_reset", False):

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -111,6 +111,8 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
     def __init__(self, app, req, **kwargs):
         tornado.websocket.WebSocketHandler.__init__(self, app, req, **kwargs)
         self.username = None
+        self.user_id = None
+        self.user_email = None
         self.timeout = None
         self.watched_game = None
         self.process = None
@@ -149,6 +151,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             "watch": self.watch,
             "chat_msg": self.post_chat_message,
             "register": self.register,
+            "start_change_email": self.start_change_email,
             "change_email": self.change_email,
             "forgot_password": self.forgot_password,
             "reset_password": self.reset_password,
@@ -370,6 +373,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
 
     def do_login(self, username):
         self.username = username
+        self.user_id, self.user_email = userdb.get_user_info(username)
         self.logger.extra["username"] = username
         if not self.init_user():
             msg = ("Could not initialize your rc and morgue!<br>" +
@@ -544,14 +548,18 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
                              username, error)
             self.send_message("register_fail", reason = error)
 
+    def start_change_email(self):
+        self.send_message("start_change_email", email = self.user_email)
+
     def change_email(self, email):
         if self.username is None:
             self.send_message("change_email_fail", reason = "You need to log in to change your email")
             return
-        error = userdb.change_email(self.username, email)
+        error = userdb.change_email(self.user_id, email)
         if error is None:
-            self.logger.info("User %s changed email to %s.", self.username, email)
-            self.send_message("change_email_done")
+            self.user_id, self.user_email = userdb.get_user_info(self.username)
+            self.logger.info("User %s changed email to %s.", self.username, email if email else "null")
+            self.send_message("change_email_done", email = email)
         else:
             self.logger.info("Failed to change username for %s: %s", self.username, error)
             self.send_message("change_email_fail", reason = error)


### PR DESCRIPTION
This PR adds a form to webtiles to allow users to change their email address. This form should mirror the existing DGL email change operation as closely as possible.

DGL supports user flags that allow for locking a user account, or preventing password and email changes. These flags appear to be ignored for logins in webtiles, so I have also ignored them here. It is possible that a user may not be able to login or change their password or email via DGL, but they can do those things via webtiles.

![image](https://user-images.githubusercontent.com/437315/48985208-399a9d80-f0d3-11e8-9610-16e110c77ecd.png)

![image](https://user-images.githubusercontent.com/437315/48985218-52a34e80-f0d3-11e8-97fb-8b8ddea30145.png)