### PR TITLE
Fix information leak for invisible monsters

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -109,7 +109,10 @@ bool melee_attack::handle_phase_attempted()
     if (attacker->is_player() && defender && defender->is_monster())
     {
         // Unrands with secondary effects that can harm nearby friendlies.
-        if (weapon && is_unrandom_artefact(*weapon, UNRAND_DEVASTATOR))
+        // Don't prompt for confirmation (and leak information about the
+        // monster's position) if the player can't see the monster.
+        if (weapon && is_unrandom_artefact(*weapon, UNRAND_DEVASTATOR)
+            && you.can_see(*defender))
         {
 
             targeter_smite hitfunc(attacker, 1, 1, 1, false);
@@ -125,7 +128,8 @@ bool melee_attack::handle_phase_attempted()
         else if (weapon &&
                 (is_unrandom_artefact(*weapon, UNRAND_SINGING_SWORD)
                  || is_unrandom_artefact(*weapon, UNRAND_VARIABILITY)
-                 || is_unrandom_artefact(*weapon, UNRAND_SPELLBINDER)))
+                 || is_unrandom_artefact(*weapon, UNRAND_SPELLBINDER))
+                 && you.can_see(*defender))
         {
             targeter_los hitfunc(&you, LOS_NO_TRANS);
 
@@ -136,7 +140,8 @@ bool melee_attack::handle_phase_attempted()
                 return false;
             }
         }
-        else if (weapon && is_unrandom_artefact(*weapon, UNRAND_ARC_BLADE))
+        else if (weapon && is_unrandom_artefact(*weapon, UNRAND_ARC_BLADE)
+                 && you.can_see(*defender))
         {
             vector<const actor *> exclude;
             if (!safe_discharge(defender->pos(), exclude))


### PR DESCRIPTION
Fixes bug #0011815 on Mantis.

If the player wielded certain unrands that do damage to nearby actors on
attack, and had allies nearby, then they got a prompt for confirmation
when attacking. This prompt happened even if the player could not see
the enemy. So the location of the enemy was revealed, in no time, by the
player's trying to move into the cell. This commit changes that: the
player trying to move into a cell with an unseen monster will attack
without a prompt.

NB: now characters walking around with one of these weapons equipped and
without SInv may inadvertently anger their allies or their god.