### PR TITLE
Convert spret_type to an enum class

### DIFF
--- a/crawl-ref/docs/develop/mutation_creation.txt
+++ b/crawl-ref/docs/develop/mutation_creation.txt
@@ -146,7 +146,7 @@ at the end:
         if (!spell_direction(abild, beam)
             || !player_tracer(ZAP_DISINTEGRATE, power, beam))
         {
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
         else
         {

--- a/crawl-ref/docs/develop/mutation_creation.txt
+++ b/crawl-ref/docs/develop/mutation_creation.txt
@@ -146,7 +146,7 @@ at the end:
         if (!spell_direction(abild, beam)
             || !player_tracer(ZAP_DISINTEGRATE, power, beam))
         {
-            return spret_type::abort;
+            return spret::abort;
         }
         else
         {

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -276,7 +276,7 @@ struct ability_def
 };
 
 static int _lookup_ability_slot(ability_type abil);
-static spret_type _do_ability(const ability_def& abil, bool fail);
+static spret _do_ability(const ability_def& abil, bool fail);
 static void _pay_ability_costs(const ability_def& abil);
 static int _scale_piety_cost(ability_type abil, int original_cost);
 
@@ -1751,23 +1751,23 @@ bool activate_talent(const talent& tal)
 
     bool fail = random2avg(100, 3) < tal.fail;
 
-    const spret_type ability_result = _do_ability(abil, fail);
+    const spret ability_result = _do_ability(abil, fail);
     switch (ability_result)
     {
-        case spret_type::success:
+        case spret::success:
             ASSERT(!fail || testbits(abil.flags, abflag::hostile));
             practise_using_ability(abil.ability);
             _pay_ability_costs(abil);
             count_action(tal.is_invocation ? CACT_INVOKE : CACT_ABIL, abil.ability);
             return true;
-        case spret_type::fail:
+        case spret::fail:
             mpr("You fail to use your ability.");
             you.turn_is_over = true;
             return false;
-        case spret_type::abort:
+        case spret::abort:
             crawl_state.zero_turns_taken();
             return false;
-        case spret_type::none:
+        case spret::none:
         default:
             die("Weird ability return type");
             return false;
@@ -1839,12 +1839,12 @@ static bool _cleansing_flame_affects(const actor *act)
  * Use an ability.
  *
  * @param abil The actual ability used.
- * @param fail If true, the ability is doomed to fail, and spret_type::fail will
- * be returned if the ability is not spret_type::aborted.
- * @returns Whether the spell succeeded (spret_type::success), failed (spret_type::fail),
- *  or was canceled (spret_type::abort). Never returns spret_type::none.
+ * @param fail If true, the ability is doomed to fail, and spret::fail will
+ * be returned if the ability is not spret::aborted.
+ * @returns Whether the spell succeeded (spret::success), failed (spret::fail),
+ *  or was canceled (spret::abort). Never returns spret::none.
  */
-static spret_type _do_ability(const ability_def& abil, bool fail)
+static spret _do_ability(const ability_def& abil, bool fail)
 {
     dist abild;
     bolt beam;
@@ -1885,17 +1885,17 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             if (yesno("Are you sure you want to shaft yourself?", true, 'n'))
                 start_delay<ShaftSelfDelay>(1);
             else
-                return spret_type::abort;
+                return spret::abort;
         }
         else
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_HOP:
         if (_can_hop(false))
             return frog_hop(fail);
         else
-            return spret_type::abort;
+            return spret::abort;
 
     case ABIL_SPIT_POISON:      // Naga poison spit
     {
@@ -1905,7 +1905,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!spell_direction(abild, beam)
             || !player_tracer(ZAP_SPIT_POISON, power, beam))
         {
-            return spret_type::abort;
+            return spret::abort;
         }
         else
         {
@@ -1924,10 +1924,10 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         args.mode = TARG_HOSTILE;
         args.hitfunc = &hitfunc;
         if (!spell_direction(abild, beam, &args))
-          return spret_type::abort;
+          return spret::abort;
 
         if (stop_attack_prompt(hitfunc, "spit at", _acid_breath_can_hit))
-          return spret_type::abort;
+          return spret::abort;
 
         fail_check();
         zapping(ZAP_BREATHE_ACID, (you.form == transformation::dragon) ?
@@ -1947,7 +1947,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_BREATHE_MEPHITIC:
         beam.range = _calc_breath_ability_range(abil.ability);
         if (!spell_direction(abild, beam))
-            return spret_type::abort;
+            return spret::abort;
 
         // fallthrough to ABIL_BREATHE_LIGHTNING
 
@@ -1970,9 +1970,9 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             msg += (power < 15) ? '.' : '!';
 
             if (zapping(ZAP_BREATHE_FIRE, power, beam, true, msg.c_str())
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
         }
@@ -1982,18 +1982,18 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                         you.form == transformation::dragon
                             ? 2 * you.experience_level : you.experience_level,
                         beam, true, "You exhale a wave of freezing cold.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
         case ABIL_BREATHE_POISON:
             if (zapping(ZAP_BREATHE_POISON, you.experience_level, beam, true,
                         "You exhale a blast of poison gas.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
@@ -2007,9 +2007,9 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                         you.form == transformation::dragon
                             ? 2 * you.experience_level : you.experience_level,
                         beam, true, "You spit a glob of acid.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
@@ -2018,9 +2018,9 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                         you.form == transformation::dragon
                             ? 2 * you.experience_level : you.experience_level,
                         beam, true, "You breathe a bolt of dispelling energy.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
@@ -2029,9 +2029,9 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                         you.form == transformation::dragon
                             ? 2 * you.experience_level : you.experience_level,
                         beam, true, "You exhale a blast of scalding steam.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
@@ -2040,9 +2040,9 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                         you.form == transformation::dragon
                             ? 2 * you.experience_level : you.experience_level,
                         beam, true, "You exhale a blast of noxious fumes.")
-                == spret_type::abort)
+                == spret::abort)
             {
-                return spret_type::abort;
+                return spret::abort;
             }
             break;
 
@@ -2098,15 +2098,15 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         fail_check();
         if (your_spells(SPELL_HURL_DAMNATION,
                         you.experience_level * 10,
-                        false) == spret_type::abort)
+                        false) == spret::abort)
         {
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
     case ABIL_EVOKE_TURN_INVISIBLE:     // cloaks, randarts
         if (!invis_allowed())
-            return spret_type::abort;
+            return spret::abort;
         fail_check();
         surge_power(you.spec_evoke());
         potionlike_effect(POT_INVISIBILITY,
@@ -2210,7 +2210,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         else
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
     }
@@ -2227,12 +2227,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         args.mode = TARG_HOSTILE;
         args.needs_path = false;
         if (!spell_direction(spd, beam, &args))
-            return spret_type::abort;
+            return spret::abort;
 
         if (beam.target == you.pos())
         {
             mpr("You cannot imprison yourself!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         monster* mons = monster_at(beam.target);
@@ -2240,19 +2240,19 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (mons == nullptr || !you.can_see(*mons))
         {
             mpr("There is no monster there to imprison!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         if (mons_is_firewood(*mons) || mons_is_conjured(mons->type))
         {
             mpr("You cannot imprison that!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         if (mons->friendly() || mons->good_neutral())
         {
             mpr("You cannot imprison a law-abiding creature!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
@@ -2260,7 +2260,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         int power = 3 + (roll_dice(5, you.skill(SK_INVOCATIONS, 5) + 12) / 26);
 
         if (!cast_imprison(power, mons, -GOD_ZIN))
-            return spret_type::abort;
+            return spret::abort;
         break;
     }
 
@@ -2284,7 +2284,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         targeter_los hitfunc(&you, LOS_SOLID, 2);
         {
             if (stop_attack_prompt(hitfunc, "harm", _cleansing_flame_affects))
-                return spret_type::abort;
+                return spret::abort;
         }
         fail_check();
         cleansing_flame(10 + you.skill_rdiv(SK_INVOCATIONS, 7, 6),
@@ -2302,7 +2302,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         simple_god_message(" will bless one of your weapons.");
         // included in default force_more_message
         if (!bless_weapon(GOD_SHINING_ONE, SPWPN_HOLY_WRATH, YELLOW))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_KIKU_RECEIVE_CORPSES:
@@ -2315,7 +2315,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!kiku_take_corpse())
         {
             mpr("There are no corpses to sacrifice!");
-            return spret_type::abort;
+            return spret::abort;
         }
         simple_god_message(" torments the living!");
         torment(&you, TORMENT_KIKUBAAQUDGHA, you.pos());
@@ -2326,14 +2326,14 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         simple_god_message(" will bloody one of your weapons with pain.");
         // included in default force_more_message
         if (!bless_weapon(GOD_KIKUBAAQUDGHA, SPWPN_PAIN, RED))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_KIKU_GIFT_NECRONOMICON:
     {
         fail_check();
         if (!kiku_gift_necronomicon())
-            return spret_type::abort;
+            return spret::abort;
         break;
     }
 
@@ -2357,7 +2357,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                             MHITYOU, &you, "", GOD_YREDELEMNUL) < 0)
         {
             mpr("There are no remains here to animate!");
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2376,11 +2376,11 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_YRED_DRAIN_LIFE:
     {
         int damage = 0;
-        const spret_type result =
+        const spret result =
             fire_los_attack_spell(SPELL_DRAIN_LIFE,
                                   you.skill_rdiv(SK_INVOCATIONS),
                                   &you, nullptr, fail, &damage);
-        if (result != spret_type::success)
+        if (result != spret::success)
             return result;
 
         if (damage > 0)
@@ -2401,12 +2401,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         args.needs_path = false;
 
         if (!spell_direction(spd, beam, &args))
-            return spret_type::abort;
+            return spret::abort;
 
         if (beam.target == you.pos())
         {
             mpr("Your soul already belongs to Yredelemnul.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         monster* mons = monster_at(beam.target);
@@ -2414,14 +2414,14 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             || !yred_can_enslave_soul(mons))
         {
             mpr("You see nothing there you can enslave the soul of!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         // The monster can be no more than lightly wounded/damaged.
         if (mons_get_damage_level(*mons) > MDAM_LIGHTLY_DAMAGED)
         {
             simple_monster_message(*mons, "'s soul is too badly injured.");
-            return spret_type::abort;
+            return spret::abort;
         }
         fail_check();
 
@@ -2468,7 +2468,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         beam.range = min((int)you.current_vision, 5);
 
         if (!spell_direction(spd, beam))
-            return spret_type::abort;
+            return spret::abort;
 
         int power = you.skill(SK_INVOCATIONS, 1)
                     + random2(1 + you.skill(SK_INVOCATIONS, 1))
@@ -2476,7 +2476,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
         // Since the actual beam is random, check with BEAM_MMISSILE.
         if (!player_tracer(ZAP_DEBUGGING_RAY, power, beam, beam.range))
-            return spret_type::abort;
+            return spret::abort;
 
         fail_check();
         beam.origin_spell = SPELL_NO_SPELL; // let zapping reset this
@@ -2505,7 +2505,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         beam.range = you.current_vision;
 
         if (!spell_direction(spd, beam))
-            return spret_type::abort;
+            return spret::abort;
 
         int power = you.skill(SK_INVOCATIONS, 1)
                     + random2(1 + you.skill(SK_INVOCATIONS, 1))
@@ -2513,7 +2513,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
         // Since the actual beam is random, check with BEAM_MMISSILE.
         if (!player_tracer(ZAP_DEBUGGING_RAY, power, beam, beam.range))
-            return spret_type::abort;
+            return spret::abort;
 
         fail_check();
         {
@@ -2575,7 +2575,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_SIF_MUNA_FORGET_SPELL:
         fail_check();
         if (cast_selective_amnesia() <= 0)
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_SIF_MUNA_CHANNEL_ENERGY:
@@ -2630,7 +2630,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_ELYVILON_DIVINE_VIGOUR:
         fail_check();
         if (!elyvilon_divine_vigour())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_LUGONU_ABYSS_EXIT:
@@ -2654,12 +2654,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                                   zap_ench_power(ZAP_BANISHMENT, pow, false),
                                   false, nullptr);
         if (!spell_direction(spd, beam, &args))
-            return spret_type::abort;
+            return spret::abort;
 
         if (beam.target == you.pos())
         {
             mpr("You cannot banish yourself!");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
@@ -2670,7 +2670,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_LUGONU_CORRUPT:
         fail_check();
         if (!lugonu_corrupt_level(300 + you.skill(SK_INVOCATIONS, 15)))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_LUGONU_ABYSS_ENTER:
@@ -2690,66 +2690,66 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
                            "corruption of the Abyss.");
         // included in default force_more_message
         if (!bless_weapon(GOD_LUGONU, SPWPN_DISTORTION, MAGENTA))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_NEMELEX_DRAW_DESTRUCTION:
         fail_check();
         if (!deck_draw(DECK_OF_DESTRUCTION))
-            return spret_type::abort;
+            return spret::abort;
         break;
     case ABIL_NEMELEX_DRAW_ESCAPE:
         fail_check();
         if (!deck_draw(DECK_OF_ESCAPE))
-            return spret_type::abort;
+            return spret::abort;
         break;
     case ABIL_NEMELEX_DRAW_SUMMONING:
         fail_check();
         if (!deck_draw(DECK_OF_SUMMONING))
-            return spret_type::abort;
+            return spret::abort;
         break;
     case ABIL_NEMELEX_DRAW_STACK:
         fail_check();
         if (!deck_draw(DECK_STACK))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_NEMELEX_TRIPLE_DRAW:
         fail_check();
         if (!deck_triple_draw())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_NEMELEX_DEAL_FOUR:
         fail_check();
         if (!deck_deal())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_NEMELEX_STACK_FIVE:
         fail_check();
         if (!deck_stack())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_BEOGH_SMITING:
         fail_check();
         if (your_spells(SPELL_SMITING,
                         12 + skill_bump(SK_INVOCATIONS, 6),
-                        false, nullptr) == spret_type::abort)
+                        false, nullptr) == spret::abort)
         {
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
     case ABIL_BEOGH_GIFT_ITEM:
         if (!beogh_gift_item())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_BEOGH_RESURRECTION:
         if (!beogh_resurrect())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_BEOGH_RECALL_ORCISH_FOLLOWERS:
@@ -2765,7 +2765,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_FEDHAS_FUNGAL_BLOOM:
         fedhas_fungal_bloom();
-        return spret_type::success;
+        return spret::success;
 
     case ABIL_FEDHAS_SUNLIGHT:
         return fedhas_sunlight(fail);
@@ -2773,7 +2773,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_FEDHAS_PLANT_RING:
         fail_check();
         if (!fedhas_plant_ring_from_rations())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_FEDHAS_RAIN:
@@ -2781,7 +2781,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!fedhas_rain(you.pos()))
         {
             canned_msg(MSG_NOTHING_HAPPENS);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2801,7 +2801,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!transform(100, transformation::bat))
         {
             crawl_state.zero_turns_taken();
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2814,7 +2814,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         mg.non_actor_summoner = "Jiyva";
 
         if (!create_monster(mg))
-            return spret_type::abort;
+            return spret::abort;
         break;
     }
 
@@ -2854,7 +2854,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_CHEIBRIADOS_SLOUCH:
         fail_check();
         if (!cheibriados_slouch())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_ASHENZARI_CURSE:
@@ -2872,12 +2872,12 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             if (ashenzari_curse_item(iter->quantity))
                 dec_inv_item_quantity(iter - begin(you.inv), 1);
             else
-                return spret_type::abort;
+                return spret::abort;
         }
         else
         {
             mpr("You need a scroll of remove curse to do this.");
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
     }
@@ -2898,7 +2898,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!ashenzari_transfer_knowledge())
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2907,18 +2907,18 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!ashenzari_end_transfer())
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
     case ABIL_DITHMENOS_SHADOW_STEP:
         if (_abort_if_stationary())
-            return spret_type::abort;
+            return spret::abort;
         fail_check();
         if (!dithmenos_shadow_step())
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2927,7 +2927,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (!transform(you.skill(SK_INVOCATIONS, 2), transformation::shadow))
         {
             crawl_state.zero_turns_taken();
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -2944,7 +2944,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_GOZAG_BRIBE_BRANCH:
         fail_check();
         if (!gozag_bribe_branch())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_QAZLAL_UPHEAVAL:
@@ -2956,7 +2956,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_QAZLAL_DISASTER_AREA:
         fail_check();
         if (!qazlal_disaster_area())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_RU_SACRIFICE_PURITY:
@@ -2978,13 +2978,13 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_RU_SACRIFICE_RESISTANCE:
         fail_check();
         if (!ru_do_sacrifice(abil.ability))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_RU_REJECT_SACRIFICES:
         fail_check();
         if (!ru_reject_sacrifices())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_RU_DRAW_OUT_POWER:
@@ -2992,7 +2992,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (you.duration[DUR_EXHAUSTED])
         {
             mpr("You're too exhausted to draw out your power.");
-            return spret_type::abort;
+            return spret::abort;
         }
         if (you.hp == you.hp_max && you.magic_points == you.max_magic_points
             && !you.duration[DUR_CONF]
@@ -3002,7 +3002,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             && !you.is_constricted())
         {
             mpr("You have no need to draw out power.");
-            return spret_type::abort;
+            return spret::abort;
         }
         ru_draw_out_power();
         you.increase_duration(DUR_EXHAUSTED, 12 + random2(5));
@@ -3012,18 +3012,18 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (you.duration[DUR_EXHAUSTED])
         {
             mpr("You're too exhausted to power leap.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         if (_abort_if_stationary())
-            return spret_type::abort;
+            return spret::abort;
 
         fail_check();
 
         if (!ru_power_leap())
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         you.increase_duration(DUR_EXHAUSTED, 18 + random2(8));
         break;
@@ -3032,13 +3032,13 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (you.duration[DUR_EXHAUSTED])
         {
             mpr("You're too exhausted to unleash your apocalyptic power.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
 
         if (!ru_apocalypse())
-            return spret_type::abort;
+            return spret::abort;
         you.increase_duration(DUR_EXHAUSTED, 30 + random2(20));
         break;
 
@@ -3057,15 +3057,15 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_USKAYAW_STOMP:
         fail_check();
         if (!uskayaw_stomp())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_USKAYAW_LINE_PASS:
         if (_abort_if_stationary())
-            return spret_type::abort;
+            return spret::abort;
         fail_check();
         if (!uskayaw_line_pass())
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_USKAYAW_GRAND_FINALE:
@@ -3087,7 +3087,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
     case ABIL_HEPLIAKLQANA_TYPE_BATTLEMAGE:
     case ABIL_HEPLIAKLQANA_TYPE_HEXER:
         if (!hepliaklqana_choose_ancestor_type(abil.ability))
-            return spret_type::abort;
+            return spret::abort;
         break;
 
     case ABIL_HEPLIAKLQANA_IDENTITY:
@@ -3098,18 +3098,18 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         if (you.attribute[ATTR_SERPENTS_LASH])
         {
             mpr("You are already lashing out.");
-            return spret_type::abort;
+            return spret::abort;
         }
         if (you.duration[DUR_EXHAUSTED])
         {
             mpr("You are too exhausted to lash out.");
-            return spret_type::abort;
+            return spret::abort;
         }
         fail_check();
         mprf(MSGCH_GOD, "Your muscles tense, ready for explosive movement...");
         you.attribute[ATTR_SERPENTS_LASH] = 2;
         you.redraw_status_lights = true;
-        return spret_type::success;
+        return spret::success;
 
     case ABIL_WU_JIAN_HEAVENLY_STORM:
         fail_check();
@@ -3144,7 +3144,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         else
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         break;
 
@@ -3156,7 +3156,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
             spare_beogh_convert();
             break;
         }
-        return spret_type::abort;
+        return spret::abort;
 
     case ABIL_NON_ABILITY:
         fail_check();
@@ -3167,7 +3167,7 @@ static spret_type _do_ability(const ability_def& abil, bool fail)
         die("invalid ability");
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 // [ds] Increase piety cost for god abilities that are particularly

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -199,7 +199,7 @@ static bool _DISPATER_evoke(item_def *item, bool* did_work, bool* unevokable)
     *did_work = true;
     int power = you.skill(SK_EVOCATIONS, 8);
 
-    if (your_spells(SPELL_HURL_DAMNATION, power, false) == spret_type::abort)
+    if (your_spells(SPELL_HURL_DAMNATION, power, false) == spret::abort)
     {
         *unevokable = true;
         return false;
@@ -273,7 +273,7 @@ static bool _OLGREB_evoke(item_def *item, bool* did_work, bool* unevokable)
     int power = div_rand_round(20 + you.skill(SK_EVOCATIONS, 20), 4);
 
     // Allow aborting (for example if friendlies are nearby).
-    if (your_spells(SPELL_OLGREBS_TOXIC_RADIANCE, power, false) == spret_type::abort)
+    if (your_spells(SPELL_OLGREBS_TOXIC_RADIANCE, power, false) == spret::abort)
     {
         *unevokable = true;
         return false;

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -199,7 +199,7 @@ static bool _DISPATER_evoke(item_def *item, bool* did_work, bool* unevokable)
     *did_work = true;
     int power = you.skill(SK_EVOCATIONS, 8);
 
-    if (your_spells(SPELL_HURL_DAMNATION, power, false) == SPRET_ABORT)
+    if (your_spells(SPELL_HURL_DAMNATION, power, false) == spret_type::abort)
     {
         *unevokable = true;
         return false;
@@ -273,7 +273,7 @@ static bool _OLGREB_evoke(item_def *item, bool* did_work, bool* unevokable)
     int power = div_rand_round(20 + you.skill(SK_EVOCATIONS, 20), 4);
 
     // Allow aborting (for example if friendlies are nearby).
-    if (your_spells(SPELL_OLGREBS_TOXIC_RADIANCE, power, false) == SPRET_ABORT)
+    if (your_spells(SPELL_OLGREBS_TOXIC_RADIANCE, power, false) == spret_type::abort)
     {
         *unevokable = true;
         return false;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -235,7 +235,7 @@ static void _ench_animation(int flavour, const monster* mon, bool force)
 
 // If needs_tracer is true, we need to check the beam path for friendly
 // monsters.
-spret_type zapping(zap_type ztype, int power, bolt &pbolt,
+spret zapping(zap_type ztype, int power, bolt &pbolt,
                    bool needs_tracer, const char* msg, bool fail)
 {
     dprf(DIAG_BEAM, "zapping: power=%d", power);
@@ -247,7 +247,7 @@ spret_type zapping(zap_type ztype, int power, bolt &pbolt,
     // (or effect), player_tracer should be called directly with the highest
     // power possible respecting current skill, experience level, etc.
     if (needs_tracer && !player_tracer(ztype, power, pbolt))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
     // Fill in the bolt structure.
@@ -268,7 +268,7 @@ spret_type zapping(zap_type ztype, int power, bolt &pbolt,
 
     pbolt.fire();
 
-    return spret_type::success;
+    return spret::success;
 }
 
 // Returns true if the path is considered "safe", and false if there are
@@ -1720,7 +1720,7 @@ static bool _monster_resists_mass_enchantment(monster* mons,
 // If m_succumbed is non-nullptr, will be set to the number of monsters that
 // were enchanted. If m_attempted is not nullptr, will be set to the number of
 // monsters that we tried to enchant.
-spret_type mass_enchantment(enchant_type wh_enchant, int pow, bool fail)
+spret mass_enchantment(enchant_type wh_enchant, int pow, bool fail)
 {
     fail_check();
     bool did_msg = false;
@@ -1777,7 +1777,7 @@ spret_type mass_enchantment(enchant_type wh_enchant, int pow, bool fail)
     if (wh_enchant == ENCH_INSANE)
         did_god_conduct(DID_HASTY, 8, true);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 void bolt::apply_bolt_paralysis(monster* mons)

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -247,7 +247,7 @@ spret_type zapping(zap_type ztype, int power, bolt &pbolt,
     // (or effect), player_tracer should be called directly with the highest
     // power possible respecting current skill, experience level, etc.
     if (needs_tracer && !player_tracer(ztype, power, pbolt))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
     // Fill in the bolt structure.
@@ -268,7 +268,7 @@ spret_type zapping(zap_type ztype, int power, bolt &pbolt,
 
     pbolt.fire();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // Returns true if the path is considered "safe", and false if there are
@@ -1777,7 +1777,7 @@ spret_type mass_enchantment(enchant_type wh_enchant, int pow, bool fail)
     if (wh_enchant == ENCH_INSANE)
         did_god_conduct(DID_HASTY, 8, true);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void bolt::apply_bolt_paralysis(monster* mons)

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -307,7 +307,7 @@ bool enchant_monster_invisible(monster* mon, const string &how);
 
 bool ench_flavour_affects_monster(beam_type flavour, const monster* mon,
                                                   bool intrinsic_only = false);
-spret_type mass_enchantment(enchant_type wh_enchant, int pow,
+spret mass_enchantment(enchant_type wh_enchant, int pow,
                             bool fail = false);
 int ench_power_stepdown(int pow);
 
@@ -323,7 +323,7 @@ void fire_tracer(const monster* mons, bolt &pbolt,
                   bool explode_only = false, bool explosion_hole = false);
 bool imb_can_splash(coord_def origin, coord_def center,
                     vector<coord_def> path_taken, coord_def target);
-spret_type zapping(zap_type ztype, int power, bolt &pbolt,
+spret zapping(zap_type ztype, int power, bolt &pbolt,
                    bool needs_tracer = false, const char* msg = nullptr,
                    bool fail = false);
 bool player_tracer(zap_type ztype, int power, bolt &pbolt, int range = 0);

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -344,9 +344,9 @@ static bool _lightning_rod()
     const int power =
         player_adjust_evoc_power(5 + you.skill(SK_EVOCATIONS, 3), surge);
 
-    const spret_type ret = your_spells(SPELL_THUNDERBOLT, power, false);
+    const spret ret = your_spells(SPELL_THUNDERBOLT, power, false);
 
-    if (ret == spret_type::abort)
+    if (ret == spret::abort)
         return false;
 
     return true;
@@ -453,11 +453,11 @@ void zap_wand(int slot)
     const spell_type spell =
         spell_in_wand(static_cast<wand_type>(wand.sub_type));
 
-    spret_type ret = your_spells(spell, power, false, &wand);
+    spret ret = your_spells(spell, power, false, &wand);
 
-    if (ret == spret_type::abort)
+    if (ret == spret::abort)
         return;
-    else if (ret == spret_type::fail)
+    else if (ret == spret::fail)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
         you.turn_is_over = true;
@@ -1364,7 +1364,7 @@ static bool _phial_of_floods()
     return false;
 }
 
-static spret_type _phantom_mirror()
+static spret _phantom_mirror()
 {
     bolt beam;
     monster* victim = nullptr;
@@ -1378,7 +1378,7 @@ static spret_type _phantom_mirror()
     args.top_prompt = "Aiming: <white>Phantom Mirror</white>";
     args.hitfunc = &tgt;
     if (!spell_direction(spd, beam, &args))
-        return spret_type::abort;
+        return spret::abort;
     victim = monster_at(beam.target);
     if (!victim || !you.can_see(*victim))
     {
@@ -1386,7 +1386,7 @@ static spret_type _phantom_mirror()
             mpr("You can't use the mirror on yourself.");
         else
             mpr("You can't see anything there to clone.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // Mirrored monsters (including by Mara, rakshasas) can still be
@@ -1395,7 +1395,7 @@ static spret_type _phantom_mirror()
         && !victim->has_ench(ENCH_PHANTOM_MIRROR))
     {
         mpr("The mirror can't reflect that.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (player_will_anger_monster(*victim))
@@ -1404,7 +1404,7 @@ static spret_type _phantom_mirror()
             mpr("The reflection would only feel hate for you!");
         else
             simple_god_message(" forbids your reflecting this monster.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     const int surge = pakellas_surge_devices();
@@ -1414,7 +1414,7 @@ static spret_type _phantom_mirror()
     if (!mon)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::fail;
+        return spret::fail;
     }
     const int power = player_adjust_evoc_power(5 + you.skill(SK_EVOCATIONS, 3),
                                                surge);
@@ -1439,7 +1439,7 @@ static spret_type _phantom_mirror()
     mprf("You reflect %s with the mirror, and the mirror shatters!",
          victim->name(DESC_THE).c_str());
 
-    return spret_type::success;
+    return spret::success;
 }
 
 bool evoke_check(int slot, bool quiet)
@@ -1712,14 +1712,14 @@ bool evoke_item(int slot, bool check_range)
             switch (_phantom_mirror())
             {
                 default:
-                case spret_type::abort:
+                case spret::abort:
                     return false;
 
-                case spret_type::success:
+                case spret::success:
                     ASSERT(in_inventory(item));
                     dec_inv_item_quantity(item.link, 1);
                     // deliberate fall-through
-                case spret_type::fail:
+                case spret::fail:
                     practise_evoking(1);
                     break;
             }

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -346,7 +346,7 @@ static bool _lightning_rod()
 
     const spret_type ret = your_spells(SPELL_THUNDERBOLT, power, false);
 
-    if (ret == SPRET_ABORT)
+    if (ret == spret_type::abort)
         return false;
 
     return true;
@@ -455,9 +455,9 @@ void zap_wand(int slot)
 
     spret_type ret = your_spells(spell, power, false, &wand);
 
-    if (ret == SPRET_ABORT)
+    if (ret == spret_type::abort)
         return;
-    else if (ret == SPRET_FAIL)
+    else if (ret == spret_type::fail)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
         you.turn_is_over = true;
@@ -1378,7 +1378,7 @@ static spret_type _phantom_mirror()
     args.top_prompt = "Aiming: <white>Phantom Mirror</white>";
     args.hitfunc = &tgt;
     if (!spell_direction(spd, beam, &args))
-        return SPRET_ABORT;
+        return spret_type::abort;
     victim = monster_at(beam.target);
     if (!victim || !you.can_see(*victim))
     {
@@ -1386,7 +1386,7 @@ static spret_type _phantom_mirror()
             mpr("You can't use the mirror on yourself.");
         else
             mpr("You can't see anything there to clone.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // Mirrored monsters (including by Mara, rakshasas) can still be
@@ -1395,7 +1395,7 @@ static spret_type _phantom_mirror()
         && !victim->has_ench(ENCH_PHANTOM_MIRROR))
     {
         mpr("The mirror can't reflect that.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (player_will_anger_monster(*victim))
@@ -1404,7 +1404,7 @@ static spret_type _phantom_mirror()
             mpr("The reflection would only feel hate for you!");
         else
             simple_god_message(" forbids your reflecting this monster.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     const int surge = pakellas_surge_devices();
@@ -1414,7 +1414,7 @@ static spret_type _phantom_mirror()
     if (!mon)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_FAIL;
+        return spret_type::fail;
     }
     const int power = player_adjust_evoc_power(5 + you.skill(SK_EVOCATIONS, 3),
                                                surge);
@@ -1439,7 +1439,7 @@ static spret_type _phantom_mirror()
     mprf("You reflect %s with the mirror, and the mirror shatters!",
          victim->name(DESC_THE).c_str());
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 bool evoke_check(int slot, bool quiet)
@@ -1712,14 +1712,14 @@ bool evoke_item(int slot, bool check_range)
             switch (_phantom_mirror())
             {
                 default:
-                case SPRET_ABORT:
+                case spret_type::abort:
                     return false;
 
-                case SPRET_SUCCESS:
+                case spret_type::success:
                     ASSERT(in_inventory(item));
                     dec_inv_item_quantity(item.link, 1);
                     // deliberate fall-through
-                case SPRET_FAIL:
+                case spret_type::fail:
                     practise_evoking(1);
                     break;
             }

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -2573,7 +2573,7 @@ static bool _create_plant(coord_def& target, int hp_adjust = 0)
 
 #define SUNLIGHT_DURATION 80
 
-spret_type fedhas_sunlight(bool fail)
+spret fedhas_sunlight(bool fail)
 {
     dist spelld;
 
@@ -2591,7 +2591,7 @@ spret_type fedhas_sunlight(bool fail)
     direction(spelld, args);
 
     if (!spelld.isValid)
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -2645,7 +2645,7 @@ spret_type fedhas_sunlight(bool fail)
              "an invisible shape" : "some invisible shapes");
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 void process_sunlights(bool future)
@@ -3291,7 +3291,7 @@ static vector<string> _evolution_name(const monster_info& mon)
         return { "cannot be evolved" };
 }
 
-spret_type fedhas_evolve_flora(bool fail)
+spret fedhas_evolve_flora(bool fail)
 {
     dist spelld;
 
@@ -3311,7 +3311,7 @@ spret_type fedhas_evolve_flora(bool fail)
     {
         // Check for user cancel.
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster* const plant = monster_at(spelld.target);
@@ -3322,7 +3322,7 @@ spret_type fedhas_evolve_flora(bool fail)
             mpr("The tree has already reached the pinnacle of evolution.");
         else
             mpr("You must target a plant or fungus.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (!mons_is_evolvable(plant))
@@ -3339,7 +3339,7 @@ spret_type fedhas_evolve_flora(bool fail)
                                    " of evolution.");
         }
 
-        return spret_type::abort;
+        return spret::abort;
     }
     auto upgrade_ptr = map_find(conversions, plant->type);
     ASSERT(upgrade_ptr);
@@ -3353,14 +3353,14 @@ spret_type fedhas_evolve_flora(bool fail)
         if (total_rations < upgrade.ration_cost)
         {
             mpr("Not enough rations available.");
-            return spret_type::abort;
+            return spret::abort;
         }
     }
 
     if (upgrade.piety_cost && upgrade.piety_cost > you.piety)
     {
         mpr("Not enough piety available.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -3441,7 +3441,7 @@ spret_type fedhas_evolve_flora(bool fail)
         mpr("Your piety has decreased.");
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static bool _lugonu_warp_monster(monster& mon, int pow)
@@ -4642,7 +4642,7 @@ static int _upheaval_radius(int pow)
     return pow >= 100 ? 2 : 1;
 }
 
-spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
+spret qazlal_upheaval(coord_def target, bool quiet, bool fail)
 {
     int pow = you.skill(SK_INVOCATIONS, 6);
     const int max_radius = _upheaval_radius(pow);
@@ -4674,13 +4674,13 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
         args.self = CONFIRM_CANCEL;
         args.hitfunc = &tgt;
         if (!spell_direction(spd, beam, &args))
-            return spret_type::abort;
+            return spret::abort;
 
         if (cell_is_solid(beam.target))
         {
             mprf("There is %s there.",
                  article_a(feat_type_name(grd(beam.target))).c_str());
-            return spret_type::abort;
+            return spret::abort;
         }
 
         bolt tempbeam;
@@ -4694,7 +4694,7 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
         tempbeam.is_tracer = true;
         tempbeam.explode(false);
         if (tempbeam.beam_cancelled)
-            return spret_type::abort;
+            return spret::abort;
     }
     else
         beam.target = target;
@@ -4819,10 +4819,10 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
     if (wall_count && !quiet)
         mpr("Ka-crash!");
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type qazlal_elemental_force(bool fail)
+spret qazlal_elemental_force(bool fail)
 {
     static const map<cloud_type, monster_type> elemental_clouds = {
         { CLOUD_FIRE,           MONS_FIRE_ELEMENTAL },
@@ -4853,7 +4853,7 @@ spret_type qazlal_elemental_force(bool fail)
     if (targets.empty())
     {
         mpr("You can't see any clouds you can empower.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -4891,7 +4891,7 @@ spret_type qazlal_elemental_force(bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS); // can this ever happen?
 
-    return spret_type::success;
+    return spret::success;
 }
 
 bool qazlal_disaster_area()
@@ -6651,7 +6651,7 @@ bool uskayaw_line_pass()
     return true;
 }
 
-spret_type uskayaw_grand_finale(bool fail)
+spret uskayaw_grand_finale(bool fail)
 {
     ASSERT(!crawl_state.game_is_arena());
 
@@ -6660,7 +6660,7 @@ spret_type uskayaw_grand_finale(bool fail)
         crawl_state.cant_cmd_repeat("No encores!");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // query for location:
@@ -6682,11 +6682,11 @@ spret_type uskayaw_grand_finale(bool fail)
         {
             clear_messages();
             mpr("Cancelling grand finale due to HUP.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         if (!beam.isValid || beam.target == you.pos())
-            return spret_type::abort;   // early return
+            return spret::abort;   // early return
 
         mons = monster_at(beam.target);
         if (!mons || !you.can_see(*mons))
@@ -6750,7 +6750,7 @@ spret_type uskayaw_grand_finale(bool fail)
 
     set_piety(piety_breakpoint(0)); // Reset piety to 1*.
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -6818,20 +6818,20 @@ bool hepliaklqana_choose_ancestor_type(int ancestor_choice)
  * @param fail      Whether the effect should fail after checking validity.
  * @return          Whether the healing succeeded, failed, or was aborted.
  */
-spret_type hepliaklqana_idealise(bool fail)
+spret hepliaklqana_idealise(bool fail)
 {
     const mid_t ancestor_mid = hepliaklqana_ancestor();
     if (ancestor_mid == MID_NOBODY)
     {
         mpr("You have no ancestor to preserve!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster *ancestor = monster_by_mid(ancestor_mid);
     if (!ancestor || !you.can_see(*ancestor))
     {
         mprf("%s is not nearby!", hepliaklqana_ally_name().c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -6854,7 +6854,7 @@ spret_type hepliaklqana_idealise(bool fail)
     const int dur = random_range(50, 80)
                     + random2avg(you.skill(SK_INVOCATIONS, 20), 2);
     ancestor->add_ench({ ENCH_IDEALISED, 1, &you, dur});
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -6912,20 +6912,20 @@ static void _transfer_drain_nearby(coord_def destination)
  * @param fail      Whether the effect should fail after checking validity.
  * @return          Whether the ability succeeded, failed, or was aborted.
  */
-spret_type hepliaklqana_transference(bool fail)
+spret hepliaklqana_transference(bool fail)
 {
     monster *ancestor = hepliaklqana_ancestor_mon();
     if (!ancestor || !you.can_see(*ancestor))
     {
         mprf("%s is not nearby!", hepliaklqana_ally_name().c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     coord_def target = _get_transference_target();
     if (target.origin())
     {
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     actor* victim = actor_at(target);
@@ -6935,13 +6935,13 @@ spret_type hepliaklqana_transference(bool fail)
                   true, 'n'))
     {
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (victim == ancestor)
     {
         mpr("You can't transfer your ancestor with themself.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     const bool victim_immovable
@@ -6950,19 +6950,19 @@ spret_type hepliaklqana_transference(bool fail)
     if (victim_visible && victim_immovable)
     {
         mpr("You can't transfer that.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     const coord_def destination = ancestor->pos();
     if (victim == &you && !check_moveto(destination, "transfer"))
-        return spret_type::abort;
+        return spret::abort;
 
     const bool uninhabitable = victim && !victim->is_habitable(destination);
     if (uninhabitable && victim_visible)
     {
         mprf("%s can't be transferred into %s.",
              victim->name(DESC_THE).c_str(), feat_type_name(grd(destination)));
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // we assume the ancestor flies & so can survive anywhere anything can.
@@ -6972,7 +6972,7 @@ spret_type hepliaklqana_transference(bool fail)
     if (!victim || uninhabitable || victim_immovable)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::success;
+        return spret::success;
     }
 
     if (victim->is_player())
@@ -7002,7 +7002,7 @@ spret_type hepliaklqana_transference(bool fail)
     if (have_passive(passive_t::transfer_drain))
         _transfer_drain_nearby(target);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /// Prompt to rename your ancestor.
@@ -7225,7 +7225,7 @@ bool wu_jian_do_wall_jump(coord_def targ, bool ability)
     return true;
 }
 
-spret_type wu_jian_wall_jump_ability()
+spret wu_jian_wall_jump_ability()
 {
     // This needs to be kept in sync with direct walljumping via movement.
     // TODO: Refactor to call the same code.
@@ -7236,11 +7236,11 @@ spret_type wu_jian_wall_jump_ability()
         crawl_state.cant_cmd_repeat("You can't repeat a wall jump.");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (cancel_barbed_move())
-        return spret_type::abort;
+        return spret::abort;
 
     if (you.digging)
     {
@@ -7261,24 +7261,24 @@ spret_type wu_jian_wall_jump_ability()
     if (!has_targets)
     {
         mpr("There is nothing to wall jump against here.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (you.is_nervous())
     {
         mpr("You are too terrified to wall jump!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (you.attribute[ATTR_HELD])
     {
         mprf("You cannot wall jump while caught in a %s.",
              get_trapping_net(you.pos()) == NON_ITEM ? "web" : "net");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (!you.attempt_escape())
-        return spret_type::fail;
+        return spret::fail;
 
     // query for location:
     dist beam;
@@ -7305,23 +7305,23 @@ spret_type wu_jian_wall_jump_ability()
         {
             clear_messages();
             mpr("Cancelling wall jump due to HUP.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         if (!beam.isValid || beam.target == you.pos())
-            return spret_type::abort; // early return
+            return spret::abort; // early return
 
         if (wu_jian_can_wall_jump(beam.target, wj_error))
             break;
     }
 
     if (!wu_jian_do_wall_jump(beam.target, true))
-        return spret_type::abort;
+        return spret::abort;
 
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
 
     apply_barbs_damage();
     remove_ice_armour_movement();
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -2591,7 +2591,7 @@ spret_type fedhas_sunlight(bool fail)
     direction(spelld, args);
 
     if (!spelld.isValid)
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -2645,7 +2645,7 @@ spret_type fedhas_sunlight(bool fail)
              "an invisible shape" : "some invisible shapes");
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void process_sunlights(bool future)
@@ -3311,7 +3311,7 @@ spret_type fedhas_evolve_flora(bool fail)
     {
         // Check for user cancel.
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster* const plant = monster_at(spelld.target);
@@ -3322,7 +3322,7 @@ spret_type fedhas_evolve_flora(bool fail)
             mpr("The tree has already reached the pinnacle of evolution.");
         else
             mpr("You must target a plant or fungus.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (!mons_is_evolvable(plant))
@@ -3339,7 +3339,7 @@ spret_type fedhas_evolve_flora(bool fail)
                                    " of evolution.");
         }
 
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
     auto upgrade_ptr = map_find(conversions, plant->type);
     ASSERT(upgrade_ptr);
@@ -3353,14 +3353,14 @@ spret_type fedhas_evolve_flora(bool fail)
         if (total_rations < upgrade.ration_cost)
         {
             mpr("Not enough rations available.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
     }
 
     if (upgrade.piety_cost && upgrade.piety_cost > you.piety)
     {
         mpr("Not enough piety available.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -3441,7 +3441,7 @@ spret_type fedhas_evolve_flora(bool fail)
         mpr("Your piety has decreased.");
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static bool _lugonu_warp_monster(monster& mon, int pow)
@@ -4674,13 +4674,13 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
         args.self = CONFIRM_CANCEL;
         args.hitfunc = &tgt;
         if (!spell_direction(spd, beam, &args))
-            return SPRET_ABORT;
+            return spret_type::abort;
 
         if (cell_is_solid(beam.target))
         {
             mprf("There is %s there.",
                  article_a(feat_type_name(grd(beam.target))).c_str());
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         bolt tempbeam;
@@ -4694,7 +4694,7 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
         tempbeam.is_tracer = true;
         tempbeam.explode(false);
         if (tempbeam.beam_cancelled)
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
     else
         beam.target = target;
@@ -4819,7 +4819,7 @@ spret_type qazlal_upheaval(coord_def target, bool quiet, bool fail)
     if (wall_count && !quiet)
         mpr("Ka-crash!");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type qazlal_elemental_force(bool fail)
@@ -4853,7 +4853,7 @@ spret_type qazlal_elemental_force(bool fail)
     if (targets.empty())
     {
         mpr("You can't see any clouds you can empower.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -4891,7 +4891,7 @@ spret_type qazlal_elemental_force(bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS); // can this ever happen?
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 bool qazlal_disaster_area()
@@ -6559,7 +6559,7 @@ bool uskayaw_line_pass()
         args.range = 8;
 
         if (!spell_direction(beam, line_pass, &args))
-            return SPRET_ABORT;
+            return false;
 
         if (crawl_state.seen_hups)
         {
@@ -6660,7 +6660,7 @@ spret_type uskayaw_grand_finale(bool fail)
         crawl_state.cant_cmd_repeat("No encores!");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // query for location:
@@ -6682,11 +6682,11 @@ spret_type uskayaw_grand_finale(bool fail)
         {
             clear_messages();
             mpr("Cancelling grand finale due to HUP.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         if (!beam.isValid || beam.target == you.pos())
-            return SPRET_ABORT;   // early return
+            return spret_type::abort;   // early return
 
         mons = monster_at(beam.target);
         if (!mons || !you.can_see(*mons))
@@ -6750,7 +6750,7 @@ spret_type uskayaw_grand_finale(bool fail)
 
     set_piety(piety_breakpoint(0)); // Reset piety to 1*.
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -6824,14 +6824,14 @@ spret_type hepliaklqana_idealise(bool fail)
     if (ancestor_mid == MID_NOBODY)
     {
         mpr("You have no ancestor to preserve!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster *ancestor = monster_by_mid(ancestor_mid);
     if (!ancestor || !you.can_see(*ancestor))
     {
         mprf("%s is not nearby!", hepliaklqana_ally_name().c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -6854,7 +6854,7 @@ spret_type hepliaklqana_idealise(bool fail)
     const int dur = random_range(50, 80)
                     + random2avg(you.skill(SK_INVOCATIONS, 20), 2);
     ancestor->add_ench({ ENCH_IDEALISED, 1, &you, dur});
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -6918,14 +6918,14 @@ spret_type hepliaklqana_transference(bool fail)
     if (!ancestor || !you.can_see(*ancestor))
     {
         mprf("%s is not nearby!", hepliaklqana_ally_name().c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     coord_def target = _get_transference_target();
     if (target.origin())
     {
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     actor* victim = actor_at(target);
@@ -6935,13 +6935,13 @@ spret_type hepliaklqana_transference(bool fail)
                   true, 'n'))
     {
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (victim == ancestor)
     {
         mpr("You can't transfer your ancestor with themself.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     const bool victim_immovable
@@ -6950,19 +6950,19 @@ spret_type hepliaklqana_transference(bool fail)
     if (victim_visible && victim_immovable)
     {
         mpr("You can't transfer that.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     const coord_def destination = ancestor->pos();
     if (victim == &you && !check_moveto(destination, "transfer"))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     const bool uninhabitable = victim && !victim->is_habitable(destination);
     if (uninhabitable && victim_visible)
     {
         mprf("%s can't be transferred into %s.",
              victim->name(DESC_THE).c_str(), feat_type_name(grd(destination)));
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // we assume the ancestor flies & so can survive anywhere anything can.
@@ -6972,7 +6972,7 @@ spret_type hepliaklqana_transference(bool fail)
     if (!victim || uninhabitable || victim_immovable)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     if (victim->is_player())
@@ -7002,7 +7002,7 @@ spret_type hepliaklqana_transference(bool fail)
     if (have_passive(passive_t::transfer_drain))
         _transfer_drain_nearby(target);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /// Prompt to rename your ancestor.
@@ -7236,11 +7236,11 @@ spret_type wu_jian_wall_jump_ability()
         crawl_state.cant_cmd_repeat("You can't repeat a wall jump.");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (cancel_barbed_move())
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     if (you.digging)
     {
@@ -7261,24 +7261,24 @@ spret_type wu_jian_wall_jump_ability()
     if (!has_targets)
     {
         mpr("There is nothing to wall jump against here.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (you.is_nervous())
     {
         mpr("You are too terrified to wall jump!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (you.attribute[ATTR_HELD])
     {
         mprf("You cannot wall jump while caught in a %s.",
              get_trapping_net(you.pos()) == NON_ITEM ? "web" : "net");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (!you.attempt_escape())
-        return SPRET_FAIL;
+        return spret_type::fail;
 
     // query for location:
     dist beam;
@@ -7305,23 +7305,23 @@ spret_type wu_jian_wall_jump_ability()
         {
             clear_messages();
             mpr("Cancelling wall jump due to HUP.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         if (!beam.isValid || beam.target == you.pos())
-            return SPRET_ABORT; // early return
+            return spret_type::abort; // early return
 
         if (wu_jian_can_wall_jump(beam.target, wj_error))
             break;
     }
 
     if (!wu_jian_do_wall_jump(beam.target, true))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
 
     apply_barbs_damage();
     remove_ice_armour_movement();
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/god-abil.h
+++ b/crawl-ref/source/god-abil.h
@@ -117,7 +117,7 @@ int place_ring(vector<coord_def>& ring_points,
 void collect_radius_points(vector<vector<coord_def> > &radius_points,
                            const coord_def &origin, los_type los);
 int fedhas_fungal_bloom();
-spret_type fedhas_sunlight(bool fail = false);
+spret fedhas_sunlight(bool fail = false);
 void process_sunlights(bool future = false);
 bool prioritise_adjacent(const coord_def& target, vector<coord_def>& candidates);
 bool fedhas_plant_ring_from_rations();
@@ -127,7 +127,7 @@ int fedhas_check_corpse_spores(bool quiet = false);
 int fedhas_corpse_spores(beh_type attitude = BEH_FRIENDLY);
 bool mons_is_evolvable(const monster* mon);
 bool fedhas_check_evolve_flora(bool quiet);
-spret_type fedhas_evolve_flora(bool fail);
+spret fedhas_evolve_flora(bool fail);
 
 void lugonu_bend_space();
 
@@ -157,9 +157,9 @@ void gozag_deduct_bribe(branch_type br, int amount);
 bool gozag_check_bribe_branch(bool quiet = false);
 bool gozag_bribe_branch();
 
-spret_type qazlal_upheaval(coord_def target, bool quiet = false,
+spret qazlal_upheaval(coord_def target, bool quiet = false,
                            bool fail = false);
-spret_type qazlal_elemental_force(bool fail);
+spret qazlal_elemental_force(bool fail);
 bool qazlal_disaster_area();
 
 void init_sac_index();
@@ -184,14 +184,14 @@ int pakellas_surge_devices();
 
 bool uskayaw_stomp();
 bool uskayaw_line_pass();
-spret_type uskayaw_grand_finale(bool fail);
+spret uskayaw_grand_finale(bool fail);
 
 bool hepliaklqana_choose_ancestor_type(int ancestor_type);
-spret_type hepliaklqana_idealise(bool fail);
-spret_type hepliaklqana_transference(bool fail);
+spret hepliaklqana_idealise(bool fail);
+spret hepliaklqana_transference(bool fail);
 void hepliaklqana_choose_identity();
 
 bool wu_jian_can_wall_jump_in_principle(const coord_def& target);
 bool wu_jian_can_wall_jump(const coord_def& target, string &error_ret);
 bool wu_jian_do_wall_jump(coord_def targ, bool ability);
-spret_type wu_jian_wall_jump_ability();
+spret wu_jian_wall_jump_ability();

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2874,7 +2874,7 @@ void read_scroll(item_def& scroll)
         else
         {
             cancel_scroll = (cast_controlled_blink(false, safely_cancellable)
-                             == spret_type::abort) && alreadyknown;
+                             == spret::abort) && alreadyknown;
         }
 
         if (!cancel_scroll)

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2874,7 +2874,7 @@ void read_scroll(item_def& scroll)
         else
         {
             cancel_scroll = (cast_controlled_blink(false, safely_cancellable)
-                             == SPRET_ABORT) && alreadyknown;
+                             == spret_type::abort) && alreadyknown;
         }
 
         if (!cancel_scroll)

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -395,7 +395,7 @@ static const map<spell_type, mons_spell_logic> spell_to_logic = {
             const int splpow = mons_spellpower(caster, slot.spell);
             if ((!in_bounds(pbolt.target)
                  || conjure_flame(&caster, splpow, pbolt.target, false)
-                    != SPRET_SUCCESS)
+                    != spret_type::success)
                 && you.can_see(caster))
             {
                 canned_msg(MSG_NOTHING_HAPPENS);
@@ -809,7 +809,7 @@ static void _cast_grasping_roots(monster &caster, mon_spell_slot, bolt&)
 static bool _los_spell_worthwhile(const monster &mons, spell_type spell)
 {
     return trace_los_attack_spell(spell, mons_spellpower(mons, spell), &mons)
-           == SPRET_SUCCESS;
+           == spret_type::success;
 }
 
 /// Set up a fake beam, for noise-generating purposes (?)
@@ -8042,9 +8042,9 @@ static bool _ms_waste_of_time(monster* mon, mon_spell_slot slot)
 
     case SPELL_OLGREBS_TOXIC_RADIANCE:
         return mon->has_ench(ENCH_TOXIC_RADIANCE)
-               || cast_toxic_radiance(mon, 100, false, true) != SPRET_SUCCESS;
+               || cast_toxic_radiance(mon, 100, false, true) != spret_type::success;
     case SPELL_IGNITE_POISON:
-        return cast_ignite_poison(mon, 0, false, true) != SPRET_SUCCESS;
+        return cast_ignite_poison(mon, 0, false, true) != spret_type::success;
 
     case SPELL_GLACIATE:
         return !foe

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -395,7 +395,7 @@ static const map<spell_type, mons_spell_logic> spell_to_logic = {
             const int splpow = mons_spellpower(caster, slot.spell);
             if ((!in_bounds(pbolt.target)
                  || conjure_flame(&caster, splpow, pbolt.target, false)
-                    != spret_type::success)
+                    != spret::success)
                 && you.can_see(caster))
             {
                 canned_msg(MSG_NOTHING_HAPPENS);
@@ -809,7 +809,7 @@ static void _cast_grasping_roots(monster &caster, mon_spell_slot, bolt&)
 static bool _los_spell_worthwhile(const monster &mons, spell_type spell)
 {
     return trace_los_attack_spell(spell, mons_spellpower(mons, spell), &mons)
-           == spret_type::success;
+           == spret::success;
 }
 
 /// Set up a fake beam, for noise-generating purposes (?)
@@ -8042,9 +8042,9 @@ static bool _ms_waste_of_time(monster* mon, mon_spell_slot slot)
 
     case SPELL_OLGREBS_TOXIC_RADIANCE:
         return mon->has_ench(ENCH_TOXIC_RADIANCE)
-               || cast_toxic_radiance(mon, 100, false, true) != spret_type::success;
+               || cast_toxic_radiance(mon, 100, false, true) != spret::success;
     case SPELL_IGNITE_POISON:
-        return cast_ignite_poison(mon, 0, false, true) != spret_type::success;
+        return cast_ignite_poison(mon, 0, false, true) != spret::success;
 
     case SPELL_GLACIATE:
         return !foe

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -37,7 +37,7 @@ spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
     if (beam && is_player && needs_tracer
              && !player_tracer(ZAP_IOOD, pow, *beam))
     {
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -53,7 +53,7 @@ spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
     if (!mon)
     {
         mprf(MSGCH_ERROR, "Failed to spawn projectile.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (beam)
@@ -115,7 +115,7 @@ spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
             mon->foe = foe;
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -30,14 +30,14 @@
 
 static void _fuzz_direction(const actor *caster, monster& mon, int pow);
 
-spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
+spret cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
                      int foe, bool fail, bool needs_tracer)
 {
     const bool is_player = caster->is_player();
     if (beam && is_player && needs_tracer
              && !player_tracer(ZAP_IOOD, pow, *beam))
     {
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -53,7 +53,7 @@ spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
     if (!mon)
     {
         mprf(MSGCH_ERROR, "Failed to spawn projectile.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (beam)
@@ -115,7 +115,7 @@ spret_type cast_iood(actor *caster, int pow, bolt *beam, float vx, float vy,
             mon->foe = foe;
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**

--- a/crawl-ref/source/mon-project.h
+++ b/crawl-ref/source/mon-project.h
@@ -8,7 +8,7 @@
 #include "beam.h"
 #include "spl-cast.h"
 
-spret_type cast_iood(actor *caster, int pow, bolt *beam,
+spret cast_iood(actor *caster, int pow, bolt *beam,
                      float vx = 0, float vy = 0, int foe = MHITNOT,
                      bool fail = false, bool needs_tracer = true);
 void cast_iood_burst(int pow, coord_def target);

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -854,7 +854,7 @@ bool cast_a_spell(bool check_range, spell_type spell)
     dec_mp(cost, true);
 
     const spret_type cast_result = your_spells(spell, 0, true);
-    if (cast_result == SPRET_ABORT)
+    if (cast_result == spret_type::abort)
     {
         crawl_state.zero_turns_taken();
         // Return the MP since the spell is aborted.
@@ -863,8 +863,8 @@ bool cast_a_spell(bool check_range, spell_type spell)
         return false;
     }
 
-    practise_casting(spell, cast_result == SPRET_SUCCESS);
-    if (cast_result == SPRET_SUCCESS)
+    practise_casting(spell, cast_result == spret_type::success);
+    if (cast_result == spret_type::success)
     {
         did_god_conduct(DID_SPELL_CASTING, 1 + random2(5));
         count_action(CACT_CAST, spell);
@@ -1297,8 +1297,8 @@ vector<string> desc_success_chance(const monster_info& mi, int pow, bool evoked,
  *
  * @param evoked_item   The wand the spell was evoked from if applicable, or
                         nullptr.
- * @return SPRET_SUCCESS if spell is successfully cast for purposes of
- * exercising, SPRET_FAIL otherwise, or SPRET_ABORT if the player cancelled
+ * @return spret_type::success if spell is successfully cast for purposes of
+ * exercising, spret_type::fail otherwise, or spret_type::abort if the player cancelled
  * the casting.
  **/
 spret_type your_spells(spell_type spell, int powc, bool allow_fail,
@@ -1316,7 +1316,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
     // [dshaligram] Any action that depends on the spellcasting attempt to have
     // succeeded must be performed after the switch.
     if (!wiz_cast && _spellcasting_aborted(spell, !allow_fail))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     const unsigned int flags = get_spell_flags(spell);
 
@@ -1397,7 +1397,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
             args.self = CONFIRM_NONE;
         args.get_desc_func = additional_desc;
         if (!spell_direction(spd, beam, &args))
-            return SPRET_ABORT;
+            return spret_type::abort;
 
         beam.range = range;
 
@@ -1408,11 +1408,11 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
             else
                 canned_msg(MSG_UNTHINKING_ACT);
 
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         if (spd.isMe() && spell == SPELL_INVISIBILITY && !invis_allowed())
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
 
     if (evoked_item)
@@ -1445,7 +1445,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
     else
 #endif
     if (evoked_item && evoked_item->charges == 0)
-        return SPRET_FAIL;
+        return spret_type::fail;
     else if (allow_fail)
     {
         int spfl = random2avg(100, 3);
@@ -1507,7 +1507,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
 
     switch (cast_result)
     {
-    case SPRET_SUCCESS:
+    case spret_type::success:
     {
         if (you.props.exists("battlesphere") && allow_fail)
             trigger_battlesphere(&you, beam);
@@ -1524,13 +1524,13 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
             dithmenos_shadow_spell(&beam, spell);
         }
         _spellcasting_side_effects(spell, god, !allow_fail);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
-    case SPRET_FAIL:
+    case spret_type::fail:
     {
 #if TAG_MAJOR_VERSION == 34
         if (antimagic)
-            return SPRET_FAIL;
+            return spret_type::fail;
 #endif
 
         mprf("You miscast %s.", spell_title(spell));
@@ -1540,7 +1540,7 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
         if (decimal_chance(_chance_miscast_prot()))
         {
             simple_god_message(" protects you from the effects of your miscast!");
-            return SPRET_FAIL;
+            return spret_type::fail;
         }
 
         // All spell failures give a bit of magical radiation.
@@ -1559,19 +1559,19 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
         MiscastEffect(&you, nullptr, SPELL_MISCAST, spell,
                       spell_difficulty(spell), fail);
 
-        return SPRET_FAIL;
+        return spret_type::fail;
     }
 
-    case SPRET_ABORT:
-        return SPRET_ABORT;
+    case spret_type::abort:
+        return spret_type::abort;
 
-    case SPRET_NONE:
+    case spret_type::none:
 #ifdef WIZARD
         if (you.wizard && !allow_fail && is_valid_spell(spell)
             && (flags & SPFLAG_MONSTER))
         {
             _try_monster_cast(spell, powc, spd, beam);
-            return SPRET_SUCCESS;
+            return spret_type::success;
         }
 #endif
 
@@ -1583,14 +1583,14 @@ spret_type your_spells(spell_type spell, int powc, bool allow_fail,
         else
             mprf(MSGCH_ERROR, "Invalid spell!");
 
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
-// Returns SPRET_SUCCESS, SPRET_ABORT, SPRET_FAIL
-// or SPRET_NONE (not a player spell).
+// Returns spret_type::success, spret_type::abort, spret_type::fail
+// or spret_type::none (not a player spell).
 static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
                            bolt& beam, god_type god, bool fail)
 {
@@ -1598,7 +1598,7 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
     if (spell == SPELL_FREEZE || spell == SPELL_VAMPIRIC_DRAINING)
     {
         if (!adjacent(you.pos(), target))
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
 
     switch (spell)
@@ -1626,14 +1626,14 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
 
     // Demonspawn ability, no failure.
     case SPELL_CALL_DOWN_DAMNATION:
-        return cast_smitey_damnation(powc, beam) ? SPRET_SUCCESS : SPRET_ABORT;
+        return cast_smitey_damnation(powc, beam) ? spret_type::success : spret_type::abort;
 
     // LOS spells
 
     // Beogh ability, no failure.
     case SPELL_SMITING:
-        return cast_smiting(powc, monster_at(target)) ? SPRET_SUCCESS
-                                                      : SPRET_ABORT;
+        return cast_smiting(powc, monster_at(target)) ? spret_type::success
+                                                      : spret_type::abort;
 
     case SPELL_AIRSTRIKE:
         return cast_airstrike(powc, spd, fail);
@@ -1926,13 +1926,13 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
     // non-player spells that have a zap, but that shouldn't be called (e.g
     // because they will crash as a player zap).
     case SPELL_DRAIN_LIFE:
-        return SPRET_NONE;
+        return spret_type::none;
 
     default:
         if (spell_removed(spell))
         {
             mpr("Sorry, this spell is gone!");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
         break;
     }
@@ -1945,7 +1945,7 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
                        fail);
     }
 
-    return SPRET_NONE;
+    return spret_type::none;
 }
 
 // _tetrahedral_number: returns the nth tetrahedral number.

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -49,7 +49,7 @@ enum spflag_type
                                                  // used by Yred enslaved souls)
 };
 
-enum class spret_type
+enum class spret
 {
     abort = 0,            // should be left as 0
     fail,
@@ -70,7 +70,7 @@ enum class spret_type
 #define IOOD_FLAWED "iood_flawed"
 #define IOOD_TPOS "iood_tpos"
 
-#define fail_check() if (fail) return spret_type::fail
+#define fail_check() if (fail) return spret::fail
 
 void surge_power(const int enhanced);
 void surge_power_wand(const int mp_cost);
@@ -101,7 +101,7 @@ int hex_success_chance(const int mr, int powc, int scale,
 class targeter;
 vector<string> desc_success_chance(const monster_info& mi, int pow, bool evoked,
                                    targeter* hitfunc);
-spret_type your_spells(spell_type spell, int powc = 0, bool allow_fail = true,
+spret your_spells(spell_type spell, int powc = 0, bool allow_fail = true,
                        const item_def* const evoked_item = nullptr);
 
 extern const char *fail_severity_adjs[];

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -49,12 +49,12 @@ enum spflag_type
                                                  // used by Yred enslaved souls)
 };
 
-enum spret_type
+enum class spret_type
 {
-    SPRET_ABORT = 0,            // should be left as 0
-    SPRET_FAIL,
-    SPRET_SUCCESS,
-    SPRET_NONE,                 // spell was not handled
+    abort = 0,            // should be left as 0
+    fail,
+    success,
+    none,                 // spell was not handled
 };
 
 #define IOOD_X "iood_x"
@@ -70,7 +70,7 @@ enum spret_type
 #define IOOD_FLAWED "iood_flawed"
 #define IOOD_TPOS "iood_tpos"
 
-#define fail_check() if (fail) return SPRET_FAIL
+#define fail_check() if (fail) return spret_type::fail
 
 void surge_power(const int enhanced);
 void surge_power_wand(const int mp_cost);

--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -42,7 +42,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     {
         if (agent->is_player())
             mpr("That's too far away.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (cell_is_solid(where))
@@ -52,7 +52,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
             const char *feat = feat_type_name(grd(where));
             mprf("You can't place the cloud on %s.", article_a(feat).c_str());
         }
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     cloud_struct* cloud = cloud_at(where);
@@ -61,7 +61,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     {
         if (agent->is_player())
             mpr("There's already a cloud there!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     actor* victim = actor_at(where);
@@ -71,7 +71,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         {
             if (agent->is_player())
                 mpr("You can't place the cloud on a creature.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         fail_check();
@@ -79,7 +79,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         // FIXME: maybe should do _paranoid_option_disable() here?
         if (agent->is_player())
             canned_msg(MSG_GHOSTLY_OUTLINE);
-        return SPRET_SUCCESS;      // Don't give free detection!
+        return spret_type::success;      // Don't give free detection!
     }
 
     fail_check();
@@ -112,7 +112,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     }
     noisy(spell_effect_noise(SPELL_CONJURE_FLAME), where);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
@@ -120,7 +120,7 @@ spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster* mons = monster_at(beam.target);
@@ -128,25 +128,25 @@ spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
     {
         fail_check();
         canned_msg(MSG_SPELL_FIZZLES);
-        return SPRET_SUCCESS; // still losing a turn
+        return spret_type::success; // still losing a turn
     }
 
     if (actor_cloud_immune(*mons, CLOUD_POISON) && mons->observable())
     {
         mprf("But poisonous vapours would do no harm to %s!",
              mons->name(DESC_THE).c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     cloud_struct* cloud = cloud_at(beam.target);
     if (cloud && cloud->type != CLOUD_POISON)
     {
         // XXX: consider replacing the cloud instead?
         mpr("There's already a cloud there!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -167,7 +167,7 @@ spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
 
     behaviour_event(mons, ME_WHACK, &you);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
@@ -177,14 +177,14 @@ spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
         || !in_bounds(beam.target))
     {
         mpr("That is beyond the maximum range.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (cell_is_solid(beam.target))
     {
         const char *feat = feat_type_name(grd(beam.target));
         mprf("You can't place clouds on %s.", article_a(feat).c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     cloud_type cty = CLOUD_NONE;
@@ -208,7 +208,7 @@ spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
             break;
         default:
             mpr("That kind of cloud doesn't exist!");
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
 
     beam.thrower           = KILL_YOU;
@@ -219,13 +219,13 @@ spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
     beam.origin_spell      = spl;
     beam.affect_endpoint();
     if (beam.beam_cancelled)
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
     big_cloud(cty, caster, beam.target, pow, 8 + random2(3), -1);
     noisy(spell_effect_noise(spl), beam.target);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _make_a_normal_cloud(coord_def where, int pow, int spread_rate,
@@ -254,7 +254,7 @@ spret_type cast_ring_of_flames(int power, bool fail)
                           6 + (power / 10) + (random2(power) / 5), 50,
                           "The air around you leaps into flame!");
     manage_fire_shield(1);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void manage_fire_shield(int delay)
@@ -285,7 +285,7 @@ spret_type cast_corpse_rot(bool fail)
                 if (!yesno(("Really cast Corpse Rot while standing on " + si->name(DESC_A) + "?").c_str(), false, 'n'))
                 {
                     canned_msg(MSG_OK);
-                    return SPRET_ABORT;
+                    return spret_type::abort;
                 }
                 break;
             }
@@ -293,7 +293,7 @@ spret_type cast_corpse_rot(bool fail)
     }
     fail_check();
     corpse_rot(&you);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void corpse_rot(actor* caster)
@@ -384,7 +384,7 @@ spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
     {
         if (caster->is_player())
             mpr("The air is too still to form clouds.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // For monsters:
@@ -399,7 +399,7 @@ spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
     if (caster->is_player())
     {
         if (stop_attack_prompt(hitfunc, "cloud"))
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
 
     fail_check();
@@ -420,5 +420,5 @@ spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
          caster->conj_verb("create").c_str(),
          cloud_type_name(cloud).c_str());
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -33,7 +33,7 @@
 #include "terrain.h"
 #include "viewchar.h"
 
-spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
+spret conjure_flame(const actor *agent, int pow, const coord_def& where,
                          bool fail)
 {
     // FIXME: This would be better handled by a flag to enforce max range.
@@ -42,7 +42,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     {
         if (agent->is_player())
             mpr("That's too far away.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (cell_is_solid(where))
@@ -52,7 +52,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
             const char *feat = feat_type_name(grd(where));
             mprf("You can't place the cloud on %s.", article_a(feat).c_str());
         }
-        return spret_type::abort;
+        return spret::abort;
     }
 
     cloud_struct* cloud = cloud_at(where);
@@ -61,7 +61,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     {
         if (agent->is_player())
             mpr("There's already a cloud there!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     actor* victim = actor_at(where);
@@ -71,7 +71,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         {
             if (agent->is_player())
                 mpr("You can't place the cloud on a creature.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
@@ -79,7 +79,7 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
         // FIXME: maybe should do _paranoid_option_disable() here?
         if (agent->is_player())
             canned_msg(MSG_GHOSTLY_OUTLINE);
-        return spret_type::success;      // Don't give free detection!
+        return spret::success;      // Don't give free detection!
     }
 
     fail_check();
@@ -112,15 +112,15 @@ spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
     }
     noisy(spell_effect_noise(SPELL_CONJURE_FLAME), where);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
+spret cast_poisonous_vapours(int pow, const dist &beam, bool fail)
 {
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster* mons = monster_at(beam.target);
@@ -128,25 +128,25 @@ spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
     {
         fail_check();
         canned_msg(MSG_SPELL_FIZZLES);
-        return spret_type::success; // still losing a turn
+        return spret::success; // still losing a turn
     }
 
     if (actor_cloud_immune(*mons, CLOUD_POISON) && mons->observable())
     {
         mprf("But poisonous vapours would do no harm to %s!",
              mons->name(DESC_THE).c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
-        return spret_type::abort;
+        return spret::abort;
 
     cloud_struct* cloud = cloud_at(beam.target);
     if (cloud && cloud->type != CLOUD_POISON)
     {
         // XXX: consider replacing the cloud instead?
         mpr("There's already a cloud there!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -167,24 +167,24 @@ spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail)
 
     behaviour_event(mons, ME_WHACK, &you);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
+spret cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
                       bool fail)
 {
     if (grid_distance(beam.target, you.pos()) > beam.range
         || !in_bounds(beam.target))
     {
         mpr("That is beyond the maximum range.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (cell_is_solid(beam.target))
     {
         const char *feat = feat_type_name(grd(beam.target));
         mprf("You can't place clouds on %s.", article_a(feat).c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     cloud_type cty = CLOUD_NONE;
@@ -208,7 +208,7 @@ spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
             break;
         default:
             mpr("That kind of cloud doesn't exist!");
-            return spret_type::abort;
+            return spret::abort;
     }
 
     beam.thrower           = KILL_YOU;
@@ -219,13 +219,13 @@ spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
     beam.origin_spell      = spl;
     beam.affect_endpoint();
     if (beam.beam_cancelled)
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
     big_cloud(cty, caster, beam.target, pow, 8 + random2(3), -1);
     noisy(spell_effect_noise(spl), beam.target);
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _make_a_normal_cloud(coord_def where, int pow, int spread_rate,
@@ -247,14 +247,14 @@ void big_cloud(cloud_type cl_type, const actor *agent,
                      cl_type, agent, spread_rate, -1);
 }
 
-spret_type cast_ring_of_flames(int power, bool fail)
+spret cast_ring_of_flames(int power, bool fail)
 {
     fail_check();
     you.increase_duration(DUR_FIRE_SHIELD,
                           6 + (power / 10) + (random2(power) / 5), 50,
                           "The air around you leaps into flame!");
     manage_fire_shield(1);
-    return spret_type::success;
+    return spret::success;
 }
 
 void manage_fire_shield(int delay)
@@ -274,7 +274,7 @@ void manage_fire_shield(int delay)
             place_cloud(CLOUD_FIRE, *ai, 1 + random2(6), &you);
 }
 
-spret_type cast_corpse_rot(bool fail)
+spret cast_corpse_rot(bool fail)
 {
     if (!you.res_rotting())
     {
@@ -285,7 +285,7 @@ spret_type cast_corpse_rot(bool fail)
                 if (!yesno(("Really cast Corpse Rot while standing on " + si->name(DESC_A) + "?").c_str(), false, 'n'))
                 {
                     canned_msg(MSG_OK);
-                    return spret_type::abort;
+                    return spret::abort;
                 }
                 break;
             }
@@ -293,7 +293,7 @@ spret_type cast_corpse_rot(bool fail)
     }
     fail_check();
     corpse_rot(&you);
-    return spret_type::success;
+    return spret::success;
 }
 
 void corpse_rot(actor* caster)
@@ -377,14 +377,14 @@ random_pick_entry<cloud_type> cloud_cone_clouds[] =
   { 0,0,0,FLAT,CLOUD_NONE }
 };
 
-spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
+spret cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
                            bool fail)
 {
     if (env.level_state & LSTATE_STILL_WINDS)
     {
         if (caster->is_player())
             mpr("The air is too still to form clouds.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // For monsters:
@@ -399,7 +399,7 @@ spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
     if (caster->is_player())
     {
         if (stop_attack_prompt(hitfunc, "cloud"))
-            return spret_type::abort;
+            return spret::abort;
     }
 
     fail_check();
@@ -420,5 +420,5 @@ spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
          caster->conj_verb("create").c_str(),
          cloud_type_name(cloud).c_str());
 
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-clouds.h
+++ b/crawl-ref/source/spl-clouds.h
@@ -5,24 +5,24 @@
 struct bolt;
 class dist;
 
-spret_type conjure_flame(const actor *agent, int pow, const coord_def& where,
+spret conjure_flame(const actor *agent, int pow, const coord_def& where,
                          bool fail);
 
-spret_type cast_poisonous_vapours(int pow, const dist &beam, bool fail);
+spret cast_poisonous_vapours(int pow, const dist &beam, bool fail);
 
 void big_cloud(cloud_type cl_type, const actor *agent, const coord_def& where,
                int pow, int size, int spread_rate = -1);
 
-spret_type cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
+spret cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
                       bool fail);
 
-spret_type cast_ring_of_flames(int power, bool fail);
+spret cast_ring_of_flames(int power, bool fail);
 void manage_fire_shield(int delay);
 
-spret_type cast_corpse_rot(bool fail);
+spret cast_corpse_rot(bool fail);
 void corpse_rot(actor* caster);
 
 void holy_flames(monster* caster, actor* defender);
 
-spret_type cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
+spret cast_cloud_cone(const actor *caster, int pow, const coord_def &pos,
                            bool fail = false);

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -65,19 +65,19 @@ void setup_fire_storm(const actor *source, int pow, bolt &beam)
     beam.origin_spell = SPELL_FIRE_STORM;
 }
 
-spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
+spret cast_fire_storm(int pow, bolt &beam, bool fail)
 {
     if (grid_distance(beam.target, beam.source) > beam.range)
     {
         mpr("That is beyond the maximum range.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (cell_is_solid(beam.target))
     {
         const char *feat = feat_type_name(grd(beam.target));
         mprf("You can't place the storm on %s.", article_a(feat).c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     setup_fire_storm(&you, pow, beam);
@@ -88,7 +88,7 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
 
     tempbeam.explode(false);
     if (tempbeam.beam_cancelled)
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -97,7 +97,7 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
     beam.explode(false);
 
     viewwindow();
-    return spret_type::success;
+    return spret::success;
 }
 
 // No setup/cast split here as monster damnation is completely different.
@@ -141,7 +141,7 @@ bool cast_smitey_damnation(int pow, bolt &beam)
 }
 
 // XXX no friendly check
-spret_type cast_chain_spell(spell_type spell_cast, int pow,
+spret cast_chain_spell(spell_type spell_cast, int pow,
                             const actor *caster, bool fail)
 {
     fail_check();
@@ -336,7 +336,7 @@ spret_type cast_chain_spell(spell_type spell_cast, int pow,
         beam.fire();
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /*
@@ -513,7 +513,7 @@ static int _los_spell_damage_monster(const actor* agent, monster &target,
 }
 
 
-static spret_type _cast_los_attack_spell(spell_type spell, int pow,
+static spret _cast_los_attack_spell(spell_type spell, int pow,
                                          const actor* agent, actor* defender,
                                          bool actual, bool fail,
                                          int* damage_done)
@@ -522,7 +522,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
 
     const zap_type zap = spell_to_zap(spell);
     if (zap == NUM_ZAPS)
-        return spret_type::abort;
+        return spret::abort;
 
     bolt beam;
     zappy(zap, pow, mons, beam);
@@ -569,7 +569,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
             };
             break;
 
-        default: return spret_type::abort;
+        default: return spret::abort;
     }
 
     auto vul_hitfunc = [vulnerable](const actor *act) -> bool
@@ -586,7 +586,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
         if (spell != SPELL_SONIC_WAVE)
         {
             if (stop_attack_prompt(hitfunc, "harm", vul_hitfunc))
-                return spret_type::abort;
+                return spret::abort;
 
             fail_check();
         }
@@ -684,29 +684,29 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
         *damage_done = total_damage;
 
     if (actual)
-        return spret_type::success;
-    return mons_should_fire(beam) ? spret_type::success : spret_type::abort;
+        return spret::success;
+    return mons_should_fire(beam) ? spret::success : spret::abort;
 }
 
-spret_type trace_los_attack_spell(spell_type spell, int pow, const actor* agent)
+spret trace_los_attack_spell(spell_type spell, int pow, const actor* agent)
 {
     return _cast_los_attack_spell(spell, pow, agent, nullptr, false, false,
                                   nullptr);
 }
 
-spret_type fire_los_attack_spell(spell_type spell, int pow, const actor* agent,
+spret fire_los_attack_spell(spell_type spell, int pow, const actor* agent,
                                  actor *defender, bool fail, int* damage_done)
 {
     return _cast_los_attack_spell(spell, pow, agent, defender, true, fail,
                                   damage_done);
 }
 
-spret_type vampiric_drain(int pow, monster* mons, bool fail)
+spret vampiric_drain(int pow, monster* mons, bool fail)
 {
     if (you.hp == you.hp_max)
     {
         canned_msg(MSG_FULL_HEALTH);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (!mons || mons->submerged())
@@ -716,20 +716,20 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
         canned_msg(MSG_NOTHING_CLOSE_ENOUGH);
         // Cost to disallow freely locating invisible/submerged
         // monsters.
-        return spret_type::success;
+        return spret::success;
     }
 
     // TODO: check known rN instead of holiness
     if (mons->observable() && !(mons->holiness() & MH_NATURAL))
     {
         mpr("You can't drain life from that!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
     {
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -737,7 +737,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
     if (!mons->alive())
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::success;
+        return spret::success;
     }
 
     // The practical maximum of this is about 25 (pow @ 100). - bwr
@@ -751,7 +751,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
     if (!hp_gain)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::success;
+        return spret::success;
     }
 
     _player_hurt_monster(*mons, hp_gain, BEAM_NEG);
@@ -764,10 +764,10 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
         inc_hp(hp_gain);
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_freeze(int pow, monster* mons, bool fail)
+spret cast_freeze(int pow, monster* mons, bool fail)
 {
     pow = min(25, pow);
 
@@ -777,13 +777,13 @@ spret_type cast_freeze(int pow, monster* mons, bool fail)
         canned_msg(MSG_NOTHING_CLOSE_ENOUGH);
         // If there's no monster there, you still pay the costs in
         // order to prevent locating invisible/submerged monsters.
-        return spret_type::success;
+        return spret::success;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
     {
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -806,15 +806,15 @@ spret_type cast_freeze(int pow, monster* mons, bool fail)
     if (mons->alive())
         mons->expose_to_element(BEAM_COLD, orig_hurted);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_airstrike(int pow, const dist &beam, bool fail)
+spret cast_airstrike(int pow, const dist &beam, bool fail)
 {
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster* mons = monster_at(beam.target);
@@ -822,11 +822,11 @@ spret_type cast_airstrike(int pow, const dist &beam, bool fail)
     {
         fail_check();
         canned_msg(MSG_SPELL_FIZZLES);
-        return spret_type::success; // still losing a turn
+        return spret::success; // still losing a turn
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
-        return spret_type::abort;
+        return spret::abort;
     fail_check();
 
     god_conduct_trigger conducts[3];
@@ -849,7 +849,7 @@ spret_type cast_airstrike(int pow, const dist &beam, bool fail)
     dprf("preac: %d, postac: %d", preac, hurted);
     _player_hurt_monster(*mons, hurted, pbeam.flavour);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 // Here begin the actual spells:
@@ -1013,11 +1013,11 @@ static bool _shatterable(const actor *act)
     return _shatter_mon_dice(act->as_monster());
 }
 
-spret_type cast_shatter(int pow, bool fail)
+spret cast_shatter(int pow, bool fail)
 {
     targeter_los hitfunc(&you, LOS_ARENA);
     if (stop_attack_prompt(hitfunc, "attack", _shatterable))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
     const bool silence = silenced(you.pos());
@@ -1046,7 +1046,7 @@ spret_type cast_shatter(int pow, bool fail)
     if (dest && !silence)
         mprf(MSGCH_SOUND, "Ka-crash!");
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _shatter_player(int pow, actor *wielder, bool devastator = false)
@@ -1249,14 +1249,14 @@ static int _irradiate_cell(coord_def where, int pow, actor *agent)
  * @param pow   The power at which the spell is being cast.
  * @param who   The actor doing the irradiating.
  * @param fail  Whether the player has failed to cast the spell.
- * @return      spret_type::abort if the player changed their mind about casting after
- *              realizing they would hit an ally; spret_type::fail if they failed the
- *              cast chance; spret_type::success otherwise.
+ * @return      spret::abort if the player changed their mind about casting after
+ *              realizing they would hit an ally; spret::fail if they failed the
+ *              cast chance; spret::success otherwise.
  */
-spret_type cast_irradiate(int powc, actor* who, bool fail)
+spret cast_irradiate(int powc, actor* who, bool fail)
 {
     if (!_irradiate_is_safe())
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -1291,7 +1291,7 @@ spret_type cast_irradiate(int powc, actor* who, bool fail)
 
     if (who->is_player())
         contaminate_player(1000 + random2(500));
-    return spret_type::success;
+    return spret::success;
 }
 
 // How much work can we consider we'll have done by igniting a cloud here?
@@ -1556,13 +1556,13 @@ bool ignite_poison_affects(const actor* act)
  *                      player chooses not to abort the casting)
  * @param mon_tracer    Whether the 'casting' is just a tracer (a check to see
  *                      if it's worth actually casting)
- * @return              If it's a tracer, spret_type::success if the spell should
- *                      be cast & spret_type::abort otherwise.
- *                      If it's a real spell, spret_type::abort if the player chose
- *                      to abort the spell, spret_type::fail if they failed the cast
- *                      chance, and spret_type::success otherwise.
+ * @return              If it's a tracer, spret::success if the spell should
+ *                      be cast & spret::abort otherwise.
+ *                      If it's a real spell, spret::abort if the player chose
+ *                      to abort the spell, spret::fail if they failed the cast
+ *                      chance, and spret::success otherwise.
  */
-spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
+spret cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
 {
     if (tracer)
     {
@@ -1573,7 +1573,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
                  + _ignite_poison_player(where, -1, agent);
         }, agent->pos());
 
-        return work > 0 ? spret_type::success : spret_type::abort;
+        return work > 0 ? spret::success : spret::abort;
     }
 
     if (agent->is_player())
@@ -1581,7 +1581,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
         if (maybe_abort_ignite())
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
         fail_check();
     }
@@ -1608,7 +1608,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
         return 0; // ignored
     }, agent->pos());
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static void _ignition_square(const actor *agent, bolt beam, coord_def square, bool center)
@@ -1621,7 +1621,7 @@ static void _ignition_square(const actor *agent, bolt beam, coord_def square, bo
         noisy(spell_effect_noise(SPELL_IGNITION),square);
 }
 
-spret_type cast_ignition(const actor *agent, int pow, bool fail)
+spret cast_ignition(const actor *agent, int pow, bool fail)
 {
     ASSERT(agent->is_player());
 
@@ -1715,7 +1715,7 @@ spret_type cast_ignition(const actor *agent, int pow, bool fail)
             _ignition_square(agent, beam_actual, pos, false);
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _discharge_monsters(const coord_def &where, int pow,
@@ -1828,11 +1828,11 @@ bool safe_discharge(coord_def where, vector<const actor *> &exclude)
     return true;
 }
 
-spret_type cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
+spret cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
 {
     vector<const actor *> exclude;
     if (agent.is_player() && prompt && !safe_discharge(you.pos(), exclude))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -1859,7 +1859,7 @@ spret_type cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
                  plural ? " themselves" : "s itself");
         }
     }
-    return spret_type::success;
+    return spret::success;
 }
 
 bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
@@ -2093,7 +2093,7 @@ bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
     return true;
 }
 
-spret_type cast_fragmentation(int pow, const actor *caster,
+spret cast_fragmentation(int pow, const actor *caster,
                               const coord_def target, bool fail)
 {
     bool hole                = true;
@@ -2104,7 +2104,7 @@ spret_type cast_fragmentation(int pow, const actor *caster,
     if (!setup_fragmentation_beam(beam, pow, caster, target, false, &what,
                 hole))
     {
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (caster->is_player())
@@ -2118,7 +2118,7 @@ spret_type cast_fragmentation(int pow, const actor *caster,
         if (tempbeam.beam_cancelled)
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
     }
 
@@ -2157,10 +2157,10 @@ spret_type cast_fragmentation(int pow, const actor *caster,
 
     beam.explode(true, hole);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_sandblast(int pow, bolt &beam, bool fail)
+spret cast_sandblast(int pow, bolt &beam, bool fail)
 {
     item_def *stone = nullptr;
     int num_stones = 0;
@@ -2177,13 +2177,13 @@ spret_type cast_sandblast(int pow, bolt &beam, bool fail)
     if (num_stones == 0)
     {
         mpr("You don't have any stones to cast with.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     zap_type zap = ZAP_SANDBLAST;
-    const spret_type ret = zapping(zap, pow, beam, true, nullptr, fail);
+    const spret ret = zapping(zap, pow, beam, true, nullptr, fail);
 
-    if (ret == spret_type::success)
+    if (ret == spret::success)
     {
         if (dec_inv_item_quantity(letter_to_index(stone->slot), 1))
             mpr("You now have no stones remaining.");
@@ -2199,7 +2199,7 @@ static bool _elec_not_immune(const actor *act)
     return act->res_elec() < 3;
 }
 
-spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
+spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
 {
     coord_def prev;
 
@@ -2222,7 +2222,7 @@ spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
     if (caster->is_player()
         && stop_attack_prompt(hitfunc, "zap", _elec_not_immune))
     {
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -2285,7 +2285,7 @@ spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
     if (charges < LIGHTNING_MAX_CHARGE)
         charges++;
 
-    return spret_type::success;
+    return spret::success;
 }
 
 // Find an enemy who would suffer from Awaken Forest.
@@ -2498,21 +2498,21 @@ static bool _dazzle_can_hit(const actor *act)
         return false;
 }
 
-spret_type cast_dazzling_spray(int pow, coord_def aim, bool fail)
+spret cast_dazzling_spray(int pow, coord_def aim, bool fail)
 {
     int range = spell_range(SPELL_DAZZLING_SPRAY, pow);
 
     targeter_spray hitfunc(&you, range, ZAP_DAZZLING_SPRAY);
     hitfunc.set_aim(aim);
     if (stop_attack_prompt(hitfunc, "fire towards", _dazzle_can_hit))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
     if (hitfunc.beams.size() == 0)
     {
         mpr("You can't see any targets in that direction!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     for (bolt &beam : hitfunc.beams)
@@ -2521,7 +2521,7 @@ spret_type cast_dazzling_spray(int pow, coord_def aim, bool fail)
         beam.fire();
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static bool _toxic_can_affect(const actor *act)
@@ -2533,14 +2533,14 @@ static bool _toxic_can_affect(const actor *act)
     return act->res_poison() < (act->is_player() ? 3 : 1);
 }
 
-spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
+spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
 {
     if (agent->is_player())
     {
         targeter_los hitfunc(&you, LOS_NO_TRANS);
         {
             if (stop_attack_prompt(hitfunc, "poison", _toxic_can_affect))
-                return spret_type::abort;
+                return spret::abort;
         }
         fail_check();
 
@@ -2553,7 +2553,7 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
 
         flash_view_delay(UA_PLAYER, GREEN, 300, &hitfunc);
 
-        return spret_type::success;
+        return spret::success;
     }
     else if (mon_tracer)
     {
@@ -2562,11 +2562,11 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
             if (!_toxic_can_affect(*ai) || mons_aligned(agent, *ai))
                 continue;
             else
-                return spret_type::success;
+                return spret::success;
         }
 
         // Didn't find any susceptible targets
-        return spret_type::abort;
+        return spret::abort;
     }
     else
     {
@@ -2580,7 +2580,7 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
         targeter_los hitfunc(mon_agent, LOS_NO_TRANS);
         flash_view_delay(UA_MONSTER, GREEN, 300, &hitfunc);
 
-        return spret_type::success;
+        return spret::success;
     }
 }
 
@@ -2639,12 +2639,12 @@ void toxic_radiance_effect(actor* agent, int mult)
         remove_sanctuary(true);
 }
 
-spret_type cast_searing_ray(int pow, bolt &beam, bool fail)
+spret cast_searing_ray(int pow, bolt &beam, bool fail)
 {
-    const spret_type ret = zapping(ZAP_SEARING_RAY_I, pow, beam, true, nullptr,
+    const spret ret = zapping(ZAP_SEARING_RAY_I, pow, beam, true, nullptr,
                                    fail);
 
-    if (ret == spret_type::success)
+    if (ret == spret::success)
     {
         // Special value, used to avoid terminating ray immediately, since we
         // took a non-wait action on this turn (ie: casting it)
@@ -2738,7 +2738,7 @@ static bool _player_glaciate_affects(const actor *victim)
             && (!mons_is_avatar(mon->type) || !mons_aligned(&you, mon));
 }
 
-spret_type cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
+spret cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
 {
     const int range = spell_range(SPELL_GLACIATE, pow);
     targeter_cone hitfunc(caster, range);
@@ -2747,7 +2747,7 @@ spret_type cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
     if (caster->is_player()
         && stop_attack_prompt(hitfunc, "glaciate", _player_glaciate_affects))
     {
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -2822,17 +2822,17 @@ spret_type cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
 
     noisy(spell_effect_noise(SPELL_GLACIATE), hitfunc.origin);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_random_bolt(int pow, bolt& beam, bool fail)
+spret cast_random_bolt(int pow, bolt& beam, bool fail)
 {
     // Need to use a 'generic' tracer regardless of the actual beam type,
     // to account for the possibility of both bouncing and irresistible damage
     // (even though only one of these two ever occurs on the same bolt type).
     bolt tracer = beam;
     if (!player_tracer(ZAP_RANDOM_BOLT_TRACER, 200, tracer))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -2847,7 +2847,7 @@ spret_type cast_random_bolt(int pow, bolt& beam, bool fail)
     beam.origin_spell = SPELL_NO_SPELL; // let zapping reset this
     zapping(zap, pow * 7 / 6 + 15, beam, false);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 size_t shotgun_beam_count(int pow)
@@ -2855,7 +2855,7 @@ size_t shotgun_beam_count(int pow)
     return 1 + stepdown((pow - 5) / 3, 5, ROUND_CLOSE);
 }
 
-spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
+spret cast_scattershot(const actor *caster, int pow, const coord_def &pos,
                             bool fail)
 {
     const size_t range = spell_range(SPELL_SCATTERSHOT, pow);
@@ -2868,7 +2868,7 @@ spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
     if (caster->is_player())
     {
         if (stop_attack_prompt(hitfunc, "scattershot"))
-            return spret_type::abort;
+            return spret::abort;
     }
 
     fail_check();
@@ -2929,7 +2929,7 @@ spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
         print_wounds(*mons);
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static void _setup_borgnjors_vile_clutch(bolt &beam, int pow)
@@ -2947,12 +2947,12 @@ static void _setup_borgnjors_vile_clutch(bolt &beam, int pow)
     beam.origin_spell = SPELL_BORGNJORS_VILE_CLUTCH;
 }
 
-spret_type cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail)
+spret cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail)
 {
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -2961,5 +2961,5 @@ spret_type cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail)
     mpr("Decaying hands burst forth from the earth!");
     beam.explode();
 
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -70,14 +70,14 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
     if (grid_distance(beam.target, beam.source) > beam.range)
     {
         mpr("That is beyond the maximum range.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (cell_is_solid(beam.target))
     {
         const char *feat = feat_type_name(grd(beam.target));
         mprf("You can't place the storm on %s.", article_a(feat).c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     setup_fire_storm(&you, pow, beam);
@@ -88,7 +88,7 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
 
     tempbeam.explode(false);
     if (tempbeam.beam_cancelled)
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -97,7 +97,7 @@ spret_type cast_fire_storm(int pow, bolt &beam, bool fail)
     beam.explode(false);
 
     viewwindow();
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // No setup/cast split here as monster damnation is completely different.
@@ -336,7 +336,7 @@ spret_type cast_chain_spell(spell_type spell_cast, int pow,
         beam.fire();
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /*
@@ -522,7 +522,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
 
     const zap_type zap = spell_to_zap(spell);
     if (zap == NUM_ZAPS)
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     bolt beam;
     zappy(zap, pow, mons, beam);
@@ -569,7 +569,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
             };
             break;
 
-        default: return SPRET_ABORT;
+        default: return spret_type::abort;
     }
 
     auto vul_hitfunc = [vulnerable](const actor *act) -> bool
@@ -586,7 +586,7 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
         if (spell != SPELL_SONIC_WAVE)
         {
             if (stop_attack_prompt(hitfunc, "harm", vul_hitfunc))
-                return SPRET_ABORT;
+                return spret_type::abort;
 
             fail_check();
         }
@@ -684,8 +684,8 @@ static spret_type _cast_los_attack_spell(spell_type spell, int pow,
         *damage_done = total_damage;
 
     if (actual)
-        return SPRET_SUCCESS;
-    return mons_should_fire(beam) ? SPRET_SUCCESS : SPRET_ABORT;
+        return spret_type::success;
+    return mons_should_fire(beam) ? spret_type::success : spret_type::abort;
 }
 
 spret_type trace_los_attack_spell(spell_type spell, int pow, const actor* agent)
@@ -706,7 +706,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
     if (you.hp == you.hp_max)
     {
         canned_msg(MSG_FULL_HEALTH);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (!mons || mons->submerged())
@@ -716,20 +716,20 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
         canned_msg(MSG_NOTHING_CLOSE_ENOUGH);
         // Cost to disallow freely locating invisible/submerged
         // monsters.
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     // TODO: check known rN instead of holiness
     if (mons->observable() && !(mons->holiness() & MH_NATURAL))
     {
         mpr("You can't drain life from that!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
     {
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -737,7 +737,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
     if (!mons->alive())
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     // The practical maximum of this is about 25 (pow @ 100). - bwr
@@ -751,7 +751,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
     if (!hp_gain)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     _player_hurt_monster(*mons, hp_gain, BEAM_NEG);
@@ -764,7 +764,7 @@ spret_type vampiric_drain(int pow, monster* mons, bool fail)
         inc_hp(hp_gain);
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_freeze(int pow, monster* mons, bool fail)
@@ -777,13 +777,13 @@ spret_type cast_freeze(int pow, monster* mons, bool fail)
         canned_msg(MSG_NOTHING_CLOSE_ENOUGH);
         // If there's no monster there, you still pay the costs in
         // order to prevent locating invisible/submerged monsters.
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
     {
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -806,7 +806,7 @@ spret_type cast_freeze(int pow, monster* mons, bool fail)
     if (mons->alive())
         mons->expose_to_element(BEAM_COLD, orig_hurted);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_airstrike(int pow, const dist &beam, bool fail)
@@ -814,7 +814,7 @@ spret_type cast_airstrike(int pow, const dist &beam, bool fail)
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster* mons = monster_at(beam.target);
@@ -822,11 +822,11 @@ spret_type cast_airstrike(int pow, const dist &beam, bool fail)
     {
         fail_check();
         canned_msg(MSG_SPELL_FIZZLES);
-        return SPRET_SUCCESS; // still losing a turn
+        return spret_type::success; // still losing a turn
     }
 
     if (stop_attack_prompt(mons, false, you.pos()))
-        return SPRET_ABORT;
+        return spret_type::abort;
     fail_check();
 
     god_conduct_trigger conducts[3];
@@ -849,7 +849,7 @@ spret_type cast_airstrike(int pow, const dist &beam, bool fail)
     dprf("preac: %d, postac: %d", preac, hurted);
     _player_hurt_monster(*mons, hurted, pbeam.flavour);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // Here begin the actual spells:
@@ -1017,7 +1017,7 @@ spret_type cast_shatter(int pow, bool fail)
 {
     targeter_los hitfunc(&you, LOS_ARENA);
     if (stop_attack_prompt(hitfunc, "attack", _shatterable))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
     const bool silence = silenced(you.pos());
@@ -1046,7 +1046,7 @@ spret_type cast_shatter(int pow, bool fail)
     if (dest && !silence)
         mprf(MSGCH_SOUND, "Ka-crash!");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _shatter_player(int pow, actor *wielder, bool devastator = false)
@@ -1249,14 +1249,14 @@ static int _irradiate_cell(coord_def where, int pow, actor *agent)
  * @param pow   The power at which the spell is being cast.
  * @param who   The actor doing the irradiating.
  * @param fail  Whether the player has failed to cast the spell.
- * @return      SPRET_ABORT if the player changed their mind about casting after
- *              realizing they would hit an ally; SPRET_FAIL if they failed the
- *              cast chance; SPRET_SUCCESS otherwise.
+ * @return      spret_type::abort if the player changed their mind about casting after
+ *              realizing they would hit an ally; spret_type::fail if they failed the
+ *              cast chance; spret_type::success otherwise.
  */
 spret_type cast_irradiate(int powc, actor* who, bool fail)
 {
     if (!_irradiate_is_safe())
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -1291,7 +1291,7 @@ spret_type cast_irradiate(int powc, actor* who, bool fail)
 
     if (who->is_player())
         contaminate_player(1000 + random2(500));
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // How much work can we consider we'll have done by igniting a cloud here?
@@ -1556,11 +1556,11 @@ bool ignite_poison_affects(const actor* act)
  *                      player chooses not to abort the casting)
  * @param mon_tracer    Whether the 'casting' is just a tracer (a check to see
  *                      if it's worth actually casting)
- * @return              If it's a tracer, SPRET_SUCCESS if the spell should
- *                      be cast & SPRET_ABORT otherwise.
- *                      If it's a real spell, SPRET_ABORT if the player chose
- *                      to abort the spell, SPRET_FAIL if they failed the cast
- *                      chance, and SPRET_SUCCESS otherwise.
+ * @return              If it's a tracer, spret_type::success if the spell should
+ *                      be cast & spret_type::abort otherwise.
+ *                      If it's a real spell, spret_type::abort if the player chose
+ *                      to abort the spell, spret_type::fail if they failed the cast
+ *                      chance, and spret_type::success otherwise.
  */
 spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
 {
@@ -1573,7 +1573,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
                  + _ignite_poison_player(where, -1, agent);
         }, agent->pos());
 
-        return work > 0 ? SPRET_SUCCESS : SPRET_ABORT;
+        return work > 0 ? spret_type::success : spret_type::abort;
     }
 
     if (agent->is_player())
@@ -1581,7 +1581,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
         if (maybe_abort_ignite())
         {
             canned_msg(MSG_OK);
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
         fail_check();
     }
@@ -1608,7 +1608,7 @@ spret_type cast_ignite_poison(actor* agent, int pow, bool fail, bool tracer)
         return 0; // ignored
     }, agent->pos());
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static void _ignition_square(const actor *agent, bolt beam, coord_def square, bool center)
@@ -1715,7 +1715,7 @@ spret_type cast_ignition(const actor *agent, int pow, bool fail)
             _ignition_square(agent, beam_actual, pos, false);
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _discharge_monsters(const coord_def &where, int pow,
@@ -1832,7 +1832,7 @@ spret_type cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
 {
     vector<const actor *> exclude;
     if (agent.is_player() && prompt && !safe_discharge(you.pos(), exclude))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -1859,7 +1859,7 @@ spret_type cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
                  plural ? " themselves" : "s itself");
         }
     }
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
@@ -2104,7 +2104,7 @@ spret_type cast_fragmentation(int pow, const actor *caster,
     if (!setup_fragmentation_beam(beam, pow, caster, target, false, &what,
                 hole))
     {
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (caster->is_player())
@@ -2118,7 +2118,7 @@ spret_type cast_fragmentation(int pow, const actor *caster,
         if (tempbeam.beam_cancelled)
         {
             canned_msg(MSG_OK);
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
     }
 
@@ -2157,7 +2157,7 @@ spret_type cast_fragmentation(int pow, const actor *caster,
 
     beam.explode(true, hole);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_sandblast(int pow, bolt &beam, bool fail)
@@ -2177,13 +2177,13 @@ spret_type cast_sandblast(int pow, bolt &beam, bool fail)
     if (num_stones == 0)
     {
         mpr("You don't have any stones to cast with.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     zap_type zap = ZAP_SANDBLAST;
     const spret_type ret = zapping(zap, pow, beam, true, nullptr, fail);
 
-    if (ret == SPRET_SUCCESS)
+    if (ret == spret_type::success)
     {
         if (dec_inv_item_quantity(letter_to_index(stone->slot), 1))
             mpr("You now have no stones remaining.");
@@ -2222,7 +2222,7 @@ spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
     if (caster->is_player()
         && stop_attack_prompt(hitfunc, "zap", _elec_not_immune))
     {
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -2285,7 +2285,7 @@ spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
     if (charges < LIGHTNING_MAX_CHARGE)
         charges++;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // Find an enemy who would suffer from Awaken Forest.
@@ -2505,14 +2505,14 @@ spret_type cast_dazzling_spray(int pow, coord_def aim, bool fail)
     targeter_spray hitfunc(&you, range, ZAP_DAZZLING_SPRAY);
     hitfunc.set_aim(aim);
     if (stop_attack_prompt(hitfunc, "fire towards", _dazzle_can_hit))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
     if (hitfunc.beams.size() == 0)
     {
         mpr("You can't see any targets in that direction!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     for (bolt &beam : hitfunc.beams)
@@ -2521,7 +2521,7 @@ spret_type cast_dazzling_spray(int pow, coord_def aim, bool fail)
         beam.fire();
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static bool _toxic_can_affect(const actor *act)
@@ -2540,7 +2540,7 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
         targeter_los hitfunc(&you, LOS_NO_TRANS);
         {
             if (stop_attack_prompt(hitfunc, "poison", _toxic_can_affect))
-                return SPRET_ABORT;
+                return spret_type::abort;
         }
         fail_check();
 
@@ -2553,7 +2553,7 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
 
         flash_view_delay(UA_PLAYER, GREEN, 300, &hitfunc);
 
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
     else if (mon_tracer)
     {
@@ -2562,11 +2562,11 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
             if (!_toxic_can_affect(*ai) || mons_aligned(agent, *ai))
                 continue;
             else
-                return SPRET_SUCCESS;
+                return spret_type::success;
         }
 
         // Didn't find any susceptible targets
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
     else
     {
@@ -2580,7 +2580,7 @@ spret_type cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer
         targeter_los hitfunc(mon_agent, LOS_NO_TRANS);
         flash_view_delay(UA_MONSTER, GREEN, 300, &hitfunc);
 
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 }
 
@@ -2644,7 +2644,7 @@ spret_type cast_searing_ray(int pow, bolt &beam, bool fail)
     const spret_type ret = zapping(ZAP_SEARING_RAY_I, pow, beam, true, nullptr,
                                    fail);
 
-    if (ret == SPRET_SUCCESS)
+    if (ret == spret_type::success)
     {
         // Special value, used to avoid terminating ray immediately, since we
         // took a non-wait action on this turn (ie: casting it)
@@ -2747,7 +2747,7 @@ spret_type cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
     if (caster->is_player()
         && stop_attack_prompt(hitfunc, "glaciate", _player_glaciate_affects))
     {
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -2822,7 +2822,7 @@ spret_type cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
 
     noisy(spell_effect_noise(SPELL_GLACIATE), hitfunc.origin);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_random_bolt(int pow, bolt& beam, bool fail)
@@ -2832,7 +2832,7 @@ spret_type cast_random_bolt(int pow, bolt& beam, bool fail)
     // (even though only one of these two ever occurs on the same bolt type).
     bolt tracer = beam;
     if (!player_tracer(ZAP_RANDOM_BOLT_TRACER, 200, tracer))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -2847,7 +2847,7 @@ spret_type cast_random_bolt(int pow, bolt& beam, bool fail)
     beam.origin_spell = SPELL_NO_SPELL; // let zapping reset this
     zapping(zap, pow * 7 / 6 + 15, beam, false);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 size_t shotgun_beam_count(int pow)
@@ -2868,7 +2868,7 @@ spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
     if (caster->is_player())
     {
         if (stop_attack_prompt(hitfunc, "scattershot"))
-            return SPRET_ABORT;
+            return spret_type::abort;
     }
 
     fail_check();
@@ -2929,7 +2929,7 @@ spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
         print_wounds(*mons);
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static void _setup_borgnjors_vile_clutch(bolt &beam, int pow)
@@ -2952,7 +2952,7 @@ spret_type cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail)
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -2961,5 +2961,5 @@ spret_type cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail)
     mpr("Decaying hands burst forth from the earth!");
     beam.explode();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -8,42 +8,42 @@ struct bolt;
 class dist;
 
 void setup_fire_storm(const actor *source, int pow, bolt &beam);
-spret_type cast_fire_storm(int pow, bolt &beam, bool fail);
+spret cast_fire_storm(int pow, bolt &beam, bool fail);
 bool cast_smitey_damnation(int pow, bolt &beam);
-spret_type cast_chain_spell(spell_type spell_cast, int pow,
+spret cast_chain_spell(spell_type spell_cast, int pow,
                             const actor *caster, bool fail = false);
 
-spret_type trace_los_attack_spell(spell_type spell, int pow,
+spret trace_los_attack_spell(spell_type spell, int pow,
                                   const actor* agent);
-spret_type fire_los_attack_spell(spell_type spell, int pow, const actor* agent,
+spret fire_los_attack_spell(spell_type spell, int pow, const actor* agent,
                                  actor* defender = nullptr,
                                  bool fail = false,
                                  int* damage_done = nullptr);
 void sonic_damage(bool scream);
 bool mons_shatter(monster* caster, bool actual = true);
 void shillelagh(actor *wielder, coord_def where, int pow);
-spret_type vampiric_drain(int pow, monster* mons, bool fail);
-spret_type cast_freeze(int pow, monster* mons, bool fail);
-spret_type cast_airstrike(int pow, const dist &beam, bool fail);
-spret_type cast_shatter(int pow, bool fail);
-spret_type cast_irradiate(int powc, actor* who, bool fail);
+spret vampiric_drain(int pow, monster* mons, bool fail);
+spret cast_freeze(int pow, monster* mons, bool fail);
+spret cast_airstrike(int pow, const dist &beam, bool fail);
+spret cast_shatter(int pow, bool fail);
+spret cast_irradiate(int powc, actor* who, bool fail);
 bool ignite_poison_affects(const actor* act);
-spret_type cast_ignite_poison(actor *agent, int pow, bool fail,
+spret cast_ignite_poison(actor *agent, int pow, bool fail,
                               bool tracer = false);
 bool safe_discharge(coord_def where, vector<const actor *> &exclude);
-spret_type cast_discharge(int pow, const actor &agent, bool fail = false,
+spret cast_discharge(int pow, const actor &agent, bool fail = false,
                           bool prompt = true);
 bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
                               const coord_def target, bool quiet,
                               const char **what, bool &hole);
-spret_type cast_fragmentation(int powc, const actor *caster,
+spret cast_fragmentation(int powc, const actor *caster,
                               const coord_def target, bool fail);
-spret_type cast_sandblast(int powc, bolt &beam, bool fail);
-spret_type cast_tornado(int powc, bool fail);
+spret cast_sandblast(int powc, bolt &beam, bool fail);
+spret cast_tornado(int powc, bool fail);
 void tornado_damage(actor *caster, int dur, bool is_vortex = false);
 void cancel_tornado(bool tloc = false);
 void tornado_move(const coord_def &pos);
-spret_type cast_thunderbolt(actor *caster, int pow, coord_def aim,
+spret cast_thunderbolt(actor *caster, int pow, coord_def aim,
                             bool fail);
 
 actor* forest_near_enemy(const actor *mon);
@@ -53,25 +53,25 @@ void forest_damage(const actor *mon);
 
 vector<bolt> get_spray_rays(const actor *caster, coord_def aim, int range,
                             int max_rays, int max_spacing = 3);
-spret_type cast_dazzling_spray(int pow, coord_def aim, bool fail);
+spret cast_dazzling_spray(int pow, coord_def aim, bool fail);
 
-spret_type cast_toxic_radiance(actor *caster, int pow, bool fail = false,
+spret cast_toxic_radiance(actor *caster, int pow, bool fail = false,
                                bool mon_tracer = false);
 void toxic_radiance_effect(actor* agent, int mult);
 
-spret_type cast_searing_ray(int pow, bolt &beam, bool fail);
+spret cast_searing_ray(int pow, bolt &beam, bool fail);
 void handle_searing_ray();
 void end_searing_ray();
 
-spret_type cast_glaciate(actor *caster, int pow, coord_def aim,
+spret cast_glaciate(actor *caster, int pow, coord_def aim,
                          bool fail = false);
 
-spret_type cast_random_bolt(int pow, bolt& beam, bool fail = false);
+spret cast_random_bolt(int pow, bolt& beam, bool fail = false);
 
 size_t shotgun_beam_count(int pow);
-spret_type cast_scattershot(const actor *caster, int pow, const coord_def &pos,
+spret cast_scattershot(const actor *caster, int pow, const coord_def &pos,
                             bool fail = false);
 
-spret_type cast_ignition(const actor *caster, int pow, bool fail);
+spret cast_ignition(const actor *caster, int pow, bool fail);
 
-spret_type cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail);
+spret cast_borgnjors_vile_clutch(int pow, bolt &beam, bool fail);

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -172,10 +172,10 @@ static int _pacification_hp(monster_type mc)
  * @param healed        The amount of healing the pacification attempt uses.
  * @param pow           The healing power.
  * @param fail          Whether the healing invocation has failed (and will
- *                      return SPRET_FAILED after targeting checks finish).
+ *                      return spret_type::failED after targeting checks finish).
  * @return              Whether the pacification effect was aborted
- *                      (SPRET_ABORT) or the invocation failed (SPRET_FAIL);
- *                      returns SPRET_SUCCESS otherwise, regardless of whether
+ *                      (spret_type::abort) or the invocation failed (spret_type::fail);
+ *                      returns spret_type::success otherwise, regardless of whether
  *                      the target was actually pacified.
  */
 static spret_type _try_to_pacify(monster &mon, int healed, int pow,
@@ -186,7 +186,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
     if (!illegal_reason.empty())
     {
         mpr(illegal_reason);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -198,7 +198,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // monster avg hp too high to ever be pacified with your invo skill.
         mprf("%s would be completely unfazed by your meager offer of peace.",
              mon.name(DESC_THE).c_str());
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // Take the min of two rolls of 1d(_pacification_sides)
@@ -209,7 +209,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // not even close.
         mprf("The light of Elyvilon fails to reach %s.",
              mon.name(DESC_THE).c_str());
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     if (pacified_roll < mon_hp)
@@ -217,7 +217,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // closer! ...but not quite.
         mprf("The light of Elyvilon almost touches upon %s.",
              mon.name(DESC_THE).c_str());
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     // we did it!
@@ -247,7 +247,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
     mons_pacify(mon, ATT_NEUTRAL);
 
     heal_monster(mon, healed);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -333,11 +333,11 @@ spret_type cast_healing(int pow, bool fail)
     direction(spd, args);
 
     if (!spd.isValid)
-        return SPRET_ABORT;
+        return spret_type::abort;
     if (cell_is_solid(spd.target))
     {
         canned_msg(MSG_NOTHING_THERE);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster* mons = monster_at(spd.target);
@@ -346,7 +346,7 @@ spret_type cast_healing(int pow, bool fail)
         canned_msg(MSG_NOTHING_THERE);
         // This isn't a cancel, to avoid leaking invisible monster
         // locations.
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     if (_mons_hostile(mons))
@@ -357,7 +357,7 @@ spret_type cast_healing(int pow, bool fail)
     if (!heal_monster(*mons, healed))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /// Effects that occur when the player is debuffed.
@@ -1309,7 +1309,7 @@ spret_type cast_random_effects(int pow, bolt& beam, bool fail)
 {
     bolt tracer = beam;
     if (!player_tracer(ZAP_DEBUGGING_RAY, 200, tracer, LOS_RADIUS))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -1331,5 +1331,5 @@ spret_type cast_random_effects(int pow, bolt& beam, bool fail)
 
     zapping(zap, pow, beam, false);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -172,13 +172,13 @@ static int _pacification_hp(monster_type mc)
  * @param healed        The amount of healing the pacification attempt uses.
  * @param pow           The healing power.
  * @param fail          Whether the healing invocation has failed (and will
- *                      return spret_type::failED after targeting checks finish).
+ *                      return spret::failED after targeting checks finish).
  * @return              Whether the pacification effect was aborted
- *                      (spret_type::abort) or the invocation failed (spret_type::fail);
- *                      returns spret_type::success otherwise, regardless of whether
+ *                      (spret::abort) or the invocation failed (spret::fail);
+ *                      returns spret::success otherwise, regardless of whether
  *                      the target was actually pacified.
  */
-static spret_type _try_to_pacify(monster &mon, int healed, int pow,
+static spret _try_to_pacify(monster &mon, int healed, int pow,
                                  bool fail)
 {
     const monster_info mi(&mon);
@@ -186,7 +186,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
     if (!illegal_reason.empty())
     {
         mpr(illegal_reason);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -198,7 +198,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // monster avg hp too high to ever be pacified with your invo skill.
         mprf("%s would be completely unfazed by your meager offer of peace.",
              mon.name(DESC_THE).c_str());
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // Take the min of two rolls of 1d(_pacification_sides)
@@ -209,7 +209,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // not even close.
         mprf("The light of Elyvilon fails to reach %s.",
              mon.name(DESC_THE).c_str());
-        return spret_type::success;
+        return spret::success;
     }
 
     if (pacified_roll < mon_hp)
@@ -217,7 +217,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
         // closer! ...but not quite.
         mprf("The light of Elyvilon almost touches upon %s.",
              mon.name(DESC_THE).c_str());
-        return spret_type::success;
+        return spret::success;
     }
 
     // we did it!
@@ -247,7 +247,7 @@ static spret_type _try_to_pacify(monster &mon, int healed, int pow,
     mons_pacify(mon, ATT_NEUTRAL);
 
     heal_monster(mon, healed);
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -314,7 +314,7 @@ static vector<string> _desc_pacify_chance(const monster_info& mi, const int pow)
     return descs;
 }
 
-spret_type cast_healing(int pow, bool fail)
+spret cast_healing(int pow, bool fail)
 {
     // This arithmetic is to make the healing amount match Greater Healing
     const int base = div_rand_round(pow, 3);
@@ -333,11 +333,11 @@ spret_type cast_healing(int pow, bool fail)
     direction(spd, args);
 
     if (!spd.isValid)
-        return spret_type::abort;
+        return spret::abort;
     if (cell_is_solid(spd.target))
     {
         canned_msg(MSG_NOTHING_THERE);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster* mons = monster_at(spd.target);
@@ -346,7 +346,7 @@ spret_type cast_healing(int pow, bool fail)
         canned_msg(MSG_NOTHING_THERE);
         // This isn't a cancel, to avoid leaking invisible monster
         // locations.
-        return spret_type::success;
+        return spret::success;
     }
 
     if (_mons_hostile(mons))
@@ -357,7 +357,7 @@ spret_type cast_healing(int pow, bool fail)
     if (!heal_monster(*mons, healed))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /// Effects that occur when the player is debuffed.
@@ -1305,11 +1305,11 @@ void cleansing_flame(int pow, int caster, coord_def where,
     beam.explode();
 }
 
-spret_type cast_random_effects(int pow, bolt& beam, bool fail)
+spret cast_random_effects(int pow, bolt& beam, bool fail)
 {
     bolt tracer = beam;
     if (!player_tracer(ZAP_DEBUGGING_RAY, 200, tracer, LOS_RADIUS))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -1331,5 +1331,5 @@ spret_type cast_random_effects(int pow, bolt& beam, bool fail)
 
     zapping(zap, pow, beam, false);
 
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-goditem.h
+++ b/crawl-ref/source/spl-goditem.h
@@ -6,7 +6,7 @@
 #include "spl-cast.h"
 #include "torment-source-type.h"
 
-spret_type cast_healing(int pow, bool fail);
+spret cast_healing(int pow, bool fail);
 bool heal_monster(monster& patient, int amount);
 
 /// List of monster enchantments which can be dispelled.
@@ -84,4 +84,4 @@ void setup_cleansing_flame_beam(bolt &beam, int pow, int caster,
 void cleansing_flame(int pow, int caster, coord_def where,
                      actor *attacker = nullptr);
 
-spret_type cast_random_effects(int pow, bolt& beam, bool fail);
+spret cast_random_effects(int pow, bolt& beam, bool fail);

--- a/crawl-ref/source/spl-monench.cc
+++ b/crawl-ref/source/spl-monench.cc
@@ -60,14 +60,14 @@ int englaciate(coord_def where, int pow, actor *agent)
     return do_slow_monster(*mons, agent, duration);
 }
 
-spret_type cast_englaciation(int pow, bool fail)
+spret cast_englaciation(int pow, bool fail)
 {
     fail_check();
     mpr("You radiate an aura of cold.");
     apply_area_visible([pow] (coord_def where) {
         return englaciate(where, pow, &you);
     }, you.pos());
-    return spret_type::success;
+    return spret::success;
 }
 
 /** Corona a monster.

--- a/crawl-ref/source/spl-monench.cc
+++ b/crawl-ref/source/spl-monench.cc
@@ -67,7 +67,7 @@ spret_type cast_englaciation(int pow, bool fail)
     apply_area_visible([pow] (coord_def where) {
         return englaciate(where, pow, &you);
     }, you.pos());
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /** Corona a monster.

--- a/crawl-ref/source/spl-monench.h
+++ b/crawl-ref/source/spl-monench.h
@@ -3,7 +3,7 @@
 #include "spl-cast.h"
 
 int englaciate(coord_def where, int pow, actor *agent);
-spret_type cast_englaciation(int pow, bool fail);
+spret cast_englaciation(int pow, bool fail);
 bool backlight_monster(monster* mons);
 
 //returns true if it slowed the monster

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -66,7 +66,7 @@ spret_type cast_sublimation_of_blood(int pow, bool fail)
             mpr("Your attempt to draw power from your own body fails.");
     }
 
-    return success ? SPRET_SUCCESS : SPRET_ABORT;
+    return success ? spret_type::success : spret_type::abort;
 }
 
 spret_type cast_death_channel(int pow, god_type god, bool fail)
@@ -74,7 +74,7 @@ spret_type cast_death_channel(int pow, god_type god, bool fail)
     if (you.duration[DUR_DEATH_CHANNEL] >= 60 * BASELINE_DELAY)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -85,14 +85,14 @@ spret_type cast_death_channel(int pow, god_type god, bool fail)
     if (god != GOD_NO_GOD)
         you.attribute[ATTR_DIVINE_DEATH_CHANNEL] = static_cast<int>(god);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_recall(bool fail)
 {
     fail_check();
     start_recall(RECALL_SPELL);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void start_recall(recall_t type)
@@ -396,7 +396,7 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
     {
         if (fail_msg.size())
             mpr(fail_msg);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -409,7 +409,7 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
     else if (p.check_moveto())
     {
         start_delay<PasswallDelay>(p.actual_walls() + 1, p.actual_dest);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     // at this point, the spell failed or was cancelled. Does it cost MP?
@@ -423,9 +423,9 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
         // are standing next to the map edge, which is a leak of sorts, but
         // already apparent from the targeting (and we leak this info all over
         // the place, really).
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _intoxicate_monsters(coord_def where, int pow)
@@ -466,7 +466,7 @@ spret_type cast_intoxicate(int pow, bool fail)
         }
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_darkness(int pow, bool fail)
@@ -479,5 +479,5 @@ spret_type cast_darkness(int pow, bool fail)
     you.increase_duration(DUR_DARKNESS, 15 + random2(1 + pow/3), 100);
     update_vision_range();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -25,7 +25,7 @@
 #include "spl-util.h"
 #include "terrain.h"
 
-spret_type cast_sublimation_of_blood(int pow, bool fail)
+spret cast_sublimation_of_blood(int pow, bool fail)
 {
     bool success = false;
 
@@ -66,15 +66,15 @@ spret_type cast_sublimation_of_blood(int pow, bool fail)
             mpr("Your attempt to draw power from your own body fails.");
     }
 
-    return success ? spret_type::success : spret_type::abort;
+    return success ? spret::success : spret::abort;
 }
 
-spret_type cast_death_channel(int pow, god_type god, bool fail)
+spret cast_death_channel(int pow, god_type god, bool fail)
 {
     if (you.duration[DUR_DEATH_CHANNEL] >= 60 * BASELINE_DELAY)
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -85,14 +85,14 @@ spret_type cast_death_channel(int pow, god_type god, bool fail)
     if (god != GOD_NO_GOD)
         you.attribute[ATTR_DIVINE_DEATH_CHANNEL] = static_cast<int>(god);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_recall(bool fail)
+spret cast_recall(bool fail)
 {
     fail_check();
     start_recall(RECALL_SPELL);
-    return spret_type::success;
+    return spret::success;
 }
 
 void start_recall(recall_t type)
@@ -386,7 +386,7 @@ bool passwall_path::check_moveto() const
 
 }
 
-spret_type cast_passwall(const coord_def& c, int pow, bool fail)
+spret cast_passwall(const coord_def& c, int pow, bool fail)
 {
     coord_def delta = c - you.pos();
     passwall_path p(you, delta, spell_range(SPELL_PASSWALL, pow));
@@ -396,7 +396,7 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
     {
         if (fail_msg.size())
             mpr(fail_msg);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -409,7 +409,7 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
     else if (p.check_moveto())
     {
         start_delay<PasswallDelay>(p.actual_walls() + 1, p.actual_dest);
-        return spret_type::success;
+        return spret::success;
     }
 
     // at this point, the spell failed or was cancelled. Does it cost MP?
@@ -423,9 +423,9 @@ spret_type cast_passwall(const coord_def& c, int pow, bool fail)
         // are standing next to the map edge, which is a leak of sorts, but
         // already apparent from the targeting (and we leak this info all over
         // the place, really).
-        return spret_type::abort;
+        return spret::abort;
     }
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _intoxicate_monsters(coord_def where, int pow)
@@ -449,7 +449,7 @@ static int _intoxicate_monsters(coord_def where, int pow)
     return 0;
 }
 
-spret_type cast_intoxicate(int pow, bool fail)
+spret cast_intoxicate(int pow, bool fail)
 {
     fail_check();
     mpr("You attempt to intoxicate your foes!");
@@ -466,10 +466,10 @@ spret_type cast_intoxicate(int pow, bool fail)
         }
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_darkness(int pow, bool fail)
+spret cast_darkness(int pow, bool fail)
 {
     fail_check();
     if (you.duration[DUR_DARKNESS])
@@ -479,5 +479,5 @@ spret_type cast_darkness(int pow, bool fail)
     you.increase_duration(DUR_DARKNESS, 15 + random2(1 + pow/3), 100);
     update_vision_range();
 
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-other.h
+++ b/crawl-ref/source/spl-other.h
@@ -3,8 +3,8 @@
 #include "god-type.h"
 #include "spl-cast.h"
 
-spret_type cast_sublimation_of_blood(int pow, bool fail);
-spret_type cast_death_channel(int pow, god_type god, bool fail);
+spret cast_sublimation_of_blood(int pow, bool fail);
+spret cast_death_channel(int pow, god_type god, bool fail);
 
 enum recall_t
 {
@@ -32,13 +32,13 @@ struct passwall_path
     vector <coord_def> possible_dests() const;
 };
 
-spret_type cast_recall(bool fail);
+spret cast_recall(bool fail);
 void start_recall(recall_t type);
 void recall_orders(monster *mons);
 bool try_recall(mid_t mid);
 void do_recall(int time);
 void end_recall();
 
-spret_type cast_passwall(const coord_def& delta, int pow, bool fail);
-spret_type cast_intoxicate(int pow, bool fail);
-spret_type cast_darkness(int pow, bool fail);
+spret cast_passwall(const coord_def& delta, int pow, bool fail);
+spret cast_intoxicate(int pow, bool fail);
+spret cast_darkness(int pow, bool fail);

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -51,7 +51,7 @@ spret_type cast_deaths_door(int pow, bool fail)
 
     if (you.duration[DUR_DEATHS_DOOR] > 25 * BASELINE_DELAY)
         you.duration[DUR_DEATHS_DOOR] = (23 + random2(5)) * BASELINE_DELAY;
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void remove_ice_armour()
@@ -82,7 +82,7 @@ spret_type ice_armour(int pow, bool fail)
     you.props[ICY_ARMOUR_KEY] = pow;
     you.redraw_armour_class = true;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type deflection(int pow, bool fail)
@@ -91,7 +91,7 @@ spret_type deflection(int pow, bool fail)
     you.attribute[ATTR_DEFLECT_MISSILES] = 1;
     mpr("You feel very safe from missiles.");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_regen(int pow, bool fail)
@@ -100,7 +100,7 @@ spret_type cast_regen(int pow, bool fail)
     you.increase_duration(DUR_REGENERATION, 5 + roll_dice(2, pow / 3 + 1), 100,
                           "Your skin crawls.");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_revivification(int pow, bool fail)
@@ -119,7 +119,7 @@ spret_type cast_revivification(int pow, bool fail)
         paralyse_player("Death's Door abortion");
         you.duration[DUR_DEATHS_DOOR] = 0;
     }
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_swiftness(int power, bool fail)
@@ -137,7 +137,7 @@ spret_type cast_swiftness(int power, bool fail)
                      "You feel quick.");
     you.attribute[ATTR_SWIFTNESS] = you.duration[DUR_SWIFTNESS];
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 int cast_selective_amnesia(const string &pre_msg)
@@ -196,7 +196,7 @@ spret_type cast_infusion(int pow, bool fail)
     you.increase_duration(DUR_INFUSION,  8 + roll_dice(2, pow), 100);
     you.props["infusion_power"] = pow;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_song_of_slaying(int pow, bool fail)
@@ -211,7 +211,7 @@ spret_type cast_song_of_slaying(int pow, bool fail)
     you.set_duration(DUR_SONG_OF_SLAYING, 20 + random2avg(pow, 2));
 
     you.props[SONG_OF_SLAYING_KEY] = 0;
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_silence(int pow, bool fail)
@@ -226,7 +226,7 @@ spret_type cast_silence(int pow, bool fail)
         you.update_beholders();
 
     learned_something_new(HINT_YOU_SILENCE);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_liquefaction(int pow, bool fail)
@@ -240,7 +240,7 @@ spret_type cast_liquefaction(int pow, bool fail)
 
     you.increase_duration(DUR_LIQUEFYING, 10 + random2avg(pow, 2), 100);
     invalidate_agrid(true);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_shroud_of_golubria(int pow, bool fail)
@@ -252,7 +252,7 @@ spret_type cast_shroud_of_golubria(int pow, bool fail)
         mpr("Space distorts slightly along a thin shroud covering your body.");
 
     you.increase_duration(DUR_SHROUD_OF_GOLUBRIA, 7 + roll_dice(2, pow), 50);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_transform(int pow, transformation which_trans, bool fail)
@@ -260,10 +260,10 @@ spret_type cast_transform(int pow, transformation which_trans, bool fail)
     if (!transform(pow, which_trans, false, true)
         || !check_form_stat_safety(which_trans))
     {
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
     transform(pow, which_trans);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -38,7 +38,7 @@ int allowed_deaths_door_hp()
     return max(hp, 1);
 }
 
-spret_type cast_deaths_door(int pow, bool fail)
+spret cast_deaths_door(int pow, bool fail)
 {
     fail_check();
     mpr("You stand defiantly in death's doorway!");
@@ -51,7 +51,7 @@ spret_type cast_deaths_door(int pow, bool fail)
 
     if (you.duration[DUR_DEATHS_DOOR] > 25 * BASELINE_DELAY)
         you.duration[DUR_DEATHS_DOOR] = (23 + random2(5)) * BASELINE_DELAY;
-    return spret_type::success;
+    return spret::success;
 }
 
 void remove_ice_armour()
@@ -61,7 +61,7 @@ void remove_ice_armour()
     you.duration[DUR_ICY_ARMOUR] = 0;
 }
 
-spret_type ice_armour(int pow, bool fail)
+spret ice_armour(int pow, bool fail)
 {
     fail_check();
 
@@ -82,28 +82,28 @@ spret_type ice_armour(int pow, bool fail)
     you.props[ICY_ARMOUR_KEY] = pow;
     you.redraw_armour_class = true;
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type deflection(int pow, bool fail)
+spret deflection(int pow, bool fail)
 {
     fail_check();
     you.attribute[ATTR_DEFLECT_MISSILES] = 1;
     mpr("You feel very safe from missiles.");
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_regen(int pow, bool fail)
+spret cast_regen(int pow, bool fail)
 {
     fail_check();
     you.increase_duration(DUR_REGENERATION, 5 + roll_dice(2, pow / 3 + 1), 100,
                           "Your skin crawls.");
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_revivification(int pow, bool fail)
+spret cast_revivification(int pow, bool fail)
 {
     fail_check();
     mpr("Your body is healed in an amazingly painful way.");
@@ -119,10 +119,10 @@ spret_type cast_revivification(int pow, bool fail)
         paralyse_player("Death's Door abortion");
         you.duration[DUR_DEATHS_DOOR] = 0;
     }
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_swiftness(int power, bool fail)
+spret cast_swiftness(int power, bool fail)
 {
     fail_check();
 
@@ -137,7 +137,7 @@ spret_type cast_swiftness(int power, bool fail)
                      "You feel quick.");
     you.attribute[ATTR_SWIFTNESS] = you.duration[DUR_SWIFTNESS];
 
-    return spret_type::success;
+    return spret::success;
 }
 
 int cast_selective_amnesia(const string &pre_msg)
@@ -185,7 +185,7 @@ int cast_selective_amnesia(const string &pre_msg)
     return -1;
 }
 
-spret_type cast_infusion(int pow, bool fail)
+spret cast_infusion(int pow, bool fail)
 {
     fail_check();
     if (!you.duration[DUR_INFUSION])
@@ -196,10 +196,10 @@ spret_type cast_infusion(int pow, bool fail)
     you.increase_duration(DUR_INFUSION,  8 + roll_dice(2, pow), 100);
     you.props["infusion_power"] = pow;
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_song_of_slaying(int pow, bool fail)
+spret cast_song_of_slaying(int pow, bool fail)
 {
     fail_check();
 
@@ -211,10 +211,10 @@ spret_type cast_song_of_slaying(int pow, bool fail)
     you.set_duration(DUR_SONG_OF_SLAYING, 20 + random2avg(pow, 2));
 
     you.props[SONG_OF_SLAYING_KEY] = 0;
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_silence(int pow, bool fail)
+spret cast_silence(int pow, bool fail)
 {
     fail_check();
     mpr("A profound silence engulfs you.");
@@ -226,10 +226,10 @@ spret_type cast_silence(int pow, bool fail)
         you.update_beholders();
 
     learned_something_new(HINT_YOU_SILENCE);
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_liquefaction(int pow, bool fail)
+spret cast_liquefaction(int pow, bool fail)
 {
     fail_check();
     flash_view_delay(UA_PLAYER, BROWN, 80);
@@ -240,10 +240,10 @@ spret_type cast_liquefaction(int pow, bool fail)
 
     you.increase_duration(DUR_LIQUEFYING, 10 + random2avg(pow, 2), 100);
     invalidate_agrid(true);
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_shroud_of_golubria(int pow, bool fail)
+spret cast_shroud_of_golubria(int pow, bool fail)
 {
     fail_check();
     if (you.duration[DUR_SHROUD_OF_GOLUBRIA])
@@ -252,18 +252,18 @@ spret_type cast_shroud_of_golubria(int pow, bool fail)
         mpr("Space distorts slightly along a thin shroud covering your body.");
 
     you.increase_duration(DUR_SHROUD_OF_GOLUBRIA, 7 + roll_dice(2, pow), 50);
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_transform(int pow, transformation which_trans, bool fail)
+spret cast_transform(int pow, transformation which_trans, bool fail)
 {
     if (!transform(pow, which_trans, false, true)
         || !check_form_stat_safety(which_trans))
     {
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
     transform(pow, which_trans);
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-selfench.h
+++ b/crawl-ref/source/spl-selfench.h
@@ -5,27 +5,27 @@
 #include "transformation.h"
 
 int allowed_deaths_door_hp();
-spret_type cast_deaths_door(int pow, bool fail);
+spret cast_deaths_door(int pow, bool fail);
 void remove_ice_armour();
-spret_type ice_armour(int pow, bool fail);
+spret ice_armour(int pow, bool fail);
 
 int harvest_corpses(const actor &harvester,
                     bool dry_run = false, bool defy_god = false);
-spret_type corpse_armour(int pow, bool fail);
+spret corpse_armour(int pow, bool fail);
 
-spret_type deflection(int pow, bool fail);
+spret deflection(int pow, bool fail);
 
-spret_type cast_regen(int pow, bool fail);
-spret_type cast_revivification(int pow, bool fail);
+spret cast_regen(int pow, bool fail);
+spret cast_revivification(int pow, bool fail);
 
-spret_type cast_swiftness(int power, bool fail);
+spret cast_swiftness(int power, bool fail);
 
 int cast_selective_amnesia(const string &pre_msg = "");
-spret_type cast_silence(int pow, bool fail = false);
+spret cast_silence(int pow, bool fail = false);
 
-spret_type cast_infusion(int pow, bool fail);
-spret_type cast_song_of_slaying(int pow, bool fail);
+spret cast_infusion(int pow, bool fail);
+spret cast_song_of_slaying(int pow, bool fail);
 
-spret_type cast_liquefaction(int pow, bool fail);
-spret_type cast_shroud_of_golubria(int pow, bool fail);
-spret_type cast_transform(int pow, transformation which_trans, bool fail);
+spret cast_liquefaction(int pow, bool fail);
+spret cast_shroud_of_golubria(int pow, bool fail);
+spret cast_transform(int pow, transformation which_trans, bool fail);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -90,7 +90,7 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
     return _summon_data(you, pal, dur, god, spell);
 }
 
-spret_type cast_summon_butterflies(int pow, god_type god, bool fail)
+spret cast_summon_butterflies(int pow, god_type god, bool fail)
 {
     fail_check();
     bool success = false;
@@ -109,10 +109,10 @@ spret_type cast_summon_butterflies(int pow, god_type god, bool fail)
     if (!success)
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_small_mammal(int pow, god_type god, bool fail)
+spret cast_summon_small_mammal(int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -126,10 +126,10 @@ spret_type cast_summon_small_mammal(int pow, god_type god, bool fail)
     if (!create_monster(_pal_data(mon, 3, god, SPELL_SUMMON_SMALL_MAMMAL)))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
+spret cast_sticks_to_snakes(int pow, god_type god, bool fail)
 {
     // The first items placed into this list will be the first
     // to be converted; for players with bow skill we prefer
@@ -155,7 +155,7 @@ spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
     if (valid_sticks.empty())
     {
         mpr("You don't have anything to turn into a snake.");
-        return spret_type::abort;
+        return spret::abort;
     }
     // Sort by the quantity if the player has no bow skill; this will
     // put arrows with the smallest quantity first in line
@@ -222,10 +222,10 @@ spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
     else
         mpr("You fail to create any snakes.");
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_call_canine_familiar(int pow, god_type god, bool fail)
+spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 {
     fail_check();
     monster_type mon = MONS_PROGRAM_BUG;
@@ -244,10 +244,10 @@ spret_type cast_call_canine_familiar(int pow, god_type god, bool fail)
     if (!create_monster(_pal_data(mon, dur, god, SPELL_CALL_CANINE_FAMILIAR)))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_ice_beast(int pow, god_type god, bool fail)
+spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 {
     fail_check();
     const int dur = min(2 + (random2(pow) / 4), 4);
@@ -261,10 +261,10 @@ spret_type cast_summon_ice_beast(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
+spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 {
     fail_check();
     monster_type type = MONS_PROGRAM_BUG;
@@ -327,10 +327,10 @@ spret_type cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool f
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
+spret cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
 {
     fail_check();
     // Power determines number of heads. Minimum 4 heads, maximum 12.
@@ -350,7 +350,7 @@ spret_type cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
     else if (caster->is_player())
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static monster_type _choose_dragon_type(int pow, god_type god, bool player)
@@ -373,13 +373,13 @@ static monster_type _choose_dragon_type(int pow, god_type god, bool player)
     return mon;
 }
 
-spret_type cast_dragon_call(int pow, bool fail)
+spret cast_dragon_call(int pow, bool fail)
 {
     if (you.duration[DUR_DRAGON_CALL]
         || you.duration[DUR_DRAGON_CALL_COOLDOWN])
     {
         mpr("You cannot issue another dragon's call so soon.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -389,7 +389,7 @@ spret_type cast_dragon_call(int pow, bool fail)
 
     you.duration[DUR_DRAGON_CALL] = (15 + pow / 5 + random2(15)) * BASELINE_DELAY;
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static void _place_dragon()
@@ -537,7 +537,7 @@ void doom_howl(int time)
     }
 }
 
-spret_type cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
+spret cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
 {
     // Dragons are always friendly. Dragon type depends on power and
     // random chance, with two low-tier dragons possible at high power.
@@ -569,10 +569,10 @@ spret_type cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
     if (!success && caster->is_player())
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_mana_viper(int pow, god_type god, bool fail)
+spret cast_summon_mana_viper(int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -588,7 +588,7 @@ spret_type cast_summon_mana_viper(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 // This assumes that the specified monster can go berserk.
@@ -699,7 +699,7 @@ bool summon_holy_warrior(int pow, bool punish)
  * information about invisible enemies. (Not implemented as a macro because I
  * find they create unreadable code.)
  *
- * @return spret_type::success
+ * @return spret::success
  **/
 static bool _fail_tukimas()
 {
@@ -887,7 +887,7 @@ void cast_tukimas_dance(int pow, actor* target)
     _animate_weapon(pow, target);
 }
 
-spret_type cast_conjure_ball_lightning(int pow, god_type god, bool fail)
+spret cast_conjure_ball_lightning(int pow, god_type god, bool fail)
 {
     fail_check();
     bool success = false;
@@ -915,10 +915,10 @@ spret_type cast_conjure_ball_lightning(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type god, bool fail)
+spret cast_summon_lightning_spire(int pow, const coord_def& where, god_type god, bool fail)
 {
     const int dur = 2;
 
@@ -927,13 +927,13 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         || !in_bounds(where))
     {
         mpr("That's too far away.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (!monster_habitable_grid(MONS_HUMAN, grd(where)))
     {
         mpr("You can't construct there.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     monster* mons = monster_at(where);
@@ -942,14 +942,14 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         if (you.can_see(*mons))
         {
             mpr("That space is already occupied.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
 
         // invisible monster
         mpr("Something you can't see is blocking your construction!");
-        return spret_type::success;
+        return spret::success;
     }
 
     fail_check();
@@ -967,11 +967,11 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 
 }
 
-spret_type cast_summon_guardian_golem(int pow, god_type god, bool fail)
+spret cast_summon_guardian_golem(int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -992,7 +992,7 @@ spret_type cast_summon_guardian_golem(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -1030,9 +1030,9 @@ static map<monster_type, const char*> _imp_summon_messages = {
  * @param pow   The spellpower at which the spell is being cast.
  * @param god   The god of the caster.
  * @param fail  Whether the caster (you) failed to cast the spell.
- * @return      spret_type::fail if fail is true; spret_type::success otherwise.
+ * @return      spret::fail if fail is true; spret::success otherwise.
  */
-spret_type cast_call_imp(int pow, god_type god, bool fail)
+spret cast_call_imp(int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -1052,7 +1052,7 @@ spret_type cast_call_imp(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static bool _summon_demon_wrapper(int pow, god_type god, int spell,
@@ -1146,7 +1146,7 @@ bool summon_demon_type(monster_type mon, int pow, god_type god,
                                  friendly, false, false);
 }
 
-spret_type cast_summon_demon(int pow, god_type god, bool fail)
+spret cast_summon_demon(int pow, god_type god, bool fail)
 {
     fail_check();
     mpr("You open a gate to Pandemonium!");
@@ -1154,10 +1154,10 @@ spret_type cast_summon_demon(int pow, god_type god, bool fail)
     if (!_summon_common_demon(pow, god, SPELL_SUMMON_DEMON, false))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_summon_greater_demon(int pow, god_type god, bool fail)
+spret cast_summon_greater_demon(int pow, god_type god, bool fail)
 {
     fail_check();
     mpr("You open a gate to Pandemonium!");
@@ -1165,10 +1165,10 @@ spret_type cast_summon_greater_demon(int pow, god_type god, bool fail)
     if (!_summon_greater_demon(pow, god, SPELL_SUMMON_GREATER_DEMON, false))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_shadow_creatures(int st, god_type god, level_id place,
+spret cast_shadow_creatures(int st, god_type god, level_id place,
                                  bool fail)
 {
     fail_check();
@@ -1247,7 +1247,7 @@ spret_type cast_shadow_creatures(int st, god_type god, level_id place,
     if (!num_created)
         mpr("The shadows disperse without effect.");
 
-    return spret_type::success;
+    return spret::success;
 }
 
 bool can_cast_malign_gateway()
@@ -1291,7 +1291,7 @@ coord_def find_gateway_location(actor* caster)
     return points[random2(points.size())];
 }
 
-spret_type cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
+spret cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
 {
     coord_def point = find_gateway_location(caster);
     bool success = (point != coord_def(0, 0));
@@ -1321,16 +1321,16 @@ spret_type cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
         mprf(MSGCH_WARN, "The dungeon shakes, a horrible noise fills the air, "
                          "and a portal to some otherworldly place is opened!");
 
-        return spret_type::success;
+        return spret::success;
     }
     // We don't care if monsters fail to cast it.
     if (is_player)
         mpr("A gateway cannot be opened in this cramped space!");
 
-    return spret_type::abort;
+    return spret::abort;
 }
 
-spret_type cast_summon_horrible_things(int pow, god_type god, bool fail)
+spret cast_summon_horrible_things(int pow, god_type god, bool fail)
 {
     fail_check();
     if (god == GOD_NO_GOD && one_chance_in(5))
@@ -1367,7 +1367,7 @@ spret_type cast_summon_horrible_things(int pow, god_type god, bool fail)
     if (!count)
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static bool _water_adjacent(coord_def p)
@@ -1388,11 +1388,11 @@ static bool _water_adjacent(coord_def p)
  * @param pow    The spell power.
  * @param god    The god of the summoned dryad (usually the caster's).
  * @param fail   Did this spell miscast? If true, abort the cast.
- * @return       spret_type::abort if a summoning area couldn't be found,
- *               spret_type::fail if one could be found but we miscast, and
- *               spret_type::success if the spell was successfully cast.
+ * @return       spret::abort if a summoning area couldn't be found,
+ *               spret::fail if one could be found but we miscast, and
+ *               spret::success if the spell was successfully cast.
 */
-spret_type cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
+spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 {
     const int duration = random_range(120 + pow, 200 + pow * 3 / 2);
 
@@ -1475,11 +1475,11 @@ spret_type cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 
         you.duration[DUR_FORESTED] = duration;
 
-        return spret_type::success;
+        return spret::success;
     }
 
     mpr("You need more open space to cast this spell.");
-    return spret_type::abort;
+    return spret::abort;
 }
 
 static bool _animatable_remains(const item_def& item)
@@ -1820,7 +1820,7 @@ int animate_dead(actor *caster, int /*pow*/, beh_type beha,
     return number_raised;
 }
 
-spret_type cast_animate_skeleton(god_type god, bool fail)
+spret cast_animate_skeleton(god_type god, bool fail)
 {
     bool found = false;
 
@@ -1837,7 +1837,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
     if (!found)
     {
         mpr("There is nothing here that can be animated!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -1853,7 +1853,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
     {
         if (animate_skel_result == 0)
             mpr(no_space);
-        return spret_type::success;
+        return spret::success;
     }
 
     // If not, look for a corpse and butcher it.
@@ -1890,10 +1890,10 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
             break;
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_animate_dead(int pow, god_type god, bool fail)
+spret cast_animate_dead(int pow, god_type god, bool fail)
 {
     fail_check();
     canned_msg(MSG_CALL_DEAD);
@@ -1901,7 +1901,7 @@ spret_type cast_animate_dead(int pow, god_type god, bool fail)
     if (!animate_dead(&you, pow + 1, BEH_FRIENDLY, MHITYOU, &you, "", god))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -1909,11 +1909,11 @@ spret_type cast_animate_dead(int pow, god_type god, bool fail)
  *
  * @param pow The spell power.
  * @param god The god casting the spell.
- * @param fail If true, return spret_type::fail unless the spell is aborted.
- * @returns spret_type::abort if no viable corpse was at the player's location,
- *          otherwise spret_type::success or spret_type::fail based on fail.
+ * @param fail If true, return spret::fail unless the spell is aborted.
+ * @return spret::abort if no viable corpse was at the player's location,
+ *         otherwise spret::success or spret::fail based on fail.
  */
-spret_type cast_simulacrum(int pow, god_type god, bool fail)
+spret cast_simulacrum(int pow, god_type god, bool fail)
 {
     bool found = false;
     int co = -1;
@@ -1930,7 +1930,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
     if (!found)
     {
         mpr("There is nothing here that can be animated!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -1958,7 +1958,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
                  how_many == 1 ? "um" : "a", how_many == 1 ? "s" : "");
             if (!turn_corpse_into_skeleton(corpse))
                 butcher_corpse(corpse, false, false);
-            return spret_type::success;
+            return spret::success;
         }
         mg.props[MGEN_NUM_HEADS] = corpse.props[CORPSE_HEADS].get_short();
     }
@@ -1978,7 +1978,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
     else if (!turn_corpse_into_skeleton(corpse))
         butcher_corpse(corpse, false, false);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -2248,7 +2248,7 @@ monster_type pick_random_wraith()
                                   2, MONS_PHANTASMAL_WARRIOR);
 }
 
-spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
+spret cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
 {
     monster* m = monster_at(where);
 
@@ -2256,19 +2256,19 @@ spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
     {
         fail_check();
         mpr("An evil force gathers, but it quickly dissipates.");
-        return spret_type::success; // still losing a turn
+        return spret::success; // still losing a turn
     }
     else if (m->wont_attack())
     {
         mpr("You cannot haunt those who bear you no hostility.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     int mi = m->mindex();
     ASSERT(!invalid_monster_index(mi));
 
     if (stop_attack_prompt(m, false, you.pos()))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
@@ -2310,10 +2310,10 @@ spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
     else
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return spret_type::success;
+        return spret::success;
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 
@@ -2424,7 +2424,7 @@ void init_servitor(monster* servitor, actor* caster)
     servitor->props["ideal_range"].get_int() = shortest_range;
 }
 
-spret_type cast_spellforged_servitor(int pow, god_type god, bool fail)
+spret cast_spellforged_servitor(int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -2436,7 +2436,7 @@ spret_type cast_spellforged_servitor(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _abjuration(int pow, monster *mon)
@@ -2486,7 +2486,7 @@ static int _abjuration(int pow, monster *mon)
     return true;
 }
 
-spret_type cast_aura_of_abjuration(int pow, bool fail)
+spret cast_aura_of_abjuration(int pow, bool fail)
 {
     fail_check();
 
@@ -2498,7 +2498,7 @@ spret_type cast_aura_of_abjuration(int pow, bool fail)
     you.increase_duration(DUR_ABJURATION_AURA,  6 + roll_dice(2, pow / 12), 50);
     you.props["abj_aura_pow"].get_int() = pow;
 
-    return spret_type::success;
+    return spret::success;
 }
 
 void do_aura_of_abjuration(int delay)
@@ -2516,7 +2516,7 @@ monster* find_battlesphere(const actor* agent)
         return nullptr;
 }
 
-spret_type cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
+spret cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
 {
     fail_check();
 
@@ -2589,7 +2589,7 @@ spret_type cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
             canned_msg(MSG_NOTHING_HAPPENS);
     }
 
-    return spret_type::success;
+    return spret::success;
 }
 
 void end_battlesphere(monster* mons, bool killed)
@@ -2947,7 +2947,7 @@ bool fire_battlesphere(monster* mons)
     return used;
 }
 
-spret_type cast_fulminating_prism(actor* caster, int pow,
+spret cast_fulminating_prism(actor* caster, int pow,
                                   const coord_def& where, bool fail)
 {
     if (grid_distance(where, caster->pos())
@@ -2955,14 +2955,14 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     {
         if (caster->is_player())
             mpr("That's too far away.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (cell_is_solid(where))
     {
         if (caster->is_player())
             mpr("You can't conjure that within a solid object!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     actor* victim = monster_at(where);
@@ -2972,7 +2972,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         {
             if (caster->is_player())
                 mpr("You can't place the prism on a creature.");
-            return spret_type::abort;
+            return spret::abort;
         }
 
         fail_check();
@@ -2989,7 +2989,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
             else
                 canned_msg(MSG_GHOSTLY_OUTLINE);
         }
-        return spret_type::success;      // Don't give free detection!
+        return spret::success;      // Don't give free detection!
     }
 
     fail_check();
@@ -3019,7 +3019,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     else if (you.can_see(*caster))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return spret_type::success;
+    return spret::success;
 }
 
 monster* find_spectral_weapon(const actor* agent)
@@ -3036,7 +3036,7 @@ bool weapon_can_be_spectral(const item_def *wpn)
         && !is_special_unrandom_artefact(*wpn);
 }
 
-spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
+spret cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
 {
     ASSERT(agent);
 
@@ -3058,7 +3058,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
                 mpr(you.hands_act("twitch", "."));
         }
 
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -3084,7 +3084,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
         //if (agent->is_player())
             canned_msg(MSG_NOTHING_HAPPENS);
 
-        return spret_type::success;
+        return spret::success;
     }
 
     if (agent->is_player())
@@ -3109,7 +3109,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
     mons->summoner = agent->mid;
     agent->props["spectral_weapon"].get_int() = mons->mid;
 
-    return spret_type::success;
+    return spret::success;
 }
 
 void end_spectral_weapon(monster* mons, bool killed, bool quiet)
@@ -3230,12 +3230,12 @@ static void _setup_infestation(bolt &beam, int pow)
     beam.origin_spell = SPELL_INFESTATION;
 }
 
-spret_type cast_infestation(int pow, bolt &beam, bool fail)
+spret cast_infestation(int pow, bolt &beam, bool fail)
 {
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -3244,7 +3244,7 @@ spret_type cast_infestation(int pow, bolt &beam, bool fail)
     mpr("You call forth a plague of scarabs!");
     beam.explode();
 
-    return spret_type::success;
+    return spret::success;
 }
 
 struct summon_cap

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -109,7 +109,7 @@ spret_type cast_summon_butterflies(int pow, god_type god, bool fail)
     if (!success)
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_small_mammal(int pow, god_type god, bool fail)
@@ -126,7 +126,7 @@ spret_type cast_summon_small_mammal(int pow, god_type god, bool fail)
     if (!create_monster(_pal_data(mon, 3, god, SPELL_SUMMON_SMALL_MAMMAL)))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
@@ -155,7 +155,7 @@ spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
     if (valid_sticks.empty())
     {
         mpr("You don't have anything to turn into a snake.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
     // Sort by the quantity if the player has no bow skill; this will
     // put arrows with the smallest quantity first in line
@@ -222,7 +222,7 @@ spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail)
     else
         mpr("You fail to create any snakes.");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_call_canine_familiar(int pow, god_type god, bool fail)
@@ -244,7 +244,7 @@ spret_type cast_call_canine_familiar(int pow, god_type god, bool fail)
     if (!create_monster(_pal_data(mon, dur, god, SPELL_CALL_CANINE_FAMILIAR)))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_ice_beast(int pow, god_type god, bool fail)
@@ -261,7 +261,7 @@ spret_type cast_summon_ice_beast(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
@@ -327,7 +327,7 @@ spret_type cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool f
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
@@ -350,7 +350,7 @@ spret_type cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
     else if (caster->is_player())
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static monster_type _choose_dragon_type(int pow, god_type god, bool player)
@@ -379,7 +379,7 @@ spret_type cast_dragon_call(int pow, bool fail)
         || you.duration[DUR_DRAGON_CALL_COOLDOWN])
     {
         mpr("You cannot issue another dragon's call so soon.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -389,7 +389,7 @@ spret_type cast_dragon_call(int pow, bool fail)
 
     you.duration[DUR_DRAGON_CALL] = (15 + pow / 5 + random2(15)) * BASELINE_DELAY;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static void _place_dragon()
@@ -569,7 +569,7 @@ spret_type cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
     if (!success && caster->is_player())
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_mana_viper(int pow, god_type god, bool fail)
@@ -588,7 +588,7 @@ spret_type cast_summon_mana_viper(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 // This assumes that the specified monster can go berserk.
@@ -699,7 +699,7 @@ bool summon_holy_warrior(int pow, bool punish)
  * information about invisible enemies. (Not implemented as a macro because I
  * find they create unreadable code.)
  *
- * @return SPRET_SUCCESS
+ * @return spret_type::success
  **/
 static bool _fail_tukimas()
 {
@@ -915,7 +915,7 @@ spret_type cast_conjure_ball_lightning(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type god, bool fail)
@@ -927,13 +927,13 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         || !in_bounds(where))
     {
         mpr("That's too far away.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (!monster_habitable_grid(MONS_HUMAN, grd(where)))
     {
         mpr("You can't construct there.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     monster* mons = monster_at(where);
@@ -942,14 +942,14 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
         if (you.can_see(*mons))
         {
             mpr("That space is already occupied.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         fail_check();
 
         // invisible monster
         mpr("Something you can't see is blocking your construction!");
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     fail_check();
@@ -967,7 +967,7 @@ spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 
 }
 
@@ -992,7 +992,7 @@ spret_type cast_summon_guardian_golem(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -1030,7 +1030,7 @@ static map<monster_type, const char*> _imp_summon_messages = {
  * @param pow   The spellpower at which the spell is being cast.
  * @param god   The god of the caster.
  * @param fail  Whether the caster (you) failed to cast the spell.
- * @return      SPRET_FAIL if fail is true; SPRET_SUCCESS otherwise.
+ * @return      spret_type::fail if fail is true; spret_type::success otherwise.
  */
 spret_type cast_call_imp(int pow, god_type god, bool fail)
 {
@@ -1052,7 +1052,7 @@ spret_type cast_call_imp(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static bool _summon_demon_wrapper(int pow, god_type god, int spell,
@@ -1154,7 +1154,7 @@ spret_type cast_summon_demon(int pow, god_type god, bool fail)
     if (!_summon_common_demon(pow, god, SPELL_SUMMON_DEMON, false))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_summon_greater_demon(int pow, god_type god, bool fail)
@@ -1165,7 +1165,7 @@ spret_type cast_summon_greater_demon(int pow, god_type god, bool fail)
     if (!_summon_greater_demon(pow, god, SPELL_SUMMON_GREATER_DEMON, false))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_shadow_creatures(int st, god_type god, level_id place,
@@ -1247,7 +1247,7 @@ spret_type cast_shadow_creatures(int st, god_type god, level_id place,
     if (!num_created)
         mpr("The shadows disperse without effect.");
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 bool can_cast_malign_gateway()
@@ -1321,13 +1321,13 @@ spret_type cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
         mprf(MSGCH_WARN, "The dungeon shakes, a horrible noise fills the air, "
                          "and a portal to some otherworldly place is opened!");
 
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
     // We don't care if monsters fail to cast it.
     if (is_player)
         mpr("A gateway cannot be opened in this cramped space!");
 
-    return SPRET_ABORT;
+    return spret_type::abort;
 }
 
 spret_type cast_summon_horrible_things(int pow, god_type god, bool fail)
@@ -1367,7 +1367,7 @@ spret_type cast_summon_horrible_things(int pow, god_type god, bool fail)
     if (!count)
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static bool _water_adjacent(coord_def p)
@@ -1388,9 +1388,9 @@ static bool _water_adjacent(coord_def p)
  * @param pow    The spell power.
  * @param god    The god of the summoned dryad (usually the caster's).
  * @param fail   Did this spell miscast? If true, abort the cast.
- * @return       SPRET_ABORT if a summoning area couldn't be found,
- *               SPRET_FAIL if one could be found but we miscast, and
- *               SPRET_SUCCESS if the spell was successfully cast.
+ * @return       spret_type::abort if a summoning area couldn't be found,
+ *               spret_type::fail if one could be found but we miscast, and
+ *               spret_type::success if the spell was successfully cast.
 */
 spret_type cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 {
@@ -1475,11 +1475,11 @@ spret_type cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 
         you.duration[DUR_FORESTED] = duration;
 
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     mpr("You need more open space to cast this spell.");
-    return SPRET_ABORT;
+    return spret_type::abort;
 }
 
 static bool _animatable_remains(const item_def& item)
@@ -1837,7 +1837,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
     if (!found)
     {
         mpr("There is nothing here that can be animated!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -1853,7 +1853,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
     {
         if (animate_skel_result == 0)
             mpr(no_space);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     // If not, look for a corpse and butcher it.
@@ -1890,7 +1890,7 @@ spret_type cast_animate_skeleton(god_type god, bool fail)
             break;
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_animate_dead(int pow, god_type god, bool fail)
@@ -1901,7 +1901,7 @@ spret_type cast_animate_dead(int pow, god_type god, bool fail)
     if (!animate_dead(&you, pow + 1, BEH_FRIENDLY, MHITYOU, &you, "", god))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -1909,9 +1909,9 @@ spret_type cast_animate_dead(int pow, god_type god, bool fail)
  *
  * @param pow The spell power.
  * @param god The god casting the spell.
- * @param fail If true, return SPRET_FAIL unless the spell is aborted.
- * @returns SPRET_ABORT if no viable corpse was at the player's location,
- *          otherwise SPRET_TRUE or SPRET_FAIL based on fail.
+ * @param fail If true, return spret_type::fail unless the spell is aborted.
+ * @returns spret_type::abort if no viable corpse was at the player's location,
+ *          otherwise spret_type::success or spret_type::fail based on fail.
  */
 spret_type cast_simulacrum(int pow, god_type god, bool fail)
 {
@@ -1930,7 +1930,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
     if (!found)
     {
         mpr("There is nothing here that can be animated!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -1958,7 +1958,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
                  how_many == 1 ? "um" : "a", how_many == 1 ? "s" : "");
             if (!turn_corpse_into_skeleton(corpse))
                 butcher_corpse(corpse, false, false);
-            return SPRET_SUCCESS;
+            return spret_type::success;
         }
         mg.props[MGEN_NUM_HEADS] = corpse.props[CORPSE_HEADS].get_short();
     }
@@ -1978,7 +1978,7 @@ spret_type cast_simulacrum(int pow, god_type god, bool fail)
     else if (!turn_corpse_into_skeleton(corpse))
         butcher_corpse(corpse, false, false);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -2256,19 +2256,19 @@ spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
     {
         fail_check();
         mpr("An evil force gathers, but it quickly dissipates.");
-        return SPRET_SUCCESS; // still losing a turn
+        return spret_type::success; // still losing a turn
     }
     else if (m->wont_attack())
     {
         mpr("You cannot haunt those who bear you no hostility.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     int mi = m->mindex();
     ASSERT(!invalid_monster_index(mi));
 
     if (stop_attack_prompt(m, false, you.pos()))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
@@ -2310,10 +2310,10 @@ spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
     else
     {
         canned_msg(MSG_NOTHING_HAPPENS);
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 
@@ -2436,7 +2436,7 @@ spret_type cast_spellforged_servitor(int pow, god_type god, bool fail)
     else
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _abjuration(int pow, monster *mon)
@@ -2498,7 +2498,7 @@ spret_type cast_aura_of_abjuration(int pow, bool fail)
     you.increase_duration(DUR_ABJURATION_AURA,  6 + roll_dice(2, pow / 12), 50);
     you.props["abj_aura_pow"].get_int() = pow;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void do_aura_of_abjuration(int delay)
@@ -2589,7 +2589,7 @@ spret_type cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
             canned_msg(MSG_NOTHING_HAPPENS);
     }
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void end_battlesphere(monster* mons, bool killed)
@@ -2955,14 +2955,14 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     {
         if (caster->is_player())
             mpr("That's too far away.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (cell_is_solid(where))
     {
         if (caster->is_player())
             mpr("You can't conjure that within a solid object!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     actor* victim = monster_at(where);
@@ -2972,7 +2972,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
         {
             if (caster->is_player())
                 mpr("You can't place the prism on a creature.");
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         fail_check();
@@ -2989,7 +2989,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
             else
                 canned_msg(MSG_GHOSTLY_OUTLINE);
         }
-        return SPRET_SUCCESS;      // Don't give free detection!
+        return spret_type::success;      // Don't give free detection!
     }
 
     fail_check();
@@ -3019,7 +3019,7 @@ spret_type cast_fulminating_prism(actor* caster, int pow,
     else if (you.can_see(*caster))
         canned_msg(MSG_NOTHING_HAPPENS);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 monster* find_spectral_weapon(const actor* agent)
@@ -3058,7 +3058,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
                 mpr(you.hands_act("twitch", "."));
         }
 
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -3084,7 +3084,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
         //if (agent->is_player())
             canned_msg(MSG_NOTHING_HAPPENS);
 
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
 
     if (agent->is_player())
@@ -3109,7 +3109,7 @@ spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail)
     mons->summoner = agent->mid;
     agent->props["spectral_weapon"].get_int() = mons->mid;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void end_spectral_weapon(monster* mons, bool killed, bool quiet)
@@ -3235,7 +3235,7 @@ spret_type cast_infestation(int pow, bolt &beam, bool fail)
     if (cell_is_solid(beam.target))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -3244,7 +3244,7 @@ spret_type cast_infestation(int pow, bolt &beam, bool fail)
     mpr("You call forth a plague of scarabs!");
     beam.explode();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 struct summon_cap

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -23,55 +23,55 @@
 // How many aut until the next doom hound pops out of doom howl?
 #define NEXT_DOOM_HOUND_KEY "next_doom_hound"
 
-spret_type cast_summon_butterflies(int pow, god_type god = GOD_NO_GOD,
+spret cast_summon_butterflies(int pow, god_type god = GOD_NO_GOD,
                                    bool fail = false);
-spret_type cast_summon_small_mammal(int pow, god_type god, bool fail);
+spret cast_summon_small_mammal(int pow, god_type god, bool fail);
 
-spret_type cast_sticks_to_snakes(int pow, god_type god, bool fail);
+spret cast_sticks_to_snakes(int pow, god_type god, bool fail);
 
-spret_type cast_call_canine_familiar(int pow, god_type god, bool fail);
-spret_type cast_summon_ice_beast(int pow, god_type god, bool fail);
-spret_type cast_monstrous_menagerie(actor* caster, int pow, god_type god,
+spret cast_call_canine_familiar(int pow, god_type god, bool fail);
+spret cast_summon_ice_beast(int pow, god_type god, bool fail);
+spret cast_monstrous_menagerie(actor* caster, int pow, god_type god,
                                  bool fail = false);
-spret_type cast_summon_dragon(actor *caster, int pow,
+spret cast_summon_dragon(actor *caster, int pow,
                               god_type god = GOD_NO_GOD, bool fail = false);
-spret_type cast_summon_hydra(actor *caster, int pow, god_type god = GOD_NO_GOD,
+spret cast_summon_hydra(actor *caster, int pow, god_type god = GOD_NO_GOD,
                              bool fail = false);
-spret_type cast_summon_mana_viper(int pow, god_type god, bool fail);
+spret cast_summon_mana_viper(int pow, god_type god, bool fail);
 bool summon_berserker(int pow, actor *caster,
                       monster_type override_mons = MONS_PROGRAM_BUG);
 bool summon_holy_warrior(int pow, bool punish);
 
 bool tukima_affects(const actor &target);
 void cast_tukimas_dance(int pow, actor *target);
-spret_type cast_conjure_ball_lightning(int pow, god_type god, bool fail);
-spret_type cast_summon_lightning_spire(int pow, const coord_def& where, god_type god, bool fail);
+spret cast_conjure_ball_lightning(int pow, god_type god, bool fail);
+spret cast_summon_lightning_spire(int pow, const coord_def& where, god_type god, bool fail);
 
-spret_type cast_call_imp(int pow, god_type god, bool fail);
+spret cast_call_imp(int pow, god_type god, bool fail);
 bool summon_demon_type(monster_type mon, int pow, god_type god = GOD_NO_GOD,
                        int spell = 0, bool friendly = true);
-spret_type cast_summon_demon(int pow, god_type god = GOD_NO_GOD,
+spret cast_summon_demon(int pow, god_type god = GOD_NO_GOD,
                              bool fail = false);
-spret_type cast_summon_greater_demon(int pow, god_type god, bool fail);
-spret_type cast_shadow_creatures(int st = SPELL_SHADOW_CREATURES,
+spret cast_summon_greater_demon(int pow, god_type god, bool fail);
+spret cast_shadow_creatures(int st = SPELL_SHADOW_CREATURES,
                                  god_type god = GOD_NO_GOD,
                                  level_id place = level_id::current(),
                                  bool fail = false);
-spret_type cast_summon_horrible_things(int pow, god_type god, bool fail);
+spret cast_summon_horrible_things(int pow, god_type god, bool fail);
 bool can_cast_malign_gateway();
-spret_type cast_malign_gateway(actor* caster, int pow,
+spret cast_malign_gateway(actor* caster, int pow,
                                god_type god = GOD_NO_GOD, bool fail = false);
 coord_def find_gateway_location(actor* caster);
-spret_type cast_summon_forest(actor* caster, int pow, god_type god, bool fail);
-spret_type cast_summon_guardian_golem(int pow, god_type god, bool fail);
+spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail);
+spret cast_summon_guardian_golem(int pow, god_type god, bool fail);
 
-spret_type cast_dragon_call(int pow, bool fail);
+spret cast_dragon_call(int pow, bool fail);
 void do_dragon_call(int time);
 
 void doom_howl(int time);
 
 void init_servitor(monster* servitor, actor* caster);
-spret_type cast_spellforged_servitor(int pow, god_type god, bool fail);
+spret cast_spellforged_servitor(int pow, god_type god, bool fail);
 
 int animate_remains(const coord_def &a, corpse_type class_allowed,
                     beh_type beha, unsigned short hitting,
@@ -80,26 +80,26 @@ int animate_remains(const coord_def &a, corpse_type class_allowed,
                     bool quiet = false, bool force_beh = false,
                     monster** mon = nullptr, int* motions = nullptr);
 
-spret_type cast_animate_skeleton(god_type god, bool fail);
-spret_type cast_animate_dead(int pow, god_type god, bool fail);
+spret cast_animate_skeleton(god_type god, bool fail);
+spret cast_animate_dead(int pow, god_type god, bool fail);
 int animate_dead(actor *caster, int /*pow*/, beh_type beha,
                  unsigned short hitting, actor *as = nullptr, string nas = "",
                  god_type god = GOD_NO_GOD, bool actual = true);
 
-spret_type cast_simulacrum(int pow, god_type god, bool fail);
+spret cast_simulacrum(int pow, god_type god, bool fail);
 bool monster_simulacrum(monster *caster, bool actual);
 
 bool twisted_resurrection(actor *caster, int pow, beh_type beha,
                           unsigned short foe, god_type god, bool actual = true);
 
 monster_type pick_random_wraith();
-spret_type cast_haunt(int pow, const coord_def& where, god_type god, bool fail);
+spret cast_haunt(int pow, const coord_def& where, god_type god, bool fail);
 
-spret_type cast_aura_of_abjuration(int pow, bool fail);
+spret cast_aura_of_abjuration(int pow, bool fail);
 void do_aura_of_abjuration(int delay);
 
 monster* find_battlesphere(const actor* agent);
-spret_type cast_battlesphere(actor* agent, int pow, god_type god, bool fail);
+spret cast_battlesphere(actor* agent, int pow, god_type god, bool fail);
 void end_battlesphere(monster* mons, bool killed);
 bool battlesphere_can_mirror(spell_type spell);
 bool aim_battlesphere(actor* agent, spell_type spell, int powc, bolt& beam);
@@ -107,18 +107,18 @@ bool trigger_battlesphere(actor* agent, bolt& beam);
 bool fire_battlesphere(monster* mons);
 void reset_battlesphere(monster* mons);
 
-spret_type cast_fulminating_prism(actor* caster, int pow,
+spret cast_fulminating_prism(actor* caster, int pow,
                                   const coord_def& where, bool fail);
 
 monster* find_spectral_weapon(const actor* agent);
 bool weapon_can_be_spectral(const item_def *weapon);
-spret_type cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail);
+spret cast_spectral_weapon(actor *agent, int pow, god_type god, bool fail);
 void end_spectral_weapon(monster* mons, bool killed, bool quiet = false);
 bool trigger_spectral_weapon(actor* agent, const actor* target);
 bool confirm_attack_spectral_weapon(monster* mons, const actor *defender);
 void reset_spectral_weapon(monster* mons);
 
-spret_type cast_infestation(int pow, bolt &beam, bool fail);
+spret cast_infestation(int pow, bolt &beam, bool fail);
 
 void summoned_monster(const monster* mons, const actor* caster,
                       spell_type spell);

--- a/crawl-ref/source/spl-tornado.cc
+++ b/crawl-ref/source/spl-tornado.cc
@@ -136,7 +136,7 @@ spret_type cast_tornado(int powc, bool fail)
                   true, 'n'))
     {
         canned_msg(MSG_OK);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -153,7 +153,7 @@ spret_type cast_tornado(int powc, bool fail)
     if (you.species == SP_TENGU)
         you.redraw_evasion = true;
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static bool _mons_is_unmovable(const monster *mons)

--- a/crawl-ref/source/spl-tornado.cc
+++ b/crawl-ref/source/spl-tornado.cc
@@ -115,7 +115,7 @@ static void _set_tornado_durations(int powc)
     }
 }
 
-spret_type cast_tornado(int powc, bool fail)
+spret cast_tornado(int powc, bool fail)
 {
     bool friendlies = false;
     for (radius_iterator ri(you.pos(), TORNADO_RADIUS, C_SQUARE); ri; ++ri)
@@ -136,7 +136,7 @@ spret_type cast_tornado(int powc, bool fail)
                   true, 'n'))
     {
         canned_msg(MSG_OK);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -153,7 +153,7 @@ spret_type cast_tornado(int powc, bool fail)
     if (you.species == SP_TENGU)
         you.redraw_evasion = true;
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static bool _mons_is_unmovable(const monster *mons)

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -64,7 +64,7 @@ static void _place_tloc_cloud(const coord_def &origin)
         place_cloud(CLOUD_TLOC_ENERGY, origin, 1 + random2(3), &you);
 }
 
-spret_type cast_disjunction(int pow, bool fail)
+spret cast_disjunction(int pow, bool fail)
 {
     fail_check();
     int rand = random_range(35, 45) + random2(pow / 12);
@@ -73,7 +73,7 @@ spret_type cast_disjunction(int pow, bool fail)
         30 + rand));
     contaminate_player(750 + random2(500), true);
     disjunction_spell();
-    return spret_type::success;
+    return spret::success;
 }
 
 void disjunction_spell()
@@ -322,7 +322,7 @@ static coord_def _fuzz_hop_destination(coord_def target)
  *                      therefore fail after selecting a target)
  * @return              Whether the hop succeeded, aborted, or was miscast.
  */
-spret_type frog_hop(bool fail)
+spret frog_hop(bool fail)
 {
     const int hop_range = 2 + you.get_mutation_level(MUT_HOP) * 2; // 4-6
     coord_def target;
@@ -331,7 +331,7 @@ spret_type frog_hop(bool fail)
     while (true)
     {
         if (!_find_cblink_target(target, true, "hop", &tgt))
-            return spret_type::abort;
+            return spret::abort;
         if (grid_distance(you.pos(), target) > hop_range)
         {
             mpr("That's out of range!"); // ! targeting
@@ -344,14 +344,14 @@ spret_type frog_hop(bool fail)
     fail_check();
 
     if (!you.attempt_escape(2)) // XXX: 1?
-        return spret_type::success; // of a sort
+        return spret::success; // of a sort
 
     // invisible monster that the targeter didn't know to avoid, or similar
     if (target.origin())
     {
         mpr("You tried to hop, but there was no room to land!");
         // TODO: what to do here?
-        return spret_type::success; // of a sort
+        return spret::success; // of a sort
     }
 
     if (!cell_is_solid(you.pos())) // should be safe.....
@@ -362,7 +362,7 @@ spret_type frog_hop(bool fail)
     mpr("Boing!");
     you.increase_duration(DUR_NO_HOP, 12 + random2(13));
 
-    return spret_type::success; // TODO
+    return spret::success; // TODO
 }
 
 /**
@@ -375,31 +375,31 @@ spret_type frog_hop(bool fail)
  *                      for e.g. ?blink with blurryvis)
  * @return              Whether the blink succeeded, aborted, or was miscast.
  */
-spret_type controlled_blink(bool fail, bool safe_cancel)
+spret controlled_blink(bool fail, bool safe_cancel)
 {
     coord_def target;
     targeter_smite tgt(&you, LOS_RADIUS);
     tgt.obeys_mesmerise = true;
     if (!_find_cblink_target(target, safe_cancel, "blink", &tgt))
-        return spret_type::abort;
+        return spret::abort;
 
     fail_check();
 
     if (you.no_tele(true, true, true))
     {
         canned_msg(MSG_STRANGE_STASIS);
-        return spret_type::success; // of a sort
+        return spret::success; // of a sort
     }
 
     if (!you.attempt_escape(2))
-        return spret_type::success; // of a sort
+        return spret::success; // of a sort
 
     // invisible monster that the targeter didn't know to avoid
     if (monster_at(target))
     {
         mpr("Oops! There was something there already!");
         uncontrolled_blink();
-        return spret_type::success; // of a sort
+        return spret::success; // of a sort
     }
 
     _place_tloc_cloud(you.pos());
@@ -410,7 +410,7 @@ spret_type controlled_blink(bool fail, bool safe_cancel)
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
 
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -420,15 +420,15 @@ spret_type controlled_blink(bool fail, bool safe_cancel)
  * @return                  Whether the spell was successfully cast, aborted,
  *                          or miscast.
  */
-spret_type cast_blink(bool fail)
+spret cast_blink(bool fail)
 {
     // effects that cast the spell through the player, I guess (e.g. xom)
     if (you.no_tele(false, false, true))
-        return fail ? spret_type::fail : spret_type::success; // probably always SUCCESS
+        return fail ? spret::fail : spret::success; // probably always SUCCESS
 
     fail_check();
     uncontrolled_blink();
-    return spret_type::success;
+    return spret::success;
 }
 
 /**
@@ -438,13 +438,13 @@ spret_type cast_blink(bool fail)
  * @param safe    Whether it's safe to abort (not e.g. unknown ?blink)
  * @return        Whether the spell was successfully cast, aborted, or miscast.
  */
-spret_type cast_controlled_blink(bool fail, bool safe)
+spret cast_controlled_blink(bool fail, bool safe)
 {
     // don't prompt if it's useless
     if (you.no_tele(true, true, true))
     {
         canned_msg(MSG_STRANGE_STASIS);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (crawl_state.is_repeating_cmd())
@@ -452,7 +452,7 @@ spret_type cast_controlled_blink(bool fail, bool safe)
         crawl_state.cant_cmd_repeat("You can't repeat controlled blinks.");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return spret_type::abort;
+        return spret::abort;
     }
 
     if (orb_limits_translocation())
@@ -460,7 +460,7 @@ spret_type cast_controlled_blink(bool fail, bool safe)
         if (!yesno("Your blink will be uncontrolled - continue anyway?",
                    false, 'n'))
         {
-            return spret_type::abort;
+            return spret::abort;
         }
 
         mprf(MSGCH_ORB, "The Orb prevents control of your translocation!");
@@ -782,7 +782,7 @@ void you_teleport_now(bool wizard_tele, bool teleportitis, string reason)
     }
 }
 
-spret_type cast_portal_projectile(int pow, bool fail)
+spret cast_portal_projectile(int pow, bool fail)
 {
     fail_check();
     if (!you.duration[DUR_PORTAL_PROJECTILE])
@@ -792,17 +792,17 @@ spret_type cast_portal_projectile(int pow, bool fail)
     // Calculate the accuracy bonus based on current spellpower.
     you.attribute[ATTR_PORTAL_PROJECTILE] = pow;
     you.increase_duration(DUR_PORTAL_PROJECTILE, 3 + random2(pow / 2) + random2(pow / 5), 50);
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_apportation(int pow, bolt& beam, bool fail)
+spret cast_apportation(int pow, bolt& beam, bool fail)
 {
     const coord_def where = beam.target;
 
     if (!cell_see_cell(you.pos(), where, LOS_SOLID))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // Let's look at the top item in that square...
@@ -812,7 +812,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (item_idx == NON_ITEM || !in_bounds(where))
     {
         mpr("You don't see anything to apport there.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     item_def& item = mitm[item_idx];
@@ -821,7 +821,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (item_is_stationary(item) && !item_is_stationary_net(item))
     {
         mpr("You cannot apport that!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -840,7 +840,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
                 "The Orb shrieks and becomes a dead weight against your magic!",
                 "The Orb lets out a furious burst of light and becomes "
                     "a dead weight against your magic!");
-            return spret_type::success;
+            return spret::success;
         }
         else // Otherwise it's just a noisy little shiny thing
         {
@@ -894,7 +894,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (location_on_path == dist)
     {
         mpr("Not with that terrain in the way!");
-        return spret_type::success;
+        return spret::success;
     }
     dprf("Apport: new spot is %d/%d", new_spot.x, new_spot.y);
 
@@ -907,15 +907,15 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     // Mark the item as found now.
     origin_set(new_spot);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_golubrias_passage(const coord_def& where, bool fail)
+spret cast_golubrias_passage(const coord_def& where, bool fail)
 {
     if (orb_limits_translocation())
     {
         mprf(MSGCH_ORB, "The Orb prevents you from opening a passage!");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     // randomize position a bit to make it not as useful to use on monsters
@@ -961,7 +961,7 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail)
         else
             // XXX: bleh, dumb message
             mpr("Creating a passage of Golubria requires sufficient empty space.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -974,13 +974,13 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail)
     if (!trap || !trap2)
     {
         mpr("Something buggy happened.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     trap->reveal();
     trap2->reveal();
 
-    return spret_type::success;
+    return spret::success;
 }
 
 static int _disperse_monster(monster& mon, int pow)
@@ -1000,7 +1000,7 @@ static int _disperse_monster(monster& mon, int pow)
     return true;
 }
 
-spret_type cast_dispersal(int pow, bool fail)
+spret cast_dispersal(int pow, bool fail)
 {
     fail_check();
     const int radius = spell_range(SPELL_DISPERSAL, pow);
@@ -1010,7 +1010,7 @@ spret_type cast_dispersal(int pow, bool fail)
     {
         mpr("The air shimmers briefly around you.");
     }
-    return spret_type::success;
+    return spret::success;
 }
 
 int gravitas_range(int pow)
@@ -1101,12 +1101,12 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
     return affected;
 }
 
-spret_type cast_gravitas(int pow, const coord_def& where, bool fail)
+spret cast_gravitas(int pow, const coord_def& where, bool fail)
 {
     if (cell_is_solid(where))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return spret_type::abort;
+        return spret::abort;
     }
 
     fail_check();
@@ -1121,7 +1121,7 @@ spret_type cast_gravitas(int pow, const coord_def& where, bool fail)
                                                          .c_str()
                                    : "empty space");
     fatal_attraction(where, &you, pow);
-    return spret_type::success;
+    return spret::success;
 }
 
 /**

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -73,7 +73,7 @@ spret_type cast_disjunction(int pow, bool fail)
         30 + rand));
     contaminate_player(750 + random2(500), true);
     disjunction_spell();
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 void disjunction_spell()
@@ -331,7 +331,7 @@ spret_type frog_hop(bool fail)
     while (true)
     {
         if (!_find_cblink_target(target, true, "hop", &tgt))
-            return SPRET_ABORT;
+            return spret_type::abort;
         if (grid_distance(you.pos(), target) > hop_range)
         {
             mpr("That's out of range!"); // ! targeting
@@ -344,14 +344,14 @@ spret_type frog_hop(bool fail)
     fail_check();
 
     if (!you.attempt_escape(2)) // XXX: 1?
-        return SPRET_SUCCESS; // of a sort
+        return spret_type::success; // of a sort
 
     // invisible monster that the targeter didn't know to avoid, or similar
     if (target.origin())
     {
         mpr("You tried to hop, but there was no room to land!");
         // TODO: what to do here?
-        return SPRET_SUCCESS; // of a sort
+        return spret_type::success; // of a sort
     }
 
     if (!cell_is_solid(you.pos())) // should be safe.....
@@ -362,7 +362,7 @@ spret_type frog_hop(bool fail)
     mpr("Boing!");
     you.increase_duration(DUR_NO_HOP, 12 + random2(13));
 
-    return SPRET_SUCCESS; // TODO
+    return spret_type::success; // TODO
 }
 
 /**
@@ -381,25 +381,25 @@ spret_type controlled_blink(bool fail, bool safe_cancel)
     targeter_smite tgt(&you, LOS_RADIUS);
     tgt.obeys_mesmerise = true;
     if (!_find_cblink_target(target, safe_cancel, "blink", &tgt))
-        return SPRET_ABORT;
+        return spret_type::abort;
 
     fail_check();
 
     if (you.no_tele(true, true, true))
     {
         canned_msg(MSG_STRANGE_STASIS);
-        return SPRET_SUCCESS; // of a sort
+        return spret_type::success; // of a sort
     }
 
     if (!you.attempt_escape(2))
-        return SPRET_SUCCESS; // of a sort
+        return spret_type::success; // of a sort
 
     // invisible monster that the targeter didn't know to avoid
     if (monster_at(target))
     {
         mpr("Oops! There was something there already!");
         uncontrolled_blink();
-        return SPRET_SUCCESS; // of a sort
+        return spret_type::success; // of a sort
     }
 
     _place_tloc_cloud(you.pos());
@@ -410,7 +410,7 @@ spret_type controlled_blink(bool fail, bool safe_cancel)
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -424,11 +424,11 @@ spret_type cast_blink(bool fail)
 {
     // effects that cast the spell through the player, I guess (e.g. xom)
     if (you.no_tele(false, false, true))
-        return fail ? SPRET_FAIL : SPRET_SUCCESS; // probably always SUCCESS
+        return fail ? spret_type::fail : spret_type::success; // probably always SUCCESS
 
     fail_check();
     uncontrolled_blink();
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**
@@ -444,7 +444,7 @@ spret_type cast_controlled_blink(bool fail, bool safe)
     if (you.no_tele(true, true, true))
     {
         canned_msg(MSG_STRANGE_STASIS);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (crawl_state.is_repeating_cmd())
@@ -452,7 +452,7 @@ spret_type cast_controlled_blink(bool fail, bool safe)
         crawl_state.cant_cmd_repeat("You can't repeat controlled blinks.");
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     if (orb_limits_translocation())
@@ -460,7 +460,7 @@ spret_type cast_controlled_blink(bool fail, bool safe)
         if (!yesno("Your blink will be uncontrolled - continue anyway?",
                    false, 'n'))
         {
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
 
         mprf(MSGCH_ORB, "The Orb prevents control of your translocation!");
@@ -792,7 +792,7 @@ spret_type cast_portal_projectile(int pow, bool fail)
     // Calculate the accuracy bonus based on current spellpower.
     you.attribute[ATTR_PORTAL_PROJECTILE] = pow;
     you.increase_duration(DUR_PORTAL_PROJECTILE, 3 + random2(pow / 2) + random2(pow / 5), 50);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_apportation(int pow, bolt& beam, bool fail)
@@ -802,7 +802,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (!cell_see_cell(you.pos(), where, LOS_SOLID))
     {
         canned_msg(MSG_SOMETHING_IN_WAY);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // Let's look at the top item in that square...
@@ -812,7 +812,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (item_idx == NON_ITEM || !in_bounds(where))
     {
         mpr("You don't see anything to apport there.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     item_def& item = mitm[item_idx];
@@ -821,7 +821,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (item_is_stationary(item) && !item_is_stationary_net(item))
     {
         mpr("You cannot apport that!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -840,7 +840,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
                 "The Orb shrieks and becomes a dead weight against your magic!",
                 "The Orb lets out a furious burst of light and becomes "
                     "a dead weight against your magic!");
-            return SPRET_SUCCESS;
+            return spret_type::success;
         }
         else // Otherwise it's just a noisy little shiny thing
         {
@@ -894,7 +894,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     if (location_on_path == dist)
     {
         mpr("Not with that terrain in the way!");
-        return SPRET_SUCCESS;
+        return spret_type::success;
     }
     dprf("Apport: new spot is %d/%d", new_spot.x, new_spot.y);
 
@@ -907,7 +907,7 @@ spret_type cast_apportation(int pow, bolt& beam, bool fail)
     // Mark the item as found now.
     origin_set(new_spot);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_golubrias_passage(const coord_def& where, bool fail)
@@ -915,7 +915,7 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail)
     if (orb_limits_translocation())
     {
         mprf(MSGCH_ORB, "The Orb prevents you from opening a passage!");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     // randomize position a bit to make it not as useful to use on monsters
@@ -961,7 +961,7 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail)
         else
             // XXX: bleh, dumb message
             mpr("Creating a passage of Golubria requires sufficient empty space.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -974,13 +974,13 @@ spret_type cast_golubrias_passage(const coord_def& where, bool fail)
     if (!trap || !trap2)
     {
         mpr("Something buggy happened.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     trap->reveal();
     trap2->reveal();
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 static int _disperse_monster(monster& mon, int pow)
@@ -1010,7 +1010,7 @@ spret_type cast_dispersal(int pow, bool fail)
     {
         mpr("The air shimmers briefly around you.");
     }
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 int gravitas_range(int pow)
@@ -1106,7 +1106,7 @@ spret_type cast_gravitas(int pow, const coord_def& where, bool fail)
     if (cell_is_solid(where))
     {
         canned_msg(MSG_UNTHINKING_ACT);
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     fail_check();
@@ -1121,7 +1121,7 @@ spret_type cast_gravitas(int pow, const coord_def& where, bool fail)
                                                          .c_str()
                                    : "empty space");
     fatal_attraction(where, &you, pow);
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 /**

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -2,14 +2,14 @@
 
 #include "spl-cast.h"
 
-spret_type cast_disjunction(int pow, bool fail);
+spret cast_disjunction(int pow, bool fail);
 void disjunction_spell();
 
-spret_type cast_blink(bool fail = false);
-spret_type cast_controlled_blink(bool fail = false, bool safe = true);
+spret cast_blink(bool fail = false);
+spret cast_controlled_blink(bool fail = false, bool safe = true);
 void uncontrolled_blink(bool override_stasis = false);
-spret_type controlled_blink(bool fail, bool safe_cancel = true);
-spret_type frog_hop(bool fail);
+spret controlled_blink(bool fail, bool safe_cancel = true);
+spret frog_hop(bool fail);
 void wizard_blink();
 
 void you_teleport();
@@ -18,16 +18,16 @@ void you_teleport_now(bool wizard_tele = false, bool teleportitis = false,
 bool you_teleport_to(const coord_def where,
                      bool move_monsters = false);
 
-spret_type cast_portal_projectile(int pow, bool fail);
+spret cast_portal_projectile(int pow, bool fail);
 
 struct bolt;
-spret_type cast_apportation(int pow, bolt& beam, bool fail);
-spret_type cast_golubrias_passage(const coord_def& where, bool fail);
+spret cast_apportation(int pow, bolt& beam, bool fail);
+spret cast_golubrias_passage(const coord_def& where, bool fail);
 
-spret_type cast_dispersal(int pow, bool fail);
+spret cast_dispersal(int pow, bool fail);
 
 int gravitas_range(int pow);
 bool fatal_attraction(const coord_def& pos, const actor *agent, int pow);
-spret_type cast_gravitas(int pow, const coord_def& where, bool fail);
+spret cast_gravitas(int pow, const coord_def& where, bool fail);
 
 bool beckon(actor &beckoned, const bolt &path);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1396,7 +1396,7 @@ bool spell_no_hostile_in_range(spell_type spell)
     }
 
     case SPELL_IGNITE_POISON:
-        return cast_ignite_poison(&you, -1, false, true) == spret_type::abort;
+        return cast_ignite_poison(&you, -1, false, true) == spret::abort;
 
     default:
         break;

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1396,7 +1396,7 @@ bool spell_no_hostile_in_range(spell_type spell)
     }
 
     case SPELL_IGNITE_POISON:
-        return cast_ignite_poison(&you, -1, false, true) == SPRET_ABORT;
+        return cast_ignite_poison(&you, -1, false, true) == spret_type::abort;
 
     default:
         break;

--- a/crawl-ref/source/spl-wpnench.cc
+++ b/crawl-ref/source/spl-wpnench.cc
@@ -57,7 +57,7 @@ void end_weapon_brand(item_def &weapon, bool verbose)
  * @param[in] fail          Whether you've already failed to cast.
  * @return                  Success, fail, or abort.
  */
-spret_type cast_excruciating_wounds(int power, bool fail)
+spret cast_excruciating_wounds(int power, bool fail)
 {
     item_def& weapon = *you.weapon();
     const brand_type which_brand = SPWPN_PAIN;
@@ -67,14 +67,14 @@ spret_type cast_excruciating_wounds(int power, bool fail)
     if (is_range_weapon(weapon))
     {
         mpr("You cannot brand ranged weapons with this spell.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     bool has_temp_brand = you.duration[DUR_EXCRUCIATING_WOUNDS];
     if (!has_temp_brand && get_weapon_brand(weapon) == which_brand)
     {
         mpr("This weapon is already branded with pain.");
-        return spret_type::abort;
+        return spret::abort;
     }
 
     const bool dangerous_disto = orig_brand == SPWPN_DISTORTION
@@ -86,7 +86,7 @@ spret_type cast_excruciating_wounds(int power, bool fail)
         if (!yesno(prompt.c_str(), false, 'n'))
         {
             canned_msg(MSG_OK);
-            return spret_type::abort;
+            return spret::abort;
         }
     }
 
@@ -119,10 +119,10 @@ spret_type cast_excruciating_wounds(int power, bool fail)
 
     you.increase_duration(DUR_EXCRUCIATING_WOUNDS, 8 + roll_dice(2, power), 50);
 
-    return spret_type::success;
+    return spret::success;
 }
 
-spret_type cast_confusing_touch(int power, bool fail)
+spret cast_confusing_touch(int power, bool fail)
 {
     fail_check();
     msg::stream << you.hands_act("begin", "to glow ")
@@ -134,5 +134,5 @@ spret_type cast_confusing_touch(int power, bool fail)
                          you.duration[DUR_CONFUSING_TOUCH]),
                      20, nullptr);
 
-    return spret_type::success;
+    return spret::success;
 }

--- a/crawl-ref/source/spl-wpnench.cc
+++ b/crawl-ref/source/spl-wpnench.cc
@@ -67,14 +67,14 @@ spret_type cast_excruciating_wounds(int power, bool fail)
     if (is_range_weapon(weapon))
     {
         mpr("You cannot brand ranged weapons with this spell.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     bool has_temp_brand = you.duration[DUR_EXCRUCIATING_WOUNDS];
     if (!has_temp_brand && get_weapon_brand(weapon) == which_brand)
     {
         mpr("This weapon is already branded with pain.");
-        return SPRET_ABORT;
+        return spret_type::abort;
     }
 
     const bool dangerous_disto = orig_brand == SPWPN_DISTORTION
@@ -86,7 +86,7 @@ spret_type cast_excruciating_wounds(int power, bool fail)
         if (!yesno(prompt.c_str(), false, 'n'))
         {
             canned_msg(MSG_OK);
-            return SPRET_ABORT;
+            return spret_type::abort;
         }
     }
 
@@ -119,7 +119,7 @@ spret_type cast_excruciating_wounds(int power, bool fail)
 
     you.increase_duration(DUR_EXCRUCIATING_WOUNDS, 8 + roll_dice(2, power), 50);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }
 
 spret_type cast_confusing_touch(int power, bool fail)
@@ -134,5 +134,5 @@ spret_type cast_confusing_touch(int power, bool fail)
                          you.duration[DUR_CONFUSING_TOUCH]),
                      20, nullptr);
 
-    return SPRET_SUCCESS;
+    return spret_type::success;
 }

--- a/crawl-ref/source/spl-wpnench.h
+++ b/crawl-ref/source/spl-wpnench.h
@@ -9,5 +9,5 @@ class dist;
 
 void end_weapon_brand(item_def &weapon, bool verbose = false);
 
-spret_type cast_excruciating_wounds(int power, bool fail);
-spret_type cast_confusing_touch(int power, bool fail);
+spret cast_excruciating_wounds(int power, bool fail);
+spret cast_confusing_touch(int power, bool fail);

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -163,7 +163,7 @@ void wizard_cast_spec_spell()
         }
     }
 
-    if (your_spells(static_cast<spell_type>(spell), 0, false) == spret_type::abort)
+    if (your_spells(static_cast<spell_type>(spell), 0, false) == spret::abort)
         crawl_state.cancel_cmd_repeat();
 }
 

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -163,7 +163,7 @@ void wizard_cast_spec_spell()
         }
     }
 
-    if (your_spells(static_cast<spell_type>(spell), 0, false) == SPRET_ABORT)
+    if (your_spells(static_cast<spell_type>(spell), 0, false) == spret_type::abort)
         crawl_state.cancel_cmd_repeat();
 }
 


### PR DESCRIPTION
Change spret_type to an enum class, and change its name to spret.

If this is appreciated, I would be happy to continue to class-ify enums, because I think it is the general opinion that enum classes are superior to enums for type security reasons.

This PR should now be ready to be merged.