### PR TITLE
Make giant creatures no longer tear through webs

### DIFF
--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -773,16 +773,6 @@ void trap_def::trigger(actor& triggerer)
         break;
 
     case TRAP_WEB:
-        if (triggerer.body_size(PSIZE_BODY) >= SIZE_GIANT)
-        {
-            trap_destroyed = true;
-            if (you_trigger)
-                mpr("You tear through the web.");
-            else if (m)
-                simple_monster_message(*m, " tears through a web.");
-            break;
-        }
-
         if (triggerer.is_web_immune())
         {
             if (m)


### PR DESCRIPTION
Web traps were made permanent to prevent the player from tediously
stepping in and out of them to remove them. But it is still possible to
remove them by luring a giant enemy (e.g., an emperor scorpion) through
a web. (Less realistically, the player may also transform into a giant
form, e.g., using dragon form, and then tear through them.)

Since webs frequently block choke points in retreat paths, this can
easily be worth doing, but is not rewarding gameplay after the first
time the interaction is noticed. In the absence of compelling positive
effect on gameplay from the interaction between size and web traps, the
problem is solved by removing the special case.