### PR TITLE
Issue #11791: Fix Sif Muna dud gift bug

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1490,7 +1490,10 @@ static bool _gift_sif_kiku_gift(bool forced)
         // Sif Muna special: Keep quiet if acquirement fails
         // because the player already has seen all spells.
         if (you_worship(GOD_SIF_MUNA))
-            success = acquirement(OBJ_BOOKS, you.religion, true);
+        {
+            int item_index = acquirement_create_item(OBJ_BOOKS, you.religion, true, you.pos());
+            success = (item_index != NON_ITEM);
+        }
     }
 
     if (gift != NUM_BOOKS)


### PR DESCRIPTION
If the player has every spell in their library, Sif Muna will still
send the "Sif Muna grants you a gift!" message and trigger gift timeout.
This commit corrects the bug. When the player has all spells in their
library, Sif's gift timeout will no longer be triggered.

The cause of the error was an incorrect check in Sif's gift logic.
The return value of the acquirement(...) method was used to check
success, but that method returns true even if no item was created.