### PR TITLE
MSVC support cont.

### DIFF
--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -150,6 +150,7 @@ makefile.dep
 *.ncb
 *.vcproj.user
 *.vcxproj.user
+/source/MSVC/*.user
 
 # Visual C++ outputs
 /source/*.exe
@@ -157,8 +158,12 @@ makefile.dep
 /source/*.dll
 /source/*.exp
 /source/*.lib
+/source/*.iobj
+/source/*.ipdb
 /source/MSVC/.vs/*
 /source/contrib/.vs/*
+*.coverage
+*.vsp
 
 # Packaging
 /source/util/release_ver

--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -374,7 +374,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     </Midl>
     <ClCompile>
       <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;__STDC_LIMIT_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>AppHdr.h</PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>

--- a/crawl-ref/source/MSVC/include/stdint.h
+++ b/crawl-ref/source/MSVC/include/stdint.h
@@ -125,7 +125,7 @@ typedef uint64_t  uintmax_t;
 
 
 // 7.18.2 Limits of specified-width integer types
-#define __STDC_LIMIT_MACROS
+
 #if !defined(__cplusplus) || defined(__STDC_LIMIT_MACROS) // [   See footnote 220 at page 257 and footnote 221 at page 259
 
 // 7.18.2.1 Limits of exact-width integer types

--- a/crawl-ref/source/util/gen-all.cmd
+++ b/crawl-ref/source/util/gen-all.cmd
@@ -1,8 +1,31 @@
+:: 1139-1141 in Makefile
+
+:: docs/FAQ.html This file needs 
+:: to be run from inside /util, 
+:: or it can't find FAQ.txt
+perl FAQ2html.pl
+
 cd ..
-perl util/art-data.pl
+:: art-enum.h ,art-data.h
+perl util/art-data.pl 
+:: mon-mst.h
 perl util/gen-mst.pl
+:: cmd-name.h
 perl util/cmd-name.pl
+:: dat/dlua/tags.lua
 perl util/gen-luatags.pl
+:: mi-enum.h
 perl util/gen-mi-enum
+:: docs/aptitudes.txt
+perl util/gen-apt.pl ../docs/aptitudes.txt ../docs/template/apt-tmpl.txt species-data.h aptitudes.h
+:: docs/aptitudes-wide.txt
+perl util/gen-apt.pl ../docs/aptitudes-wide.txt ../docs/template/apt-tmpl-wide.txt species-data.h aptitudes.h
+
+::Change encoding to UTF-8
+::which cuts the size in half
+chcp 65001
+:: crawl_manual.txt
+perl util/unrest.pl ../docs/crawl_manual.rst > ../docs/crawl_manual.txt
+
 cd util
 pause


### PR DESCRIPTION
Update gen-all.cmd to be up to date with the current makefile,
namely adding aptitudes and crawl_manual.txt, which stops
MSVC builds from crashing when they can't find the files.

Add some more MSVC build outputs to gitignore
Copy CREDITS.txt from the root directory to docs/CREDITS.txt
to match the makefile/release versions; add it to gitignore.

Change MSVC/stdint.h to match MSVC/include/stdint.h , which
we changed earlier in the first MSVC compatability commits.