### PR TITLE
Fix display of rotted HP on WebTiles (11759)

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -867,7 +867,7 @@ void TilesFramework::_send_player(bool force_full)
 
     _update_int(force_full, c.hp, you.hp, "hp");
     _update_int(force_full, c.hp_max, you.hp_max, "hp_max");
-    int max_max_hp = get_real_hp(true, true);
+    int max_max_hp = get_real_hp(true, false);
 
     _update_int(force_full, c.real_hp_max, max_max_hp, "real_hp_max");
     _update_int(force_full, c.mp, you.magic_points, "mp");


### PR DESCRIPTION
Commit 1406302deb reversed the meaning of the get_real_hp()'s second
parameter and updated all instances of this function, except for one
in tileweb.cc.