### PR TITLE
Don't grant exploration piety for Deep water, Lava, and the Temple

### DIFF
--- a/crawl-ref/source/dat/descript/branches.txt
+++ b/crawl-ref/source/dat/descript/branches.txt
@@ -11,7 +11,8 @@ some sliver of sanity sufficient to tell the tale.
 Temple
 
 The Ecumenical Temple is a place of peace and refuge from the insanity of the
-dungeon. It usually contains altars to most of the known gods.
+dungeon. It usually contains altars to most of the known gods. Gods that value
+exploration grant no piety for exploring the Temple.
 %%%%
 Orcish Mines
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1974,6 +1974,20 @@ void set_terrain_changed(const coord_def p)
             act->check_clinging(false, feat_is_door(grd(p)));
 }
 
+/**
+ * Does this cell count for exploraation piety?
+ *
+ * Don't count: endless map borders, deep water, lava, and cells explicitly
+ * marked. (player_view_update_at in view.cc updates the flags)
+ */
+bool cell_triggers_conduct(const coord_def p)
+{
+    return !(feat_is_endless(grd(p))
+             || grd(p) == DNGN_LAVA
+             || grd(p) == DNGN_DEEP_WATER
+             || env.pgrid(p) & FPROP_SEEN_OR_NOEXP);
+}
+
 bool is_boring_terrain(dungeon_feature_type feat)
 {
     if (!is_notable_terrain(feat))

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -140,6 +140,7 @@ void destroy_wall(const coord_def& p);
 void set_terrain_changed(const coord_def c);
 bool cell_is_clingable(const coord_def pos);
 bool cell_can_cling_to(const coord_def& from, const coord_def to);
+bool cell_triggers_conduct(const coord_def pos);
 bool is_boring_terrain(dungeon_feature_type feat);
 
 dungeon_feature_type orig_terrain(coord_def pos);

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1016,13 +1016,15 @@ static update_flags player_view_update_at(const coord_def &gc)
 
     if (!(env.pgrid(gc) & FPROP_SEEN_OR_NOEXP))
     {
-        env.pgrid(gc) |= FPROP_SEEN_OR_NOEXP;
-        if (!crawl_state.game_is_arena())
+        if (!crawl_state.game_is_arena()
+            && cell_triggers_conduct(gc)
+            && !player_in_branch(BRANCH_TEMPLE))
         {
             did_god_conduct(DID_EXPLORATION, 2500);
             const int density = env.density ? env.density : 2000;
             you.exploration += div_rand_round(1<<16, density);
         }
+        env.pgrid(gc) |= FPROP_SEEN_OR_NOEXP;
     }
 
 #ifdef USE_TILE


### PR DESCRIPTION
Granting exploration piety for deep water, lava, and "endless" features
encouraged players with flight or deep water swimmers to wander around
the non-threatening boundaries of shoals and certain lava vaults.

Granting exploration piety in the Temple encouraged a player to
autoexplore the threat-free temple.

I'm not totally happy with the way this is communicated to the player in this branch, and wanted to get some feedback before merging it. However I think the mechanical change is a good one to make.