### PR TITLE
Add dispersal traps to Zot:5

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5875,6 +5875,7 @@ static void _place_specific_trap(const coord_def& where, trap_spec* spec,
                 env.placing_vault.c_str());
     }
 
+    // find an appropriate trap for TRAP_RANDOM
     while (spec_type >= NUM_TRAPS
 #if TAG_MAJOR_VERSION == 34
            || spec_type == TRAP_DART || spec_type == TRAP_GAS
@@ -5882,7 +5883,11 @@ static void _place_specific_trap(const coord_def& where, trap_spec* spec,
 #endif
            || !is_valid_shaft_level() && spec_type == TRAP_SHAFT)
     {
-        spec_type = static_cast<trap_type>(random2(TRAP_MAX_REGULAR + 1));
+        do
+        {
+            spec_type = static_cast<trap_type>(random2(NUM_TRAPS));
+        }
+        while (!is_regular_trap(spec_type));
     }
 
     trap_def t;

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5876,18 +5876,18 @@ static void _place_specific_trap(const coord_def& where, trap_spec* spec,
     }
 
     // find an appropriate trap for TRAP_RANDOM
-    while (spec_type >= NUM_TRAPS
-#if TAG_MAJOR_VERSION == 34
-           || spec_type == TRAP_DART || spec_type == TRAP_GAS
-           || spec_type == TRAP_SHADOW || spec_type == TRAP_SHADOW_DORMANT
-#endif
-           || !is_valid_shaft_level() && spec_type == TRAP_SHAFT)
+    if (spec_type == TRAP_RANDOM)
     {
         do
         {
             spec_type = static_cast<trap_type>(random2(NUM_TRAPS));
         }
-        while (!is_regular_trap(spec_type));
+        while (!is_regular_trap(spec_type)
+#if TAG_MAJOR_VERSION == 34
+               || spec_type == TRAP_DART || spec_type == TRAP_GAS
+               || spec_type == TRAP_SHADOW || spec_type == TRAP_SHADOW_DORMANT
+#endif
+               || !is_valid_shaft_level() && spec_type == TRAP_SHAFT);
     }
 
     trap_def t;

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -1735,3 +1735,9 @@ bool ensnare(actor *fly)
     check_monsters_sense(SENSE_WEB_VIBRATION, 9, fly->pos());
     return true;
 }
+
+// Whether the trap can be placed in vaults such as hall_of_Zot
+bool is_regular_trap(trap_type trap)
+{
+    return trap <= TRAP_MAX_REGULAR || trap == TRAP_DISPERSAL;
+}

--- a/crawl-ref/source/traps.h
+++ b/crawl-ref/source/traps.h
@@ -50,3 +50,5 @@ bool ensnare(actor *fly);
 void leave_web(bool quiet = false);
 void monster_web_cleanup(const monster &mons, bool quiet = false);
 void stop_being_held();
+
+bool is_regular_trap(trap_type trap);


### PR DESCRIPTION
This commit creates a new function is_regular_trap in traps.cc, which
returns whether a particular trap can spawn from a vault which places
"any trap" (that is, a trap that can be spawned from TRAP_RANDOM).

The primary purpose of this is to add dispersal traps to the
hall_of_Zot, in the hope that it will create interesting and dangerous
situations in Zot:5 with the player having to deal with themself and
their enemies being thrown around everywhere. Regarding the forced trap
locations in Zot:5, dispersal traps should be less punishing than
teleport or Zot traps, since the player can get over the other side
simply by repeatedly entering the trap.

I would appreciate feedback on how to make this code less awkward.