### PR TITLE
Fix surge of power message order when evoking enhanced wands (11753)

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -367,12 +367,15 @@ void black_drac_breath()
 }
 
 /**
- * Returns the MP cost of zapping a wand. Usually zero.
+ * Returns the MP cost of zapping a wand:
+ *     3 if player has MP-powered wands and enough MP available,
+ *     1-2 if player has MP-powered wands and only 1-2 MP left,
+ *     0 otherwise.
  */
 int wand_mp_cost()
 {
     // Update mutation-data.h when updating this value.
-    return you.get_mutation_level(MUT_MP_WANDS) * 3;
+    return min(you.magic_points, you.get_mutation_level(MUT_MP_WANDS) * 3);
 }
 
 void zap_wand(int slot)
@@ -408,7 +411,7 @@ void zap_wand(int slot)
         return;
     }
 
-    const int mp_cost = min(you.magic_points, wand_mp_cost());
+    const int mp_cost = wand_mp_cost();
 
     int item_slot;
     if (slot != -1)

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -463,12 +463,7 @@ void zap_wand(int slot)
 
     // Spend MP.
     if (mp_cost)
-    {
         dec_mp(mp_cost, false);
-        mprf("You feel a %ssurge of power%s",
-             mp_cost < 3 ? "slight " : "",
-             mp_cost < 3 ? "."       : "!");
-    }
 
     // Take off a charge.
     wand.charges--;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1418,7 +1418,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
     if (evoked_item)
     {
         int mp_cost_of_wand = evoked_item->base_type == OBJ_WANDS
-                              ? min(you.magic_points, wand_mp_cost()) : 0;
+                              ? wand_mp_cost() : 0;
         surge_power_wand(mp_cost_of_wand);
     }
     else if (allow_fail)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -23,6 +23,7 @@
 #include "directn.h"
 #include "english.h"
 #include "env.h"
+#include "evoke.h"
 #include "exercise.h"
 #include "food.h"
 #include "format.h"
@@ -98,6 +99,17 @@ void surge_power(const int enhanced)
                                 : article_a(modifier).c_str(),
              (enhanced < 0) ? "numb sensation."
                             : "surge of power!");
+    }
+}
+
+void surge_power_wand(const int mp_cost)
+{
+    if (mp_cost)
+    {
+        const bool slight = mp_cost < 3;
+        mprf("You feel a %ssurge of power%s",
+             slight ? "slight " : "",
+             slight ? "."      : "!");
     }
 }
 
@@ -1405,9 +1417,9 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
 
     if (evoked_item)
     {
-        const int surge = pakellas_surge_devices();
-        powc = player_adjust_evoc_power(powc, surge);
-        surge_power(you.spec_evoke() + surge);
+        int mp_cost_of_wand = evoked_item->base_type == OBJ_WANDS
+                              ? min(you.magic_points, wand_mp_cost()) : 0;
+        surge_power_wand(mp_cost_of_wand);
     }
     else if (allow_fail)
         surge_power(_spell_enhancement(spell));

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -73,6 +73,7 @@ enum spret_type
 #define fail_check() if (fail) return SPRET_FAIL
 
 void surge_power(const int enhanced);
+void surge_power_wand(const int mp_cost);
 
 typedef bool (*spell_selector)(spell_type spell);
 


### PR DESCRIPTION
This commit adds functionality to deal with the "surge of power" message
when zapping wands under MP-powered wands in your_spells directly, so
that this message is displayed before any of the wand's effects and any
world_reacts effects caused by zapping the wand are displayed.

In the process this removes some old, unused Pakellas code.

Additional note: after this change there is still the unrelated issue that the "You feel a surge of power" message for both spells and wands is displayed even when the spell fails to cast or the player chooses to abort the casting/zapping due to effects such as allies in the way of the beam.