### PR TITLE
Convert five spell-related enums to enum classes

### DIFF
--- a/crawl-ref/docs/obsolete/cut_spells.txt
+++ b/crawl-ref/docs/obsolete/cut_spells.txt
@@ -1,4 +1,12 @@
-Spell definitions cut from the code:
+Spell definitions cut from the code.
+
+Note: several things in spell definitions have been changed since these spells
+were removed. These things include the spell_desc struct itself and the order
+of parameters, the addition of tile enum values to the struct, the changing of
+the enums containing SPFLAG_s and SPTYP_s to the enum classes spflag:: and
+spschool::, and the removal of some spell schools and flags. These would
+therefore need to be carefully updated to the new struct format if these spells
+were to be restored.
 
 {
     SPELL_CREATE_NOISE, "Create Noise",

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2370,7 +2370,7 @@ static spret _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_YRED_RECALL_UNDEAD_SLAVES:
         fail_check();
-        start_recall(RECALL_YRED);
+        start_recall(recall_t::yred);
         break;
 
     case ABIL_YRED_DRAIN_LIFE:
@@ -2754,7 +2754,7 @@ static spret _do_ability(const ability_def& abil, bool fail)
 
     case ABIL_BEOGH_RECALL_ORCISH_FOLLOWERS:
         fail_check();
-        start_recall(RECALL_BEOGH);
+        start_recall(recall_t::beogh);
         break;
 
     case ABIL_STOP_RECALL:

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -678,8 +678,8 @@ namespace arena
             if (mon->type == MONS_TEST_SPAWNER)
                 continue;
 
-            MiscastEffect(*mon, *mon, {WIZARD_MISCAST}, spschool::random,
-                          random_range(1, 3), "arena miscast",
+            MiscastEffect(*mon, *mon, {miscast_source::wizard},
+                          spschool::random, random_range(1, 3), "arena miscast",
                           nothing_happens::NEVER);
         }
     }

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -678,7 +678,7 @@ namespace arena
             if (mon->type == MONS_TEST_SPAWNER)
                 continue;
 
-            MiscastEffect(*mon, *mon, WIZARD_MISCAST, spschool::random,
+            MiscastEffect(*mon, *mon, {WIZARD_MISCAST}, spschool::random,
                           random_range(1, 3), "arena miscast",
                           nothing_happens::NEVER);
         }

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -148,7 +148,7 @@ namespace arena
     {
         monster_spells &spells(mons->spells);
         erase_if(spells, [&](const mon_spell_slot &t) {
-            return (no_summons && spell_typematch(t.spell, SPTYP_SUMMONING))
+            return (no_summons && spell_typematch(t.spell, spschool::summoning))
                 || (no_animate && t.spell == SPELL_ANIMATE_DEAD);
         });
     }
@@ -678,7 +678,7 @@ namespace arena
             if (mon->type == MONS_TEST_SPAWNER)
                 continue;
 
-            MiscastEffect(*mon, *mon, WIZARD_MISCAST, SPTYP_RANDOM,
+            MiscastEffect(*mon, *mon, WIZARD_MISCAST, spschool::random,
                           random_range(1, 3), "arena miscast", NH_NEVER);
         }
     }

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -679,7 +679,8 @@ namespace arena
                 continue;
 
             MiscastEffect(*mon, *mon, WIZARD_MISCAST, spschool::random,
-                          random_range(1, 3), "arena miscast", NH_NEVER);
+                          random_range(1, 3), "arena miscast",
+                          nothing_happens::NEVER);
         }
     }
 

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -154,9 +154,9 @@ static void _CURSES_equip(item_def *item, bool *show_msgs, bool unmeld)
     _equip_mpr(show_msgs, "A shiver runs down your spine.");
     if (!unmeld)
     {
-        MiscastEffect(&you, nullptr, {WIELD_MISCAST}, spschool::necromancy,
-                      random2(9), random2(70), "the scythe of Curses",
-                      nothing_happens::NEVER);
+        MiscastEffect(&you, nullptr, {miscast_source::wield},
+                      spschool::necromancy, random2(9), random2(70),
+                      "the scythe of Curses", nothing_happens::NEVER);
     }
 }
 
@@ -174,9 +174,9 @@ static void _CURSES_melee_effects(item_def* weapon, actor* attacker,
         did_god_conduct(DID_EVIL, 3);
     if (!mondied && defender->holiness() == MH_NATURAL)
     {
-        MiscastEffect(defender, attacker, {MELEE_MISCAST}, spschool::necromancy,
-                      random2(9), random2(70), "the scythe of Curses",
-                      nothing_happens::NEVER);
+        MiscastEffect(defender, attacker, {miscast_source::melee},
+                      spschool::necromancy, random2(9), random2(70),
+                      "the scythe of Curses", nothing_happens::NEVER);
     }
 }
 
@@ -845,7 +845,7 @@ static void _PLUTONIUM_SWORD_melee_effects(item_def* weapon, actor* attacker,
              || !mons_immune_magic(*defender->as_monster())))
     {
         mpr("Mutagenic energy flows through the plutonium sword!");
-        MiscastEffect(defender, attacker, {MELEE_MISCAST},
+        MiscastEffect(defender, attacker, {miscast_source::melee},
                       spschool::transmutation, random2(9), random2(70),
                       "the plutonium sword", nothing_happens::NEVER);
 
@@ -1034,8 +1034,8 @@ static void _SPELLBINDER_melee_effects(item_def* weapon, actor* attacker,
     if (defender->antimagic_susceptible()
         && !mondied)
     {
-        MiscastEffect(defender, attacker, {MELEE_MISCAST}, spschool::random,
-                      random2(9), random2(70),
+        MiscastEffect(defender, attacker, {miscast_source::melee},
+                      spschool::random, random2(9), random2(70),
                       "the demon whip \"Spellbinder\"", nothing_happens::NEVER);
     }
 }

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -154,7 +154,7 @@ static void _CURSES_equip(item_def *item, bool *show_msgs, bool unmeld)
     _equip_mpr(show_msgs, "A shiver runs down your spine.");
     if (!unmeld)
     {
-        MiscastEffect(&you, nullptr, WIELD_MISCAST, spschool::necromancy,
+        MiscastEffect(&you, nullptr, {WIELD_MISCAST}, spschool::necromancy,
                       random2(9), random2(70), "the scythe of Curses",
                       nothing_happens::NEVER);
     }
@@ -174,7 +174,7 @@ static void _CURSES_melee_effects(item_def* weapon, actor* attacker,
         did_god_conduct(DID_EVIL, 3);
     if (!mondied && defender->holiness() == MH_NATURAL)
     {
-        MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::necromancy,
+        MiscastEffect(defender, attacker, {MELEE_MISCAST}, spschool::necromancy,
                       random2(9), random2(70), "the scythe of Curses",
                       nothing_happens::NEVER);
     }
@@ -845,7 +845,7 @@ static void _PLUTONIUM_SWORD_melee_effects(item_def* weapon, actor* attacker,
              || !mons_immune_magic(*defender->as_monster())))
     {
         mpr("Mutagenic energy flows through the plutonium sword!");
-        MiscastEffect(defender, attacker, MELEE_MISCAST,
+        MiscastEffect(defender, attacker, {MELEE_MISCAST},
                       spschool::transmutation, random2(9), random2(70),
                       "the plutonium sword", nothing_happens::NEVER);
 
@@ -1034,7 +1034,7 @@ static void _SPELLBINDER_melee_effects(item_def* weapon, actor* attacker,
     if (defender->antimagic_susceptible()
         && !mondied)
     {
-        MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::random,
+        MiscastEffect(defender, attacker, {MELEE_MISCAST}, spschool::random,
                       random2(9), random2(70),
                       "the demon whip \"Spellbinder\"", nothing_happens::NEVER);
     }

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -156,7 +156,7 @@ static void _CURSES_equip(item_def *item, bool *show_msgs, bool unmeld)
     {
         MiscastEffect(&you, nullptr, WIELD_MISCAST, spschool::necromancy,
                       random2(9), random2(70), "the scythe of Curses",
-                      NH_NEVER);
+                      nothing_happens::NEVER);
     }
 }
 
@@ -176,7 +176,7 @@ static void _CURSES_melee_effects(item_def* weapon, actor* attacker,
     {
         MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::necromancy,
                       random2(9), random2(70), "the scythe of Curses",
-                      NH_NEVER);
+                      nothing_happens::NEVER);
     }
 }
 
@@ -847,7 +847,7 @@ static void _PLUTONIUM_SWORD_melee_effects(item_def* weapon, actor* attacker,
         mpr("Mutagenic energy flows through the plutonium sword!");
         MiscastEffect(defender, attacker, MELEE_MISCAST,
                       spschool::transmutation, random2(9), random2(70),
-                      "the plutonium sword", NH_NEVER);
+                      "the plutonium sword", nothing_happens::NEVER);
 
         if (attacker->is_player())
             did_god_conduct(DID_CHAOS, 3);
@@ -1036,7 +1036,7 @@ static void _SPELLBINDER_melee_effects(item_def* weapon, actor* attacker,
     {
         MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::random,
                       random2(9), random2(70),
-                      "the demon whip \"Spellbinder\"", NH_NEVER);
+                      "the demon whip \"Spellbinder\"", nothing_happens::NEVER);
     }
 }
 

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -154,8 +154,9 @@ static void _CURSES_equip(item_def *item, bool *show_msgs, bool unmeld)
     _equip_mpr(show_msgs, "A shiver runs down your spine.");
     if (!unmeld)
     {
-        MiscastEffect(&you, nullptr, WIELD_MISCAST, SPTYP_NECROMANCY, random2(9),
-                      random2(70), "the scythe of Curses", NH_NEVER);
+        MiscastEffect(&you, nullptr, WIELD_MISCAST, spschool::necromancy,
+                      random2(9), random2(70), "the scythe of Curses",
+                      NH_NEVER);
     }
 }
 
@@ -173,7 +174,7 @@ static void _CURSES_melee_effects(item_def* weapon, actor* attacker,
         did_god_conduct(DID_EVIL, 3);
     if (!mondied && defender->holiness() == MH_NATURAL)
     {
-        MiscastEffect(defender, attacker, MELEE_MISCAST, SPTYP_NECROMANCY,
+        MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::necromancy,
                       random2(9), random2(70), "the scythe of Curses",
                       NH_NEVER);
     }
@@ -844,8 +845,9 @@ static void _PLUTONIUM_SWORD_melee_effects(item_def* weapon, actor* attacker,
              || !mons_immune_magic(*defender->as_monster())))
     {
         mpr("Mutagenic energy flows through the plutonium sword!");
-        MiscastEffect(defender, attacker, MELEE_MISCAST, SPTYP_TRANSMUTATION,
-                      random2(9), random2(70), "the plutonium sword", NH_NEVER);
+        MiscastEffect(defender, attacker, MELEE_MISCAST,
+                      spschool::transmutation, random2(9), random2(70),
+                      "the plutonium sword", NH_NEVER);
 
         if (attacker->is_player())
             did_god_conduct(DID_CHAOS, 3);
@@ -1032,7 +1034,7 @@ static void _SPELLBINDER_melee_effects(item_def* weapon, actor* attacker,
     if (defender->antimagic_susceptible()
         && !mondied)
     {
-        MiscastEffect(defender, attacker, MELEE_MISCAST, SPTYP_RANDOM,
+        MiscastEffect(defender, attacker, MELEE_MISCAST, spschool::random,
                       random2(9), random2(70),
                       "the demon whip \"Spellbinder\"", NH_NEVER);
     }

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -902,7 +902,7 @@ void attack::do_miscast()
         }
     }
 
-    MiscastEffect(miscast_target, attacker, MELEE_MISCAST,
+    MiscastEffect(miscast_target, attacker, {MELEE_MISCAST},
                   (spschool) miscast_type, miscast_level, cause,
                   nothing_happens::NEVER, 0, hand_str, false);
 

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -902,7 +902,7 @@ void attack::do_miscast()
         }
     }
 
-    MiscastEffect(miscast_target, attacker, {MELEE_MISCAST},
+    MiscastEffect(miscast_target, attacker, {miscast_source::melee},
                   (spschool) miscast_type, miscast_level, cause,
                   nothing_happens::NEVER, 0, hand_str, false);
 

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -38,6 +38,7 @@
 #include "pronoun-type.h"
 #include "religion.h"
 #include "spl-miscast.h"
+#include "spl-util.h"
 #include "state.h"
 #include "stepdown.h"
 #include "stringutil.h"
@@ -62,7 +63,7 @@ attack::attack(actor *attk, actor *defn, actor *blame)
       attacker_to_hit_penalty(0), attack_verb("bug"), verb_degree(),
       no_damage_message(), special_damage_message(), aux_attack(), aux_verb(),
       attacker_armour_tohit_penalty(0), attacker_shield_tohit_penalty(0),
-      defender_shield(nullptr), miscast_level(-1), miscast_type(SPTYP_NONE),
+      defender_shield(nullptr), miscast_level(-1), miscast_type(spschool::none),
       miscast_target(nullptr), fake_chaos_attack(false), simu(false),
       aux_source(""), kill_type(KILLED_BY_MONSTER)
 {
@@ -658,7 +659,7 @@ static const vector<chaos_effect> chaos_effects = {
                                                            level1_chance, 1,
                                                            level2_chance, 2,
                                                            level3_chance, 3);
-            attack.miscast_type   = SPTYP_RANDOM;
+            attack.miscast_type   = spschool::random;
             attack.miscast_target = attack.defender;
 
             return false;
@@ -858,7 +859,7 @@ void attack::do_miscast()
 
     ASSERT(miscast_target != nullptr);
     ASSERT_RANGE(miscast_level, 0, 4);
-    ASSERT(count_bits(miscast_type) == 1);
+    ASSERT(count_bits(static_cast<uint64_t>(miscast_type)) == 1);
 
     if (!miscast_target->alive())
         return;
@@ -902,7 +903,7 @@ void attack::do_miscast()
     }
 
     MiscastEffect(miscast_target, attacker, MELEE_MISCAST,
-                  (spschool_flag_type) miscast_type, miscast_level, cause,
+                  (spschool) miscast_type, miscast_level, cause,
                   NH_NEVER, 0, hand_str, false);
 
     // Don't do miscast twice for one attack.
@@ -1655,7 +1656,7 @@ bool attack::apply_damage_brand(const char *what)
             && miscast_level == -1 && one_chance_in(20))
         {
             miscast_level  = 0;
-            miscast_type   = SPTYP_RANDOM;
+            miscast_type   = spschool::random;
             miscast_target = random_choose(attacker, defender);
         }
 

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -904,7 +904,7 @@ void attack::do_miscast()
 
     MiscastEffect(miscast_target, attacker, MELEE_MISCAST,
                   (spschool) miscast_type, miscast_level, cause,
-                  NH_NEVER, 0, hand_str, false);
+                  nothing_happens::NEVER, 0, hand_str, false);
 
     // Don't do miscast twice for one attack.
     miscast_level = -1;

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -6,6 +6,7 @@
 #include "mon-enum.h"
 #include "ouch.h"
 #include "pronoun-type.h"
+#include "spl-util.h" // spschool type definition
 
 // Used throughout inheriting classes, define them here for universal access
 const int HIT_WEAK   = 7;
@@ -85,9 +86,9 @@ public:
 
     // Miscast to cause after special damage is done. If miscast_level == 0
     // the miscast is discarded if special_damage_message isn't empty.
-    int    miscast_level;
-    int    miscast_type;
-    actor* miscast_target;
+    int       miscast_level;
+    spschool  miscast_type;
+    actor*    miscast_target;
 
     bool      fake_chaos_attack;
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3030,7 +3030,7 @@ bool bolt::is_reflectable(const actor &whom) const
 
 bool bolt::is_big_cloud() const
 {
-    return get_spell_flags(origin_spell) & SPFLAG_CLOUD;
+    return testbits(get_spell_flags(origin_spell), spflag::cloud);
 }
 
 coord_def bolt::leg_source() const

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -816,7 +816,7 @@ static void _sdump_skills(dump_params &par)
     text += "\n";
 }
 
-static string spell_type_shortname(spschool_flag_type spell_class, bool slash)
+static string spell_type_shortname(spschool spell_class, bool slash)
 {
     string ret;
 

--- a/crawl-ref/source/dbg-asrt.cc
+++ b/crawl-ref/source/dbg-asrt.cc
@@ -237,14 +237,14 @@ static void _dump_player(FILE *file)
             continue;
         }
 
-        const unsigned int flags = get_spell_flags(spell);
+        const spell_flags flags = get_spell_flags(spell);
 
-        if (flags & SPFLAG_MONSTER)
+        if (flags & spflag::monster)
         {
             fprintf(file, "    spell slot #%d: monster only spell %s\n",
                     (int)i, spell_title(spell));
         }
-        else if (flags & SPFLAG_TESTING)
+        else if (flags & spflag::testing)
             fprintf(file, "    spell slot #%d: testing spell %s\n",
                     (int)i, spell_title(spell));
         else if (count_bits(get_spell_disciplines(spell)) == 0)

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1628,12 +1628,12 @@ static void _wild_magic_card(int power)
         if (x_chance_in_y((power_level + 1) * 5 + random2(5),
                            mons->get_hit_dice()))
         {
-            spschool_flag_type type = random_choose(SPTYP_CONJURATION,
-                                                    SPTYP_FIRE,
-                                                    SPTYP_ICE,
-                                                    SPTYP_EARTH,
-                                                    SPTYP_AIR,
-                                                    SPTYP_POISON);
+            spschool type = random_choose(spschool::conjuration,
+                                          spschool::fire,
+                                          spschool::ice,
+                                          spschool::earth,
+                                          spschool::air,
+                                          spschool::poison);
 
             MiscastEffect(mons, actor_by_mid(MID_YOU_FAULTLESS),
                           DECK_MISCAST, type,

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1636,7 +1636,7 @@ static void _wild_magic_card(int power)
                                           spschool::poison);
 
             MiscastEffect(mons, actor_by_mid(MID_YOU_FAULTLESS),
-                          DECK_MISCAST, type,
+                          {DECK_MISCAST}, type,
                           random2(power/15) + 5, random2(power),
                           "a card of wild magic");
 

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1636,7 +1636,7 @@ static void _wild_magic_card(int power)
                                           spschool::poison);
 
             MiscastEffect(mons, actor_by_mid(MID_YOU_FAULTLESS),
-                          {DECK_MISCAST}, type,
+                          {miscast_source::deck}, type,
                           random2(power/15) + 5, random2(power),
                           "a card of wild magic");
 

--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -278,7 +278,7 @@ static void _monster_spellbooks(const monster_info &mi,
             if (!spell_is_soh_breath(spell))
             {
                 output_book.spells.emplace_back(spell);
-                if (get_spell_flags(spell) & SPFLAG_MONS_ABJURE)
+                if (get_spell_flags(spell) & spflag::mons_abjure)
                     mons_abjure = true;
                 continue;
             }
@@ -468,7 +468,7 @@ static string _range_string(const spell_type &spell, const monster_info *mon_own
     int range = spell_range(spell, pow, false);
     const bool has_range = mon_owner
                         && range > 0
-                        && !testbits(flags, SPFLAG_SELFENCH);
+                        && !testbits(flags, spflag::selfench);
     if (!has_range)
         return "";
     const bool in_range = has_range
@@ -537,7 +537,7 @@ static void _describe_book(const spellbook_contents &book,
 #ifndef DEBUG_DIAGNOSTICS
             && mon_owner->attitude != ATT_FRIENDLY
 #endif
-            && testbits(get_spell_flags(spell), SPFLAG_MR_CHECK))
+            && testbits(get_spell_flags(spell), spflag::MR_check))
         {
             if (you.immune_to_hex(spell))
                 hex_str = "(immune) ";
@@ -631,7 +631,7 @@ static void _write_book(const spellbook_contents &book,
 #ifndef DEBUG_DIAGNOSTICS
             && mon_owner->attitude != ATT_FRIENDLY
 #endif
-            && (get_spell_flags(spell) & SPFLAG_MR_CHECK))
+            && (get_spell_flags(spell) & spflag::MR_check))
         {
             if (you.immune_to_hex(spell))
                 tiles.json_write_string("hex_chance", "immune");

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2840,7 +2840,7 @@ static string _player_spell_stats(const spell_type spell)
                      schools.c_str());
 
     if (!crawl_state.need_save
-        || (get_spell_flags(spell) & SPFLAG_MONSTER))
+        || (get_spell_flags(spell) & spflag::monster))
     {
         return description; // all other info is player-dependent
     }
@@ -2938,7 +2938,7 @@ int hex_chance(const spell_type spell, const int hd)
  */
 static string _player_spell_desc(spell_type spell)
 {
-    if (!crawl_state.need_save || (get_spell_flags(spell) & SPFLAG_MONSTER))
+    if (!crawl_state.need_save || (get_spell_flags(spell) & spflag::monster))
         return ""; // all info is player-dependent
 
     ostringstream description;
@@ -3040,7 +3040,7 @@ static bool _get_spell_description(const spell_type spell,
                        + "\n";
 
         // only display this if the player exists (not in the main menu)
-        if (crawl_state.need_save && (get_spell_flags(spell) & SPFLAG_MR_CHECK)
+        if (crawl_state.need_save && (get_spell_flags(spell) & spflag::MR_check)
 #ifndef DEBUG_DIAGNOSTICS
             && mon_owner->attitude != ATT_FRIENDLY
 #endif

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -4334,21 +4334,19 @@ static bool _apply_item_props(item_def &item, const item_spec &spec,
         for (unsigned int i = 0; i < spell_list.size(); ++i)
             spells.push_back((spell_type) spell_list[i].get_int());
 
-        spschool_flag_type disc1
-            = (spschool_flag_type)props[RANDBK_DISC1_KEY].get_short();
-        spschool_flag_type disc2
-            = (spschool_flag_type)props[RANDBK_DISC2_KEY].get_short();
-        if (disc1 == SPTYP_NONE && disc2 == SPTYP_NONE)
+        spschool disc1 = (spschool)props[RANDBK_DISC1_KEY].get_short();
+        spschool disc2 = (spschool)props[RANDBK_DISC2_KEY].get_short();
+        if (disc1 == spschool::none && disc2 == spschool::none)
         {
             if (spells.size())
                 disc1 = matching_book_theme(spells);
             else
                 disc1 = random_book_theme();
             disc2 = random_book_theme();
-        } else if (disc2 == SPTYP_NONE)
+        } else if (disc2 == spschool::none)
             disc2 = disc1;
         else
-            ASSERT(disc1 != SPTYP_NONE); // mapdef should've handled this
+            ASSERT(disc1 != spschool::none); // mapdef should've handled this
 
         int num_spells = props[RANDBK_NSPELLS_KEY].get_short();
         if (num_spells < 1)

--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -627,7 +627,7 @@ void ghost_demon::add_spells(bool actual_ghost)
         const int chance = max(0, 50 - failure_rate_to_int(raw_spell_fail(you.spells[i])));
         const spell_type spell = translate_spell(you.spells[i]);
         if (spell != SPELL_NO_SPELL
-            && !(get_spell_flags(spell) & SPFLAG_NO_GHOST)
+            && !(get_spell_flags(spell) & spflag::no_ghost)
             && is_valid_mon_spell(spell)
             && x_chance_in_y(chance*chance, 50*50))
         {

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1438,7 +1438,7 @@ void elyvilon_remove_divine_vigour()
 
 bool vehumet_supports_spell(spell_type spell)
 {
-    if (spell_typematch(spell, SPTYP_CONJURATION))
+    if (spell_typematch(spell, spschool::conjuration))
         return true;
 
     // Conjurations work by conjuring up a chunk of short-lived matter and
@@ -5226,7 +5226,7 @@ static const char* _arcane_mutation_to_school_name(mutation_type mutation)
     // XXX: this does a really silly dance back and forth between school &
     // spelltype.
     const skill_type sk = arcane_mutation_to_skill(mutation);
-    const spschool_flag_type school = skill2spell_type(sk);
+    const spschool school = skill2spell_type(sk);
     return spelltype_long_name(school);
 }
 

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1844,7 +1844,7 @@ void yred_make_enslaved_soul(monster* mon, bool force_hostile)
     mon->flags |= orig.flags & MF_MELEE_MASK;
     monster_spells spl = orig.spells;
     for (const mon_spell_slot &slot : spl)
-        if (!(get_spell_flags(slot.spell) & SPFLAG_HOLY))
+        if (!(get_spell_flags(slot.spell) & spflag::holy))
             mon->spells.push_back(slot);
     if (mon->spells.size())
         mon->props[CUSTOM_SPELLS_KEY] = true;

--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -382,7 +382,7 @@ bool is_evil_spell(spell_type spell)
 
     if (flags & spflag::unholy)
         return true;
-    return bool(disciplines & SPTYP_NECROMANCY)
+    return bool(disciplines & spschool::necromancy)
            && !bool(flags & spflag::not_evil);
 }
 

--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -22,6 +22,7 @@
 #include "item-name.h"
 #include "item-prop.h"
 #include "items.h"
+#include "libutil.h"
 #include "potion-type.h"
 #include "religion.h"
 #include "skills.h"
@@ -363,9 +364,9 @@ bool is_channeling_item(const item_def& item, bool calc_unid)
 
 bool is_corpse_violating_spell(spell_type spell)
 {
-    unsigned int flags = get_spell_flags(spell);
+    spell_flags flags = get_spell_flags(spell);
 
-    return flags & SPFLAG_CORPSE_VIOLATING;
+    return testbits(flags, spflag::corpse_violating);
 }
 
 /**
@@ -377,33 +378,33 @@ bool is_corpse_violating_spell(spell_type spell)
 bool is_evil_spell(spell_type spell)
 {
     const spschools_type disciplines = get_spell_disciplines(spell);
-    unsigned int flags = get_spell_flags(spell);
+    spell_flags flags = get_spell_flags(spell);
 
-    if (flags & SPFLAG_UNHOLY)
+    if (flags & spflag::unholy)
         return true;
     return bool(disciplines & SPTYP_NECROMANCY)
-           && !bool(flags & SPFLAG_NOT_EVIL);
+           && !bool(flags & spflag::not_evil);
 }
 
 bool is_unclean_spell(spell_type spell)
 {
-    unsigned int flags = get_spell_flags(spell);
+    spell_flags flags = get_spell_flags(spell);
 
-    return bool(flags & SPFLAG_UNCLEAN);
+    return bool(flags & spflag::unclean);
 }
 
 bool is_chaotic_spell(spell_type spell)
 {
-    unsigned int flags = get_spell_flags(spell);
+    spell_flags flags = get_spell_flags(spell);
 
-    return bool(flags & SPFLAG_CHAOTIC);
+    return bool(flags & spflag::chaotic);
 }
 
 bool is_hasty_spell(spell_type spell)
 {
-    unsigned int flags = get_spell_flags(spell);
+    spell_flags flags = get_spell_flags(spell);
 
-    return bool(flags & SPFLAG_HASTY);
+    return bool(flags & spflag::hasty);
 }
 
 /**

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -372,7 +372,7 @@ static bool _cheibriados_retribution()
     // Very high tension wrath
     case 4:
         simple_god_message(" adjusts the clock.", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::random,
+        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         if (one_chance_in(3))
@@ -399,7 +399,7 @@ static bool _cheibriados_retribution()
     case 1:
     case 0:
         mpr("Time shudders.");
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::random,
+        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         break;
@@ -633,7 +633,7 @@ static bool _kikubaaqudgha_retribution()
         {
             for (int i = 0; i < 3; ++i)
             {
-                MiscastEffect(&you, nullptr, GOD_MISCAST + god,
+                MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
                               spschool::necromancy,
                               2 + div_rand_round(you.experience_level, 9),
                               random2avg(88, 3), _god_wrath_name(god));
@@ -646,7 +646,7 @@ static bool _kikubaaqudgha_retribution()
         const int num_miscasts = one_chance_in(4) ? 2 : 1;
         for (int i = 0; i < num_miscasts; i++)
         {
-            MiscastEffect(&you, nullptr, GOD_MISCAST + god,
+            MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
                           spschool::necromancy,
                           2 + div_rand_round(you.experience_level, 9),
                           random2avg(88, 3), _god_wrath_name(god));
@@ -700,7 +700,7 @@ static bool _yredelemnul_retribution()
     else
     {
         simple_god_message("'s anger turns toward you for a moment.", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::necromancy,
+        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::necromancy,
                       2 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
     }
@@ -793,7 +793,7 @@ static bool _trog_retribution()
         //    we'll leave this effect in, but we'll remove the wild
         //    fire magic. -- bwr
         mprf(MSGCH_WARN, "You feel Trog's fiery rage upon you!");
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::fire,
+        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::fire,
                       8 + you.experience_level, random2avg(98, 3),
                       _god_wrath_name(god));
     }
@@ -976,8 +976,8 @@ static void _lugonu_transloc_retribution()
     if (coinflip())
     {
         simple_god_message("'s wrath finds you!", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::translocation,
-                      9, 90, "Lugonu's touch");
+        MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
+                      spschool::translocation, 9, 90, "Lugonu's touch");
     }
     else if (coinflip())
     {
@@ -1293,7 +1293,7 @@ static void _fedhas_elemental_miscast()
 
     const spschool stype = random_choose(spschool::ice, spschool::fire,
                                          spschool::earth, spschool::air);
-    MiscastEffect(&you, nullptr, GOD_MISCAST + god, stype,
+    MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, stype,
                   5 + you.experience_level, random2avg(88, 3),
                   _god_wrath_name(god));
 }

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -372,7 +372,8 @@ static bool _cheibriados_retribution()
     // Very high tension wrath
     case 4:
         simple_god_message(" adjusts the clock.", god);
-        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::random,
+        MiscastEffect(&you, nullptr, {miscast_source::god, god},
+                      spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         if (one_chance_in(3))
@@ -399,7 +400,8 @@ static bool _cheibriados_retribution()
     case 1:
     case 0:
         mpr("Time shudders.");
-        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::random,
+        MiscastEffect(&you, nullptr, {miscast_source::god, god},
+                      spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         break;
@@ -633,7 +635,7 @@ static bool _kikubaaqudgha_retribution()
         {
             for (int i = 0; i < 3; ++i)
             {
-                MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
+                MiscastEffect(&you, nullptr, {miscast_source::god, god},
                               spschool::necromancy,
                               2 + div_rand_round(you.experience_level, 9),
                               random2avg(88, 3), _god_wrath_name(god));
@@ -646,7 +648,7 @@ static bool _kikubaaqudgha_retribution()
         const int num_miscasts = one_chance_in(4) ? 2 : 1;
         for (int i = 0; i < num_miscasts; i++)
         {
-            MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
+            MiscastEffect(&you, nullptr, {miscast_source::god, god},
                           spschool::necromancy,
                           2 + div_rand_round(you.experience_level, 9),
                           random2avg(88, 3), _god_wrath_name(god));
@@ -700,7 +702,8 @@ static bool _yredelemnul_retribution()
     else
     {
         simple_god_message("'s anger turns toward you for a moment.", god);
-        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::necromancy,
+        MiscastEffect(&you, nullptr, {miscast_source::god, god},
+                      spschool::necromancy,
                       2 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
     }
@@ -793,7 +796,7 @@ static bool _trog_retribution()
         //    we'll leave this effect in, but we'll remove the wild
         //    fire magic. -- bwr
         mprf(MSGCH_WARN, "You feel Trog's fiery rage upon you!");
-        MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, spschool::fire,
+        MiscastEffect(&you, nullptr, {miscast_source::god, god}, spschool::fire,
                       8 + you.experience_level, random2avg(98, 3),
                       _god_wrath_name(god));
     }
@@ -976,7 +979,7 @@ static void _lugonu_transloc_retribution()
     if (coinflip())
     {
         simple_god_message("'s wrath finds you!", god);
-        MiscastEffect(&you, nullptr, {GOD_MISCAST, god},
+        MiscastEffect(&you, nullptr, {miscast_source::god, god},
                       spschool::translocation, 9, 90, "Lugonu's touch");
     }
     else if (coinflip())
@@ -1293,7 +1296,7 @@ static void _fedhas_elemental_miscast()
 
     const spschool stype = random_choose(spschool::ice, spschool::fire,
                                          spschool::earth, spschool::air);
-    MiscastEffect(&you, nullptr, {GOD_MISCAST, god}, stype,
+    MiscastEffect(&you, nullptr, {miscast_source::god, god}, stype,
                   5 + you.experience_level, random2avg(88, 3),
                   _god_wrath_name(god));
 }

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -372,7 +372,7 @@ static bool _cheibriados_retribution()
     // Very high tension wrath
     case 4:
         simple_god_message(" adjusts the clock.", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_RANDOM,
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         if (one_chance_in(3))
@@ -399,7 +399,7 @@ static bool _cheibriados_retribution()
     case 1:
     case 0:
         mpr("Time shudders.");
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_RANDOM,
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::random,
                       5 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
         break;
@@ -634,7 +634,7 @@ static bool _kikubaaqudgha_retribution()
             for (int i = 0; i < 3; ++i)
             {
                 MiscastEffect(&you, nullptr, GOD_MISCAST + god,
-                              SPTYP_NECROMANCY,
+                              spschool::necromancy,
                               2 + div_rand_round(you.experience_level, 9),
                               random2avg(88, 3), _god_wrath_name(god));
             }
@@ -646,9 +646,10 @@ static bool _kikubaaqudgha_retribution()
         const int num_miscasts = one_chance_in(4) ? 2 : 1;
         for (int i = 0; i < num_miscasts; i++)
         {
-            MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
-                      2 + div_rand_round(you.experience_level, 9),
-                      random2avg(88, 3), _god_wrath_name(god));
+            MiscastEffect(&you, nullptr, GOD_MISCAST + god,
+                          spschool::necromancy,
+                          2 + div_rand_round(you.experience_level, 9),
+                          random2avg(88, 3), _god_wrath_name(god));
         }
     }
 
@@ -699,7 +700,7 @@ static bool _yredelemnul_retribution()
     else
     {
         simple_god_message("'s anger turns toward you for a moment.", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_NECROMANCY,
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::necromancy,
                       2 + div_rand_round(you.experience_level, 9),
                       random2avg(88, 3), _god_wrath_name(god));
     }
@@ -792,7 +793,7 @@ static bool _trog_retribution()
         //    we'll leave this effect in, but we'll remove the wild
         //    fire magic. -- bwr
         mprf(MSGCH_WARN, "You feel Trog's fiery rage upon you!");
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_FIRE,
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::fire,
                       8 + you.experience_level, random2avg(98, 3),
                       _god_wrath_name(god));
     }
@@ -975,8 +976,8 @@ static void _lugonu_transloc_retribution()
     if (coinflip())
     {
         simple_god_message("'s wrath finds you!", god);
-        MiscastEffect(&you, nullptr, GOD_MISCAST + god, SPTYP_TRANSLOCATION, 9,
-                      90, "Lugonu's touch");
+        MiscastEffect(&you, nullptr, GOD_MISCAST + god, spschool::translocation,
+                      9, 90, "Lugonu's touch");
     }
     else if (coinflip())
     {
@@ -1290,8 +1291,8 @@ static void _fedhas_elemental_miscast()
     const god_type god = GOD_FEDHAS;
     simple_god_message(" invokes the elements against you.", god);
 
-    const spschool_flag_type stype = random_choose(SPTYP_ICE, SPTYP_FIRE,
-                                                   SPTYP_EARTH, SPTYP_AIR);
+    const spschool stype = random_choose(spschool::ice, spschool::fire,
+                                         spschool::earth, spschool::air);
     MiscastEffect(&you, nullptr, GOD_MISCAST + god, stype,
                   5 + you.experience_level, random2avg(88, 3),
                   _god_wrath_name(god));

--- a/crawl-ref/source/l-spells.cc
+++ b/crawl-ref/source/l-spells.cc
@@ -161,8 +161,8 @@ LUAFN(l_spells_max_power)
 LUAFN(l_spells_dir_or_target)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    const unsigned int flags = get_spell_flags(spell);
-    PLUARET(boolean, flags & SPFLAG_DIR_OR_TARGET);
+    const spell_flags flags = get_spell_flags(spell);
+    PLUARET(boolean, bool(flags & spflag::dir_or_target));
 }
 
 /*** Is this spell targetable?
@@ -173,8 +173,8 @@ LUAFN(l_spells_dir_or_target)
 LUAFN(l_spells_target)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    const unsigned int flags = get_spell_flags(spell);
-    PLUARET(boolean, flags & SPFLAG_TARGET);
+    const spell_flags flags = get_spell_flags(spell);
+    PLUARET(boolean, bool(flags & spflag::target));
 }
 
 /*** Is this spell castable in a direction?
@@ -185,8 +185,8 @@ LUAFN(l_spells_target)
 LUAFN(l_spells_dir)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    const unsigned int flags = get_spell_flags(spell);
-    PLUARET(boolean, flags & SPFLAG_DIR);
+    const spell_flags flags = get_spell_flags(spell);
+    PLUARET(boolean, bool(flags & spflag::dir));
 }
 
 /*** Can this spell target objects?
@@ -197,8 +197,8 @@ LUAFN(l_spells_dir)
 LUAFN(l_spells_targ_obj)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    const unsigned int flags = get_spell_flags(spell);
-    PLUARET(boolean, flags & SPFLAG_OBJ);
+    const spell_flags flags = get_spell_flags(spell);
+    PLUARET(boolean, bool(flags & spflag::obj));
 }
 
 /*** Does our god like this spell?

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -427,7 +427,7 @@ static bool _spell_filter(string key, string body)
     if (spell == SPELL_NO_SPELL)
         return true;
 
-    if (get_spell_flags(spell) & SPFLAG_TESTING)
+    if (get_spell_flags(spell) & spflag::testing)
         return !you.wizard;
 
     return false;

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -5241,14 +5241,14 @@ bool item_list::parse_single_spec(item_spec& result, string s)
         // spell: <include this spell>, owner:<name of owner>
         // None of these are required, but if you don't intend on using any
         // of them, use "any fixed theme book" instead.
-        spschool_flag_type disc1 = SPTYP_NONE;
-        spschool_flag_type disc2 = SPTYP_NONE;
+        spschool disc1 = spschool::none;
+        spschool disc2 = spschool::none;
 
         string st_disc1 = strip_tag_prefix(s, "disc:");
         if (!st_disc1.empty())
         {
             disc1 = school_by_name(st_disc1);
-            if (disc1 == SPTYP_NONE)
+            if (disc1 == spschool::none)
             {
                 error = make_stringf("Bad spell school: %s", st_disc1.c_str());
                 return false;
@@ -5259,14 +5259,14 @@ bool item_list::parse_single_spec(item_spec& result, string s)
         if (!st_disc2.empty())
         {
             disc2 = school_by_name(st_disc2);
-            if (disc2 == SPTYP_NONE)
+            if (disc2 == spschool::none)
             {
                 error = make_stringf("Bad spell school: %s", st_disc2.c_str());
                 return false;
             }
         }
 
-        if (disc1 == SPTYP_NONE && disc2 != 0)
+        if (disc1 == spschool::none && disc2 != spschool::none)
         {
             // Don't fail, just quietly swap. Any errors in disc1's syntax will
             // have been caught above, anyway.
@@ -5315,9 +5315,8 @@ bool item_list::parse_single_spec(item_spec& result, string s)
         const string owner = replace_all_of(strip_tag_prefix(s, "owner:"),
                                             "_", " ");
 
-        COMPILE_CHECK(SPTYP_LAST_SCHOOL < SHRT_MAX);
-        result.props[RANDBK_DISC1_KEY].get_short() = disc1;
-        result.props[RANDBK_DISC2_KEY].get_short() = disc2;
+        result.props[RANDBK_DISC1_KEY].get_short() = static_cast<short>(disc1);
+        result.props[RANDBK_DISC2_KEY].get_short() = static_cast<short>(disc2);
         result.props[RANDBK_NSPELLS_KEY] = num_spells;
         result.props[RANDBK_SLVLS_KEY] = slevels;
         result.props[RANDBK_TITLE_KEY] = title;

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -1992,7 +1992,7 @@ static bool _animate_dead_okay(spell_type spell)
 static bool _ms_direct_nasty(spell_type monspell)
 {
     return !(get_spell_flags(monspell) & spflag::utility
-             || spell_typematch(monspell, SPTYP_SUMMONING));
+             || spell_typematch(monspell, spschool::summoning));
 }
 
 // Checks if the foe *appears* to be immune to negative energy. We
@@ -7697,7 +7697,7 @@ static bool _ms_waste_of_time(monster* mon, mon_spell_slot slot)
     const bool friendly = mon->friendly();
 
     // Keep friendly summoners from spamming summons constantly.
-    if (friendly && !foe && spell_typematch(monspell, SPTYP_SUMMONING))
+    if (friendly && !foe && spell_typematch(monspell, spschool::summoning))
         return true;
 
     // Don't try to cast spells at players who are stepped from time.

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1055,7 +1055,7 @@ static void _mummy_curse(monster* mons, int pow, killer_type killer, int index)
     }
     const string cause = make_stringf("%s death curse",
                             apostrophise(mons->name(DESC_A)).c_str());
-    MiscastEffect(target, mons, {MUMMY_MISCAST}, spschool::necromancy,
+    MiscastEffect(target, mons, {miscast_source::mummy}, spschool::necromancy,
                   pow, random2avg(88, 3), cause.c_str());
 }
 

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1055,7 +1055,7 @@ static void _mummy_curse(monster* mons, int pow, killer_type killer, int index)
     }
     const string cause = make_stringf("%s death curse",
                             apostrophise(mons->name(DESC_A)).c_str());
-    MiscastEffect(target, mons, MUMMY_MISCAST, SPTYP_NECROMANCY,
+    MiscastEffect(target, mons, MUMMY_MISCAST, spschool::necromancy,
                   pow, random2avg(88, 3), cause.c_str());
 }
 

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1055,7 +1055,7 @@ static void _mummy_curse(monster* mons, int pow, killer_type killer, int index)
     }
     const string cause = make_stringf("%s death curse",
                             apostrophise(mons->name(DESC_A)).c_str());
-    MiscastEffect(target, mons, MUMMY_MISCAST, spschool::necromancy,
+    MiscastEffect(target, mons, {MUMMY_MISCAST}, spschool::necromancy,
                   pow, random2avg(88, 3), cause.c_str());
 }
 

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3722,12 +3722,12 @@ static bool _ms_ranged_spell(spell_type monspell, bool attack_only = false,
         return !attack_only;
     }
 
-    const unsigned int flags = get_spell_flags(monspell);
+    const spell_flags flags = get_spell_flags(monspell);
 
     // buffs & escape spells aren't considered 'ranged'.
-    if (testbits(flags, SPFLAG_SELFENCH)
+    if (testbits(flags, spflag::selfench)
         || spell_typematch(monspell, SPTYP_CHARMS)
-        || testbits(flags, SPFLAG_ESCAPE)
+        || testbits(flags, spflag::escape)
         || monspell == SPELL_BLINK_OTHER_CLOSE)
     {
         return false;

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -847,7 +847,7 @@ bool mons_is_fiery(const monster& mon)
     return mon.has_attack_flavour(AF_FIRE)
            || mon.has_attack_flavour(AF_PURE_FIRE)
            || mon.has_attack_flavour(AF_STICKY_FLAME)
-           || mon.has_spell_of_type(SPTYP_FIRE);
+           || mon.has_spell_of_type(spschool::fire);
 }
 
 bool mons_is_projectile(monster_type mc)
@@ -3716,7 +3716,7 @@ static bool _ms_ranged_spell(spell_type monspell, bool attack_only = false,
                              bool ench_too = true)
 {
     // summoning spells are usable from ranged, but not direct attacks.
-    if (spell_typematch(monspell, SPTYP_SUMMONING)
+    if (spell_typematch(monspell, spschool::summoning)
         || monspell == SPELL_CONJURE_BALL_LIGHTNING)
     {
         return !attack_only;
@@ -3726,7 +3726,7 @@ static bool _ms_ranged_spell(spell_type monspell, bool attack_only = false,
 
     // buffs & escape spells aren't considered 'ranged'.
     if (testbits(flags, spflag::selfench)
-        || spell_typematch(monspell, SPTYP_CHARMS)
+        || spell_typematch(monspell, spschool::charms)
         || testbits(flags, spflag::escape)
         || monspell == SPELL_BLINK_OTHER_CLOSE)
     {
@@ -3734,11 +3734,11 @@ static bool _ms_ranged_spell(spell_type monspell, bool attack_only = false,
     }
 
     // conjurations are attacks.
-    if (spell_typematch(monspell, SPTYP_CONJURATION))
+    if (spell_typematch(monspell, spschool::conjuration))
         return true;
 
     // hexes that aren't conjurations or summons are enchantments.
-    if (spell_typematch(monspell, SPTYP_HEXES))
+    if (spell_typematch(monspell, spschool::hexes))
         return !attack_only && ench_too;
 
     switch (monspell)

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -705,7 +705,7 @@ bool monster::search_spells(function<bool (spell_type)> func) const
                         { return func(s.spell); });
 }
 
-bool monster::has_spell_of_type(spschool_flag_type discipline) const
+bool monster::has_spell_of_type(spschool discipline) const
 {
     return search_spells(bind(spell_typematch, placeholders::_1, discipline));
 }
@@ -733,11 +733,11 @@ void monster::bind_spell_flags()
 static bool _needs_ranged_attack(const monster* mon)
 {
     // Prevent monsters that have conjurations from grabbing missiles.
-    if (mon->has_spell_of_type(SPTYP_CONJURATION))
+    if (mon->has_spell_of_type(spschool::conjuration))
         return false;
 
     // Same for summonings, but make an exception for friendlies.
-    if (!mon->friendly() && mon->has_spell_of_type(SPTYP_SUMMONING))
+    if (!mon->friendly() && mon->has_spell_of_type(spschool::summoning))
         return false;
 
     // Blademasters don't want to throw stuff.
@@ -4189,7 +4189,7 @@ int monster::skill(skill_type sk, int scale, bool real, bool drained, bool temp)
         return hd;
 
     case SK_NECROMANCY:
-        return (has_spell_of_type(SPTYP_NECROMANCY)) ? hd : hd/2;
+        return (has_spell_of_type(spschool::necromancy)) ? hd : hd/2;
 
     case SK_POISON_MAGIC:
     case SK_FIRE_MAGIC:

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -534,7 +534,7 @@ public:
     int action_energy(energy_use_type et) const;
 
     bool do_shaft() override;
-    bool has_spell_of_type(spschool_flag_type discipline) const;
+    bool has_spell_of_type(spschool discipline) const;
 
     void bind_melee_flags();
     void bind_spell_flags();

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -332,8 +332,8 @@ static void _give_wanderer_book(skill_type skill)
  * @param spell             The spell to be filtered.
  * @return                  Whether the spell can be included.
  */
-static bool exact_level_spell_filter(spschool_flag_type discipline_1,
-                                     spschool_flag_type discipline_2,
+static bool exact_level_spell_filter(spschool discipline_1,
+                                     spschool discipline_2,
                                      int agent,
                                      const vector<spell_type> &prev,
                                      spell_type spell)
@@ -381,7 +381,7 @@ static void _give_wanderer_minor_book(skill_type skill)
         skill = skill_type(SK_FIRST_MAGIC_SCHOOL + random2(value));
     }
 
-    spschool_flag_type school = skill2spell_type(skill);
+    spschool school = skill2spell_type(skill);
 
     item_def* item = newgame_make_item(OBJ_BOOKS, BOOK_RANDART_THEME);
     if (!item)

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -732,7 +732,7 @@ static void _unequip_weapon_effect(item_def& real_item, bool showMsgs,
                     // branded weapon since you can wait it out. This also
                     // fixes problems with unwield prompts (mantis #793).
                     MiscastEffect(&you, nullptr, WIELD_MISCAST,
-                                  SPTYP_TRANSLOCATION, 9, 90,
+                                  spschool::translocation, 9, 90,
                                   "a distortion unwield");
                 }
                 break;

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -731,7 +731,7 @@ static void _unequip_weapon_effect(item_def& real_item, bool showMsgs,
                     // Makes no sense to discourage unwielding a temporarily
                     // branded weapon since you can wait it out. This also
                     // fixes problems with unwield prompts (mantis #793).
-                    MiscastEffect(&you, nullptr, WIELD_MISCAST,
+                    MiscastEffect(&you, nullptr, {WIELD_MISCAST},
                                   spschool::translocation, 9, 90,
                                   "a distortion unwield");
                 }

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -731,7 +731,7 @@ static void _unequip_weapon_effect(item_def& real_item, bool showMsgs,
                     // Makes no sense to discourage unwielding a temporarily
                     // branded weapon since you can wait it out. This also
                     // fixes problems with unwield prompts (mantis #793).
-                    MiscastEffect(&you, nullptr, {WIELD_MISCAST},
+                    MiscastEffect(&you, nullptr, {miscast_source::wield},
                                   spschool::translocation, 9, 90,
                                   "a distortion unwield");
                 }

--- a/crawl-ref/source/randbook.cc
+++ b/crawl-ref/source/randbook.cc
@@ -21,25 +21,24 @@
 #include "stringutil.h"
 
 static string _gen_randbook_name(string subject, string owner,
-                                 spschool_flag_type disc1,
-                                 spschool_flag_type disc2);
-static string _gen_randbook_owner(god_type god, spschool_flag_type disc1,
-                                  spschool_flag_type disc2,
+                                 spschool disc1, spschool disc2);
+static string _gen_randbook_owner(god_type god, spschool disc1,
+                                  spschool disc2,
                                   const vector<spell_type> &spells);
 
 /// How many spells should be in a random theme book?
 int theme_book_size() { return random2avg(7, 3) + 2; }
 
 /// A discipline chooser that only ever returns the given discipline.
-function<spschool_flag_type()> forced_book_theme(spschool_flag_type theme)
+function<spschool()> forced_book_theme(spschool theme)
 {
     return [theme]() { return theme; };
 }
 
 /// Choose a random valid discipline for a themed randbook.
-spschool_flag_type random_book_theme()
+spschool random_book_theme()
 {
-    vector<spschool_flag_type> disciplines;
+    vector<spschool> disciplines;
     for (auto discipline : spschools_type::range())
         disciplines.push_back(discipline);
     return disciplines[random2(disciplines.size())];
@@ -56,9 +55,9 @@ spschool_flag_type random_book_theme()
  * @return                  A discipline which will match as many of those
  *                          spells as possible.
  */
-spschool_flag_type matching_book_theme(const vector<spell_type> &forced_spells)
+spschool matching_book_theme(const vector<spell_type> &forced_spells)
 {
-    map<spschool_flag_type, int> seen_disciplines;
+    map<spschool, int> seen_disciplines;
     for (auto spell : forced_spells)
     {
         const spschools_type disciplines = get_spell_disciplines(spell);
@@ -79,7 +78,7 @@ spschool_flag_type matching_book_theme(const vector<spell_type> &forced_spells)
 
     if (!matched)
     {
-        const spschool_flag_type *discipline
+        const spschool *discipline
             = random_choose_weighted(seen_disciplines);
         if (discipline)
             return *discipline;
@@ -88,7 +87,7 @@ spschool_flag_type matching_book_theme(const vector<spell_type> &forced_spells)
 
     for (auto seen : seen_disciplines)
         seen.second = seen.second == (int)forced_spells.size() ? 1 : 0;
-    const spschool_flag_type *discipline
+    const spschool *discipline
         = random_choose_weighted(seen_disciplines);
     ASSERT(discipline);
     return *discipline;
@@ -146,8 +145,8 @@ static bool _agent_spell_filter(int agent, spell_type spell)
  * @param spell             The spell to be filtered.
  * @return                  Whether the spell can be included.
  */
-bool basic_themed_spell_filter(spschool_flag_type discipline_1,
-                               spschool_flag_type discipline_2,
+bool basic_themed_spell_filter(spschool discipline_1,
+                               spschool discipline_2,
                                int agent,
                                const vector<spell_type> &prev,
                                spell_type spell)
@@ -183,8 +182,8 @@ themed_spell_filter capped_spell_filter(int max_levels,
     if (max_levels < 1)
         return subfilter; // don't even bother.
 
-    return [max_levels, subfilter](spschool_flag_type discipline_1,
-                                   spschool_flag_type discipline_2,
+    return [max_levels, subfilter](spschool discipline_1,
+                                   spschool discipline_2,
                                    int agent,
                                    const vector<spell_type> &prev,
                                    spell_type spell)
@@ -212,8 +211,8 @@ themed_spell_filter capped_spell_filter(int max_levels,
 themed_spell_filter forced_spell_filter(const vector<spell_type> &forced_spells,
                                         themed_spell_filter subfilter)
 {
-    return [&forced_spells, subfilter](spschool_flag_type discipline_1,
-                                       spschool_flag_type discipline_2,
+    return [&forced_spells, subfilter](spschool discipline_1,
+                                       spschool discipline_2,
                                        int agent,
                                        const vector<spell_type> &prev,
                                        spell_type spell)
@@ -234,8 +233,8 @@ themed_spell_filter forced_spell_filter(const vector<spell_type> &forced_spells,
  * @param num_spells        How many spells should be included.
  * @param spells[out]       The list to be populated.
  */
-void theme_book_spells(spschool_flag_type discipline_1,
-                       spschool_flag_type discipline_2,
+void theme_book_spells(spschool discipline_1,
+                       spschool discipline_2,
                        themed_spell_filter filter,
                        int agent,
                        int num_spells,
@@ -275,8 +274,8 @@ void theme_book_spells(spschool_flag_type discipline_1,
  * @param discipline_1[in,out]      The second book discipline.
  * @param spells[in]                The list of spells the book should contain.
  */
-void fixup_randbook_disciplines(spschool_flag_type &discipline_1,
-                                spschool_flag_type &discipline_2,
+void fixup_randbook_disciplines(spschool &discipline_1,
+                                spschool &discipline_2,
                                 const vector<spell_type> &spells)
 {
     bool has_d1 = false, has_d2 = false;
@@ -310,14 +309,14 @@ void fixup_randbook_disciplines(spschool_flag_type &discipline_1,
  * @param subject           The subject of the book, if any. Cosmetic.
  */
 void build_themed_book(item_def &book, themed_spell_filter filter,
-                       function<spschool_flag_type()> get_discipline,
+                       function<spschool()> get_discipline,
                        int num_spells, string owner, string subject)
 {
     if (num_spells < 1)
         num_spells = theme_book_size();
 
-    spschool_flag_type discipline_1 = get_discipline();
-    spschool_flag_type discipline_2 = get_discipline();
+    spschool discipline_1 = get_discipline();
+    spschool discipline_2 = get_discipline();
 
     item_source_type agent;
     if (!origin_is_acquirement(book, &agent))
@@ -349,8 +348,8 @@ static bool _compare_spells(spell_type a, spell_type b)
     spschools_type schools_a = get_spell_disciplines(a);
     spschools_type schools_b = get_spell_disciplines(b);
 
-    if (schools_a != schools_b && schools_a != SPTYP_NONE
-        && schools_b != SPTYP_NONE)
+    if (schools_a != schools_b && schools_a != spschool::none
+        && schools_b != spschool::none)
     {
         const char* a_type = nullptr;
         const char* b_type = nullptr;
@@ -727,8 +726,8 @@ void init_book_theme_randart(item_def &book, vector<spell_type> spells)
  * @param owner             The book's owner; e.g. "Xom". May be empty.
  * @param subject           The subject of the book. May be empty.
  */
-void name_book_theme_randart(item_def &book, spschool_flag_type discipline_1,
-                             spschool_flag_type discipline_2,
+void name_book_theme_randart(item_def &book, spschool discipline_1,
+                             spschool discipline_2,
                              string owner, string subject)
 {
     if (owner.empty())
@@ -775,8 +774,8 @@ static string _maybe_gen_book_subject(string owner)
  * @return              A book name. May contain placeholders (@foo@).
  */
 static string _gen_randbook_name(string subject, string owner,
-                                 spschool_flag_type disc1,
-                                 spschool_flag_type disc2)
+                                 spschool disc1,
+                                 spschool disc2)
 {
     const string apostrophised_owner = owner.empty() ?
         "" :
@@ -862,8 +861,8 @@ static string _gen_randbook_name(string subject, string owner,
  * @param spells        The spells in the book.
  * @return              The name of the book's 'owner', or the empty string.
  */
-static string _gen_randbook_owner(god_type god, spschool_flag_type disc1,
-                                  spschool_flag_type disc2,
+static string _gen_randbook_owner(god_type god, spschool disc1,
+                                  spschool disc2,
                                   const vector<spell_type> &spells)
 {
     // If the owner hasn't been set already use
@@ -934,11 +933,11 @@ static string _gen_randbook_owner(god_type god, spschool_flag_type disc1,
     {
         switch (disc1)
         {
-            case SPTYP_NECROMANCY:
+            case spschool::necromancy:
                 if (all_spells_disc1 && !one_chance_in(6))
                     return god_name(GOD_KIKUBAAQUDGHA, false);
                 break;
-            case SPTYP_CONJURATION:
+            case spschool::conjuration:
                 if (all_spells_disc1 && !one_chance_in(4))
                     return god_name(GOD_VEHUMET, false);
                 break;
@@ -955,7 +954,7 @@ static string _gen_randbook_owner(god_type god, spschool_flag_type disc1,
 // that includes Statue Form and is named after her.
 void make_book_roxanne_special(item_def *book)
 {
-    spschool_flag_type disc = random_choose(SPTYP_TRANSMUTATION, SPTYP_EARTH);
+    spschool disc = random_choose(spschool::transmutation, spschool::earth);
     vector<spell_type> forced_spell = {SPELL_STATUE_FORM};
     build_themed_book(*book,
                       forced_spell_filter(forced_spell,
@@ -1131,13 +1130,13 @@ static void _get_weighted_randbook_spells(weighted_spells &possible_spells,
  * @param possibles     A weighted list of all possible spells to include in
  *                      the book.
  * @param agent         The entity creating the item; possibly a god.
- * @return              An appropriate spell school; e.g. SPTYP_FIRE.
+ * @return              An appropriate spell school; e.g. spschool::fire.
  */
-static spschool_flag_type _choose_randbook_discipline(weighted_spells
+static spschool _choose_randbook_discipline(weighted_spells
                                                       &possible_spells,
                                                       int agent)
 {
-    map<spschool_flag_type, int> discipline_weights;
+    map<spschool, int> discipline_weights;
     for (auto weighted_spell : possible_spells)
     {
         const spell_type spell = weighted_spell.first;
@@ -1155,7 +1154,7 @@ static spschool_flag_type _choose_randbook_discipline(weighted_spells
         }
     }
 
-    const spschool_flag_type *discipline
+    const spschool *discipline
         = random_choose_weighted(discipline_weights);
     ASSERT(discipline);
     return *discipline;
@@ -1173,8 +1172,8 @@ static spschool_flag_type _choose_randbook_discipline(weighted_spells
  * @param[out] spells               The chosen spells.
  */
 static void _choose_themed_randbook_spells(weighted_spells &possible_spells,
-                                           spschool_flag_type discipline_1,
-                                           spschool_flag_type discipline_2,
+                                           spschool discipline_1,
+                                           spschool discipline_2,
                                            int size, vector<spell_type> &spells)
 {
     for (auto &weighted_spell : possible_spells)
@@ -1211,9 +1210,9 @@ void acquire_themed_randbook(item_def &book, int agent)
     ASSERT(size);
 
     // XXX: we could cache this...
-    spschool_flag_type discipline_1
+    spschool discipline_1
         = _choose_randbook_discipline(possible_spells, agent);
-    spschool_flag_type discipline_2
+    spschool discipline_2
         = _choose_randbook_discipline(possible_spells, agent);
 
     vector<spell_type> spells;

--- a/crawl-ref/source/randbook.h
+++ b/crawl-ref/source/randbook.h
@@ -9,8 +9,8 @@
 
 #include "spl-util.h"
 
-typedef function<bool(spschool_flag_type discipline_1,
-                      spschool_flag_type discipline_2,
+typedef function<bool(spschool discipline_1,
+                      spschool discipline_2,
                       int agent,
                       const vector<spell_type> &prev,
                       spell_type spell)> themed_spell_filter;
@@ -18,12 +18,12 @@ typedef function<bool(spschool_flag_type discipline_1,
 /// How many spells should be in a random theme book?
 int theme_book_size();
 
-spschool_flag_type random_book_theme();
-spschool_flag_type matching_book_theme(const vector<spell_type> &forced_spells);
-function<spschool_flag_type()> forced_book_theme(spschool_flag_type theme);
+spschool random_book_theme();
+spschool matching_book_theme(const vector<spell_type> &forced_spells);
+function<spschool()> forced_book_theme(spschool theme);
 
-bool basic_themed_spell_filter(spschool_flag_type discipline_1,
-                               spschool_flag_type discipline_2,
+bool basic_themed_spell_filter(spschool discipline_1,
+                               spschool discipline_2,
                                int agent,
                                const vector<spell_type> &prev,
                                spell_type spell);
@@ -34,8 +34,8 @@ themed_spell_filter forced_spell_filter(const vector<spell_type> &forced_spells,
                                         themed_spell_filter subfilter
                                             = basic_themed_spell_filter);
 
-void theme_book_spells(spschool_flag_type discipline_1,
-                       spschool_flag_type discipline_2,
+void theme_book_spells(spschool discipline_1,
+                       spschool discipline_2,
                        themed_spell_filter filter,
                        int agent,
                        int num_spells,
@@ -43,17 +43,17 @@ void theme_book_spells(spschool_flag_type discipline_1,
 
 void build_themed_book(item_def &book,
                        themed_spell_filter filter = basic_themed_spell_filter,
-                       function<spschool_flag_type()> get_discipline
+                       function<spschool()> get_discipline
                             = random_book_theme,
                        int num_spells = -1,
                        string owner = "", string subject = "");
 
-void fixup_randbook_disciplines(spschool_flag_type &discipline_1,
-                                spschool_flag_type &discipline_2,
+void fixup_randbook_disciplines(spschool &discipline_1,
+                                spschool &discipline_2,
                                 const vector<spell_type> &spells);
 void init_book_theme_randart(item_def &book, vector<spell_type> spells);
-void name_book_theme_randart(item_def &book, spschool_flag_type discipline_1,
-                             spschool_flag_type discipline_2,
+void name_book_theme_randart(item_def &book, spschool discipline_1,
+                             spschool discipline_2,
                              string owner = "", string subject = "");
 
 bool make_book_level_randart(item_def &book, int level = -1);

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3878,7 +3878,7 @@ bool god_likes_spell(spell_type spell, god_type god)
     case GOD_VEHUMET:
         return vehumet_supports_spell(spell);
     case GOD_KIKUBAAQUDGHA:
-        return spell_typematch(spell, SPTYP_NECROMANCY);
+        return spell_typematch(spell, spschool::necromancy);
     default: // quash unhandled constants warnings
         return false;
     }

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -271,9 +271,9 @@ void init_spell_rarities()
             }
             last = spell;
 
-            unsigned int flags = get_spell_flags(spell);
+            spell_flags flags = get_spell_flags(spell);
 
-            if (flags & (SPFLAG_MONSTER | SPFLAG_TESTING))
+            if (flags & (spflag::monster | spflag::testing))
             {
                 item_def item;
                 item.base_type = OBJ_BOOKS;

--- a/crawl-ref/source/spl-book.h
+++ b/crawl-ref/source/spl-book.h
@@ -7,7 +7,7 @@
 
 #define RANDBOOK_SIZE 8
 #include "item-prop-enum.h"
-#include "spl-util.h" // spschool_flag_type
+#include "spl-util.h" // spschool
 
 #define SPELL_LIST_KEY "spell_list"
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1318,9 +1318,9 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
     if (!wiz_cast && _spellcasting_aborted(spell, !allow_fail))
         return spret::abort;
 
-    const unsigned int flags = get_spell_flags(spell);
+    const spell_flags flags = get_spell_flags(spell);
 
-    ASSERT(wiz_cast || !(flags & SPFLAG_TESTING));
+    ASSERT(wiz_cast || !(flags & spflag::testing));
 
     if (!powc)
         powc = calc_spell_power(spell, true);
@@ -1329,25 +1329,25 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
     // targeting. There are others that do their own that will be
     // missed by this (and thus will not properly ESC without cost
     // because of it). Hopefully, those will eventually be fixed. - bwr
-    if (flags & SPFLAG_TARGETING_MASK)
+    if (flags & spflag::targeting_mask)
     {
         const targ_mode_type targ =
-              testbits(flags, SPFLAG_NEUTRAL)    ? TARG_ANY :
-              testbits(flags, SPFLAG_HELPFUL)    ? TARG_FRIEND :
-              testbits(flags, SPFLAG_OBJ)        ? TARG_MOVABLE_OBJECT :
+              testbits(flags, spflag::neutral)    ? TARG_ANY :
+              testbits(flags, spflag::helpful)    ? TARG_FRIEND :
+              testbits(flags, spflag::obj)        ? TARG_MOVABLE_OBJECT :
                                                    TARG_HOSTILE;
 
         const targeting_type dir =
-             testbits(flags, SPFLAG_TARGET) ? DIR_TARGET :
-             testbits(flags, SPFLAG_DIR)    ? DIR_DIR    :
+             testbits(flags, spflag::target) ? DIR_TARGET :
+             testbits(flags, spflag::dir)    ? DIR_DIR    :
                                               DIR_NONE;
 
         const char *prompt = get_spell_target_prompt(spell);
         if (dir == DIR_DIR)
             mprf(MSGCH_PROMPT, "%s", prompt ? prompt : "Which direction?");
 
-        const bool needs_path = !testbits(flags, SPFLAG_TARGET)
-                                // Apportation must be SPFLAG_TARGET, since a
+        const bool needs_path = !testbits(flags, spflag::target)
+                                // Apportation must be spflag::target, since a
                                 // shift-direction makes no sense for it, but
                                 // it nevertheless requires line-of-fire.
                                 || spell == SPELL_APPORTATION;
@@ -1357,9 +1357,9 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
         unique_ptr<targeter> hitfunc = _spell_targeter(spell, powc, range);
 
         // Add success chance to targeted spells checking monster MR
-        const bool mr_check = testbits(flags, SPFLAG_MR_CHECK)
-                              && testbits(flags, SPFLAG_DIR_OR_TARGET)
-                              && !testbits(flags, SPFLAG_HELPFUL);
+        const bool mr_check = testbits(flags, spflag::MR_check)
+                              && testbits(flags, spflag::dir_or_target)
+                              && !testbits(flags, spflag::helpful);
         desc_filter additional_desc = nullptr;
         if (mr_check)
         {
@@ -1391,7 +1391,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
             args.show_floor_desc = true;
             args.show_boring_feats = false; // don't show "The floor."
         }
-        if (testbits(flags, SPFLAG_NOT_SELF))
+        if (testbits(flags, spflag::not_self))
             args.self = CONFIRM_CANCEL;
         else
             args.self = CONFIRM_NONE;
@@ -1401,7 +1401,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
 
         beam.range = range;
 
-        if (testbits(flags, SPFLAG_NOT_SELF) && spd.isMe())
+        if (testbits(flags, spflag::not_self) && spd.isMe())
         {
             if (spell == SPELL_TELEPORT_OTHER)
                 mpr("Sorry, this spell works on others only.");
@@ -1515,8 +1515,8 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
         if (will_have_passive(passive_t::shadow_spells)
             && allow_fail
             && !god_hates_spell(spell, you.religion, !allow_fail)
-            && (flags & SPFLAG_TARGETING_MASK)
-            && !(flags & SPFLAG_NEUTRAL)
+            && (flags & spflag::targeting_mask)
+            && !(flags & spflag::neutral)
             && (beam.is_enchantment()
                 || battlesphere_can_mirror(spell))
             && (!old_target || (victim && !victim->is_player())))
@@ -1568,7 +1568,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
     case spret::none:
 #ifdef WIZARD
         if (you.wizard && !allow_fail && is_valid_spell(spell)
-            && (flags & SPFLAG_MONSTER))
+            && (flags & spflag::monster))
         {
             _try_monster_cast(spell, powc, spd, beam);
             return spret::success;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1468,7 +1468,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
                                "death!", GOD_KIKUBAAQUDGHA);
 
             // The spell still goes through, but you get a miscast anyway.
-            MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_KIKUBAAQUDGHA,
+            MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_KIKUBAAQUDGHA},
                           spschool::necromancy,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Kikubaaqudgha");
@@ -1483,7 +1483,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
                                "destruction!", GOD_VEHUMET);
 
             // The spell still goes through, but you get a miscast anyway.
-            MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_VEHUMET,
+            MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_VEHUMET},
                           spschool::conjuration,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Vehumet");
@@ -1556,7 +1556,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
         // miscasts are uncontrolled
         contaminate_player(cont_points, true);
 
-        MiscastEffect(&you, nullptr, SPELL_MISCAST, spell,
+        MiscastEffect(&you, nullptr, {SPELL_MISCAST}, spell,
                       spell_difficulty(spell), fail);
 
         return spret::fail;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -493,34 +493,34 @@ static int _spell_enhancement(spell_type spell)
     const spschools_type typeflags = get_spell_disciplines(spell);
     int enhanced = 0;
 
-    if (typeflags & SPTYP_CONJURATION)
+    if (typeflags & spschool::conjuration)
         enhanced += player_spec_conj();
 
-    if (typeflags & SPTYP_HEXES)
+    if (typeflags & spschool::hexes)
         enhanced += player_spec_hex();
 
-    if (typeflags & SPTYP_CHARMS)
+    if (typeflags & spschool::charms)
         enhanced += player_spec_charm();
 
-    if (typeflags & SPTYP_SUMMONING)
+    if (typeflags & spschool::summoning)
         enhanced += player_spec_summ();
 
-    if (typeflags & SPTYP_POISON)
+    if (typeflags & spschool::poison)
         enhanced += player_spec_poison();
 
-    if (typeflags & SPTYP_NECROMANCY)
+    if (typeflags & spschool::necromancy)
         enhanced += player_spec_death();
 
-    if (typeflags & SPTYP_FIRE)
+    if (typeflags & spschool::fire)
         enhanced += player_spec_fire();
 
-    if (typeflags & SPTYP_ICE)
+    if (typeflags & spschool::ice)
         enhanced += player_spec_cold();
 
-    if (typeflags & SPTYP_EARTH)
+    if (typeflags & spschool::earth)
         enhanced += player_spec_earth();
 
-    if (typeflags & SPTYP_AIR)
+    if (typeflags & spschool::air)
         enhanced += player_spec_air();
 
     if (you.form == transformation::shadow)
@@ -1458,7 +1458,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
             // This will cause failure and increase the miscast effect.
             spfl = -you.penance[GOD_SIF_MUNA];
         }
-        else if (spell_typematch(spell, SPTYP_NECROMANCY)
+        else if (spell_typematch(spell, spschool::necromancy)
                  && !you_worship(GOD_KIKUBAAQUDGHA)
                  && you.penance[GOD_KIKUBAAQUDGHA]
                  && one_chance_in(20))
@@ -1469,7 +1469,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
 
             // The spell still goes through, but you get a miscast anyway.
             MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_KIKUBAAQUDGHA,
-                          SPTYP_NECROMANCY,
+                          spschool::necromancy,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Kikubaaqudgha");
         }
@@ -1484,7 +1484,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
 
             // The spell still goes through, but you get a miscast anyway.
             MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_VEHUMET,
-                          SPTYP_CONJURATION,
+                          spschool::conjuration,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Vehumet");
         }

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1468,7 +1468,8 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
                                "death!", GOD_KIKUBAAQUDGHA);
 
             // The spell still goes through, but you get a miscast anyway.
-            MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_KIKUBAAQUDGHA},
+            MiscastEffect(&you, nullptr,
+                          {miscast_source::god, GOD_KIKUBAAQUDGHA},
                           spschool::necromancy,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Kikubaaqudgha");
@@ -1483,7 +1484,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
                                "destruction!", GOD_VEHUMET);
 
             // The spell still goes through, but you get a miscast anyway.
-            MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_VEHUMET},
+            MiscastEffect(&you, nullptr, {miscast_source::god, GOD_VEHUMET},
                           spschool::conjuration,
                           (you.experience_level / 2) + (spell_difficulty(spell) * 2),
                           random2avg(88, 3), "the malice of Vehumet");
@@ -1556,7 +1557,7 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
         // miscasts are uncontrolled
         contaminate_player(cont_points, true);
 
-        MiscastEffect(&you, nullptr, {SPELL_MISCAST}, spell,
+        MiscastEffect(&you, nullptr, {miscast_source::spell}, spell,
                       spell_difficulty(spell), fail);
 
         return spret::fail;

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -7,47 +7,48 @@
 
 #include "enum.h"
 
-enum spflag_type
+enum class spflag
 {
-    SPFLAG_NONE                 = 0x000000,
-    SPFLAG_DIR_OR_TARGET        = 0x000001,      // use DIR_NONE targeting
-    SPFLAG_TARGET               = 0x000002,      // use DIR_TARGET targeting
-                                //0x000004,
-    SPFLAG_DIR                  = 0x000008,      // use DIR_DIR targeting
-    SPFLAG_TARGETING_MASK       = SPFLAG_DIR_OR_TARGET | SPFLAG_TARGET
-                                   | SPFLAG_DIR , // used to test for targeting
+    none               = 0x00000000,
+    dir_or_target      = 0x00000001,      // use DIR_NONE targeting
+    target             = 0x00000002,      // use DIR_TARGET targeting
+                     //  0x00000004,
+    dir                = 0x00000008,      // use DIR_DIR targeting
+    targeting_mask     = spflag::dir_or_target | spflag::target
+                             | spflag::dir, // used to test for targeting
     // TODO: we need a new flag if we want to target corpses too.
-    SPFLAG_OBJ                  = 0x000010,      // TARG_MOVABLE_OBJECT used
-    SPFLAG_HELPFUL              = 0x000020,      // TARG_FRIEND used
-    SPFLAG_NEUTRAL              = 0x000040,      // TARG_ANY used
-    SPFLAG_NOT_SELF             = 0x000080,      // aborts on isMe
-    SPFLAG_UNHOLY               = 0x000100,      // counts as "unholy"
-    SPFLAG_UNCLEAN              = 0x000200,      // counts as "unclean"
-    SPFLAG_CHAOTIC              = 0x000400,      // counts as "chaotic"
-    SPFLAG_HASTY                = 0x000800,      // counts as "hasty"
-    SPFLAG_EMERGENCY            = 0x001000,      // monsters use in emergencies
-    SPFLAG_ESCAPE               = 0x002000,      // useful for running away
-    SPFLAG_RECOVERY             = 0x004000,      // healing or recovery spell
-    SPFLAG_AREA                 = 0x008000,      // area affect
-                            //  = 0x010000,      // was SPFLAG_BATTLE
-    SPFLAG_SELFENCH             = 0x020000,      // monsters use as selfench
-    SPFLAG_MONSTER              = 0x040000,      // monster-only spell
-    SPFLAG_NEEDS_TRACER         = 0x080000,      // monster casting needs tracer
-    SPFLAG_NOISY                = 0x100000,      // makes noise, even if innate
-    SPFLAG_TESTING              = 0x200000,      // a testing/debugging spell
-    SPFLAG_CORPSE_VIOLATING     = 0x400000,      // Conduct violation for Fedhas
-                               // 0x800000,      // was SPFLAG_ALLOW_SELF
-    SPFLAG_UTILITY             = 0x1000000,      // usable no matter what foe is
-    SPFLAG_NO_GHOST            = 0x2000000,      // ghosts can't get this spell
-    SPFLAG_CLOUD               = 0x4000000,      // makes a cloud
-    SPFLAG_MR_CHECK            = 0x8000000,      // spell that checks monster MR
-    SPFLAG_MONS_ABJURE        = 0x10000000,      // monsters can cast abjuration
-                                                 // instead of this spell
-    SPFLAG_NOT_EVIL           = 0x20000000,      // not considered evil by the
-                                                 // good gods
-    SPFLAG_HOLY               = 0x40000000,      // considered holy (can't be
-                                                 // used by Yred enslaved souls)
+    obj                = 0x00000010,      // TARG_MOVABLE_OBJECT used
+    helpful            = 0x00000020,      // TARG_FRIEND used
+    neutral            = 0x00000040,      // TARG_ANY used
+    not_self           = 0x00000080,      // aborts on isMe
+    unholy             = 0x00000100,      // counts as "unholy"
+    unclean            = 0x00000200,      // counts as "unclean"
+    chaotic            = 0x00000400,      // counts as "chaotic"
+    hasty              = 0x00000800,      // counts as "hasty"
+    emergency          = 0x00001000,      // monsters use in emergencies
+    escape             = 0x00002000,      // useful for running away
+    recovery           = 0x00004000,      // healing or recovery spell
+    area               = 0x00008000,      // area affect
+                     //  0x00010000,      // was SPFLAG_BATTLE
+    selfench           = 0x00020000,      // monsters use as selfench
+    monster            = 0x00040000,      // monster-only spell
+    needs_tracer       = 0x00080000,      // monster casting needs tracer
+    noisy              = 0x00100000,      // makes noise, even if innate
+    testing            = 0x00200000,      // a testing/debugging spell
+    corpse_violating   = 0x00400000,      // Conduct violation for Fedhas
+                     //  0x00800000,      // was SPFLAG_ALLOW_SELF
+    utility            = 0x01000000,      // usable no matter what foe is
+    no_ghost           = 0x02000000,      // ghosts can't get this spell
+    cloud              = 0x04000000,      // makes a cloud
+    MR_check           = 0x08000000,      // spell that checks monster MR
+    mons_abjure        = 0x10000000,      // monsters can cast abjuration
+                                          // instead of this spell
+    not_evil           = 0x20000000,      // not considered evil by the
+                                          // good gods
+    holy               = 0x40000000,      // considered holy (can't be
+                                          // used by Yred enslaved souls)
 };
+DEF_BITFIELD(spell_flags, spflag);
 
 enum class spret
 {

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -24,7 +24,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TELEPORT_SELF, "Teleport Self",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::emergency | spflag::utility | spflag::monster,
     5,
     0,
@@ -35,7 +35,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CAUSE_FEAR, "Cause Fear",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::MR_check,
     4,
     200,
@@ -46,7 +46,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MAGIC_DART, "Magic Dart",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
@@ -57,7 +57,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FIREBALL, "Fireball",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -68,7 +68,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_APPORTATION, "Apportation",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::obj | spflag::not_self,
     1,
     50,
@@ -79,7 +79,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_DELAYED_FIREBALL, "Delayed Fireball",
-    SPTYP_FIRE | SPTYP_CONJURATION,
+    spschool::fire | spschool::conjuration,
     spflag::utility,
     7,
     0,
@@ -90,7 +90,7 @@ static const struct spell_desc spelldata[] =
 #endif
 {
     SPELL_CONJURE_FLAME, "Conjure Flame",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::target | spflag::neutral | spflag::not_self,
     3,
     100,
@@ -101,7 +101,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DIG, "Dig",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::dir_or_target | spflag::not_self | spflag::neutral
         | spflag::utility,
     4,
@@ -113,7 +113,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BOLT_OF_FIRE, "Bolt of Fire",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -124,7 +124,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BOLT_OF_COLD, "Bolt of Cold",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -135,7 +135,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LIGHTNING_BOLT, "Lightning Bolt",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -146,7 +146,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINKBOLT, "Blinkbolt",
-    SPTYP_AIR | SPTYP_TRANSLOCATION,
+    spschool::air | spschool::translocation,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -158,7 +158,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BOLT_OF_MAGMA, "Bolt of Magma",
-    SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_EARTH,
+    spschool::conjuration | spschool::fire | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -169,7 +169,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_POLYMORPH, "Polymorph",
-    SPTYP_TRANSMUTATION | SPTYP_HEXES,
+    spschool::transmutation | spschool::hexes,
     spflag::dir_or_target | spflag::chaotic | spflag::monster
         | spflag::needs_tracer | spflag::MR_check,
     4,
@@ -181,7 +181,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SLOW, "Slow",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     2,
     200,
@@ -192,7 +192,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HASTE, "Haste",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::helpful | spflag::hasty | spflag::selfench | spflag::utility,
     6,
     200,
@@ -203,7 +203,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PETRIFY, "Petrify",
-    SPTYP_TRANSMUTATION | SPTYP_EARTH,
+    spschool::transmutation | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
@@ -214,7 +214,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CONFUSE, "Confuse",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     3,
     200,
@@ -225,7 +225,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INVISIBILITY, "Invisibility",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::helpful | spflag::selfench
         | spflag::emergency | spflag::needs_tracer,
     6,
@@ -237,7 +237,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_FLAME, "Throw Flame",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
@@ -248,7 +248,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_FROST, "Throw Frost",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
@@ -259,7 +259,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CONTROLLED_BLINK, "Controlled Blink",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::emergency | spflag::utility,
     8,
     0,
@@ -271,7 +271,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISJUNCTION, "Disjunction",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::utility,
     8,
     200,
@@ -282,7 +282,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FREEZING_CLOUD, "Freezing Cloud",
-    SPTYP_CONJURATION | SPTYP_ICE | SPTYP_AIR,
+    spschool::conjuration | spschool::ice | spschool::air,
     spflag::target | spflag::area | spflag::needs_tracer
         | spflag::cloud,
     6,
@@ -294,7 +294,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MEPHITIC_CLOUD, "Mephitic Cloud",
-    SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
+    spschool::conjuration | spschool::poison | spschool::air,
     spflag::dir_or_target | spflag::area
         | spflag::needs_tracer | spflag::cloud,
     3,
@@ -306,7 +306,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RING_OF_FLAMES, "Ring of Flames",
-    SPTYP_CHARMS | SPTYP_FIRE,
+    spschool::charms | spschool::fire,
     spflag::area,
     7,
     200,
@@ -317,7 +317,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RING_OF_THUNDER, "Ring of Thunder",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::area,
     7,
     200,
@@ -328,7 +328,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_VENOM_BOLT, "Venom Bolt",
-    SPTYP_CONJURATION | SPTYP_POISON,
+    spschool::conjuration | spschool::poison,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -339,7 +339,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_OLGREBS_TOXIC_RADIANCE, "Olgreb's Toxic Radiance",
-    SPTYP_POISON,
+    spschool::poison,
     spflag::area,
     4,
     100,
@@ -350,7 +350,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TELEPORT_OTHER, "Teleport Other",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::dir_or_target | spflag::not_self | spflag::escape
         | spflag::emergency | spflag::needs_tracer | spflag::MR_check,
     3,
@@ -362,7 +362,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DEATHS_DOOR, "Death's Door",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::emergency | spflag::utility | spflag::no_ghost,
     8,
     200,
@@ -373,7 +373,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MASS_CONFUSION, "Mass Confusion",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::MR_check,
     6,
     200,
@@ -384,7 +384,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SMITING, "Smiting",
-    SPTYP_NONE,
+    spschool::none,
     spflag::target | spflag::not_self,
     4,
     200,
@@ -395,7 +395,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_SMALL_MAMMAL, "Summon Small Mammal",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     1,
     25,
@@ -407,7 +407,7 @@ static const struct spell_desc spelldata[] =
 // Used indirectly, by monsters abjuring via other summon spells.
 {
     SPELL_ABJURATION, "Abjuration",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::escape | spflag::needs_tracer | spflag::monster,
     3,
     200,
@@ -418,7 +418,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AURA_OF_ABJURATION, "Aura of Abjuration",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::area | spflag::neutral | spflag::escape,
     5,
     200,
@@ -430,7 +430,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUMMON_SCORPIONS, "Summon Scorpions",
-    SPTYP_SUMMONING | SPTYP_POISON,
+    spschool::summoning | spschool::poison,
     spflag::none,
     4,
     200,
@@ -442,7 +442,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BOLT_OF_DRAINING, "Bolt of Draining",
-    SPTYP_CONJURATION | SPTYP_NECROMANCY,
+    spschool::conjuration | spschool::necromancy,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -453,7 +453,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LEHUDIBS_CRYSTAL_SPEAR, "Lehudib's Crystal Spear",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer,
     8,
     200,
@@ -465,7 +465,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_BOLT_OF_INACCURACY, "Bolt of Inaccuracy",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer, // rod/tome of destruction
     3,
     1000,
@@ -477,7 +477,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TORNADO, "Tornado",
-    SPTYP_AIR,
+    spschool::air,
     spflag::area,
     9,
     200,
@@ -488,7 +488,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_POISONOUS_CLOUD, "Poisonous Cloud",
-    SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
+    spschool::conjuration | spschool::poison | spschool::air,
     spflag::target | spflag::area | spflag::needs_tracer | spflag::cloud,
     5,
     200,
@@ -499,7 +499,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FIRE_STORM, "Fire Storm",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::target | spflag::area | spflag::needs_tracer,
     9,
     200,
@@ -510,7 +510,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_DOWN_DAMNATION, "Call Down Damnation",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::target | spflag::area | spflag::unholy | spflag::needs_tracer,
     9,
     200,
@@ -521,7 +521,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK, "Blink",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::selfench | spflag::emergency | spflag::utility,
     2,
     0,
@@ -532,7 +532,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_RANGE, "Blink Range", // XXX needs better name
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::monster | spflag::selfench | spflag::emergency,
     2,
     0,
@@ -543,7 +543,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_AWAY, "Blink Away",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::escape | spflag::monster | spflag::emergency | spflag::selfench,
     2,
     0,
@@ -554,7 +554,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_CLOSE, "Blink Close",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::monster,
     2,
     0,
@@ -567,7 +567,7 @@ static const struct spell_desc spelldata[] =
 // of PCHACK - credit goes to its creator (whoever that may be):
 {
     SPELL_ISKENDERUNS_MYSTIC_BLAST, "Iskenderun's Mystic Blast",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
@@ -579,7 +579,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUMMON_SWARM, "Summon Swarm",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     5,
     200,
@@ -591,7 +591,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_HORRIBLE_THINGS, "Summon Horrible Things",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::chaotic | spflag::mons_abjure,
     8,
     200,
@@ -602,7 +602,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MALIGN_GATEWAY, "Malign Gateway",
-    SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
+    spschool::summoning | spschool::translocation,
     spflag::unholy | spflag::chaotic,
     7,
     200,
@@ -613,7 +613,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ENSLAVEMENT, "Enslavement",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::monster | spflag::MR_check,
     4,
@@ -625,7 +625,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ANIMATE_DEAD, "Animate Dead",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::area | spflag::neutral | spflag::corpse_violating | spflag::utility,
     4,
     0,
@@ -636,7 +636,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PAIN, "Pain",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     1,
     25,
@@ -648,7 +648,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CONTROL_UNDEAD, "Control Undead",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::MR_check,
     4,
     200,
@@ -660,7 +660,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ANIMATE_SKELETON, "Animate Skeleton",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::corpse_violating | spflag::utility,
     1,
     0,
@@ -671,7 +671,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_VAMPIRIC_DRAINING, "Vampiric Draining",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::not_self | spflag::emergency
         | spflag::selfench,
     3,
@@ -683,7 +683,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HAUNT, "Haunt",
-    SPTYP_SUMMONING | SPTYP_NECROMANCY,
+    spschool::summoning | spschool::necromancy,
     spflag::target | spflag::not_self | spflag::mons_abjure,
     7,
     200,
@@ -694,7 +694,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BORGNJORS_REVIVIFICATION, "Borgnjor's Revivification",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::utility,
     8,
     200,
@@ -705,7 +705,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FREEZE, "Freeze",
-    SPTYP_ICE,
+    spschool::ice,
     spflag::dir_or_target | spflag::not_self,
     1,
     25,
@@ -717,7 +717,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUMMON_ELEMENTAL, "Summon Elemental",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     4,
     200,
@@ -729,7 +729,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_OZOCUBUS_REFRIGERATION, "Ozocubu's Refrigeration",
-    SPTYP_ICE,
+    spschool::ice,
     spflag::area,
     6,
     200,
@@ -740,7 +740,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STICKY_FLAME, "Sticky Flame",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
@@ -751,7 +751,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_ICE_BEAST, "Summon Ice Beast",
-    SPTYP_ICE | SPTYP_SUMMONING,
+    spschool::ice | spschool::summoning,
     spflag::none,
     4,
     100,
@@ -762,7 +762,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_OZOCUBUS_ARMOUR, "Ozocubu's Armour",
-    SPTYP_CHARMS | SPTYP_ICE,
+    spschool::charms | spschool::ice,
     spflag::no_ghost,
     3,
     100,
@@ -773,7 +773,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_IMP, "Call Imp",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench,
     2,
     100,
@@ -784,7 +784,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_REPEL_MISSILES, "Repel Missiles",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::monster,
     2,
     50,
@@ -795,7 +795,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BERSERKER_RAGE, "Berserker Rage",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::hasty | spflag::monster,
     3,
     0,
@@ -807,7 +807,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FRENZY, "Frenzy",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::hasty | spflag::monster,
     3,
     0,
@@ -819,7 +819,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISPEL_UNDEAD, "Dispel Undead",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     100,
@@ -831,7 +831,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FULSOME_DISTILLATION, "Fulsome Distillation",
-    SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
+    spschool::transmutation | spschool::necromancy,
     spflag::corpse_violating,
     1,
     0,
@@ -843,7 +843,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_POISON_ARROW, "Poison Arrow",
-    SPTYP_CONJURATION | SPTYP_POISON,
+    spschool::conjuration | spschool::poison,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -854,7 +854,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TWISTED_RESURRECTION, "Twisted Resurrection",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::chaotic | spflag::corpse_violating | spflag::utility
         | spflag::monster,
     5,
@@ -866,7 +866,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_REGENERATION, "Regeneration",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::selfench | spflag::utility,
     3,
     200,
@@ -878,7 +878,7 @@ static const struct spell_desc spelldata[] =
 // Monster-only, players can use Lugonu's ability
 {
     SPELL_BANISHMENT, "Banishment",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::dir_or_target | spflag::unholy | spflag::chaotic | spflag::monster
         | spflag::emergency | spflag::needs_tracer | spflag::MR_check,
     4,
@@ -891,7 +891,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CIGOTUVIS_DEGENERATION, "Cigotuvi's Degeneration",
-    SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
+    spschool::transmutation | spschool::necromancy,
     spflag::dir_or_target | spflag::not_self | spflag::chaotic,
     5,
     200,
@@ -903,7 +903,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STING, "Sting",
-    SPTYP_CONJURATION | SPTYP_POISON,
+    spschool::conjuration | spschool::poison,
     spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
@@ -914,7 +914,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUBLIMATION_OF_BLOOD, "Sublimation of Blood",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::utility,
     2,
     200,
@@ -925,7 +925,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TUKIMAS_DANCE, "Tukima's Dance",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check
         | spflag::not_self,
     3,
@@ -937,7 +937,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_DEMON, "Summon Demon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench | spflag::mons_abjure,
     5,
     200,
@@ -949,7 +949,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_DEMONIC_HORDE, "Demonic Horde",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy,
     6,
     200,
@@ -961,7 +961,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_GREATER_DEMON, "Summon Greater Demon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench | spflag::mons_abjure,
     7,
     200,
@@ -972,7 +972,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CORPSE_ROT, "Corpse Rot",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::area | spflag::neutral | spflag::unclean,
     2,
     0,
@@ -984,7 +984,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FIRE_BRAND, "Fire Brand",
-    SPTYP_CHARMS | SPTYP_FIRE,
+    spschool::charms | spschool::fire,
     spflag::helpful,
     2,
     200,
@@ -995,7 +995,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FREEZING_AURA, "Freezing Aura",
-    SPTYP_CHARMS | SPTYP_ICE,
+    spschool::charms | spschool::ice,
     spflag::helpful,
     2,
     200,
@@ -1006,7 +1006,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LETHAL_INFUSION, "Lethal Infusion",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::helpful,
     2,
     200,
@@ -1018,7 +1018,7 @@ static const struct spell_desc spelldata[] =
 #endif
 {
     SPELL_IRON_SHOT, "Iron Shot",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -1029,7 +1029,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STONE_ARROW, "Stone Arrow",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer,
     3,
     50,
@@ -1040,7 +1040,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHOCK, "Shock",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
@@ -1051,7 +1051,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SWIFTNESS, "Swiftness",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::hasty | spflag::selfench | spflag::utility,
     2,
     100,
@@ -1063,7 +1063,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FLY, "Flight",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::utility,
     3,
     200,
@@ -1074,7 +1074,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INSULATION, "Insulation",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::none,
     4,
     200,
@@ -1087,7 +1087,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CURE_POISON, "Cure Poison",
-    SPTYP_POISON,
+    spschool::poison,
     spflag::recovery | spflag::helpful | spflag::utility,
     2,
     200,
@@ -1100,7 +1100,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CONTROL_TELEPORT, "Control Teleport",
-    SPTYP_CHARMS | SPTYP_TRANSLOCATION,
+    spschool::charms | spschool::translocation,
     spflag::helpful | spflag::utility,
     4,
     200,
@@ -1111,7 +1111,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_POISON_WEAPON, "Poison Weapon",
-    SPTYP_CHARMS | SPTYP_POISON,
+    spschool::charms | spschool::poison,
     spflag::helpful,
     3,
     200,
@@ -1123,7 +1123,7 @@ static const struct spell_desc spelldata[] =
 #endif
 {
     SPELL_DEBUGGING_RAY, "Debugging Ray",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::testing,
     7,
     100,
@@ -1134,7 +1134,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RECALL, "Recall",
-    SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
+    spschool::summoning | spschool::translocation,
     spflag::utility,
     3,
     0,
@@ -1145,7 +1145,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AGONY, "Agony",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::MR_check,
     5,
@@ -1157,7 +1157,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPIDER_FORM, "Spider Form",
-    SPTYP_TRANSMUTATION | SPTYP_POISON,
+    spschool::transmutation | spschool::poison,
     spflag::helpful | spflag::chaotic | spflag::utility,
     3,
     200,
@@ -1168,7 +1168,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISINTEGRATE, "Disintegrate",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::MR_check,
     6,
@@ -1180,7 +1180,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLADE_HANDS, "Blade Hands",
-    SPTYP_TRANSMUTATION,
+    spschool::transmutation,
     spflag::helpful | spflag::chaotic | spflag::utility,
     5,
     200,
@@ -1191,7 +1191,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STATUE_FORM, "Statue Form",
-    SPTYP_TRANSMUTATION | SPTYP_EARTH,
+    spschool::transmutation | spschool::earth,
     spflag::helpful | spflag::chaotic | spflag::utility,
     6,
     150,
@@ -1202,7 +1202,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ICE_FORM, "Ice Form",
-    SPTYP_ICE | SPTYP_TRANSMUTATION,
+    spschool::ice | spschool::transmutation,
     spflag::helpful | spflag::chaotic | spflag::utility,
     4,
     100,
@@ -1213,7 +1213,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRAGON_FORM, "Dragon Form",
-    SPTYP_TRANSMUTATION,
+    spschool::transmutation,
     spflag::helpful | spflag::chaotic | spflag::utility,
     7,
     200,
@@ -1224,7 +1224,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HYDRA_FORM, "Hydra Form",
-    SPTYP_TRANSMUTATION,
+    spschool::transmutation,
     spflag::helpful | spflag::chaotic | spflag::utility,
     6,
     200,
@@ -1235,7 +1235,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_NECROMUTATION, "Necromutation",
-    SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
+    spschool::transmutation | spschool::necromancy,
     spflag::helpful | spflag::corpse_violating | spflag::chaotic,
     8,
     200,
@@ -1246,7 +1246,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DEATH_CHANNEL, "Death Channel",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::helpful | spflag::utility,
     6,
     200,
@@ -1258,7 +1258,7 @@ static const struct spell_desc spelldata[] =
 // Monster-only, players can use Kiku's ability
 {
     SPELL_SYMBOL_OF_TORMENT, "Symbol of Torment",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::area | spflag::monster,
     6,
     0,
@@ -1269,7 +1269,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DEFLECT_MISSILES, "Deflect Missiles",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::helpful | spflag::utility,
     6,
     200,
@@ -1280,7 +1280,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_ICICLE, "Throw Icicle",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
@@ -1291,7 +1291,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AIRSTRIKE, "Airstrike",
-    SPTYP_AIR,
+    spschool::air,
     spflag::target | spflag::not_self,
     4,
     200,
@@ -1302,7 +1302,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHADOW_CREATURES, "Shadow Creatures",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::mons_abjure,
     6,
     0,
@@ -1313,7 +1313,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CONFUSING_TOUCH, "Confusing Touch",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::none,
     1,
     50,
@@ -1325,7 +1325,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SURE_BLADE, "Sure Blade",
-    SPTYP_HEXES | SPTYP_CHARMS,
+    spschool::hexes | spschool::charms,
     spflag::helpful | spflag::utility,
     2,
     200,
@@ -1336,7 +1336,7 @@ static const struct spell_desc spelldata[] =
 #endif
 {
     SPELL_FLAME_TONGUE, "Flame Tongue",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     1,
     40, // cap for range; damage cap is at 25
@@ -1347,7 +1347,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PASSWALL, "Passwall",
-    SPTYP_TRANSMUTATION | SPTYP_EARTH,
+    spschool::transmutation | spschool::earth,
     spflag::target | spflag::escape | spflag::not_self | spflag::utility,
     2,
     120,
@@ -1358,7 +1358,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_IGNITE_POISON, "Ignite Poison",
-    SPTYP_FIRE | SPTYP_TRANSMUTATION | SPTYP_POISON,
+    spschool::fire | spschool::transmutation | spschool::poison,
     spflag::area,
     3,
     100,
@@ -1369,7 +1369,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STICKS_TO_SNAKES, "Sticks to Snakes",
-    SPTYP_TRANSMUTATION,
+    spschool::transmutation,
     spflag::no_ghost,
     2,
     100,
@@ -1380,7 +1380,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_CANINE_FAMILIAR, "Call Canine Familiar",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     3,
     100,
@@ -1391,7 +1391,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_DRAGON, "Summon Dragon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::mons_abjure,
     9,
     200,
@@ -1402,7 +1402,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HIBERNATION, "Ensorcelled Hibernation",
-    SPTYP_HEXES | SPTYP_ICE,
+    spschool::hexes | spschool::ice,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::MR_check,
     2,
@@ -1414,7 +1414,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ENGLACIATION, "Metabolic Englaciation",
-    SPTYP_HEXES | SPTYP_ICE,
+    spschool::hexes | spschool::ice,
     spflag::area,
     5,
     200,
@@ -1426,7 +1426,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SEE_INVISIBLE, "See Invisible",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::helpful,
     4,
     200,
@@ -1437,7 +1437,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PHASE_SHIFT, "Phase Shift",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::helpful | spflag::utility,
     5,
     200,
@@ -1449,7 +1449,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_BUTTERFLIES, "Summon Butterflies",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     1,
     100,
@@ -1461,7 +1461,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_WARP_BRAND, "Warp Weapon",
-    SPTYP_CHARMS | SPTYP_TRANSLOCATION,
+    spschool::charms | spschool::translocation,
     spflag::helpful | spflag::utility,
     5,
     200,
@@ -1473,7 +1473,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SILENCE, "Silence",
-    SPTYP_HEXES | SPTYP_AIR,
+    spschool::hexes | spschool::air,
     spflag::area,
     5,
     200,
@@ -1484,7 +1484,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHATTER, "Shatter",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::area,
     9,
     200,
@@ -1495,7 +1495,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISPERSAL, "Dispersal",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::area | spflag::escape,
     6,
     200,
@@ -1506,7 +1506,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISCHARGE, "Static Discharge",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::area,
     3,
     100,
@@ -1517,7 +1517,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CORONA, "Corona",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::MR_check,
     1,
@@ -1529,7 +1529,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INTOXICATE, "Alistair's Intoxication",
-    SPTYP_TRANSMUTATION | SPTYP_POISON,
+    spschool::transmutation | spschool::poison,
     spflag::none,
     5,
     100,
@@ -1541,7 +1541,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_EVAPORATE, "Evaporate",
-    SPTYP_FIRE | SPTYP_TRANSMUTATION,
+    spschool::fire | spschool::transmutation,
     spflag::dir_or_target | spflag::area,
     2,
     50,
@@ -1553,7 +1553,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LRD, "Lee's Rapid Deconstruction",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::target,
     5,
     200,
@@ -1564,7 +1564,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SANDBLAST, "Sandblast",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     1,
     50,
@@ -1576,7 +1576,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CONDENSATION_SHIELD, "Condensation Shield",
-    SPTYP_ICE,
+    spschool::ice,
     spflag::helpful | spflag::utility,
     4,
     200,
@@ -1587,7 +1587,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STONESKIN, "Stoneskin",
-    SPTYP_EARTH | SPTYP_TRANSMUTATION,
+    spschool::earth | spschool::transmutation,
     spflag::helpful | spflag::utility | spflag::no_ghost | spflag::monster,
     2,
     100,
@@ -1599,7 +1599,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SIMULACRUM, "Simulacrum",
-    SPTYP_ICE | SPTYP_NECROMANCY,
+    spschool::ice | spschool::necromancy,
     spflag::corpse_violating,
     6,
     200,
@@ -1610,7 +1610,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CONJURE_BALL_LIGHTNING, "Conjure Ball Lightning",
-    SPTYP_AIR | SPTYP_CONJURATION,
+    spschool::air | spschool::conjuration,
     spflag::selfench,
     6,
     200,
@@ -1621,7 +1621,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CHAIN_LIGHTNING, "Chain Lightning",
-    SPTYP_AIR | SPTYP_CONJURATION,
+    spschool::air | spschool::conjuration,
     spflag::area,
     8,
     200,
@@ -1632,7 +1632,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_EXCRUCIATING_WOUNDS, "Excruciating Wounds",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::helpful,
     5,
     200,
@@ -1643,7 +1643,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PORTAL_PROJECTILE, "Portal Projectile",
-    SPTYP_TRANSLOCATION | SPTYP_HEXES,
+    spschool::translocation | spschool::hexes,
     spflag::none,
     3,
     50,
@@ -1654,7 +1654,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MONSTROUS_MENAGERIE, "Monstrous Menagerie",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::mons_abjure,
     7,
     200,
@@ -1665,7 +1665,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GOLUBRIAS_PASSAGE, "Passage of Golubria",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::neutral | spflag::escape | spflag::selfench,
     4,
     0,
@@ -1676,7 +1676,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FULMINANT_PRISM, "Fulminant Prism",
-    SPTYP_CONJURATION | SPTYP_HEXES,
+    spschool::conjuration | spschool::hexes,
     spflag::target | spflag::area | spflag::not_self,
     4,
     200,
@@ -1688,7 +1688,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SINGULARITY, "Singularity",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::area | spflag::not_self | spflag::monster,
     9,
     200,
@@ -1700,7 +1700,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PARALYSE, "Paralyse",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer
         | spflag::MR_check,
     4,
@@ -1712,7 +1712,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MINOR_HEALING, "Minor Healing",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::recovery | spflag::helpful | spflag::monster | spflag::selfench
         | spflag::emergency | spflag::utility | spflag::not_evil,
     2,
@@ -1724,7 +1724,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MAJOR_HEALING, "Major Healing",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::recovery | spflag::helpful | spflag::monster | spflag::selfench
         | spflag::emergency | spflag::utility | spflag::not_evil,
     6,
@@ -1736,7 +1736,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HURL_DAMNATION, "Hurl Damnation",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::unholy | spflag::monster
         | spflag::needs_tracer,
     // plus DS ability, staff of Dispater & Sceptre of Asmodeus
@@ -1750,7 +1750,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_VAMPIRE_SUMMON, "Vampire Summon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::monster,
     3,
     0,
@@ -1762,7 +1762,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BRAIN_FEED, "Brain Feed",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::target | spflag::monster,
     3,
     0,
@@ -1774,7 +1774,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FAKE_RAKSHASA_SUMMON, "Rakshasa Summon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::monster,
     3,
     0,
@@ -1786,7 +1786,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_NOXIOUS_CLOUD, "Noxious Cloud",
-    SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
+    spschool::conjuration | spschool::poison | spschool::air,
     spflag::target | spflag::area | spflag::monster | spflag::needs_tracer
         | spflag::cloud,
     5,
@@ -1798,7 +1798,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STEAM_BALL, "Steam Ball",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     0,
@@ -1809,7 +1809,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_UFETUBUS, "Summon Ufetubus",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::monster | spflag::selfench,
     4,
     0,
@@ -1820,7 +1820,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_HELL_BEAST, "Summon Hell Beast",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::monster | spflag::selfench,
     4,
     0,
@@ -1831,7 +1831,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ENERGY_BOLT, "Energy Bolt",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     0,
@@ -1842,7 +1842,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPIT_POISON, "Spit Poison",
-    SPTYP_POISON,
+    spschool::poison,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     2,
@@ -1854,7 +1854,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_UNDEAD, "Summon Undead",
-    SPTYP_SUMMONING | SPTYP_NECROMANCY,
+    spschool::summoning | spschool::necromancy,
     spflag::monster | spflag::mons_abjure,
     7,
     0,
@@ -1865,7 +1865,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CANTRIP, "Cantrip",
-    SPTYP_NONE,
+    spschool::none,
     spflag::monster,
     1,
     0,
@@ -1876,7 +1876,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_QUICKSILVER_BOLT, "Quicksilver Bolt",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -1887,7 +1887,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_METAL_SPLINTERS, "Metal Splinters",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     0,
@@ -1898,7 +1898,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MIASMA_BREATH, "Miasma Breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::unclean | spflag::monster
         | spflag::needs_tracer | spflag::cloud,
     6,
@@ -1910,7 +1910,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_DRAKES, "Summon Drakes",
-    SPTYP_SUMMONING | SPTYP_NECROMANCY, // since it can summon shadow dragons
+    spschool::summoning | spschool::necromancy, // since it can summon shadow dragons
     spflag::unclean | spflag::monster | spflag::mons_abjure,
     6,
     0,
@@ -1921,7 +1921,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_OTHER, "Blink Other",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::dir_or_target | spflag::not_self | spflag::escape | spflag::monster
         | spflag::emergency | spflag::needs_tracer,
     2,
@@ -1933,7 +1933,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_OTHER_CLOSE, "Blink Other Close",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::not_self | spflag::monster | spflag::needs_tracer,
     2,
     0,
@@ -1944,7 +1944,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_MUSHROOMS, "Summon Mushrooms",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::selfench | spflag::mons_abjure,
     4,
     0,
@@ -1955,7 +1955,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPIT_ACID, "Spit Acid",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -1966,7 +1966,7 @@ static const struct spell_desc spelldata[] =
 },
 
 { SPELL_ACID_SPLASH, "Acid Splash",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -1979,7 +1979,7 @@ static const struct spell_desc spelldata[] =
 // Monster version of the spell (with full range)
 {
     SPELL_STICKY_FLAME_RANGE, "Sticky Flame Range",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     100,
@@ -1990,7 +1990,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FIRE_BREATH, "Fire Breath",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -2002,7 +2002,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SEARING_BREATH, "Searing Breath",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -2014,7 +2014,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CHAOS_BREATH, "Chaos Breath",
-    SPTYP_CONJURATION | SPTYP_RANDOM,
+    spschool::conjuration | spschool::random,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer | spflag::cloud,
     5,
@@ -2026,7 +2026,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_COLD_BREATH, "Cold Breath",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -2038,7 +2038,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CHILLING_BREATH, "Chilling Breath",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -2051,7 +2051,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_DRACONIAN_BREATH, "Draconian Breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy,
     8,
     0,
@@ -2063,7 +2063,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_WATER_ELEMENTALS, "Summon Water Elementals",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2074,7 +2074,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PORKALATOR, "Porkalator",
-    SPTYP_HEXES | SPTYP_TRANSMUTATION,
+    spschool::hexes | spschool::transmutation,
     spflag::dir_or_target | spflag::chaotic | spflag::needs_tracer
         | spflag::MR_check,
     5,
@@ -2086,7 +2086,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CREATE_TENTACLES, "Spawn Tentacles",
-    SPTYP_NONE,
+    spschool::none,
     spflag::monster | spflag::selfench,
     5,
     0,
@@ -2097,7 +2097,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TOMB_OF_DOROKLOHE, "Tomb of Doroklohe",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::monster | spflag::emergency,
     5,
     0,
@@ -2108,7 +2108,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_EYEBALLS, "Summon Eyeballs",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2119,7 +2119,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HASTE_OTHER, "Haste Other",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::helpful
         | spflag::hasty | spflag::needs_tracer | spflag::utility,
     6,
@@ -2131,7 +2131,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_EARTH_ELEMENTALS, "Summon Earth Elementals",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2142,7 +2142,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AIR_ELEMENTALS, "Summon Air Elementals",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2153,7 +2153,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FIRE_ELEMENTALS, "Summon Fire Elementals",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2165,7 +2165,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_IRON_ELEMENTALS, "Summon Iron Elementals",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure,
     5,
     0,
@@ -2177,7 +2177,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SLEEP, "Sleep",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
         | spflag::MR_check,
     5,
@@ -2189,7 +2189,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FAKE_MARA_SUMMON, "Mara Summon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::selfench,
     5,
     0,
@@ -2201,7 +2201,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUMMON_RAKSHASA, "Summon Rakshasa",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster,
     5,
     0,
@@ -2212,7 +2212,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MISLEAD, "Mislead",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::target | spflag::not_self,
     5,
     200,
@@ -2224,7 +2224,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_ILLUSION, "Summon Illusion",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster,
     5,
     0,
@@ -2235,7 +2235,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PRIMAL_WAVE, "Primal Wave",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -2246,7 +2246,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_TIDE, "Call Tide",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::monster,
     7,
     0,
@@ -2257,7 +2257,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_IOOD, "Orb of Destruction",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     7,
     200,
@@ -2268,7 +2268,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INK_CLOUD, "Ink Cloud",
-    SPTYP_CONJURATION | SPTYP_ICE, // it's a water spell
+    spschool::conjuration | spschool::ice, // it's a water spell
     spflag::monster | spflag::emergency | spflag::utility,
     7,
     0,
@@ -2279,7 +2279,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MIGHT, "Might",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::helpful | spflag::selfench | spflag::emergency | spflag::utility,
     3,
     200,
@@ -2290,7 +2290,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MIGHT_OTHER, "Might Other",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::dir_or_target | spflag::not_self | spflag::helpful
         | spflag::needs_tracer | spflag::utility,
     5,
@@ -2303,7 +2303,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUNRAY, "Sunray",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target,
     6,
     200,
@@ -2315,7 +2315,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AWAKEN_FOREST, "Awaken Forest",
-    SPTYP_HEXES | SPTYP_SUMMONING,
+    spschool::hexes | spschool::summoning,
     spflag::area,
     6,
     200,
@@ -2326,7 +2326,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRUIDS_CALL, "Druid's Call",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::monster,
     6,
     0,
@@ -2337,7 +2337,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BROTHERS_IN_ARMS, "Brothers in Arms",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::emergency,
     6,
     0,
@@ -2348,7 +2348,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_TROGS_HAND, "Trog's Hand",
-    SPTYP_NONE,
+    spschool::none,
     spflag::monster | spflag::selfench,
     3,
     0,
@@ -2359,7 +2359,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_SPECTRAL_ORCS, "Summon Spectral Orcs",
-    SPTYP_NECROMANCY | SPTYP_SUMMONING,
+    spschool::necromancy | spschool::summoning,
     spflag::monster | spflag::target,
     4,
     0,
@@ -2371,7 +2371,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_HOLY_LIGHT, "Holy Light",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target,
     6,
     200,
@@ -2383,7 +2383,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_HOLIES, "Summon Holies",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::mons_abjure | spflag::holy,
     5,
     0,
@@ -2394,7 +2394,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HEAL_OTHER, "Heal Other",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::not_self | spflag::helpful
         | spflag::needs_tracer | spflag::utility | spflag::not_evil,
     6,
@@ -2406,7 +2406,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HOLY_FLAMES, "Holy Flames",
-    SPTYP_NONE,
+    spschool::none,
     spflag::target | spflag::not_self | spflag::holy,
     7,
     200,
@@ -2417,7 +2417,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HOLY_BREATH, "Holy Breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::area | spflag::needs_tracer | spflag::cloud
         | spflag::holy,
     5,
@@ -2429,7 +2429,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INJURY_MIRROR, "Injury Mirror",
-    SPTYP_NONE,
+    spschool::none,
     spflag::dir_or_target | spflag::helpful | spflag::selfench
         | spflag::emergency | spflag::utility,
     4,
@@ -2441,7 +2441,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRAIN_LIFE, "Drain Life",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     // n.b. marked as spflag::monster for wizmode purposes, but this spell is
     // called by the yred ability.
     spflag::area | spflag::emergency | spflag::monster,
@@ -2454,7 +2454,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LEDAS_LIQUEFACTION, "Leda's Liquefaction",
-    SPTYP_EARTH | SPTYP_HEXES,
+    spschool::earth | spschool::hexes,
     spflag::area,
     4,
     200,
@@ -2465,7 +2465,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_HYDRA, "Summon Hydra",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::mons_abjure,
     7,
     200,
@@ -2476,7 +2476,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DARKNESS, "Darkness",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::none,
     6,
     200,
@@ -2487,7 +2487,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MESMERISE, "Mesmerise",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::MR_check,
     5,
     200,
@@ -2499,7 +2499,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_MELEE, "Melee",
-    SPTYP_NONE,
+    spschool::none,
     spflag::none,
     1,
     0,
@@ -2511,7 +2511,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FIRE_SUMMON, "Fire Summon",
-    SPTYP_SUMMONING | SPTYP_FIRE,
+    spschool::summoning | spschool::fire,
     spflag::monster | spflag::mons_abjure,
     8,
     0,
@@ -2522,7 +2522,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PETRIFYING_CLOUD, "Petrifying Cloud",
-    SPTYP_CONJURATION | SPTYP_EARTH | SPTYP_AIR,
+    spschool::conjuration | spschool::earth | spschool::air,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     0,
@@ -2533,7 +2533,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHROUD_OF_GOLUBRIA, "Shroud of Golubria",
-    SPTYP_CHARMS | SPTYP_TRANSLOCATION,
+    spschool::charms | spschool::translocation,
     spflag::selfench,
     2,
     200,
@@ -2544,7 +2544,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INNER_FLAME, "Inner Flame",
-    SPTYP_HEXES | SPTYP_FIRE,
+    spschool::hexes | spschool::fire,
     spflag::dir_or_target | spflag::not_self | spflag::neutral
         | spflag::MR_check,
     3,
@@ -2556,7 +2556,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BEASTLY_APPENDAGE, "Beastly Appendage",
-    SPTYP_TRANSMUTATION,
+    spschool::transmutation,
     spflag::helpful | spflag::chaotic,
     1,
     50,
@@ -2568,7 +2568,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SILVER_BLAST, "Silver Blast",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target,
     5,
     200,
@@ -2580,7 +2580,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ENSNARE, "Ensnare",
-    SPTYP_CONJURATION | SPTYP_HEXES,
+    spschool::conjuration | spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -2591,7 +2591,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THUNDERBOLT, "Thunderbolt",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::dir_or_target | spflag::not_self,
     2, // 2-5, sort of
     200,
@@ -2602,7 +2602,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BATTLESPHERE, "Iskenderun's Battlesphere",
-    SPTYP_CONJURATION | SPTYP_CHARMS,
+    spschool::conjuration | spschool::charms,
     spflag::utility,
     5,
     100,
@@ -2613,7 +2613,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_MINOR_DEMON, "Summon Minor Demon",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench,
     2,
     200,
@@ -2624,7 +2624,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MALMUTATE, "Malmutate",
-    SPTYP_TRANSMUTATION | SPTYP_HEXES,
+    spschool::transmutation | spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::chaotic
         | spflag::needs_tracer,
     6,
@@ -2637,7 +2637,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SUMMON_TWISTER, "Summon Twister",
-    SPTYP_SUMMONING | SPTYP_AIR,
+    spschool::summoning | spschool::air,
     spflag::unclean | spflag::monster,
     9,
     0,
@@ -2649,7 +2649,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DAZZLING_SPRAY, "Dazzling Spray",
-    SPTYP_CONJURATION | SPTYP_HEXES,
+    spschool::conjuration | spschool::hexes,
     spflag::dir_or_target | spflag::not_self,
     3,
     50,
@@ -2660,7 +2660,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FORCE_LANCE, "Force Lance",
-    SPTYP_CONJURATION | SPTYP_TRANSLOCATION,
+    spschool::conjuration | spschool::translocation,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
@@ -2671,7 +2671,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SENTINEL_MARK, "Sentinel's Mark",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     5,
     200,
@@ -2683,7 +2683,7 @@ static const struct spell_desc spelldata[] =
 // Ironbrand Convoker version (delayed activation, recalls only humanoids)
 {
     SPELL_WORD_OF_RECALL, "Word of Recall",
-    SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
+    spschool::summoning | spschool::translocation,
     spflag::utility,
     3,
     0,
@@ -2694,7 +2694,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INJURY_BOND, "Injury Bond",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::area | spflag::helpful,
     5,
     200,
@@ -2705,7 +2705,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPECTRAL_CLOUD, "Spectral Cloud",
-    SPTYP_CONJURATION | SPTYP_NECROMANCY,
+    spschool::conjuration | spschool::necromancy,
     spflag::dir_or_target | spflag::monster | spflag::cloud,
     5,
     200,
@@ -2716,7 +2716,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GHOSTLY_FIREBALL, "Ghostly Fireball",
-    SPTYP_CONJURATION | SPTYP_NECROMANCY,
+    spschool::conjuration | spschool::necromancy,
     spflag::dir_or_target | spflag::monster | spflag::unholy
         | spflag::needs_tracer,
     5,
@@ -2728,7 +2728,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_LOST_SOUL, "Call Lost Soul",
-    SPTYP_SUMMONING | SPTYP_NECROMANCY,
+    spschool::summoning | spschool::necromancy,
     spflag::unholy | spflag::monster,
     5,
     200,
@@ -2739,7 +2739,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DIMENSION_ANCHOR, "Dimension Anchor",
-    SPTYP_TRANSLOCATION | SPTYP_HEXES,
+    spschool::translocation | spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
@@ -2750,7 +2750,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_ALLIES_ENCIRCLE, "Blink Allies Encircling",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::area,
     6,
     200,
@@ -2762,7 +2762,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SHAFT_SELF, "Shaft Self",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::escape,
     1,
     0,
@@ -2774,7 +2774,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AWAKEN_VINES, "Awaken Vines",
-    SPTYP_HEXES | SPTYP_SUMMONING,
+    spschool::hexes | spschool::summoning,
     spflag::area | spflag::monster,
     6,
     200,
@@ -2786,7 +2786,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CONTROL_WINDS, "Control Winds",
-    SPTYP_CHARMS | SPTYP_AIR,
+    spschool::charms | spschool::air,
     spflag::area | spflag::monster,
     6,
     200,
@@ -2798,7 +2798,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THORN_VOLLEY, "Volley of Thorns",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
@@ -2809,7 +2809,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_WALL_OF_BRAMBLES, "Wall of Brambles",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::area | spflag::monster,
     5,
     100,
@@ -2820,7 +2820,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_WATERSTRIKE, "Waterstrike",
-    SPTYP_ICE,
+    spschool::ice,
     spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
@@ -2832,7 +2832,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_HASTE_PLANTS, "Haste Plants",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::area | spflag::helpful,
     6,
     200,
@@ -2844,7 +2844,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_WIND_BLAST, "Wind Blast",
-    SPTYP_AIR,
+    spschool::air,
     spflag::area,
     3,
     200,
@@ -2855,7 +2855,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STRIP_RESISTANCE, "Strip Resistance",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     5,
     200,
@@ -2866,7 +2866,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INFUSION, "Infusion",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::utility,
     1,
     25,
@@ -2877,7 +2877,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SONG_OF_SLAYING, "Song of Slaying",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::utility,
     2,
     100,
@@ -2889,7 +2889,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_SONG_OF_SHIELDING, "Song of Shielding",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::none,
     4,
     100,
@@ -2901,7 +2901,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPECTRAL_WEAPON, "Spectral Weapon",
-    SPTYP_HEXES | SPTYP_CHARMS,
+    spschool::hexes | spschool::charms,
     spflag::selfench | spflag::utility | spflag::no_ghost,
     3,
     100,
@@ -2912,7 +2912,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_VERMIN, "Summon Vermin",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster | spflag::unholy | spflag::selfench | spflag::mons_abjure,
     5,
     0,
@@ -2923,7 +2923,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MALIGN_OFFERING, "Malign Offering",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     5,
     200,
@@ -2934,7 +2934,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SEARING_RAY, "Searing Ray",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
@@ -2945,7 +2945,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DISCORD, "Discord",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::hasty,
     8,
     200,
@@ -2956,7 +2956,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INVISIBILITY_OTHER, "Invisibility Other",
-    SPTYP_CHARMS | SPTYP_HEXES,
+    spschool::charms | spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::helpful,
     6,
     200,
@@ -2967,7 +2967,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_VIRULENCE, "Virulence",
-    SPTYP_POISON | SPTYP_HEXES,
+    spschool::poison | spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
@@ -2979,7 +2979,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_IGNITE_POISON_SINGLE, "Localized Ignite Poison",
-    SPTYP_FIRE | SPTYP_TRANSMUTATION,
+    spschool::fire | spschool::transmutation,
     spflag::monster | spflag::dir_or_target | spflag::not_self
         | spflag::needs_tracer | spflag::MR_check,
     4,
@@ -2992,7 +2992,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ORB_OF_ELECTRICITY, "Orb of Electricity",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     7,
     200,
@@ -3004,7 +3004,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_EXPLOSIVE_BOLT, "Explosive Bolt",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -3016,7 +3016,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FLASH_FREEZE, "Flash Freeze",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     7,
     200,
@@ -3027,7 +3027,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_LEGENDARY_DESTRUCTION, "Legendary Destruction",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     8,
     200,
@@ -3039,7 +3039,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_EPHEMERAL_INFUSION, "Ephemeral Infusion",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::monster | spflag::emergency,
     6,
     200,
@@ -3051,7 +3051,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FORCEFUL_INVITATION, "Forceful Invitation",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster,
     4,
     200,
@@ -3062,7 +3062,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PLANEREND, "Plane Rend",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::monster,
     8,
     200,
@@ -3073,7 +3073,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CHAIN_OF_CHAOS, "Chain of Chaos",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::area | spflag::monster | spflag::chaotic,
     8,
     200,
@@ -3084,7 +3084,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CALL_OF_CHAOS, "Call of Chaos",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::area | spflag::chaotic | spflag::monster,
     7,
     200,
@@ -3095,7 +3095,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLACK_MARK, "Black Mark",
-    SPTYP_CHARMS | SPTYP_NECROMANCY,
+    spschool::charms | spschool::necromancy,
     spflag::monster,
     7,
     200,
@@ -3107,7 +3107,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_GRAND_AVATAR, "Grand Avatar",
-    SPTYP_CONJURATION | SPTYP_CHARMS | SPTYP_HEXES,
+    spschool::conjuration | spschool::charms | spschool::hexes,
     spflag::monster | spflag::utility,
     4,
     100,
@@ -3119,7 +3119,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SAP_MAGIC, "Sap Magic",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
@@ -3131,7 +3131,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CORRUPT_BODY, "Corrupt Body",
-    SPTYP_TRANSMUTATION | SPTYP_HEXES,
+    spschool::transmutation | spschool::hexes,
     spflag::dir_or_target | spflag::not_self | spflag::chaotic
         | spflag::needs_tracer,
     4,
@@ -3143,7 +3143,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_REARRANGE_PIECES, "Rearrange the Pieces",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::monster | spflag::chaotic,
     8,
     200,
@@ -3155,7 +3155,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_MAJOR_DESTRUCTION, "Major Destruction",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::chaotic | spflag::needs_tracer,
     7,
     200,
@@ -3166,7 +3166,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BLINK_ALLIES_AWAY, "Blink Allies Away",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::area,
     6,
     200,
@@ -3177,7 +3177,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_FOREST, "Summon Forest",
-    SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
+    spschool::summoning | spschool::translocation,
     spflag::none,
     5,
     200,
@@ -3188,7 +3188,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_LIGHTNING_SPIRE, "Summon Lightning Spire",
-    SPTYP_SUMMONING | SPTYP_AIR,
+    spschool::summoning | spschool::air,
     spflag::target | spflag::not_self | spflag::neutral,
     4,
     100,
@@ -3199,7 +3199,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_GUARDIAN_GOLEM, "Summon Guardian Golem",
-    SPTYP_SUMMONING | SPTYP_HEXES,
+    spschool::summoning | spschool::hexes,
     spflag::none,
     3,
     100,
@@ -3210,7 +3210,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHADOW_SHARD, "Shadow Shard",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
@@ -3221,7 +3221,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SHADOW_BOLT, "Shadow Bolt",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
@@ -3232,7 +3232,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CRYSTAL_BOLT, "Crystal Bolt",
-    SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_ICE,
+    spschool::conjuration | spschool::fire | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -3243,7 +3243,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RANDOM_BOLT, "Random Bolt",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     200,
@@ -3254,7 +3254,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GLACIATE, "Glaciate",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::area | spflag::not_self,
     9,
     200,
@@ -3265,7 +3265,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CLOUD_CONE, "Cloud Cone",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::target | spflag::not_self,
     6,
     100,
@@ -3277,7 +3277,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_WEAVE_SHADOWS, "Weave Shadows",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     5,
     0,
@@ -3289,7 +3289,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRAGON_CALL, "Dragon's Call",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::none,
     9,
     200,
@@ -3300,7 +3300,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPELLFORGED_SERVITOR, "Spellforged Servitor",
-    SPTYP_CONJURATION | SPTYP_SUMMONING,
+    spschool::conjuration | spschool::summoning,
     spflag::none,
     7,
     200,
@@ -3312,7 +3312,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_FORCEFUL_DISMISSAL, "Forceful Dismissal",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::area,
     6,
     200,
@@ -3324,7 +3324,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_MANA_VIPER, "Summon Mana Viper",
-    SPTYP_SUMMONING | SPTYP_HEXES,
+    spschool::summoning | spschool::hexes,
     spflag::mons_abjure,
     5,
     100,
@@ -3335,7 +3335,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PHANTOM_MIRROR, "Phantom Mirror",
-    SPTYP_CHARMS | SPTYP_HEXES,
+    spschool::charms | spschool::hexes,
     spflag::helpful | spflag::selfench,
     5,
     200,
@@ -3346,7 +3346,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRAIN_MAGIC, "Drain Magic",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::dir_or_target | spflag::monster | spflag::needs_tracer
         | spflag::MR_check,
     5,
@@ -3358,7 +3358,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CORROSIVE_BOLT, "Corrosive Bolt",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
@@ -3369,7 +3369,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SERPENT_OF_HELL_GEH_BREATH, "gehenna serpent of hell breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3381,7 +3381,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SERPENT_OF_HELL_COC_BREATH, "cocytus serpent of hell breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3393,7 +3393,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SERPENT_OF_HELL_DIS_BREATH, "dis serpent of hell breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3405,7 +3405,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SERPENT_OF_HELL_TAR_BREATH, "tartarus serpent of hell breath",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3417,7 +3417,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_EMPEROR_SCORPIONS, "Summon Emperor Scorpions",
-    SPTYP_SUMMONING | SPTYP_POISON,
+    spschool::summoning | spschool::poison,
     spflag::mons_abjure,
     7,
     100,
@@ -3428,7 +3428,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_IRRADIATE, "Irradiate",
-    SPTYP_CONJURATION | SPTYP_TRANSMUTATION,
+    spschool::conjuration | spschool::transmutation,
     spflag::area | spflag::chaotic,
     5,
     200,
@@ -3439,7 +3439,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPIT_LAVA, "Spit Lava",
-    SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_EARTH,
+    spschool::conjuration | spschool::fire | spschool::earth,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3451,7 +3451,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ELECTRICAL_BOLT, "Electrical Bolt",
-    SPTYP_CONJURATION | SPTYP_AIR,
+    spschool::conjuration | spschool::air,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3463,7 +3463,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FLAMING_CLOUD, "Flaming Cloud",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::target | spflag::area | spflag::monster | spflag::needs_tracer
         | spflag::cloud,
     5,
@@ -3475,7 +3475,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_BARBS, "Throw Barbs",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::monster | spflag::noisy
         | spflag::needs_tracer,
     5,
@@ -3487,7 +3487,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BATTLECRY, "Battlecry",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::area | spflag::monster | spflag::selfench,
     6,
     0,
@@ -3498,7 +3498,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_WARNING_CRY, "Warning Cry",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::monster | spflag::selfench | spflag::noisy,
     6,
     0,
@@ -3509,7 +3509,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SEAL_DOORS, "Seal Doors",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::monster | spflag::selfench,
     6,
     0,
@@ -3520,7 +3520,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_FLAY, "Flay",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
@@ -3531,7 +3531,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BERSERK_OTHER, "Berserk Other",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::hasty | spflag::monster | spflag::not_self | spflag::helpful,
     3,
     0,
@@ -3543,7 +3543,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_THROW, "Throw",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::monster | spflag::not_self,
     5,
     200,
@@ -3555,7 +3555,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CORRUPTING_PULSE, "Corrupting Pulse",
-    SPTYP_HEXES | SPTYP_TRANSMUTATION,
+    spschool::hexes | spschool::transmutation,
     spflag::area | spflag::monster,
     6,
     200,
@@ -3566,7 +3566,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SIREN_SONG, "Siren Song",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::MR_check,
     5,
     200,
@@ -3577,7 +3577,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AVATAR_SONG, "Avatar Song",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::MR_check,
     7,
     200,
@@ -3588,7 +3588,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_PARALYSIS_GAZE, "Paralysis Gaze",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
@@ -3599,7 +3599,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CONFUSION_GAZE, "Confusion Gaze",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::target | spflag::not_self | spflag::monster | spflag::MR_check,
     3,
     200,
@@ -3610,7 +3610,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DRAINING_GAZE, "Draining Gaze",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
@@ -3621,7 +3621,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DEATH_RATTLE, "Death Rattle",
-    SPTYP_CONJURATION | SPTYP_NECROMANCY | SPTYP_AIR,
+    spschool::conjuration | spschool::necromancy | spschool::air,
     spflag::dir_or_target | spflag::monster,
     7,
     0,
@@ -3632,7 +3632,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_SCARABS, "Summon Scarabs",
-    SPTYP_SUMMONING | SPTYP_NECROMANCY,
+    spschool::summoning | spschool::necromancy,
     spflag::mons_abjure,
     7,
     100,
@@ -3643,7 +3643,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SCATTERSHOT, "Scattershot",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::not_self,
     6,
     200,
@@ -3654,7 +3654,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_ALLY, "Throw Ally",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::monster | spflag::not_self,
     2,
     50,
@@ -3666,7 +3666,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_HUNTING_CRY, "Hunting Cry",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::area | spflag::monster | spflag::selfench | spflag::noisy,
     6,
     0,
@@ -3678,7 +3678,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_CLEANSING_FLAME, "Cleansing Flame",
-    SPTYP_NONE,
+    spschool::none,
     spflag::area | spflag::monster | spflag::holy,
     8,
     200,
@@ -3690,7 +3690,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CIGOTUVIS_EMBRACE, "Cigotuvi's Embrace",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::chaotic | spflag::corpse_violating | spflag::utility
         | spflag::no_ghost,
     5,
@@ -3703,7 +3703,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GRAVITAS, "Gell's Gravitas",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::target | spflag::not_self | spflag::needs_tracer,
     3,
     200,
@@ -3715,7 +3715,7 @@ static const struct spell_desc spelldata[] =
 #if TAG_MAJOR_VERSION == 34
 {
     SPELL_CHANT_FIRE_STORM, "Chant Fire Storm",
-    SPTYP_CONJURATION | SPTYP_FIRE,
+    spschool::conjuration | spschool::fire,
     spflag::utility,
     6,
     200,
@@ -3727,7 +3727,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_VIOLENT_UNRAVELLING, "Yara's Violent Unravelling",
-    SPTYP_HEXES | SPTYP_TRANSMUTATION,
+    spschool::hexes | spschool::transmutation,
     spflag::dir_or_target | spflag::needs_tracer | spflag::no_ghost
         | spflag::chaotic,
     5,
@@ -3739,7 +3739,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ENTROPIC_WEAVE, "Entropic Weave",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::utility,
     5,
     200,
@@ -3750,7 +3750,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SUMMON_EXECUTIONERS, "Summon Executioners",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench | spflag::mons_abjure,
     9,
     200,
@@ -3761,7 +3761,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DOOM_HOWL, "Doom Howl",
-    SPTYP_TRANSLOCATION | SPTYP_HEXES,
+    spschool::translocation | spschool::hexes,
     spflag::dir_or_target,
     3,
     200,
@@ -3772,7 +3772,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AWAKEN_EARTH, "Awaken Earth",
-    SPTYP_SUMMONING | SPTYP_EARTH,
+    spschool::summoning | spschool::earth,
     spflag::monster | spflag::target,
     7,
     0,
@@ -3783,7 +3783,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_AURA_OF_BRILLIANCE, "Aura of Brilliance",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::area | spflag::monster,
     5,
     200,
@@ -3794,7 +3794,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_ICEBLAST, "Iceblast",
-    SPTYP_CONJURATION | SPTYP_ICE,
+    spschool::conjuration | spschool::ice,
     spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
@@ -3805,7 +3805,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SLUG_DART, "Slug Dart",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     1,
     25,
@@ -3816,7 +3816,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_SPRINT, "Sprint",
-    SPTYP_CHARMS,
+    spschool::charms,
     spflag::hasty | spflag::selfench | spflag::utility,
     2,
     100,
@@ -3827,7 +3827,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GREATER_SERVANT_MAKHLEB, "Greater Servant of Makhleb",
-    SPTYP_SUMMONING,
+    spschool::summoning,
     spflag::unholy | spflag::selfench | spflag::mons_abjure,
     7,
     200,
@@ -3838,7 +3838,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BIND_SOULS, "Bind Souls",
-    SPTYP_NECROMANCY | SPTYP_ICE,
+    spschool::necromancy | spschool::ice,
     spflag::area | spflag::monster,
     6,
     200,
@@ -3849,7 +3849,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_INFESTATION, "Infestation",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::target | spflag::unclean,
     8,
     200,
@@ -3860,7 +3860,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_STILL_WINDS, "Still Winds",
-    SPTYP_HEXES | SPTYP_AIR,
+    spschool::hexes | spschool::air,
     spflag::monster | spflag::selfench,
     6,
     200,
@@ -3871,7 +3871,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RESONANCE_STRIKE, "Resonance Strike",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
@@ -3882,7 +3882,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GHOSTLY_SACRIFICE, "Ghostly Sacrifice",
-    SPTYP_NECROMANCY,
+    spschool::necromancy,
     spflag::target | spflag::monster,
     7,
     200,
@@ -3893,7 +3893,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_DREAM_DUST, "Dream Dust",
-    SPTYP_HEXES,
+    spschool::hexes,
     spflag::target | spflag::not_self | spflag::monster,
     3,
     200,
@@ -3904,7 +3904,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BECKONING, "Lesser Beckoning",
-    SPTYP_TRANSLOCATION,
+    spschool::translocation,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     3,
     200,
@@ -3916,7 +3916,7 @@ static const struct spell_desc spelldata[] =
 // Monster-only, players can use Qazlal's ability
 {
     SPELL_UPHEAVAL, "Upheaval",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::target | spflag::not_self | spflag::needs_tracer | spflag::monster,
     5,
     200,
@@ -3927,7 +3927,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_RANDOM_EFFECTS, "Random Effects",
-    SPTYP_CONJURATION,
+    spschool::conjuration,
     spflag::dir_or_target | spflag::needs_tracer,
     4,
     200,
@@ -3938,7 +3938,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_POISONOUS_VAPOURS, "Poisonous Vapours",
-    SPTYP_POISON | SPTYP_AIR,
+    spschool::poison | spschool::air,
     spflag::target | spflag::not_self,
     2,
     50,
@@ -3949,7 +3949,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_IGNITION, "Ignition",
-    SPTYP_FIRE,
+    spschool::fire,
     spflag::area,
     8,
     200,
@@ -3960,7 +3960,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_VORTEX, "Vortex",
-    SPTYP_AIR,
+    spschool::air,
     spflag::area,
     5,
     200,
@@ -3971,7 +3971,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_BORGNJORS_VILE_CLUTCH, "Borgnjor's Vile Clutch",
-    SPTYP_NECROMANCY | SPTYP_EARTH,
+    spschool::necromancy | spschool::earth,
     spflag::target,
     5,
     200,
@@ -3982,7 +3982,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_HARPOON_SHOT, "Harpoon Shot",
-    SPTYP_CONJURATION | SPTYP_EARTH,
+    spschool::conjuration | spschool::earth,
     spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     4,
     200,
@@ -3993,7 +3993,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_GRASPING_ROOTS, "Grasping Roots",
-    SPTYP_EARTH,
+    spschool::earth,
     spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
@@ -4004,7 +4004,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_THROW_PIE, "Throw Klown Pie",
-    SPTYP_CONJURATION | SPTYP_HEXES,
+    spschool::conjuration | spschool::hexes,
     spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     5,
     200,
@@ -4015,7 +4015,7 @@ static const struct spell_desc spelldata[] =
 
 {
     SPELL_NO_SPELL, "nonexistent spell",
-    SPTYP_NONE,
+    spschool::none,
     spflag::testing,
     1,
     0,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -25,7 +25,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TELEPORT_SELF, "Teleport Self",
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_EMERGENCY | SPFLAG_UTILITY | SPFLAG_MONSTER,
+    spflag::escape | spflag::emergency | spflag::utility | spflag::monster,
     5,
     0,
     -1, -1,
@@ -36,7 +36,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CAUSE_FEAR, "Cause Fear",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MR_CHECK,
+    spflag::area | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -47,7 +47,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MAGIC_DART, "Magic Dart",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
     LOS_RADIUS, LOS_RADIUS,
@@ -58,7 +58,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIREBALL, "Fireball",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     5, 5,
@@ -69,7 +69,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_APPORTATION, "Apportation",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_OBJ | SPFLAG_NOT_SELF,
+    spflag::target | spflag::obj | spflag::not_self,
     1,
     50,
     LOS_RADIUS, LOS_RADIUS,
@@ -80,7 +80,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DELAYED_FIREBALL, "Delayed Fireball",
     SPTYP_FIRE | SPTYP_CONJURATION,
-    SPFLAG_UTILITY,
+    spflag::utility,
     7,
     0,
     -1, -1,
@@ -91,7 +91,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONJURE_FLAME, "Conjure Flame",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_TARGET | SPFLAG_NEUTRAL | SPFLAG_NOT_SELF,
+    spflag::target | spflag::neutral | spflag::not_self,
     3,
     100,
     3, 3,
@@ -102,7 +102,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DIG, "Dig",
     SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEUTRAL | SPFLAG_UTILITY,
+    spflag::dir_or_target | spflag::not_self | spflag::neutral
+        | spflag::utility,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -113,7 +114,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BOLT_OF_FIRE, "Bolt of Fire",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     6, 6,
@@ -124,7 +125,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BOLT_OF_COLD, "Bolt of Cold",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     5, 5,
@@ -135,7 +136,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LIGHTNING_BOLT, "Lightning Bolt",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     4, 11, // capped at LOS, yet this 11 matters since range increases linearly
@@ -146,7 +147,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINKBOLT, "Blinkbolt",
     SPTYP_AIR | SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     200,
     4, 11,
@@ -157,7 +159,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BOLT_OF_MAGMA, "Bolt of Magma",
     SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     4, 4,
@@ -168,7 +170,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_POLYMORPH, "Polymorph",
     SPTYP_TRANSMUTATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_CHAOTIC | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::chaotic | spflag::monster
+        | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -179,7 +182,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SLOW, "Slow",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     2,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -190,7 +193,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HASTE, "Haste",
     SPTYP_CHARMS,
-    SPFLAG_HELPFUL | SPFLAG_HASTY | SPFLAG_SELFENCH | SPFLAG_UTILITY,
+    spflag::helpful | spflag::hasty | spflag::selfench | spflag::utility,
     6,
     200,
     -1, -1,
@@ -201,7 +204,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PETRIFY, "Petrify",
     SPTYP_TRANSMUTATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -212,7 +215,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONFUSE, "Confuse",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -223,8 +226,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INVISIBILITY, "Invisibility",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_HELPFUL | SPFLAG_SELFENCH
-        | SPFLAG_EMERGENCY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::helpful | spflag::selfench
+        | spflag::emergency | spflag::needs_tracer,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -235,7 +238,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_FLAME, "Throw Flame",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
     LOS_RADIUS, LOS_RADIUS,
@@ -246,7 +249,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_FROST, "Throw Frost",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
     6, 6,
@@ -257,7 +260,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONTROLLED_BLINK, "Controlled Blink",
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_EMERGENCY | SPFLAG_UTILITY,
+    spflag::escape | spflag::emergency | spflag::utility,
     8,
     0,
     -1, -1,
@@ -269,7 +272,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISJUNCTION, "Disjunction",
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_UTILITY,
+    spflag::escape | spflag::utility,
     8,
     200,
     -1, -1,
@@ -280,8 +283,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FREEZING_CLOUD, "Freezing Cloud",
     SPTYP_CONJURATION | SPTYP_ICE | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_NEEDS_TRACER
-        | SPFLAG_CLOUD,
+    spflag::target | spflag::area | spflag::needs_tracer
+        | spflag::cloud,
     6,
     200,
     5, 5,
@@ -292,8 +295,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MEPHITIC_CLOUD, "Mephitic Cloud",
     SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_AREA
-        | SPFLAG_NEEDS_TRACER | SPFLAG_CLOUD,
+    spflag::dir_or_target | spflag::area
+        | spflag::needs_tracer | spflag::cloud,
     3,
     100,
     4, 4,
@@ -304,7 +307,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RING_OF_FLAMES, "Ring of Flames",
     SPTYP_CHARMS | SPTYP_FIRE,
-    SPFLAG_AREA,
+    spflag::area,
     7,
     200,
     -1, -1,
@@ -315,7 +318,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RING_OF_THUNDER, "Ring of Thunder",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     7,
     200,
     -1, -1,
@@ -326,7 +329,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VENOM_BOLT, "Venom Bolt",
     SPTYP_CONJURATION | SPTYP_POISON,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     5, 5,
@@ -337,7 +340,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_OLGREBS_TOXIC_RADIANCE, "Olgreb's Toxic Radiance",
     SPTYP_POISON,
-    SPFLAG_AREA,
+    spflag::area,
     4,
     100,
     -1, -1,
@@ -348,8 +351,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TELEPORT_OTHER, "Teleport Other",
     SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_ESCAPE
-        | SPFLAG_EMERGENCY | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::escape
+        | spflag::emergency | spflag::needs_tracer | spflag::MR_check,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -360,7 +363,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEATHS_DOOR, "Death's Door",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_EMERGENCY | SPFLAG_UTILITY | SPFLAG_NO_GHOST,
+    spflag::emergency | spflag::utility | spflag::no_ghost,
     8,
     200,
     -1, -1,
@@ -371,7 +374,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MASS_CONFUSION, "Mass Confusion",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MR_CHECK,
+    spflag::area | spflag::MR_check,
     6,
     200,
     -1, -1,
@@ -382,7 +385,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SMITING, "Smiting",
     SPTYP_NONE,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF,
+    spflag::target | spflag::not_self,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -393,7 +396,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_SMALL_MAMMAL, "Summon Small Mammal",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     1,
     25,
     -1, -1,
@@ -405,7 +408,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ABJURATION, "Abjuration",
     SPTYP_SUMMONING,
-    SPFLAG_ESCAPE | SPFLAG_NEEDS_TRACER | SPFLAG_MONSTER,
+    spflag::escape | spflag::needs_tracer | spflag::monster,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -416,7 +419,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AURA_OF_ABJURATION, "Aura of Abjuration",
     SPTYP_SUMMONING,
-    SPFLAG_AREA | SPFLAG_NEUTRAL | SPFLAG_ESCAPE,
+    spflag::area | spflag::neutral | spflag::escape,
     5,
     200,
     -1, -1,
@@ -428,7 +431,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_SCORPIONS, "Summon Scorpions",
     SPTYP_SUMMONING | SPTYP_POISON,
-    SPFLAG_NONE,
+    spflag::none,
     4,
     200,
     -1, -1,
@@ -440,7 +443,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BOLT_OF_DRAINING, "Bolt of Draining",
     SPTYP_CONJURATION | SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     5, 5,
@@ -451,7 +454,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LEHUDIBS_CRYSTAL_SPEAR, "Lehudib's Crystal Spear",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     8,
     200,
     3, 3,
@@ -463,7 +466,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BOLT_OF_INACCURACY, "Bolt of Inaccuracy",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER, // rod/tome of destruction
+    spflag::dir_or_target | spflag::needs_tracer, // rod/tome of destruction
     3,
     1000,
     6, 6,
@@ -475,7 +478,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TORNADO, "Tornado",
     SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     9,
     200,
     TORNADO_RADIUS, TORNADO_RADIUS,
@@ -486,7 +489,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_POISONOUS_CLOUD, "Poisonous Cloud",
     SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_NEEDS_TRACER | SPFLAG_CLOUD,
+    spflag::target | spflag::area | spflag::needs_tracer | spflag::cloud,
     5,
     200,
     5, 5,
@@ -497,7 +500,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIRE_STORM, "Fire Storm",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_NEEDS_TRACER,
+    spflag::target | spflag::area | spflag::needs_tracer,
     9,
     200,
     5, 5,
@@ -508,7 +511,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_DOWN_DAMNATION, "Call Down Damnation",
     SPTYP_CONJURATION,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_UNHOLY | SPFLAG_NEEDS_TRACER,
+    spflag::target | spflag::area | spflag::unholy | spflag::needs_tracer,
     9,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -519,7 +522,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK, "Blink",
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_SELFENCH | SPFLAG_EMERGENCY | SPFLAG_UTILITY,
+    spflag::escape | spflag::selfench | spflag::emergency | spflag::utility,
     2,
     0,
     -1, -1,
@@ -530,7 +533,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_RANGE, "Blink Range", // XXX needs better name
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_MONSTER | SPFLAG_SELFENCH | SPFLAG_EMERGENCY,
+    spflag::escape | spflag::monster | spflag::selfench | spflag::emergency,
     2,
     0,
     -1, -1,
@@ -541,7 +544,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_AWAY, "Blink Away",
     SPTYP_TRANSLOCATION,
-    SPFLAG_ESCAPE | SPFLAG_MONSTER | SPFLAG_EMERGENCY | SPFLAG_SELFENCH,
+    spflag::escape | spflag::monster | spflag::emergency | spflag::selfench,
     2,
     0,
     -1, -1,
@@ -552,7 +555,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_CLOSE, "Blink Close",
     SPTYP_TRANSLOCATION,
-    SPFLAG_MONSTER,
+    spflag::monster,
     2,
     0,
     -1, -1,
@@ -565,7 +568,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ISKENDERUNS_MYSTIC_BLAST, "Iskenderun's Mystic Blast",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
     6, 6,
@@ -577,7 +580,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_SWARM, "Summon Swarm",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     5,
     200,
     -1, -1,
@@ -589,7 +592,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_HORRIBLE_THINGS, "Summon Horrible Things",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_CHAOTIC | SPFLAG_MONS_ABJURE,
+    spflag::unholy | spflag::chaotic | spflag::mons_abjure,
     8,
     200,
     -1, -1,
@@ -600,7 +603,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MALIGN_GATEWAY, "Malign Gateway",
     SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
-    SPFLAG_UNHOLY | SPFLAG_CHAOTIC,
+    spflag::unholy | spflag::chaotic,
     7,
     200,
     -1, -1,
@@ -611,8 +614,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ENSLAVEMENT, "Enslavement",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER
-        | SPFLAG_MONSTER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::monster | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -623,7 +626,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ANIMATE_DEAD, "Animate Dead",
     SPTYP_NECROMANCY,
-    SPFLAG_AREA | SPFLAG_NEUTRAL | SPFLAG_CORPSE_VIOLATING | SPFLAG_UTILITY,
+    spflag::area | spflag::neutral | spflag::corpse_violating | spflag::utility,
     4,
     0,
     -1, -1,
@@ -634,7 +637,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PAIN, "Pain",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     1,
     25,
     5, 5,
@@ -646,7 +649,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONTROL_UNDEAD, "Control Undead",
     SPTYP_NECROMANCY,
-    SPFLAG_MR_CHECK,
+    spflag::MR_check,
     4,
     200,
     -1, -1,
@@ -658,7 +661,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ANIMATE_SKELETON, "Animate Skeleton",
     SPTYP_NECROMANCY,
-    SPFLAG_CORPSE_VIOLATING | SPFLAG_UTILITY,
+    spflag::corpse_violating | spflag::utility,
     1,
     0,
     -1, -1,
@@ -669,7 +672,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VAMPIRIC_DRAINING, "Vampiric Draining",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_EMERGENCY | SPFLAG_SELFENCH,
+    spflag::dir_or_target | spflag::not_self | spflag::emergency
+        | spflag::selfench,
     3,
     200,
     1, 1,
@@ -680,7 +684,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HAUNT, "Haunt",
     SPTYP_SUMMONING | SPTYP_NECROMANCY,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONS_ABJURE,
+    spflag::target | spflag::not_self | spflag::mons_abjure,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -691,7 +695,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BORGNJORS_REVIVIFICATION, "Borgnjor's Revivification",
     SPTYP_NECROMANCY,
-    SPFLAG_UTILITY,
+    spflag::utility,
     8,
     200,
     -1, -1,
@@ -702,7 +706,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FREEZE, "Freeze",
     SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::not_self,
     1,
     25,
     1, 1,
@@ -714,7 +718,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_ELEMENTAL, "Summon Elemental",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     4,
     200,
     -1, -1,
@@ -726,7 +730,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_OZOCUBUS_REFRIGERATION, "Ozocubu's Refrigeration",
     SPTYP_ICE,
-    SPFLAG_AREA,
+    spflag::area,
     6,
     200,
     -1, -1,
@@ -737,7 +741,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STICKY_FLAME, "Sticky Flame",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
     1, 1,
@@ -748,7 +752,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_ICE_BEAST, "Summon Ice Beast",
     SPTYP_ICE | SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     4,
     100,
     -1, -1,
@@ -759,7 +763,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_OZOCUBUS_ARMOUR, "Ozocubu's Armour",
     SPTYP_CHARMS | SPTYP_ICE,
-    SPFLAG_NO_GHOST,
+    spflag::no_ghost,
     3,
     100,
     -1, -1,
@@ -770,7 +774,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_IMP, "Call Imp",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH,
+    spflag::unholy | spflag::selfench,
     2,
     100,
     -1, -1,
@@ -781,7 +785,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_REPEL_MISSILES, "Repel Missiles",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_MONSTER,
+    spflag::monster,
     2,
     50,
     -1, -1,
@@ -792,7 +796,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BERSERKER_RAGE, "Berserker Rage",
     SPTYP_CHARMS,
-    SPFLAG_HASTY | SPFLAG_MONSTER,
+    spflag::hasty | spflag::monster,
     3,
     0,
     -1, -1,
@@ -804,7 +808,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FRENZY, "Frenzy",
     SPTYP_CHARMS,
-    SPFLAG_HASTY | SPFLAG_MONSTER,
+    spflag::hasty | spflag::monster,
     3,
     0,
     -1, -1,
@@ -816,7 +820,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISPEL_UNDEAD, "Dispel Undead",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     100,
     4, 4,
@@ -828,7 +832,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FULSOME_DISTILLATION, "Fulsome Distillation",
     SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
-    SPFLAG_CORPSE_VIOLATING,
+    spflag::corpse_violating,
     1,
     0,
     -1, -1,
@@ -840,7 +844,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_POISON_ARROW, "Poison Arrow",
     SPTYP_CONJURATION | SPTYP_POISON,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     6, 6,
@@ -851,7 +855,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TWISTED_RESURRECTION, "Twisted Resurrection",
     SPTYP_NECROMANCY,
-    SPFLAG_CHAOTIC | SPFLAG_CORPSE_VIOLATING | SPFLAG_UTILITY | SPFLAG_MONSTER,
+    spflag::chaotic | spflag::corpse_violating | spflag::utility
+        | spflag::monster,
     5,
     200,
     -1, -1,
@@ -862,7 +867,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_REGENERATION, "Regeneration",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_SELFENCH | SPFLAG_UTILITY,
+    spflag::selfench | spflag::utility,
     3,
     200,
     -1, -1,
@@ -874,8 +879,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BANISHMENT, "Banishment",
     SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_UNHOLY | SPFLAG_CHAOTIC | SPFLAG_MONSTER
-        | SPFLAG_EMERGENCY | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::unholy | spflag::chaotic | spflag::monster
+        | spflag::emergency | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -887,7 +892,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CIGOTUVIS_DEGENERATION, "Cigotuvi's Degeneration",
     SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_CHAOTIC,
+    spflag::dir_or_target | spflag::not_self | spflag::chaotic,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -899,7 +904,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STING, "Sting",
     SPTYP_CONJURATION | SPTYP_POISON,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
     6, 6,
@@ -910,7 +915,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUBLIMATION_OF_BLOOD, "Sublimation of Blood",
     SPTYP_NECROMANCY,
-    SPFLAG_UTILITY,
+    spflag::utility,
     2,
     200,
     -1, -1,
@@ -921,8 +926,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TUKIMAS_DANCE, "Tukima's Dance",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK
-        | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check
+        | spflag::not_self,
     3,
     100,
     LOS_RADIUS, LOS_RADIUS,
@@ -933,7 +938,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_DEMON, "Summon Demon",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::unholy | spflag::selfench | spflag::mons_abjure,
     5,
     200,
     -1, -1,
@@ -945,7 +950,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEMONIC_HORDE, "Demonic Horde",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY,
+    spflag::unholy,
     6,
     200,
     -1, -1,
@@ -957,7 +962,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_GREATER_DEMON, "Summon Greater Demon",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::unholy | spflag::selfench | spflag::mons_abjure,
     7,
     200,
     -1, -1,
@@ -968,7 +973,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CORPSE_ROT, "Corpse Rot",
     SPTYP_NECROMANCY,
-    SPFLAG_AREA | SPFLAG_NEUTRAL | SPFLAG_UNCLEAN,
+    spflag::area | spflag::neutral | spflag::unclean,
     2,
     0,
     -1, -1,
@@ -980,7 +985,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIRE_BRAND, "Fire Brand",
     SPTYP_CHARMS | SPTYP_FIRE,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     2,
     200,
     -1, -1,
@@ -991,7 +996,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FREEZING_AURA, "Freezing Aura",
     SPTYP_CHARMS | SPTYP_ICE,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     2,
     200,
     -1, -1,
@@ -1002,7 +1007,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LETHAL_INFUSION, "Lethal Infusion",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     2,
     200,
     -1, -1,
@@ -1014,7 +1019,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IRON_SHOT, "Iron Shot",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     4, 4,
@@ -1025,7 +1030,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STONE_ARROW, "Stone Arrow",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     3,
     50,
     4, 4,
@@ -1036,7 +1041,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHOCK, "Shock",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     1,
     25,
     LOS_RADIUS, LOS_RADIUS,
@@ -1047,7 +1052,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SWIFTNESS, "Swiftness",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_HASTY | SPFLAG_SELFENCH | SPFLAG_UTILITY,
+    spflag::hasty | spflag::selfench | spflag::utility,
     2,
     100,
     -1, -1,
@@ -1059,7 +1064,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FLY, "Flight",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_UTILITY,
+    spflag::utility,
     3,
     200,
     -1, -1,
@@ -1070,7 +1075,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INSULATION, "Insulation",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_NONE,
+    spflag::none,
     4,
     200,
     -1, -1,
@@ -1083,7 +1088,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CURE_POISON, "Cure Poison",
     SPTYP_POISON,
-    SPFLAG_RECOVERY | SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::recovery | spflag::helpful | spflag::utility,
     2,
     200,
     -1, -1,
@@ -1096,7 +1101,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONTROL_TELEPORT, "Control Teleport",
     SPTYP_CHARMS | SPTYP_TRANSLOCATION,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     4,
     200,
     -1, -1,
@@ -1107,7 +1112,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_POISON_WEAPON, "Poison Weapon",
     SPTYP_CHARMS | SPTYP_POISON,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     3,
     200,
     -1, -1,
@@ -1119,7 +1124,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEBUGGING_RAY, "Debugging Ray",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_TESTING,
+    spflag::dir_or_target | spflag::testing,
     7,
     100,
     LOS_RADIUS, LOS_RADIUS,
@@ -1130,7 +1135,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RECALL, "Recall",
     SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
-    SPFLAG_UTILITY,
+    spflag::utility,
     3,
     0,
     -1, -1,
@@ -1141,7 +1146,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AGONY, "Agony",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1152,7 +1158,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPIDER_FORM, "Spider Form",
     SPTYP_TRANSMUTATION | SPTYP_POISON,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     3,
     200,
     -1, -1,
@@ -1163,7 +1169,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISINTEGRATE, "Disintegrate",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::MR_check,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1174,7 +1181,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLADE_HANDS, "Blade Hands",
     SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     5,
     200,
     -1, -1,
@@ -1185,7 +1192,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STATUE_FORM, "Statue Form",
     SPTYP_TRANSMUTATION | SPTYP_EARTH,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     6,
     150,
     -1, -1,
@@ -1196,7 +1203,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ICE_FORM, "Ice Form",
     SPTYP_ICE | SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     4,
     100,
     -1, -1,
@@ -1207,7 +1214,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRAGON_FORM, "Dragon Form",
     SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     7,
     200,
     -1, -1,
@@ -1218,7 +1225,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HYDRA_FORM, "Hydra Form",
     SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC | SPFLAG_UTILITY,
+    spflag::helpful | spflag::chaotic | spflag::utility,
     6,
     200,
     -1, -1,
@@ -1229,7 +1236,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_NECROMUTATION, "Necromutation",
     SPTYP_TRANSMUTATION | SPTYP_NECROMANCY,
-    SPFLAG_HELPFUL | SPFLAG_CORPSE_VIOLATING | SPFLAG_CHAOTIC,
+    spflag::helpful | spflag::corpse_violating | spflag::chaotic,
     8,
     200,
     -1, -1,
@@ -1240,7 +1247,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEATH_CHANNEL, "Death Channel",
     SPTYP_NECROMANCY,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     6,
     200,
     -1, -1,
@@ -1252,7 +1259,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SYMBOL_OF_TORMENT, "Symbol of Torment",
     SPTYP_NECROMANCY,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     6,
     0,
     -1, -1,
@@ -1263,7 +1270,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEFLECT_MISSILES, "Deflect Missiles",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     6,
     200,
     -1, -1,
@@ -1274,7 +1281,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_ICICLE, "Throw Icicle",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
     5, 5,
@@ -1285,7 +1292,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AIRSTRIKE, "Airstrike",
     SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF,
+    spflag::target | spflag::not_self,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1296,7 +1303,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHADOW_CREATURES, "Shadow Creatures",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     6,
     0,
     -1, -1,
@@ -1307,7 +1314,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONFUSING_TOUCH, "Confusing Touch",
     SPTYP_HEXES,
-    SPFLAG_NONE,
+    spflag::none,
     1,
     50,
     -1, -1,
@@ -1319,7 +1326,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SURE_BLADE, "Sure Blade",
     SPTYP_HEXES | SPTYP_CHARMS,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     2,
     200,
     -1, -1,
@@ -1330,7 +1337,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FLAME_TONGUE, "Flame Tongue",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     1,
     40, // cap for range; damage cap is at 25
     2, 5,
@@ -1341,7 +1348,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PASSWALL, "Passwall",
     SPTYP_TRANSMUTATION | SPTYP_EARTH,
-    SPFLAG_TARGET | SPFLAG_ESCAPE | SPFLAG_NOT_SELF | SPFLAG_UTILITY,
+    spflag::target | spflag::escape | spflag::not_self | spflag::utility,
     2,
     120,
     1, 7,
@@ -1352,7 +1359,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IGNITE_POISON, "Ignite Poison",
     SPTYP_FIRE | SPTYP_TRANSMUTATION | SPTYP_POISON,
-    SPFLAG_AREA,
+    spflag::area,
     3,
     100,
     -1, -1,
@@ -1363,7 +1370,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STICKS_TO_SNAKES, "Sticks to Snakes",
     SPTYP_TRANSMUTATION,
-    SPFLAG_NO_GHOST,
+    spflag::no_ghost,
     2,
     100,
     -1, -1,
@@ -1374,7 +1381,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_CANINE_FAMILIAR, "Call Canine Familiar",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     3,
     100,
     -1, -1,
@@ -1385,7 +1392,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_DRAGON, "Summon Dragon",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     9,
     200,
     -1, -1,
@@ -1396,7 +1403,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HIBERNATION, "Ensorcelled Hibernation",
     SPTYP_HEXES | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::MR_check,
     2,
     56,
     LOS_RADIUS, LOS_RADIUS,
@@ -1407,7 +1415,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ENGLACIATION, "Metabolic Englaciation",
     SPTYP_HEXES | SPTYP_ICE,
-    SPFLAG_AREA,
+    spflag::area,
     5,
     200,
     -1, -1,
@@ -1419,7 +1427,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SEE_INVISIBLE, "See Invisible",
     SPTYP_CHARMS,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     4,
     200,
     -1, -1,
@@ -1430,7 +1438,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PHASE_SHIFT, "Phase Shift",
     SPTYP_TRANSLOCATION,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     5,
     200,
     -1, -1,
@@ -1442,7 +1450,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_BUTTERFLIES, "Summon Butterflies",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     1,
     100,
     -1, -1,
@@ -1454,7 +1462,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WARP_BRAND, "Warp Weapon",
     SPTYP_CHARMS | SPTYP_TRANSLOCATION,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     5,
     200,
     -1, -1,
@@ -1466,7 +1474,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SILENCE, "Silence",
     SPTYP_HEXES | SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     5,
     200,
     -1, -1,
@@ -1477,7 +1485,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHATTER, "Shatter",
     SPTYP_EARTH,
-    SPFLAG_AREA,
+    spflag::area,
     9,
     200,
     -1, -1,
@@ -1488,7 +1496,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISPERSAL, "Dispersal",
     SPTYP_TRANSLOCATION,
-    SPFLAG_AREA | SPFLAG_ESCAPE,
+    spflag::area | spflag::escape,
     6,
     200,
     1, 4,
@@ -1499,7 +1507,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISCHARGE, "Static Discharge",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     3,
     100,
     1, 1,
@@ -1510,7 +1518,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CORONA, "Corona",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::MR_check,
     1,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1521,7 +1530,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INTOXICATE, "Alistair's Intoxication",
     SPTYP_TRANSMUTATION | SPTYP_POISON,
-    SPFLAG_NONE,
+    spflag::none,
     5,
     100,
     -1, -1,
@@ -1533,7 +1542,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_EVAPORATE, "Evaporate",
     SPTYP_FIRE | SPTYP_TRANSMUTATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_AREA,
+    spflag::dir_or_target | spflag::area,
     2,
     50,
     5, 5,
@@ -1545,7 +1554,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LRD, "Lee's Rapid Deconstruction",
     SPTYP_EARTH,
-    SPFLAG_TARGET,
+    spflag::target,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1556,7 +1565,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SANDBLAST, "Sandblast",
     SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     1,
     50,
     3, 3,
@@ -1568,7 +1577,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONDENSATION_SHIELD, "Condensation Shield",
     SPTYP_ICE,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY,
+    spflag::helpful | spflag::utility,
     4,
     200,
     -1, -1,
@@ -1579,7 +1588,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STONESKIN, "Stoneskin",
     SPTYP_EARTH | SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_UTILITY | SPFLAG_NO_GHOST | SPFLAG_MONSTER,
+    spflag::helpful | spflag::utility | spflag::no_ghost | spflag::monster,
     2,
     100,
     -1, -1,
@@ -1591,7 +1600,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SIMULACRUM, "Simulacrum",
     SPTYP_ICE | SPTYP_NECROMANCY,
-    SPFLAG_CORPSE_VIOLATING,
+    spflag::corpse_violating,
     6,
     200,
     -1, -1,
@@ -1602,7 +1611,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONJURE_BALL_LIGHTNING, "Conjure Ball Lightning",
     SPTYP_AIR | SPTYP_CONJURATION,
-    SPFLAG_SELFENCH,
+    spflag::selfench,
     6,
     200,
     -1, -1,
@@ -1613,7 +1622,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHAIN_LIGHTNING, "Chain Lightning",
     SPTYP_AIR | SPTYP_CONJURATION,
-    SPFLAG_AREA,
+    spflag::area,
     8,
     200,
     -1, -1,
@@ -1624,7 +1633,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_EXCRUCIATING_WOUNDS, "Excruciating Wounds",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_HELPFUL,
+    spflag::helpful,
     5,
     200,
     -1, -1,
@@ -1635,7 +1644,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PORTAL_PROJECTILE, "Portal Projectile",
     SPTYP_TRANSLOCATION | SPTYP_HEXES,
-    SPFLAG_NONE,
+    spflag::none,
     3,
     50,
     -1, -1,
@@ -1646,7 +1655,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MONSTROUS_MENAGERIE, "Monstrous Menagerie",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     7,
     200,
     -1, -1,
@@ -1657,7 +1666,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GOLUBRIAS_PASSAGE, "Passage of Golubria",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_NEUTRAL | SPFLAG_ESCAPE | SPFLAG_SELFENCH,
+    spflag::target | spflag::neutral | spflag::escape | spflag::selfench,
     4,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1668,7 +1677,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FULMINANT_PRISM, "Fulminant Prism",
     SPTYP_CONJURATION | SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_NOT_SELF,
+    spflag::target | spflag::area | spflag::not_self,
     4,
     200,
     4, 4,
@@ -1680,7 +1689,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SINGULARITY, "Singularity",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::area | spflag::not_self | spflag::monster,
     9,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1692,7 +1701,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PARALYSE, "Paralyse",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer
+        | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1703,8 +1713,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MINOR_HEALING, "Minor Healing",
     SPTYP_NECROMANCY,
-    SPFLAG_RECOVERY | SPFLAG_HELPFUL | SPFLAG_MONSTER | SPFLAG_SELFENCH
-        | SPFLAG_EMERGENCY | SPFLAG_UTILITY | SPFLAG_NOT_EVIL,
+    spflag::recovery | spflag::helpful | spflag::monster | spflag::selfench
+        | spflag::emergency | spflag::utility | spflag::not_evil,
     2,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1715,8 +1725,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MAJOR_HEALING, "Major Healing",
     SPTYP_NECROMANCY,
-    SPFLAG_RECOVERY | SPFLAG_HELPFUL | SPFLAG_MONSTER | SPFLAG_SELFENCH
-        | SPFLAG_EMERGENCY | SPFLAG_UTILITY | SPFLAG_NOT_EVIL,
+    spflag::recovery | spflag::helpful | spflag::monster | spflag::selfench
+        | spflag::emergency | spflag::utility | spflag::not_evil,
     6,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1727,7 +1737,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HURL_DAMNATION, "Hurl Damnation",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_UNHOLY | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::unholy | spflag::monster
+        | spflag::needs_tracer,
     // plus DS ability, staff of Dispater & Sceptre of Asmodeus
     9,
     200,
@@ -1740,7 +1751,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VAMPIRE_SUMMON, "Vampire Summon",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_MONSTER,
+    spflag::unholy | spflag::monster,
     3,
     0,
     -1, -1,
@@ -1752,7 +1763,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BRAIN_FEED, "Brain Feed",
     SPTYP_NECROMANCY,
-    SPFLAG_TARGET | SPFLAG_MONSTER,
+    spflag::target | spflag::monster,
     3,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1764,7 +1775,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FAKE_RAKSHASA_SUMMON, "Rakshasa Summon",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_MONSTER,
+    spflag::unholy | spflag::monster,
     3,
     0,
     -1, -1,
@@ -1776,8 +1787,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_NOXIOUS_CLOUD, "Noxious Cloud",
     SPTYP_CONJURATION | SPTYP_POISON | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER
-        | SPFLAG_CLOUD,
+    spflag::target | spflag::area | spflag::monster | spflag::needs_tracer
+        | spflag::cloud,
     5,
     200,
     5, 5,
@@ -1788,7 +1799,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STEAM_BALL, "Steam Ball",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     0,
     6, 6,
@@ -1799,7 +1810,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_UFETUBUS, "Summon Ufetubus",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::unholy | spflag::monster | spflag::selfench,
     4,
     0,
     -1, -1,
@@ -1810,7 +1821,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_HELL_BEAST, "Summon Hell Beast",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::unholy | spflag::monster | spflag::selfench,
     4,
     0,
     -1, -1,
@@ -1821,7 +1832,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ENERGY_BOLT, "Energy Bolt",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1832,7 +1843,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPIT_POISON, "Spit Poison",
     SPTYP_POISON,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     2,
     0,
     6, 6,
@@ -1843,7 +1855,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_UNDEAD, "Summon Undead",
     SPTYP_SUMMONING | SPTYP_NECROMANCY,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     7,
     0,
     -1, -1,
@@ -1854,7 +1866,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CANTRIP, "Cantrip",
     SPTYP_NONE,
-    SPFLAG_MONSTER,
+    spflag::monster,
     1,
     0,
     -1, -1,
@@ -1865,7 +1877,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_QUICKSILVER_BOLT, "Quicksilver Bolt",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1876,7 +1888,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_METAL_SPLINTERS, "Metal Splinters",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     0,
     4, 4,
@@ -1887,8 +1899,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MIASMA_BREATH, "Miasma Breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_UNCLEAN | SPFLAG_MONSTER
-        | SPFLAG_NEEDS_TRACER | SPFLAG_CLOUD,
+    spflag::dir_or_target | spflag::unclean | spflag::monster
+        | spflag::needs_tracer | spflag::cloud,
     6,
     0,
     5, 5,
@@ -1899,7 +1911,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_DRAKES, "Summon Drakes",
     SPTYP_SUMMONING | SPTYP_NECROMANCY, // since it can summon shadow dragons
-    SPFLAG_UNCLEAN | SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::unclean | spflag::monster | spflag::mons_abjure,
     6,
     0,
     -1, -1,
@@ -1910,8 +1922,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_OTHER, "Blink Other",
     SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_ESCAPE | SPFLAG_MONSTER
-        | SPFLAG_EMERGENCY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::escape | spflag::monster
+        | spflag::emergency | spflag::needs_tracer,
     2,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1922,7 +1934,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_OTHER_CLOSE, "Blink Other Close",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::target | spflag::not_self | spflag::monster | spflag::needs_tracer,
     2,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1933,7 +1945,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_MUSHROOMS, "Summon Mushrooms",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::selfench | spflag::mons_abjure,
     4,
     0,
     -1, -1,
@@ -1944,7 +1956,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPIT_ACID, "Spit Acid",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1954,7 +1967,8 @@ static const struct spell_desc spelldata[] =
 
 { SPELL_ACID_SPLASH, "Acid Splash",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -1966,7 +1980,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STICKY_FLAME_RANGE, "Sticky Flame Range",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     4,
     100,
     4, 4,
@@ -1977,7 +1991,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIRE_BREATH, "Fire Breath",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -1988,7 +2003,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SEARING_BREATH, "Searing Breath",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -1999,8 +2015,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHAOS_BREATH, "Chaos Breath",
     SPTYP_CONJURATION | SPTYP_RANDOM,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY
-        | SPFLAG_NEEDS_TRACER | SPFLAG_CLOUD,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer | spflag::cloud,
     5,
     0,
     5, 5,
@@ -2011,7 +2027,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_COLD_BREATH, "Cold Breath",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -2022,7 +2039,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHILLING_BREATH, "Chilling Breath",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -2034,7 +2052,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRACONIAN_BREATH, "Draconian Breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY,
+    spflag::dir_or_target | spflag::monster | spflag::noisy,
     8,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -2046,7 +2064,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WATER_ELEMENTALS, "Summon Water Elementals",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2057,7 +2075,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PORKALATOR, "Porkalator",
     SPTYP_HEXES | SPTYP_TRANSMUTATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_CHAOTIC | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::chaotic | spflag::needs_tracer
+        | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2068,7 +2087,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CREATE_TENTACLES, "Spawn Tentacles",
     SPTYP_NONE,
-    SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::monster | spflag::selfench,
     5,
     0,
     -1, -1,
@@ -2079,7 +2098,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TOMB_OF_DOROKLOHE, "Tomb of Doroklohe",
     SPTYP_EARTH,
-    SPFLAG_MONSTER | SPFLAG_EMERGENCY,
+    spflag::monster | spflag::emergency,
     5,
     0,
     -1, -1,
@@ -2090,7 +2109,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_EYEBALLS, "Summon Eyeballs",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2101,8 +2120,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HASTE_OTHER, "Haste Other",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_HELPFUL
-        | SPFLAG_HASTY | SPFLAG_NEEDS_TRACER | SPFLAG_UTILITY,
+    spflag::dir_or_target | spflag::not_self | spflag::helpful
+        | spflag::hasty | spflag::needs_tracer | spflag::utility,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2113,7 +2132,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_EARTH_ELEMENTALS, "Summon Earth Elementals",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2124,7 +2143,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AIR_ELEMENTALS, "Summon Air Elementals",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2135,7 +2154,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIRE_ELEMENTALS, "Summon Fire Elementals",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2147,7 +2166,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IRON_ELEMENTALS, "Summon Iron Elementals",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2159,7 +2178,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SLEEP, "Sleep",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
+        | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2170,7 +2190,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FAKE_MARA_SUMMON, "Mara Summon",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::monster | spflag::selfench,
     5,
     0,
     -1, -1,
@@ -2182,7 +2202,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_RAKSHASA, "Summon Rakshasa",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER,
+    spflag::monster,
     5,
     0,
     -1, -1,
@@ -2193,7 +2213,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MISLEAD, "Mislead",
     SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF,
+    spflag::target | spflag::not_self,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2205,7 +2225,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_ILLUSION, "Summon Illusion",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER,
+    spflag::monster,
     5,
     0,
     -1, -1,
@@ -2216,7 +2236,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PRIMAL_WAVE, "Primal Wave",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     6, 6,
@@ -2227,7 +2247,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_TIDE, "Call Tide",
     SPTYP_TRANSLOCATION,
-    SPFLAG_MONSTER,
+    spflag::monster,
     7,
     0,
     -1, -1,
@@ -2238,7 +2258,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IOOD, "Orb of Destruction",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     7,
     200,
     8, 8,
@@ -2249,7 +2269,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INK_CLOUD, "Ink Cloud",
     SPTYP_CONJURATION | SPTYP_ICE, // it's a water spell
-    SPFLAG_MONSTER | SPFLAG_EMERGENCY | SPFLAG_UTILITY,
+    spflag::monster | spflag::emergency | spflag::utility,
     7,
     0,
     -1, -1,
@@ -2260,7 +2280,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MIGHT, "Might",
     SPTYP_CHARMS,
-    SPFLAG_HELPFUL | SPFLAG_SELFENCH | SPFLAG_EMERGENCY | SPFLAG_UTILITY,
+    spflag::helpful | spflag::selfench | spflag::emergency | spflag::utility,
     3,
     200,
     -1, -1,
@@ -2271,8 +2291,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MIGHT_OTHER, "Might Other",
     SPTYP_CHARMS,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_HELPFUL
-        | SPFLAG_NEEDS_TRACER | SPFLAG_UTILITY,
+    spflag::dir_or_target | spflag::not_self | spflag::helpful
+        | spflag::needs_tracer | spflag::utility,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2284,7 +2304,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUNRAY, "Sunray",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET,
+    spflag::dir_or_target,
     6,
     200,
     8, 8,
@@ -2296,7 +2316,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AWAKEN_FOREST, "Awaken Forest",
     SPTYP_HEXES | SPTYP_SUMMONING,
-    SPFLAG_AREA,
+    spflag::area,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2307,7 +2327,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRUIDS_CALL, "Druid's Call",
     SPTYP_CHARMS,
-    SPFLAG_MONSTER,
+    spflag::monster,
     6,
     0,
     -1, -1,
@@ -2318,7 +2338,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BROTHERS_IN_ARMS, "Brothers in Arms",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_EMERGENCY,
+    spflag::monster | spflag::emergency,
     6,
     0,
     -1, -1,
@@ -2329,7 +2349,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_TROGS_HAND, "Trog's Hand",
     SPTYP_NONE,
-    SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::monster | spflag::selfench,
     3,
     0,
     -1, -1,
@@ -2340,7 +2360,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_SPECTRAL_ORCS, "Summon Spectral Orcs",
     SPTYP_NECROMANCY | SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_TARGET,
+    spflag::monster | spflag::target,
     4,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -2352,7 +2372,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HOLY_LIGHT, "Holy Light",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET,
+    spflag::dir_or_target,
     6,
     200,
     5, 5,
@@ -2364,7 +2384,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_HOLIES, "Summon Holies",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE | SPFLAG_HOLY,
+    spflag::monster | spflag::mons_abjure | spflag::holy,
     5,
     0,
     -1, -1,
@@ -2375,8 +2395,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HEAL_OTHER, "Heal Other",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_HELPFUL
-        | SPFLAG_NEEDS_TRACER | SPFLAG_UTILITY | SPFLAG_NOT_EVIL,
+    spflag::dir_or_target | spflag::not_self | spflag::helpful
+        | spflag::needs_tracer | spflag::utility | spflag::not_evil,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2387,7 +2407,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HOLY_FLAMES, "Holy Flames",
     SPTYP_NONE,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_HOLY,
+    spflag::target | spflag::not_self | spflag::holy,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2398,8 +2418,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HOLY_BREATH, "Holy Breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_AREA | SPFLAG_NEEDS_TRACER | SPFLAG_CLOUD
-        | SPFLAG_HOLY,
+    spflag::dir_or_target | spflag::area | spflag::needs_tracer | spflag::cloud
+        | spflag::holy,
     5,
     200,
     5, 5,
@@ -2410,8 +2430,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INJURY_MIRROR, "Injury Mirror",
     SPTYP_NONE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_HELPFUL | SPFLAG_SELFENCH | SPFLAG_EMERGENCY
-        | SPFLAG_UTILITY,
+    spflag::dir_or_target | spflag::helpful | spflag::selfench
+        | spflag::emergency | spflag::utility,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2422,9 +2442,9 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRAIN_LIFE, "Drain Life",
     SPTYP_NECROMANCY,
-    // n.b. marked as SPFLAG_MONSTER for wizmode purposes, but this spell is
+    // n.b. marked as spflag::monster for wizmode purposes, but this spell is
     // called by the yred ability.
-    SPFLAG_AREA | SPFLAG_EMERGENCY | SPFLAG_MONSTER,
+    spflag::area | spflag::emergency | spflag::monster,
     6,
     0,
     -1, -1,
@@ -2435,7 +2455,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LEDAS_LIQUEFACTION, "Leda's Liquefaction",
     SPTYP_EARTH | SPTYP_HEXES,
-    SPFLAG_AREA,
+    spflag::area,
     4,
     200,
     -1, -1,
@@ -2446,7 +2466,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_HYDRA, "Summon Hydra",
     SPTYP_SUMMONING,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     7,
     200,
     -1, -1,
@@ -2457,7 +2477,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DARKNESS, "Darkness",
     SPTYP_HEXES,
-    SPFLAG_NONE,
+    spflag::none,
     6,
     200,
     -1, -1,
@@ -2468,7 +2488,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MESMERISE, "Mesmerise",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MR_CHECK,
+    spflag::area | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2480,7 +2500,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MELEE, "Melee",
     SPTYP_NONE,
-    SPFLAG_NONE,
+    spflag::none,
     1,
     0,
     -1, -1,
@@ -2492,7 +2512,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIRE_SUMMON, "Fire Summon",
     SPTYP_SUMMONING | SPTYP_FIRE,
-    SPFLAG_MONSTER | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::mons_abjure,
     8,
     0,
     -1, -1,
@@ -2503,7 +2523,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PETRIFYING_CLOUD, "Petrifying Cloud",
     SPTYP_CONJURATION | SPTYP_EARTH | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -2514,7 +2534,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHROUD_OF_GOLUBRIA, "Shroud of Golubria",
     SPTYP_CHARMS | SPTYP_TRANSLOCATION,
-    SPFLAG_SELFENCH,
+    spflag::selfench,
     2,
     200,
     -1, -1,
@@ -2525,7 +2545,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INNER_FLAME, "Inner Flame",
     SPTYP_HEXES | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEUTRAL | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::not_self | spflag::neutral
+        | spflag::MR_check,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2536,7 +2557,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BEASTLY_APPENDAGE, "Beastly Appendage",
     SPTYP_TRANSMUTATION,
-    SPFLAG_HELPFUL | SPFLAG_CHAOTIC,
+    spflag::helpful | spflag::chaotic,
     1,
     50,
     -1, -1,
@@ -2548,7 +2569,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SILVER_BLAST, "Silver Blast",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET,
+    spflag::dir_or_target,
     5,
     200,
     5, 5,
@@ -2560,7 +2581,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ENSNARE, "Ensnare",
     SPTYP_CONJURATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     5, 5,
@@ -2571,7 +2592,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THUNDERBOLT, "Thunderbolt",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::not_self,
     2, // 2-5, sort of
     200,
     5, 5,
@@ -2582,7 +2603,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BATTLESPHERE, "Iskenderun's Battlesphere",
     SPTYP_CONJURATION | SPTYP_CHARMS,
-    SPFLAG_UTILITY,
+    spflag::utility,
     5,
     100,
     -1, -1,
@@ -2593,7 +2614,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_MINOR_DEMON, "Summon Minor Demon",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH,
+    spflag::unholy | spflag::selfench,
     2,
     200,
     -1, -1,
@@ -2604,7 +2625,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MALMUTATE, "Malmutate",
     SPTYP_TRANSMUTATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_CHAOTIC | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::chaotic
+        | spflag::needs_tracer,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2616,7 +2638,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_TWISTER, "Summon Twister",
     SPTYP_SUMMONING | SPTYP_AIR,
-    SPFLAG_UNCLEAN | SPFLAG_MONSTER,
+    spflag::unclean | spflag::monster,
     9,
     0,
     -1, -1,
@@ -2628,7 +2650,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DAZZLING_SPRAY, "Dazzling Spray",
     SPTYP_CONJURATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::not_self,
     3,
     50,
     5, 5,
@@ -2639,7 +2661,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FORCE_LANCE, "Force Lance",
     SPTYP_CONJURATION | SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
     3, 3,
@@ -2650,7 +2672,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SENTINEL_MARK, "Sentinel's Mark",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2662,7 +2684,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WORD_OF_RECALL, "Word of Recall",
     SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
-    SPFLAG_UTILITY,
+    spflag::utility,
     3,
     0,
     -1, -1,
@@ -2673,7 +2695,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INJURY_BOND, "Injury Bond",
     SPTYP_CHARMS,
-    SPFLAG_AREA | SPFLAG_HELPFUL,
+    spflag::area | spflag::helpful,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2684,7 +2706,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPECTRAL_CLOUD, "Spectral Cloud",
     SPTYP_CONJURATION | SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_CLOUD,
+    spflag::dir_or_target | spflag::monster | spflag::cloud,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2695,7 +2717,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GHOSTLY_FIREBALL, "Ghostly Fireball",
     SPTYP_CONJURATION | SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_UNHOLY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::unholy
+        | spflag::needs_tracer,
     5,
     200,
     5, 5,
@@ -2706,7 +2729,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_LOST_SOUL, "Call Lost Soul",
     SPTYP_SUMMONING | SPTYP_NECROMANCY,
-    SPFLAG_UNHOLY | SPFLAG_MONSTER,
+    spflag::unholy | spflag::monster,
     5,
     200,
     -1, -1,
@@ -2717,7 +2740,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DIMENSION_ANCHOR, "Dimension Anchor",
     SPTYP_TRANSLOCATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2728,7 +2751,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_ALLIES_ENCIRCLE, "Blink Allies Encircling",
     SPTYP_TRANSLOCATION,
-    SPFLAG_AREA,
+    spflag::area,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2740,7 +2763,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHAFT_SELF, "Shaft Self",
     SPTYP_EARTH,
-    SPFLAG_ESCAPE,
+    spflag::escape,
     1,
     0,
     -1, -1,
@@ -2752,7 +2775,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AWAKEN_VINES, "Awaken Vines",
     SPTYP_HEXES | SPTYP_SUMMONING,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2764,7 +2787,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONTROL_WINDS, "Control Winds",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2776,7 +2799,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THORN_VOLLEY, "Volley of Thorns",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     100,
     5, 5,
@@ -2787,7 +2810,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WALL_OF_BRAMBLES, "Wall of Brambles",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     5,
     100,
     LOS_RADIUS, LOS_RADIUS,
@@ -2798,7 +2821,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WATERSTRIKE, "Waterstrike",
     SPTYP_ICE,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2810,7 +2833,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HASTE_PLANTS, "Haste Plants",
     SPTYP_CHARMS,
-    SPFLAG_AREA | SPFLAG_HELPFUL,
+    spflag::area | spflag::helpful,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2822,7 +2845,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WIND_BLAST, "Wind Blast",
     SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2833,7 +2856,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STRIP_RESISTANCE, "Strip Resistance",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2844,7 +2867,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INFUSION, "Infusion",
     SPTYP_CHARMS,
-    SPFLAG_UTILITY,
+    spflag::utility,
     1,
     25,
     -1, -1,
@@ -2855,7 +2878,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SONG_OF_SLAYING, "Song of Slaying",
     SPTYP_CHARMS,
-    SPFLAG_UTILITY,
+    spflag::utility,
     2,
     100,
     -1, -1,
@@ -2867,7 +2890,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SONG_OF_SHIELDING, "Song of Shielding",
     SPTYP_CHARMS,
-    SPFLAG_NONE,
+    spflag::none,
     4,
     100,
     -1, -1,
@@ -2879,7 +2902,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPECTRAL_WEAPON, "Spectral Weapon",
     SPTYP_HEXES | SPTYP_CHARMS,
-    SPFLAG_SELFENCH | SPFLAG_UTILITY | SPFLAG_NO_GHOST,
+    spflag::selfench | spflag::utility | spflag::no_ghost,
     3,
     100,
     -1, -1,
@@ -2890,7 +2913,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_VERMIN, "Summon Vermin",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER | SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::monster | spflag::unholy | spflag::selfench | spflag::mons_abjure,
     5,
     0,
     -1, -1,
@@ -2901,7 +2924,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MALIGN_OFFERING, "Malign Offering",
     SPTYP_NECROMANCY,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2912,7 +2935,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SEARING_RAY, "Searing Ray",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     2,
     50,
     4, 4,
@@ -2923,7 +2946,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISCORD, "Discord",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_HASTY,
+    spflag::area | spflag::hasty,
     8,
     200,
     -1, -1,
@@ -2934,7 +2957,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INVISIBILITY_OTHER, "Invisibility Other",
     SPTYP_CHARMS | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_HELPFUL,
+    spflag::dir_or_target | spflag::not_self | spflag::helpful,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2945,7 +2968,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VIRULENCE, "Virulence",
     SPTYP_POISON | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2957,7 +2980,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IGNITE_POISON_SINGLE, "Localized Ignite Poison",
     SPTYP_FIRE | SPTYP_TRANSMUTATION,
-    SPFLAG_MONSTER | SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::monster | spflag::dir_or_target | spflag::not_self
+        | spflag::needs_tracer | spflag::MR_check,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2969,7 +2993,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ORB_OF_ELECTRICITY, "Orb of Electricity",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2981,7 +3005,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_EXPLOSIVE_BOLT, "Explosive Bolt",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2993,7 +3017,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FLASH_FREEZE, "Flash Freeze",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3004,7 +3028,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LEGENDARY_DESTRUCTION, "Legendary Destruction",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     8,
     200,
     5, 5,
@@ -3016,7 +3040,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_EPHEMERAL_INFUSION, "Ephemeral Infusion",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_MONSTER | SPFLAG_EMERGENCY,
+    spflag::monster | spflag::emergency,
     6,
     200,
     -1, -1,
@@ -3028,7 +3052,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FORCEFUL_INVITATION, "Forceful Invitation",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER,
+    spflag::monster,
     4,
     200,
     -1, -1,
@@ -3039,7 +3063,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PLANEREND, "Plane Rend",
     SPTYP_SUMMONING,
-    SPFLAG_MONSTER,
+    spflag::monster,
     8,
     200,
     -1, -1,
@@ -3050,7 +3074,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHAIN_OF_CHAOS, "Chain of Chaos",
     SPTYP_CONJURATION,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_CHAOTIC,
+    spflag::area | spflag::monster | spflag::chaotic,
     8,
     200,
     -1, -1,
@@ -3061,7 +3085,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CALL_OF_CHAOS, "Call of Chaos",
     SPTYP_CHARMS,
-    SPFLAG_AREA | SPFLAG_CHAOTIC | SPFLAG_MONSTER,
+    spflag::area | spflag::chaotic | spflag::monster,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3072,7 +3096,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLACK_MARK, "Black Mark",
     SPTYP_CHARMS | SPTYP_NECROMANCY,
-    SPFLAG_MONSTER,
+    spflag::monster,
     7,
     200,
     -1, -1,
@@ -3084,7 +3108,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GRAND_AVATAR, "Grand Avatar",
     SPTYP_CONJURATION | SPTYP_CHARMS | SPTYP_HEXES,
-    SPFLAG_MONSTER | SPFLAG_UTILITY,
+    spflag::monster | spflag::utility,
     4,
     100,
     -1, -1,
@@ -3096,7 +3120,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SAP_MAGIC, "Sap Magic",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3108,7 +3132,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CORRUPT_BODY, "Corrupt Body",
     SPTYP_TRANSMUTATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_CHAOTIC | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::chaotic
+        | spflag::needs_tracer,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3119,7 +3144,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_REARRANGE_PIECES, "Rearrange the Pieces",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_CHAOTIC,
+    spflag::area | spflag::monster | spflag::chaotic,
     8,
     200,
     -1, -1,
@@ -3131,7 +3156,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MAJOR_DESTRUCTION, "Major Destruction",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_CHAOTIC | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::chaotic | spflag::needs_tracer,
     7,
     200,
     6, 6,
@@ -3142,7 +3167,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BLINK_ALLIES_AWAY, "Blink Allies Away",
     SPTYP_TRANSLOCATION,
-    SPFLAG_AREA,
+    spflag::area,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3153,7 +3178,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_FOREST, "Summon Forest",
     SPTYP_SUMMONING | SPTYP_TRANSLOCATION,
-    SPFLAG_NONE,
+    spflag::none,
     5,
     200,
     -1, -1,
@@ -3164,7 +3189,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_LIGHTNING_SPIRE, "Summon Lightning Spire",
     SPTYP_SUMMONING | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEUTRAL,
+    spflag::target | spflag::not_self | spflag::neutral,
     4,
     100,
     2, 2,
@@ -3175,7 +3200,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_GUARDIAN_GOLEM, "Summon Guardian Golem",
     SPTYP_SUMMONING | SPTYP_HEXES,
-    SPFLAG_NONE,
+    spflag::none,
     3,
     100,
     -1, -1,
@@ -3186,7 +3211,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHADOW_SHARD, "Shadow Shard",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3197,7 +3222,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHADOW_BOLT, "Shadow Bolt",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3208,7 +3233,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CRYSTAL_BOLT, "Crystal Bolt",
     SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     6, 6,
@@ -3219,7 +3244,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RANDOM_BOLT, "Random Bolt",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     200,
     5, 5,
@@ -3230,7 +3255,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GLACIATE, "Glaciate",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_AREA | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::area | spflag::not_self,
     9,
     200,
     6, 6,
@@ -3241,7 +3266,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CLOUD_CONE, "Cloud Cone",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF,
+    spflag::target | spflag::not_self,
     6,
     100,
     3, LOS_DEFAULT_RANGE,
@@ -3253,7 +3278,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WEAVE_SHADOWS, "Weave Shadows",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     5,
     0,
     -1, -1,
@@ -3265,7 +3290,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRAGON_CALL, "Dragon's Call",
     SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     9,
     200,
     -1, -1,
@@ -3276,7 +3301,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPELLFORGED_SERVITOR, "Spellforged Servitor",
     SPTYP_CONJURATION | SPTYP_SUMMONING,
-    SPFLAG_NONE,
+    spflag::none,
     7,
     200,
     -1, -1,
@@ -3288,7 +3313,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FORCEFUL_DISMISSAL, "Forceful Dismissal",
     SPTYP_SUMMONING,
-    SPFLAG_AREA,
+    spflag::area,
     6,
     200,
     -1, -1,
@@ -3300,7 +3325,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_MANA_VIPER, "Summon Mana Viper",
     SPTYP_SUMMONING | SPTYP_HEXES,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     5,
     100,
     -1, -1,
@@ -3311,7 +3336,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PHANTOM_MIRROR, "Phantom Mirror",
     SPTYP_CHARMS | SPTYP_HEXES,
-    SPFLAG_HELPFUL | SPFLAG_SELFENCH,
+    spflag::helpful | spflag::selfench,
     5,
     200,
     -1, -1,
@@ -3322,7 +3347,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRAIN_MAGIC, "Drain Magic",
     SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER | SPFLAG_MR_CHECK,
+    spflag::dir_or_target | spflag::monster | spflag::needs_tracer
+        | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3333,7 +3359,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CORROSIVE_BOLT, "Corrosive Bolt",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     6,
     200,
     5, 5,
@@ -3344,7 +3370,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SERPENT_OF_HELL_GEH_BREATH, "gehenna serpent of hell breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3355,7 +3382,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SERPENT_OF_HELL_COC_BREATH, "cocytus serpent of hell breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3366,7 +3394,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SERPENT_OF_HELL_DIS_BREATH, "dis serpent of hell breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3377,7 +3406,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SERPENT_OF_HELL_TAR_BREATH, "tartarus serpent of hell breath",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3388,7 +3418,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_EMPEROR_SCORPIONS, "Summon Emperor Scorpions",
     SPTYP_SUMMONING | SPTYP_POISON,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     7,
     100,
     -1, -1,
@@ -3399,7 +3429,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IRRADIATE, "Irradiate",
     SPTYP_CONJURATION | SPTYP_TRANSMUTATION,
-    SPFLAG_AREA | SPFLAG_CHAOTIC,
+    spflag::area | spflag::chaotic,
     5,
     200,
     1, 1,
@@ -3410,7 +3440,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPIT_LAVA, "Spit Lava",
     SPTYP_CONJURATION | SPTYP_FIRE | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -3421,7 +3452,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ELECTRICAL_BOLT, "Electrical Bolt",
     SPTYP_CONJURATION | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3432,8 +3464,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FLAMING_CLOUD, "Flaming Cloud",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_TARGET | SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_NEEDS_TRACER
-        | SPFLAG_CLOUD,
+    spflag::target | spflag::area | spflag::monster | spflag::needs_tracer
+        | spflag::cloud,
     5,
     0,
     5, 5,
@@ -3444,7 +3476,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_BARBS, "Throw Barbs",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER | SPFLAG_NOISY | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::monster | spflag::noisy
+        | spflag::needs_tracer,
     5,
     0,
     5, 5,
@@ -3455,7 +3488,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BATTLECRY, "Battlecry",
     SPTYP_CHARMS,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::area | spflag::monster | spflag::selfench,
     6,
     0,
     -1, -1,
@@ -3466,7 +3499,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_WARNING_CRY, "Warning Cry",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_SELFENCH | SPFLAG_NOISY,
+    spflag::area | spflag::monster | spflag::selfench | spflag::noisy,
     6,
     0,
     -1, -1,
@@ -3477,7 +3510,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SEAL_DOORS, "Seal Doors",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::area | spflag::monster | spflag::selfench,
     6,
     0,
     -1, -1,
@@ -3488,7 +3521,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FLAY, "Flay",
     SPTYP_NECROMANCY,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3499,7 +3532,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BERSERK_OTHER, "Berserk Other",
     SPTYP_CHARMS,
-    SPFLAG_HASTY | SPFLAG_MONSTER | SPFLAG_NOT_SELF | SPFLAG_HELPFUL,
+    spflag::hasty | spflag::monster | spflag::not_self | spflag::helpful,
     3,
     0,
     3, 3,
@@ -3511,7 +3544,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW, "Throw",
     SPTYP_TRANSLOCATION,
-    SPFLAG_MONSTER | SPFLAG_NOT_SELF,
+    spflag::monster | spflag::not_self,
     5,
     200,
     1, 1,
@@ -3523,7 +3556,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CORRUPTING_PULSE, "Corrupting Pulse",
     SPTYP_HEXES | SPTYP_TRANSMUTATION,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3534,7 +3567,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SIREN_SONG, "Siren Song",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MR_CHECK,
+    spflag::area | spflag::MR_check,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3545,7 +3578,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AVATAR_SONG, "Avatar Song",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MR_CHECK,
+    spflag::area | spflag::MR_check,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3556,7 +3589,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PARALYSIS_GAZE, "Paralysis Gaze",
     SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3567,7 +3600,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CONFUSION_GAZE, "Confusion Gaze",
     SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER | SPFLAG_MR_CHECK,
+    spflag::target | spflag::not_self | spflag::monster | spflag::MR_check,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3578,7 +3611,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DRAINING_GAZE, "Draining Gaze",
     SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3589,7 +3622,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DEATH_RATTLE, "Death Rattle",
     SPTYP_CONJURATION | SPTYP_NECROMANCY | SPTYP_AIR,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_MONSTER,
+    spflag::dir_or_target | spflag::monster,
     7,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3600,7 +3633,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_SCARABS, "Summon Scarabs",
     SPTYP_SUMMONING | SPTYP_NECROMANCY,
-    SPFLAG_MONS_ABJURE,
+    spflag::mons_abjure,
     7,
     100,
     -1, -1,
@@ -3611,7 +3644,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SCATTERSHOT, "Scattershot",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF,
+    spflag::dir_or_target | spflag::not_self,
     6,
     200,
     5, 5,
@@ -3622,7 +3655,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_ALLY, "Throw Ally",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_MONSTER | SPFLAG_NOT_SELF,
+    spflag::target | spflag::monster | spflag::not_self,
     2,
     50,
     LOS_RADIUS, LOS_RADIUS,
@@ -3634,7 +3667,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HUNTING_CRY, "Hunting Cry",
     SPTYP_HEXES,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_SELFENCH | SPFLAG_NOISY,
+    spflag::area | spflag::monster | spflag::selfench | spflag::noisy,
     6,
     0,
     -1, -1,
@@ -3646,7 +3679,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CLEANSING_FLAME, "Cleansing Flame",
     SPTYP_NONE,
-    SPFLAG_AREA | SPFLAG_MONSTER | SPFLAG_HOLY,
+    spflag::area | spflag::monster | spflag::holy,
     8,
     200,
     -1, -1,
@@ -3658,7 +3691,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CIGOTUVIS_EMBRACE, "Cigotuvi's Embrace",
     SPTYP_NECROMANCY,
-    SPFLAG_CHAOTIC | SPFLAG_CORPSE_VIOLATING | SPFLAG_UTILITY | SPFLAG_NO_GHOST,
+    spflag::chaotic | spflag::corpse_violating | spflag::utility
+        | spflag::no_ghost,
     5,
     200,
     -1, -1,
@@ -3670,7 +3704,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GRAVITAS, "Gell's Gravitas",
     SPTYP_TRANSLOCATION,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::target | spflag::not_self | spflag::needs_tracer,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3682,7 +3716,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHANT_FIRE_STORM, "Chant Fire Storm",
     SPTYP_CONJURATION | SPTYP_FIRE,
-    SPFLAG_UTILITY,
+    spflag::utility,
     6,
     200,
     -1, -1,
@@ -3694,7 +3728,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VIOLENT_UNRAVELLING, "Yara's Violent Unravelling",
     SPTYP_HEXES | SPTYP_TRANSMUTATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_NO_GHOST | SPFLAG_CHAOTIC,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::no_ghost
+        | spflag::chaotic,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3705,7 +3740,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ENTROPIC_WEAVE, "Entropic Weave",
     SPTYP_HEXES,
-    SPFLAG_UTILITY,
+    spflag::utility,
     5,
     200,
     -1, -1,
@@ -3716,7 +3751,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SUMMON_EXECUTIONERS, "Summon Executioners",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::unholy | spflag::selfench | spflag::mons_abjure,
     9,
     200,
     -1, -1,
@@ -3727,7 +3762,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DOOM_HOWL, "Doom Howl",
     SPTYP_TRANSLOCATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET,
+    spflag::dir_or_target,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3738,7 +3773,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AWAKEN_EARTH, "Awaken Earth",
     SPTYP_SUMMONING | SPTYP_EARTH,
-    SPFLAG_MONSTER | SPFLAG_TARGET,
+    spflag::monster | spflag::target,
     7,
     0,
     LOS_RADIUS, LOS_RADIUS,
@@ -3749,7 +3784,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AURA_OF_BRILLIANCE, "Aura of Brilliance",
     SPTYP_CHARMS,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     5,
     200,
     -1, -1,
@@ -3760,7 +3795,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ICEBLAST, "Iceblast",
     SPTYP_CONJURATION | SPTYP_ICE,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     5,
     200,
     5, 5,
@@ -3771,7 +3806,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SLUG_DART, "Slug Dart",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MONSTER,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     1,
     25,
     LOS_RADIUS, LOS_RADIUS,
@@ -3782,7 +3817,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SPRINT, "Sprint",
     SPTYP_CHARMS,
-    SPFLAG_HASTY | SPFLAG_SELFENCH | SPFLAG_UTILITY,
+    spflag::hasty | spflag::selfench | spflag::utility,
     2,
     100,
     -1, -1,
@@ -3793,7 +3828,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GREATER_SERVANT_MAKHLEB, "Greater Servant of Makhleb",
     SPTYP_SUMMONING,
-    SPFLAG_UNHOLY | SPFLAG_SELFENCH | SPFLAG_MONS_ABJURE,
+    spflag::unholy | spflag::selfench | spflag::mons_abjure,
     7,
     200,
     -1, -1,
@@ -3804,7 +3839,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BIND_SOULS, "Bind Souls",
     SPTYP_NECROMANCY | SPTYP_ICE,
-    SPFLAG_AREA | SPFLAG_MONSTER,
+    spflag::area | spflag::monster,
     6,
     200,
     -1, -1,
@@ -3815,7 +3850,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_INFESTATION, "Infestation",
     SPTYP_NECROMANCY,
-    SPFLAG_TARGET | SPFLAG_UNCLEAN,
+    spflag::target | spflag::unclean,
     8,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3826,7 +3861,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STILL_WINDS, "Still Winds",
     SPTYP_HEXES | SPTYP_AIR,
-    SPFLAG_MONSTER | SPFLAG_SELFENCH,
+    spflag::monster | spflag::selfench,
     6,
     200,
     -1, -1,
@@ -3837,7 +3872,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RESONANCE_STRIKE, "Resonance Strike",
     SPTYP_EARTH,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3848,7 +3883,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GHOSTLY_SACRIFICE, "Ghostly Sacrifice",
     SPTYP_NECROMANCY,
-    SPFLAG_TARGET | SPFLAG_MONSTER,
+    spflag::target | spflag::monster,
     7,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3859,7 +3894,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DREAM_DUST, "Dream Dust",
     SPTYP_HEXES,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     3,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3870,7 +3905,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BECKONING, "Lesser Beckoning",
     SPTYP_TRANSLOCATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::not_self | spflag::needs_tracer,
     3,
     200,
     2, LOS_DEFAULT_RANGE,
@@ -3882,7 +3917,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_UPHEAVAL, "Upheaval",
     SPTYP_CONJURATION,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_NEEDS_TRACER | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::needs_tracer | spflag::monster,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3893,7 +3928,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_RANDOM_EFFECTS, "Random Effects",
     SPTYP_CONJURATION,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER,
+    spflag::dir_or_target | spflag::needs_tracer,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3904,7 +3939,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_POISONOUS_VAPOURS, "Poisonous Vapours",
     SPTYP_POISON | SPTYP_AIR,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF,
+    spflag::target | spflag::not_self,
     2,
     50,
     LOS_RADIUS, LOS_RADIUS,
@@ -3915,7 +3950,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IGNITION, "Ignition",
     SPTYP_FIRE,
-    SPFLAG_AREA,
+    spflag::area,
     8,
     200,
     -1, -1,
@@ -3926,7 +3961,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_VORTEX, "Vortex",
     SPTYP_AIR,
-    SPFLAG_AREA,
+    spflag::area,
     5,
     200,
     VORTEX_RADIUS, VORTEX_RADIUS,
@@ -3937,7 +3972,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_BORGNJORS_VILE_CLUTCH, "Borgnjor's Vile Clutch",
     SPTYP_NECROMANCY | SPTYP_EARTH,
-    SPFLAG_TARGET,
+    spflag::target,
     5,
     200,
     5, 5,
@@ -3948,7 +3983,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HARPOON_SHOT, "Harpoon Shot",
     SPTYP_CONJURATION | SPTYP_EARTH,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MONSTER,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     4,
     200,
     6, 6,
@@ -3959,7 +3994,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_GRASPING_ROOTS, "Grasping Roots",
     SPTYP_EARTH,
-    SPFLAG_TARGET | SPFLAG_NOT_SELF | SPFLAG_MONSTER,
+    spflag::target | spflag::not_self | spflag::monster,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3970,7 +4005,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_THROW_PIE, "Throw Klown Pie",
     SPTYP_CONJURATION | SPTYP_HEXES,
-    SPFLAG_DIR_OR_TARGET | SPFLAG_NEEDS_TRACER | SPFLAG_MONSTER,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::monster,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3981,7 +4016,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_NO_SPELL, "nonexistent spell",
     SPTYP_NONE,
-    SPFLAG_TESTING,
+    spflag::testing,
     1,
     0,
     -1, -1,

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -54,7 +54,7 @@
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
                              int _source, spell_type _spell,
                              int _pow, int _fail, string _cause,
-                             nothing_happens_when_type _nothing_happens,
+                             nothing_happens _nothing_happens,
                              int _lethality_margin, string _hand_str,
                              bool _can_plural) :
     target(_target), act_source(_act_source),
@@ -74,7 +74,7 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
                              spschool _school, int _level,
                              string _cause,
-                             nothing_happens_when_type _nothing_happens,
+                             nothing_happens _nothing_happens,
                              int _lethality_margin, string _hand_str,
                              bool _can_plural) :
     target(_target), act_source(_act_source),
@@ -96,7 +96,7 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
                              spschool _school, int _pow, int _fail,
                              string _cause,
-                             nothing_happens_when_type _nothing_happens,
+                             nothing_happens _nothing_happens,
                              int _lethality_margin, string _hand_str,
                              bool _can_plural) :
     target(_target), act_source(_act_source),
@@ -377,9 +377,9 @@ void MiscastEffect::do_msg(bool suppress_nothing_happens)
     if (msg.empty())
     {
         if (!suppress_nothing_happens
-            && (nothing_happens_when == NH_ALWAYS
-                || (nothing_happens_when == NH_DEFAULT && source_known
-                    && target_known)))
+            && (nothing_happens_when == nothing_happens::ALWAYS
+                || (nothing_happens_when == nothing_happens::DEFAULT
+                    && source_known && target_known)))
         {
             canned_msg(MSG_NOTHING_HAPPENS);
         }

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -52,7 +52,7 @@
 #define MAX_RECURSE 100
 
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
-                             int _source, spell_type _spell,
+                             miscast_source_info _source, spell_type _spell,
                              int _pow, int _fail, string _cause,
                              nothing_happens _nothing_happens,
                              int _lethality_margin, string _hand_str,
@@ -71,7 +71,8 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
     do_miscast();
 }
 
-MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
+MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
+                             miscast_source_info _source,
                              spschool _school, int _level,
                              string _cause,
                              nothing_happens _nothing_happens,
@@ -93,7 +94,8 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
     do_miscast();
 }
 
-MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
+MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
+                             miscast_source_info _source,
                              spschool _school, int _pow, int _fail,
                              string _cause,
                              nothing_happens _nothing_happens,
@@ -157,16 +159,16 @@ void MiscastEffect::init()
 
         source_known = you.can_see(*act_source);
 
-        if (target_known && special_source == MUMMY_MISCAST)
+        if (target_known && special_source.source == MUMMY_MISCAST)
             source_known = true;
     }
     else
     {
-        ASSERT(special_source != MELEE_MISCAST);
+        ASSERT(special_source.source != MELEE_MISCAST);
 
         kt = KILL_MISCAST;
 
-        if (special_source == ZOT_TRAP_MISCAST)
+        if (special_source.source == ZOT_TRAP_MISCAST)
         {
             source_known = target_known;
 
@@ -184,7 +186,7 @@ void MiscastEffect::init()
 
     // source_known = false for MELEE_MISCAST so that melee miscasts
     // won't give a "nothing happens" message.
-    if (special_source == MELEE_MISCAST)
+    if (special_source.source == MELEE_MISCAST)
         source_known = false;
 
     if (hand_str.empty())
@@ -209,7 +211,7 @@ string MiscastEffect::get_default_cause(bool attribute_to_user) const
 {
     // This is only for true miscasts, which means both a spell and that
     // the source of the miscast is the same as the target of the miscast.
-    ASSERT(special_source == SPELL_MISCAST);
+    ASSERT(special_source.source == SPELL_MISCAST);
     ASSERT(spell != SPELL_NO_SPELL);
     ASSERT(school == spschool::none);
     ASSERT(target->is_player());
@@ -310,7 +312,7 @@ void MiscastEffect::do_miscast()
     msg_ch         = MSGCH_PLAIN;
     sound_loudness = 0;
 
-    if (special_source == ZOT_TRAP_MISCAST)
+    if (special_source.source == ZOT_TRAP_MISCAST)
     {
         _zot();
         if (target->is_player())
@@ -456,13 +458,13 @@ bool MiscastEffect::_ouch(int dam, beam_type flavour)
 
         kill_method_type method;
 
-        if (special_source == SPELL_MISCAST && spell != SPELL_NO_SPELL)
+        if (special_source.source == SPELL_MISCAST && spell != SPELL_NO_SPELL)
             method = KILLED_BY_WILD_MAGIC;
-        else if (special_source == ZOT_TRAP_MISCAST)
+        else if (special_source.source == ZOT_TRAP_MISCAST)
             method = KILLED_BY_TRAP;
-        else if (special_source >= GOD_MISCAST)
+        else if (special_source.source == GOD_MISCAST)
         {
-            god_type god = static_cast<god_type>(special_source - GOD_MISCAST);
+            god_type god = special_source.god;
 
             if (god == GOD_XOM && !player_under_penance(GOD_XOM))
                 method = KILLED_BY_XOM;
@@ -489,7 +491,7 @@ bool MiscastEffect::_explosion()
     ASSERT(beam.flavour != BEAM_NONE);
 
     // wild magic card
-    if (special_source == DECK_MISCAST)
+    if (special_source.source == DECK_MISCAST)
         beam.thrower = KILL_MISCAST;
 
     int max_dam = beam.damage.num * beam.damage.size;
@@ -517,7 +519,7 @@ bool MiscastEffect::_big_cloud(cloud_type cl_type, int cloud_pow, int size,
 
 bool MiscastEffect::_paralyse(int dur)
 {
-    if (special_source != HELL_EFFECT_MISCAST)
+    if (special_source.source != HELL_EFFECT_MISCAST)
     {
         target->paralyse(act_source, dur, cause);
         return true;
@@ -528,7 +530,7 @@ bool MiscastEffect::_paralyse(int dur)
 
 bool MiscastEffect::_sleep(int dur)
 {
-    if (!target->can_sleep() || special_source == HELL_EFFECT_MISCAST)
+    if (!target->can_sleep() || special_source.source == HELL_EFFECT_MISCAST)
         return false;
 
     if (target->is_player())
@@ -545,7 +547,7 @@ bool MiscastEffect::_send_to_abyss()
     // of doing nothing.
     if ((player_in_branch(BRANCH_ABYSS)
          && x_chance_in_y(you.depth, brdepth[BRANCH_ABYSS]))
-        || special_source == HELL_EFFECT_MISCAST)
+        || special_source.source == HELL_EFFECT_MISCAST)
     {
         return _malign_gateway();
     }
@@ -627,14 +629,14 @@ bool MiscastEffect::_create_monster(monster_type what, int abj_deg,
     data.set_summoned(nullptr, abj_deg, SPELL_NO_SPELL, god);
     data.set_non_actor_summoner(cause);
 
-    if (special_source != HELL_EFFECT_MISCAST)
+    if (special_source.source != HELL_EFFECT_MISCAST)
         data.extra_flags |= (MF_NO_REWARD | MF_HARD_RESET);
 
     // hostile_at() assumes the monster is hostile to the player,
     // but should be hostile to the target monster unless the miscast
     // is a result of either divine wrath or a Zot trap.
     if (target->is_monster() && !player_under_penance(god)
-        && special_source != ZOT_TRAP_MISCAST)
+        && special_source.source != ZOT_TRAP_MISCAST)
     {
         monster* mon_target = target->as_monster();
 
@@ -665,7 +667,7 @@ bool MiscastEffect::_create_monster(monster_type what, int abj_deg,
             data.summon_type = SPELL_SHADOW_CREATURES;
         else if (player_under_penance(god))
             data.summon_type = MON_SUMM_WRATH;
-        else if (special_source == ZOT_TRAP_MISCAST)
+        else if (special_source.source == ZOT_TRAP_MISCAST)
             data.summon_type = MON_SUMM_ZOT;
         else
             data.summon_type = MON_SUMM_MISCAST;
@@ -726,7 +728,7 @@ void MiscastEffect::_conjuration(int severity)
         switch (random2(num))
         {
         case 0:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Sparks fly from the ground!";
             you_msg      = "Sparks fly from your @hands@!";
             mon_msg_seen = "Sparks fly from @the_monster@'s @hands@!";
@@ -737,7 +739,7 @@ void MiscastEffect::_conjuration(int severity)
                            "with energy!";
             break;
         case 2:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Wisps of smoke drift around you.";
             you_msg      = "Wisps of smoke drift from your @hands@.";
             mon_msg_seen = "Wisps of smoke drift from @the_monster@'s "
@@ -791,7 +793,7 @@ void MiscastEffect::_conjuration(int severity)
         switch (random2(2))
         {
         case 0:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Smoke billows around you!";
             you_msg        = "Smoke pours from your @hands@!";
             mon_msg_seen   = "Smoke pours from @the_monster@'s @hands@!";
@@ -1149,7 +1151,7 @@ void MiscastEffect::_charms(int severity)
                 reroll = false;
                 break;
             case 2:
-                if (special_source == HELL_EFFECT_MISCAST)
+                if (special_source.source == HELL_EFFECT_MISCAST)
                     all_msg = "Magic is drained from your body!";
                 you_msg        = "Magic surges out from your body!";
                 mon_msg_seen   = "Magic surges out from @the_monster@!";
@@ -1569,7 +1571,7 @@ void MiscastEffect::_necromancy(int severity)
                 return;
             }
         }
-        else if (special_source == MUMMY_MISCAST)
+        else if (special_source.source == MUMMY_MISCAST)
         {
             if (coinflip())
             {
@@ -2020,7 +2022,7 @@ void MiscastEffect::_fire(int severity)
         switch (random2(10))
         {
         case 0:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Sparks fly from the ground!";
             you_msg      = "Sparks fly from your @hands@!";
             mon_msg_seen = "Sparks fly from @the_monster@'s @hands@!";
@@ -2030,7 +2032,7 @@ void MiscastEffect::_fire(int severity)
             mon_msg_seen = "The air around @the_monster@ burns with energy!";
             break;
         case 2:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Wisps of smoke drift around you.";
             you_msg      = "Wisps of smoke drift from your @hands@.";
             mon_msg_seen = "Wisps of smoke drift from @the_monster@'s @hands@.";
@@ -2085,7 +2087,7 @@ void MiscastEffect::_fire(int severity)
 
             if (success)
             {
-                if (special_source == HELL_EFFECT_MISCAST)
+                if (special_source.source == HELL_EFFECT_MISCAST)
                     all_msg = "Fire whirls out of nowhere!";
                 you_msg        = "Fire whirls out from your @hands@!";
                 mon_msg_seen   = "Fire whirls out @the_monster@'s @hands@!";
@@ -2223,7 +2225,7 @@ void MiscastEffect::_ice(int severity)
             // Monster messages needed.
             break;
         case 2:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Wisps of condensation drift around you.";
             you_msg        = "Wisps of condensation drift from your @hands@.";
             mon_msg_seen   = "Wisps of condensation drift from @the_monster@'s "
@@ -2350,7 +2352,7 @@ void MiscastEffect::_ice(int severity)
 
             break;
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Freezing gases billow around you!";
             you_msg        = "Freezing gases pour from your @hands@!";
             mon_msg_seen   = "Freezing gases pour from @the_monster@'s "
@@ -2390,7 +2392,7 @@ void MiscastEffect::_earth(int severity)
                              "moment.";
             break;
         case 2:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Sand pours from out of thin air.";
             you_msg        = "Sand pours from your @hands@.";
             mon_msg_seen   = "Sand pours from @the_monster@'s @hands@.";
@@ -2540,7 +2542,7 @@ void MiscastEffect::_air(int severity)
             mon_msg_seen = "@The_monster@ bobs in the air for a moment.";
             break;
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Wisps of vapour drift around you.";
             you_msg      = "Wisps of vapour drift from your @hands@.";
             mon_msg_seen = "Wisps of vapour drift from @the_monster@'s "
@@ -2548,7 +2550,7 @@ void MiscastEffect::_air(int severity)
             break;
         case 2:
         {
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Sparks of electricity dance around you.";
 
             bool pluralised = true;
@@ -2658,7 +2660,7 @@ void MiscastEffect::_air(int severity)
             _ouch(4 + random2avg(9, 2), BEAM_ELECTRICITY);
             break;
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Noxious gases billow around you.";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2698,7 +2700,7 @@ void MiscastEffect::_air(int severity)
             _explosion();
             break;
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Venomous gases billow around you!";
             you_msg        = "Venomous gases pour from your @hands@!";
             mon_msg_seen   = "Venomous gases pour from @the_monster@'s "
@@ -2752,7 +2754,7 @@ void MiscastEffect::_poison(int severity)
             mon_msg_seen = "@The_monster@ briefly looks sick.";
             break;
         case 2:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Wisps of poison gas drift around you.";
             you_msg      = "Wisps of poison gas drift from your @hands@.";
             mon_msg_seen = "Wisps of poison gas drift from @the_monster@'s "
@@ -2808,7 +2810,7 @@ void MiscastEffect::_poison(int severity)
         case 1:
             if (cell_is_solid(target->pos()))
                 break;
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Noxious gases billow around you!";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2834,7 +2836,7 @@ void MiscastEffect::_poison(int severity)
             break;
 
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Noxious gases billow around you!";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2883,7 +2885,7 @@ void MiscastEffect::_poison(int severity)
             do_msg();
             break;
         case 1:
-            if (special_source == HELL_EFFECT_MISCAST)
+            if (special_source.source == HELL_EFFECT_MISCAST)
                 all_msg = "Venomous gases billow around you!";
             you_msg        = "Venomous gases pour from your @hands@!";
             mon_msg_seen   = "Venomous gases pour from @the_monster@'s "

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -59,20 +59,20 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source,
                              bool _can_plural) :
     target(_target), act_source(_act_source),
     special_source(_source), cause(_cause), spell(_spell),
-    school(SPTYP_NONE), pow(_pow), fail(_fail), level(-1),
+    school(spschool::none), pow(_pow), fail(_fail), level(-1),
     nothing_happens_when(_nothing_happens),
     lethality_margin(_lethality_margin), hand_str(_hand_str),
     can_plural_hand(_can_plural)
 {
     ASSERT(is_valid_spell(_spell));
-    ASSERT(get_spell_disciplines(_spell) != SPTYP_NONE);
+    ASSERT(get_spell_disciplines(_spell) != spschool::none);
 
     init();
     do_miscast();
 }
 
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
-                             spschool_flag_type _school, int _level,
+                             spschool _school, int _level,
                              string _cause,
                              nothing_happens_when_type _nothing_happens,
                              int _lethality_margin, string _hand_str,
@@ -85,8 +85,8 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
     can_plural_hand(_can_plural)
 {
     ASSERT(!_cause.empty());
-    ASSERT(count_bits(_school) == 1);
-    ASSERT(_school <= SPTYP_LAST_SCHOOL || _school == SPTYP_RANDOM);
+    ASSERT(count_bits(static_cast<uint64_t>(_school)) == 1);
+    ASSERT(_school <= spschool::LAST_SCHOOL || _school == spschool::random);
     ASSERT_RANGE(level, 0, 3 + 1);
 
     init();
@@ -94,7 +94,7 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
 }
 
 MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
-                             spschool_flag_type _school, int _pow, int _fail,
+                             spschool _school, int _pow, int _fail,
                              string _cause,
                              nothing_happens_when_type _nothing_happens,
                              int _lethality_margin, string _hand_str,
@@ -107,8 +107,8 @@ MiscastEffect::MiscastEffect(actor* _target, actor* _act_source, int _source,
     can_plural_hand(_can_plural)
 {
     ASSERT(!_cause.empty());
-    ASSERT(count_bits(_school) == 1);
-    ASSERT(_school <= SPTYP_LAST_SCHOOL || _school == SPTYP_RANDOM);
+    ASSERT(count_bits(static_cast<uint64_t>(_school)) == 1);
+    ASSERT(_school <= spschool::LAST_SCHOOL || _school == spschool::random);
 
     init();
     do_miscast();
@@ -121,8 +121,8 @@ MiscastEffect::~MiscastEffect()
 
 void MiscastEffect::init()
 {
-    ASSERT(spell != SPELL_NO_SPELL && school == SPTYP_NONE
-           || spell == SPELL_NO_SPELL && school != SPTYP_NONE);
+    ASSERT(spell != SPELL_NO_SPELL && school == spschool::none
+           || spell == SPELL_NO_SPELL && school != spschool::none);
     ASSERT(pow != -1 && fail != -1 && level == -1
            || pow == -1 && fail == -1 && level >= 0 && level <= 3);
 
@@ -211,7 +211,7 @@ string MiscastEffect::get_default_cause(bool attribute_to_user) const
     // the source of the miscast is the same as the target of the miscast.
     ASSERT(special_source == SPELL_MISCAST);
     ASSERT(spell != SPELL_NO_SPELL);
-    ASSERT(school == SPTYP_NONE);
+    ASSERT(school == spschool::none);
     ASSERT(target->is_player());
 
     return string("miscasting ") + spell_title(spell);
@@ -241,12 +241,12 @@ void MiscastEffect::do_miscast()
         return;
     }
 
-    spschool_flag_type sp_type;
+    spschool sp_type;
     int                severity;
 
     if (spell != SPELL_NO_SPELL)
     {
-        vector<spschool_flag_type> school_list;
+        vector<spschool> school_list;
         for (const auto bit : spschools_type::range())
             if (spell_typematch(spell, bit))
                 school_list.push_back(bit);
@@ -256,8 +256,8 @@ void MiscastEffect::do_miscast()
     else
     {
         sp_type = school;
-        if (sp_type == SPTYP_RANDOM)
-            sp_type = spschools_type::exponent(random2(SPTYP_LAST_EXPONENT + 1));
+        if (sp_type == spschool::random)
+            sp_type = spschools_type::exponent(random2(SPSCHOOL_LAST_EXPONENT + 1));
     }
 
     if (level != -1)
@@ -320,18 +320,18 @@ void MiscastEffect::do_miscast()
 
     switch (sp_type)
     {
-    case SPTYP_CONJURATION:    _conjuration(severity);    break;
-    case SPTYP_HEXES:          _hexes(severity);          break;
-    case SPTYP_CHARMS:         _charms(severity);         break;
-    case SPTYP_TRANSLOCATION:  _translocation(severity);  break;
-    case SPTYP_SUMMONING:      _summoning(severity);      break;
-    case SPTYP_NECROMANCY:     _necromancy(severity);     break;
-    case SPTYP_TRANSMUTATION:  _transmutation(severity);  break;
-    case SPTYP_FIRE:           _fire(severity);           break;
-    case SPTYP_ICE:            _ice(severity);            break;
-    case SPTYP_EARTH:          _earth(severity);          break;
-    case SPTYP_AIR:            _air(severity);            break;
-    case SPTYP_POISON:         _poison(severity);         break;
+    case spschool::conjuration:    _conjuration(severity);    break;
+    case spschool::hexes:          _hexes(severity);          break;
+    case spschool::charms:         _charms(severity);         break;
+    case spschool::translocation:  _translocation(severity);  break;
+    case spschool::summoning:      _summoning(severity);      break;
+    case spschool::necromancy:     _necromancy(severity);     break;
+    case spschool::transmutation:  _transmutation(severity);  break;
+    case spschool::fire:           _fire(severity);           break;
+    case spschool::ice:            _ice(severity);            break;
+    case spschool::earth:          _earth(severity);          break;
+    case spschool::air:            _air(severity);            break;
+    case spschool::poison:         _poison(severity);         break;
 
     default:
         die("Invalid miscast spell discipline.");

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -159,16 +159,16 @@ void MiscastEffect::init()
 
         source_known = you.can_see(*act_source);
 
-        if (target_known && special_source.source == MUMMY_MISCAST)
+        if (target_known && special_source.source == miscast_source::mummy)
             source_known = true;
     }
     else
     {
-        ASSERT(special_source.source != MELEE_MISCAST);
+        ASSERT(special_source.source != miscast_source::melee);
 
         kt = KILL_MISCAST;
 
-        if (special_source.source == ZOT_TRAP_MISCAST)
+        if (special_source.source == miscast_source::zot_trap)
         {
             source_known = target_known;
 
@@ -184,9 +184,9 @@ void MiscastEffect::init()
 
     ASSERT(kt != KILL_NONE);
 
-    // source_known = false for MELEE_MISCAST so that melee miscasts
+    // source_known = false for miscast_source::melee so that melee miscasts
     // won't give a "nothing happens" message.
-    if (special_source.source == MELEE_MISCAST)
+    if (special_source.source == miscast_source::melee)
         source_known = false;
 
     if (hand_str.empty())
@@ -211,7 +211,7 @@ string MiscastEffect::get_default_cause(bool attribute_to_user) const
 {
     // This is only for true miscasts, which means both a spell and that
     // the source of the miscast is the same as the target of the miscast.
-    ASSERT(special_source.source == SPELL_MISCAST);
+    ASSERT(special_source.source == miscast_source::spell);
     ASSERT(spell != SPELL_NO_SPELL);
     ASSERT(school == spschool::none);
     ASSERT(target->is_player());
@@ -312,7 +312,7 @@ void MiscastEffect::do_miscast()
     msg_ch         = MSGCH_PLAIN;
     sound_loudness = 0;
 
-    if (special_source.source == ZOT_TRAP_MISCAST)
+    if (special_source.source == miscast_source::zot_trap)
     {
         _zot();
         if (target->is_player())
@@ -458,11 +458,14 @@ bool MiscastEffect::_ouch(int dam, beam_type flavour)
 
         kill_method_type method;
 
-        if (special_source.source == SPELL_MISCAST && spell != SPELL_NO_SPELL)
+        if (special_source.source == miscast_source::spell
+            && spell != SPELL_NO_SPELL)
+        {
             method = KILLED_BY_WILD_MAGIC;
-        else if (special_source.source == ZOT_TRAP_MISCAST)
+        }
+        else if (special_source.source == miscast_source::zot_trap)
             method = KILLED_BY_TRAP;
-        else if (special_source.source == GOD_MISCAST)
+        else if (special_source.source == miscast_source::god)
         {
             god_type god = special_source.god;
 
@@ -491,7 +494,7 @@ bool MiscastEffect::_explosion()
     ASSERT(beam.flavour != BEAM_NONE);
 
     // wild magic card
-    if (special_source.source == DECK_MISCAST)
+    if (special_source.source == miscast_source::deck)
         beam.thrower = KILL_MISCAST;
 
     int max_dam = beam.damage.num * beam.damage.size;
@@ -519,7 +522,7 @@ bool MiscastEffect::_big_cloud(cloud_type cl_type, int cloud_pow, int size,
 
 bool MiscastEffect::_paralyse(int dur)
 {
-    if (special_source.source != HELL_EFFECT_MISCAST)
+    if (special_source.source != miscast_source::hell_effect)
     {
         target->paralyse(act_source, dur, cause);
         return true;
@@ -530,8 +533,11 @@ bool MiscastEffect::_paralyse(int dur)
 
 bool MiscastEffect::_sleep(int dur)
 {
-    if (!target->can_sleep() || special_source.source == HELL_EFFECT_MISCAST)
+    if (!target->can_sleep()
+        || special_source.source == miscast_source::hell_effect)
+    {
         return false;
+    }
 
     if (target->is_player())
         you.put_to_sleep(act_source, dur);
@@ -547,7 +553,7 @@ bool MiscastEffect::_send_to_abyss()
     // of doing nothing.
     if ((player_in_branch(BRANCH_ABYSS)
          && x_chance_in_y(you.depth, brdepth[BRANCH_ABYSS]))
-        || special_source.source == HELL_EFFECT_MISCAST)
+        || special_source.source == miscast_source::hell_effect)
     {
         return _malign_gateway();
     }
@@ -629,14 +635,14 @@ bool MiscastEffect::_create_monster(monster_type what, int abj_deg,
     data.set_summoned(nullptr, abj_deg, SPELL_NO_SPELL, god);
     data.set_non_actor_summoner(cause);
 
-    if (special_source.source != HELL_EFFECT_MISCAST)
+    if (special_source.source != miscast_source::hell_effect)
         data.extra_flags |= (MF_NO_REWARD | MF_HARD_RESET);
 
     // hostile_at() assumes the monster is hostile to the player,
     // but should be hostile to the target monster unless the miscast
     // is a result of either divine wrath or a Zot trap.
     if (target->is_monster() && !player_under_penance(god)
-        && special_source.source != ZOT_TRAP_MISCAST)
+        && special_source.source != miscast_source::zot_trap)
     {
         monster* mon_target = target->as_monster();
 
@@ -667,7 +673,7 @@ bool MiscastEffect::_create_monster(monster_type what, int abj_deg,
             data.summon_type = SPELL_SHADOW_CREATURES;
         else if (player_under_penance(god))
             data.summon_type = MON_SUMM_WRATH;
-        else if (special_source.source == ZOT_TRAP_MISCAST)
+        else if (special_source.source == miscast_source::zot_trap)
             data.summon_type = MON_SUMM_ZOT;
         else
             data.summon_type = MON_SUMM_MISCAST;
@@ -728,7 +734,7 @@ void MiscastEffect::_conjuration(int severity)
         switch (random2(num))
         {
         case 0:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Sparks fly from the ground!";
             you_msg      = "Sparks fly from your @hands@!";
             mon_msg_seen = "Sparks fly from @the_monster@'s @hands@!";
@@ -739,7 +745,7 @@ void MiscastEffect::_conjuration(int severity)
                            "with energy!";
             break;
         case 2:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Wisps of smoke drift around you.";
             you_msg      = "Wisps of smoke drift from your @hands@.";
             mon_msg_seen = "Wisps of smoke drift from @the_monster@'s "
@@ -793,7 +799,7 @@ void MiscastEffect::_conjuration(int severity)
         switch (random2(2))
         {
         case 0:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Smoke billows around you!";
             you_msg        = "Smoke pours from your @hands@!";
             mon_msg_seen   = "Smoke pours from @the_monster@'s @hands@!";
@@ -1151,7 +1157,7 @@ void MiscastEffect::_charms(int severity)
                 reroll = false;
                 break;
             case 2:
-                if (special_source.source == HELL_EFFECT_MISCAST)
+                if (special_source.source == miscast_source::hell_effect)
                     all_msg = "Magic is drained from your body!";
                 you_msg        = "Magic surges out from your body!";
                 mon_msg_seen   = "Magic surges out from @the_monster@!";
@@ -1571,7 +1577,7 @@ void MiscastEffect::_necromancy(int severity)
                 return;
             }
         }
-        else if (special_source.source == MUMMY_MISCAST)
+        else if (special_source.source == miscast_source::mummy)
         {
             if (coinflip())
             {
@@ -2022,7 +2028,7 @@ void MiscastEffect::_fire(int severity)
         switch (random2(10))
         {
         case 0:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Sparks fly from the ground!";
             you_msg      = "Sparks fly from your @hands@!";
             mon_msg_seen = "Sparks fly from @the_monster@'s @hands@!";
@@ -2032,7 +2038,7 @@ void MiscastEffect::_fire(int severity)
             mon_msg_seen = "The air around @the_monster@ burns with energy!";
             break;
         case 2:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Wisps of smoke drift around you.";
             you_msg      = "Wisps of smoke drift from your @hands@.";
             mon_msg_seen = "Wisps of smoke drift from @the_monster@'s @hands@.";
@@ -2087,7 +2093,7 @@ void MiscastEffect::_fire(int severity)
 
             if (success)
             {
-                if (special_source.source == HELL_EFFECT_MISCAST)
+                if (special_source.source == miscast_source::hell_effect)
                     all_msg = "Fire whirls out of nowhere!";
                 you_msg        = "Fire whirls out from your @hands@!";
                 mon_msg_seen   = "Fire whirls out @the_monster@'s @hands@!";
@@ -2225,7 +2231,7 @@ void MiscastEffect::_ice(int severity)
             // Monster messages needed.
             break;
         case 2:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Wisps of condensation drift around you.";
             you_msg        = "Wisps of condensation drift from your @hands@.";
             mon_msg_seen   = "Wisps of condensation drift from @the_monster@'s "
@@ -2352,7 +2358,7 @@ void MiscastEffect::_ice(int severity)
 
             break;
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Freezing gases billow around you!";
             you_msg        = "Freezing gases pour from your @hands@!";
             mon_msg_seen   = "Freezing gases pour from @the_monster@'s "
@@ -2392,7 +2398,7 @@ void MiscastEffect::_earth(int severity)
                              "moment.";
             break;
         case 2:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Sand pours from out of thin air.";
             you_msg        = "Sand pours from your @hands@.";
             mon_msg_seen   = "Sand pours from @the_monster@'s @hands@.";
@@ -2542,7 +2548,7 @@ void MiscastEffect::_air(int severity)
             mon_msg_seen = "@The_monster@ bobs in the air for a moment.";
             break;
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Wisps of vapour drift around you.";
             you_msg      = "Wisps of vapour drift from your @hands@.";
             mon_msg_seen = "Wisps of vapour drift from @the_monster@'s "
@@ -2550,7 +2556,7 @@ void MiscastEffect::_air(int severity)
             break;
         case 2:
         {
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Sparks of electricity dance around you.";
 
             bool pluralised = true;
@@ -2660,7 +2666,7 @@ void MiscastEffect::_air(int severity)
             _ouch(4 + random2avg(9, 2), BEAM_ELECTRICITY);
             break;
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Noxious gases billow around you.";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2700,7 +2706,7 @@ void MiscastEffect::_air(int severity)
             _explosion();
             break;
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Venomous gases billow around you!";
             you_msg        = "Venomous gases pour from your @hands@!";
             mon_msg_seen   = "Venomous gases pour from @the_monster@'s "
@@ -2754,7 +2760,7 @@ void MiscastEffect::_poison(int severity)
             mon_msg_seen = "@The_monster@ briefly looks sick.";
             break;
         case 2:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Wisps of poison gas drift around you.";
             you_msg      = "Wisps of poison gas drift from your @hands@.";
             mon_msg_seen = "Wisps of poison gas drift from @the_monster@'s "
@@ -2810,7 +2816,7 @@ void MiscastEffect::_poison(int severity)
         case 1:
             if (cell_is_solid(target->pos()))
                 break;
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Noxious gases billow around you!";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2836,7 +2842,7 @@ void MiscastEffect::_poison(int severity)
             break;
 
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Noxious gases billow around you!";
             you_msg        = "Noxious gases pour from your @hands@!";
             mon_msg_seen   = "Noxious gases pour from @the_monster@'s "
@@ -2885,7 +2891,7 @@ void MiscastEffect::_poison(int severity)
             do_msg();
             break;
         case 1:
-            if (special_source.source == HELL_EFFECT_MISCAST)
+            if (special_source.source == miscast_source::hell_effect)
                 all_msg = "Venomous gases billow around you!";
             you_msg        = "Venomous gases pour from your @hands@!";
             mon_msg_seen   = "Venomous gases pour from @the_monster@'s "

--- a/crawl-ref/source/spl-miscast.h
+++ b/crawl-ref/source/spl-miscast.h
@@ -45,13 +45,13 @@ public:
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
-                  int _source, spschool_flag_type _school,
+                  int _source, spschool _school,
                   int _level, string _cause,
                   nothing_happens_when_type _nothing_happens = NH_DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
-                  int _source, spschool_flag_type _school,
+                  int _source, spschool _school,
                   int _pow, int _fail, string _cause,
                   nothing_happens_when_type _nothing_happens = NH_DEFAULT,
                   int _lethality_margin = 0,
@@ -71,7 +71,7 @@ private:
     string cause;
 
     spell_type         spell;
-    spschool_flag_type school;
+    spschool school;
 
     int pow;
     int fail;

--- a/crawl-ref/source/spl-miscast.h
+++ b/crawl-ref/source/spl-miscast.h
@@ -17,18 +17,18 @@ enum class nothing_happens
     ALWAYS,
 };
 
-enum miscast_source
+enum class miscast_source
 {
-    ZOT_TRAP_MISCAST,
-    HELL_EFFECT_MISCAST,
-    WIELD_MISCAST,
-    MELEE_MISCAST,
-    SPELL_MISCAST,
-    ABIL_MISCAST,
-    WIZARD_MISCAST,
-    MUMMY_MISCAST,
-    DECK_MISCAST,
-    GOD_MISCAST
+    zot_trap,
+    hell_effect,
+    wield,
+    melee,
+    spell,
+    ability,   // Not currently used
+    wizard,
+    mummy,
+    deck,
+    god
 };
 
 class actor;

--- a/crawl-ref/source/spl-miscast.h
+++ b/crawl-ref/source/spl-miscast.h
@@ -28,30 +28,37 @@ enum miscast_source
     WIZARD_MISCAST,
     MUMMY_MISCAST,
     DECK_MISCAST,
-    // This should always be last.
     GOD_MISCAST
 };
 
 class actor;
 // class monster;
 
+struct miscast_source_info
+{
+    // The source of the miscast
+    miscast_source source;
+    // If source == miscast_source::god, the god the miscast was created by
+    god_type god;
+};
+
 class MiscastEffect
 {
 public:
     MiscastEffect(actor* _target, actor* _act_source,
-                  int _source, spell_type _spell, int _pow,
+                  miscast_source_info _source, spell_type _spell, int _pow,
                   int _fail, string _cause = "",
                   nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
-                  int _source, spschool _school,
+                  miscast_source_info _source, spschool _school,
                   int _level, string _cause,
                   nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
-                  int _source, spschool _school,
+                  miscast_source_info _source, spschool _school,
                   int _pow, int _fail, string _cause,
                   nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
@@ -65,8 +72,8 @@ private:
     actor* target;
     // May be nullptr.
     actor* act_source;
-    // Either a miscast_source, or GOD_MISCAST + god_type enum.
-    int    special_source;
+    // Struct containing the source of the miscast and if applicable, its god
+    miscast_source_info special_source;
 
     string cause;
 

--- a/crawl-ref/source/spl-miscast.h
+++ b/crawl-ref/source/spl-miscast.h
@@ -10,11 +10,11 @@
 #include "mpr.h"
 #include "spl-util.h"
 
-enum nothing_happens_when_type
+enum class nothing_happens
 {
-    NH_DEFAULT,
-    NH_NEVER,
-    NH_ALWAYS,
+    DEFAULT,
+    NEVER,
+    ALWAYS,
 };
 
 enum miscast_source
@@ -41,19 +41,19 @@ public:
     MiscastEffect(actor* _target, actor* _act_source,
                   int _source, spell_type _spell, int _pow,
                   int _fail, string _cause = "",
-                  nothing_happens_when_type _nothing_happens = NH_DEFAULT,
+                  nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
                   int _source, spschool _school,
                   int _level, string _cause,
-                  nothing_happens_when_type _nothing_happens = NH_DEFAULT,
+                  nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
     MiscastEffect(actor* _target, actor* _act_source,
                   int _source, spschool _school,
                   int _pow, int _fail, string _cause,
-                  nothing_happens_when_type _nothing_happens = NH_DEFAULT,
+                  nothing_happens _nothing_happens = nothing_happens::DEFAULT,
                   int _lethality_margin = 0,
                   string _hand_str = "", bool _can_plural_hand = true);
 
@@ -81,7 +81,7 @@ private:
     // init() sets this to a proper value
     killer_type kt = KILL_NONE;
 
-    nothing_happens_when_type nothing_happens_when;
+    nothing_happens nothing_happens_when;
 
     int lethality_margin;
 

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -91,7 +91,7 @@ spret cast_death_channel(int pow, god_type god, bool fail)
 spret cast_recall(bool fail)
 {
     fail_check();
-    start_recall(RECALL_SPELL);
+    start_recall(recall_t::spell);
     return spret::success;
 }
 
@@ -107,12 +107,12 @@ void start_recall(recall_t type)
         if (!mons_is_recallable(&you, **mi))
             continue;
 
-        if (type == RECALL_YRED)
+        if (type == recall_t::yred)
         {
             if (!(mi->holiness() & MH_UNDEAD))
                 continue;
         }
-        else if (type == RECALL_BEOGH)
+        else if (type == recall_t::beogh)
         {
             if (!is_orcish_follower(**mi))
                 continue;
@@ -122,7 +122,7 @@ void start_recall(recall_t type)
         rlist.push_back(m);
     }
 
-    if (type != RECALL_SPELL && branch_allows_followers(you.where_are_you))
+    if (type != recall_t::spell && branch_allows_followers(you.where_are_you))
         populate_offlevel_recall_list(rlist);
 
     if (!rlist.empty())

--- a/crawl-ref/source/spl-other.h
+++ b/crawl-ref/source/spl-other.h
@@ -6,11 +6,11 @@
 spret cast_sublimation_of_blood(int pow, bool fail);
 spret cast_death_channel(int pow, god_type god, bool fail);
 
-enum recall_t
+enum class recall_t
 {
-    RECALL_SPELL,
-    RECALL_YRED,
-    RECALL_BEOGH,
+    spell,
+    yred,
+    beogh,
 };
 
 struct passwall_path

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -2631,7 +2631,7 @@ void end_battlesphere(monster* mons, bool killed)
 
 bool battlesphere_can_mirror(spell_type spell)
 {
-    return (spell_typematch(spell, SPTYP_CONJURATION)
+    return (spell_typematch(spell, spschool::conjuration)
            && spell_to_zap(spell) != NUM_ZAPS)
            || spell == SPELL_FREEZE
            || spell == SPELL_STICKY_FLAME

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -47,7 +47,7 @@ struct spell_desc
     spell_type id;
     const char  *title;
     spschools_type disciplines;
-    unsigned int flags;       // bitfield
+    spell_flags flags;       // bitfield
     unsigned int level;
 
     // Usually in the range 0..200 (0 means uncapped).
@@ -110,11 +110,11 @@ void init_spell_descs()
         ASSERTM(data.min_range <= data.max_range,
                 "spell '%s' has min_range larger than max_range", data.title);
 
-        ASSERTM(!(data.flags & SPFLAG_TARGETING_MASK)
+        ASSERTM(!(data.flags & spflag::targeting_mask)
                 || (data.min_range >= 0 && data.max_range > 0),
                 "targeted/directed spell '%s' has invalid range", data.title);
 
-        ASSERTM(!(data.flags & SPFLAG_MONSTER && is_player_spell(data.id)),
+        ASSERTM(!(data.flags & spflag::monster && is_player_spell(data.id)),
                 "spell '%s' is declared as a monster spell but is a player spell", data.title);
 
         spell_list[data.id] = i;
@@ -434,12 +434,12 @@ bool spell_is_direct_explosion(spell_type spell)
 
 bool spell_harms_target(spell_type spell)
 {
-    const unsigned int flags = _seekspell(spell)->flags;
+    const spell_flags flags = _seekspell(spell)->flags;
 
-    if (flags & (SPFLAG_HELPFUL | SPFLAG_NEUTRAL))
+    if (flags & (spflag::helpful | spflag::neutral))
         return false;
 
-    if (flags & SPFLAG_TARGETING_MASK)
+    if (flags & spflag::targeting_mask)
         return true;
 
     return false;
@@ -447,12 +447,12 @@ bool spell_harms_target(spell_type spell)
 
 bool spell_harms_area(spell_type spell)
 {
-    const unsigned int flags = _seekspell(spell)->flags;
+    const spell_flags flags = _seekspell(spell)->flags;
 
-    if (flags & (SPFLAG_HELPFUL | SPFLAG_NEUTRAL))
+    if (flags & (spflag::helpful | spflag::neutral))
         return false;
 
-    if (flags & SPFLAG_AREA)
+    if (flags & spflag::area)
         return true;
 
     return false;
@@ -491,7 +491,7 @@ int spell_levels_required(spell_type which_spell)
     return levels;
 }
 
-unsigned int get_spell_flags(spell_type which_spell)
+spell_flags get_spell_flags(spell_type which_spell)
 {
     return _seekspell(which_spell)->flags;
 }
@@ -1405,13 +1405,13 @@ bool spell_no_hostile_in_range(spell_type spell)
     if (minRange < 0 || range < 0)
         return false;
 
-    const unsigned int flags = get_spell_flags(spell);
+    const spell_flags flags = get_spell_flags(spell);
 
     // The healing spells.
-    if (testbits(flags, SPFLAG_HELPFUL))
+    if (testbits(flags, spflag::helpful))
         return false;
 
-    const bool neutral = testbits(flags, SPFLAG_NEUTRAL);
+    const bool neutral = testbits(flags, spflag::neutral);
 
     bolt beam;
     beam.flavour = BEAM_VISUAL;
@@ -1448,7 +1448,7 @@ bool spell_no_hostile_in_range(spell_type spell)
         beam.quiet_debug = true;
 #endif
 
-        const bool smite = testbits(flags, SPFLAG_TARGET);
+        const bool smite = testbits(flags, spflag::target);
 
         for (radius_iterator ri(you.pos(), range, C_SQUARE, LOS_DEFAULT);
              ri; ++ri)

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -155,17 +155,17 @@ spell_type spell_by_name(string name, bool partial_match)
     return sp == NUM_SPELLS ? SPELL_NO_SPELL : sp;
 }
 
-spschool_flag_type school_by_name(string name)
+spschool school_by_name(string name)
 {
-    spschool_flag_type short_match, long_match;
+    spschool short_match, long_match;
     int                short_matches, long_matches;
 
-    short_match   = long_match   = SPTYP_NONE;
+    short_match   = long_match   = spschool::none;
     short_matches = long_matches = 0;
 
     lowercase(name);
 
-    for (int i = 0; i <= SPTYP_RANDOM; i++)
+    for (int i = 0; i <= (int)spschool::random; i++)
     {
         const auto type = spschools_type::exponent(i);
 
@@ -193,7 +193,7 @@ spschool_flag_type school_by_name(string name)
     }
 
     if (short_matches != 1 && long_matches != 1)
-        return SPTYP_NONE;
+        return spschool::none;
 
     if (short_matches == 1 && long_matches != 1)
         return short_match;
@@ -203,7 +203,7 @@ spschool_flag_type school_by_name(string name)
     if (short_match == long_match)
         return short_match;
 
-    return SPTYP_NONE;
+    return spschool::none;
 }
 
 int get_spell_slot_by_letter(char letter)
@@ -517,7 +517,7 @@ tileidx_t get_spell_tile(spell_type which_spell)
     return _seekspell(which_spell)->tile;
 }
 
-bool spell_typematch(spell_type which_spell, spschool_flag_type which_disc)
+bool spell_typematch(spell_type which_spell, spschool which_disc)
 {
     return bool(get_spell_disciplines(which_spell) & which_disc);
 }
@@ -774,92 +774,92 @@ bool spell_direction(dist &spelld, bolt &pbolt, direction_chooser_args *args)
     return true;
 }
 
-const char* spelltype_short_name(spschool_flag_type which_spelltype)
+const char* spelltype_short_name(spschool which_spelltype)
 {
     switch (which_spelltype)
     {
-    case SPTYP_CONJURATION:
+    case spschool::conjuration:
         return "Conj";
-    case SPTYP_HEXES:
+    case spschool::hexes:
         return "Hex";
-    case SPTYP_CHARMS:
+    case spschool::charms:
         return "Chrm";
-    case SPTYP_FIRE:
+    case spschool::fire:
         return "Fire";
-    case SPTYP_ICE:
+    case spschool::ice:
         return "Ice";
-    case SPTYP_TRANSMUTATION:
+    case spschool::transmutation:
         return "Tmut";
-    case SPTYP_NECROMANCY:
+    case spschool::necromancy:
         return "Necr";
-    case SPTYP_SUMMONING:
+    case spschool::summoning:
         return "Summ";
-    case SPTYP_TRANSLOCATION:
+    case spschool::translocation:
         return "Tloc";
-    case SPTYP_POISON:
+    case spschool::poison:
         return "Pois";
-    case SPTYP_EARTH:
+    case spschool::earth:
         return "Erth";
-    case SPTYP_AIR:
+    case spschool::air:
         return "Air";
-    case SPTYP_RANDOM:
+    case spschool::random:
         return "Rndm";
     default:
         return "Bug";
     }
 }
 
-const char* spelltype_long_name(spschool_flag_type which_spelltype)
+const char* spelltype_long_name(spschool which_spelltype)
 {
     switch (which_spelltype)
     {
-    case SPTYP_CONJURATION:
+    case spschool::conjuration:
         return "Conjuration";
-    case SPTYP_HEXES:
+    case spschool::hexes:
         return "Hexes";
-    case SPTYP_CHARMS:
+    case spschool::charms:
         return "Charms";
-    case SPTYP_FIRE:
+    case spschool::fire:
         return "Fire";
-    case SPTYP_ICE:
+    case spschool::ice:
         return "Ice";
-    case SPTYP_TRANSMUTATION:
+    case spschool::transmutation:
         return "Transmutation";
-    case SPTYP_NECROMANCY:
+    case spschool::necromancy:
         return "Necromancy";
-    case SPTYP_SUMMONING:
+    case spschool::summoning:
         return "Summoning";
-    case SPTYP_TRANSLOCATION:
+    case spschool::translocation:
         return "Translocation";
-    case SPTYP_POISON:
+    case spschool::poison:
         return "Poison";
-    case SPTYP_EARTH:
+    case spschool::earth:
         return "Earth";
-    case SPTYP_AIR:
+    case spschool::air:
         return "Air";
-    case SPTYP_RANDOM:
+    case spschool::random:
         return "Random";
     default:
         return "Bug";
     }
 }
 
-skill_type spell_type2skill(spschool_flag_type spelltype)
+skill_type spell_type2skill(spschool spelltype)
 {
     switch (spelltype)
     {
-    case SPTYP_CONJURATION:    return SK_CONJURATIONS;
-    case SPTYP_HEXES:          return SK_HEXES;
-    case SPTYP_CHARMS:         return SK_CHARMS;
-    case SPTYP_FIRE:           return SK_FIRE_MAGIC;
-    case SPTYP_ICE:            return SK_ICE_MAGIC;
-    case SPTYP_TRANSMUTATION:  return SK_TRANSMUTATIONS;
-    case SPTYP_NECROMANCY:     return SK_NECROMANCY;
-    case SPTYP_SUMMONING:      return SK_SUMMONINGS;
-    case SPTYP_TRANSLOCATION:  return SK_TRANSLOCATIONS;
-    case SPTYP_POISON:         return SK_POISON_MAGIC;
-    case SPTYP_EARTH:          return SK_EARTH_MAGIC;
-    case SPTYP_AIR:            return SK_AIR_MAGIC;
+    case spschool::conjuration:    return SK_CONJURATIONS;
+    case spschool::hexes:          return SK_HEXES;
+    case spschool::charms:         return SK_CHARMS;
+    case spschool::fire:           return SK_FIRE_MAGIC;
+    case spschool::ice:            return SK_ICE_MAGIC;
+    case spschool::transmutation:  return SK_TRANSMUTATIONS;
+    case spschool::necromancy:     return SK_NECROMANCY;
+    case spschool::summoning:      return SK_SUMMONINGS;
+    case spschool::translocation:  return SK_TRANSLOCATIONS;
+    case spschool::poison:         return SK_POISON_MAGIC;
+    case spschool::earth:          return SK_EARTH_MAGIC;
+    case spschool::air:            return SK_AIR_MAGIC;
 
     default:
         dprf("spell_type2skill: called with spelltype %u", spelltype);
@@ -867,25 +867,25 @@ skill_type spell_type2skill(spschool_flag_type spelltype)
     }
 }
 
-spschool_flag_type skill2spell_type(skill_type spell_skill)
+spschool skill2spell_type(skill_type spell_skill)
 {
     switch (spell_skill)
     {
-    case SK_CONJURATIONS:    return SPTYP_CONJURATION;
-    case SK_HEXES:           return SPTYP_HEXES;
-    case SK_CHARMS:          return SPTYP_CHARMS;
-    case SK_FIRE_MAGIC:      return SPTYP_FIRE;
-    case SK_ICE_MAGIC:       return SPTYP_ICE;
-    case SK_TRANSMUTATIONS:  return SPTYP_TRANSMUTATION;
-    case SK_NECROMANCY:      return SPTYP_NECROMANCY;
-    case SK_SUMMONINGS:      return SPTYP_SUMMONING;
-    case SK_TRANSLOCATIONS:  return SPTYP_TRANSLOCATION;
-    case SK_POISON_MAGIC:    return SPTYP_POISON;
-    case SK_EARTH_MAGIC:     return SPTYP_EARTH;
-    case SK_AIR_MAGIC:       return SPTYP_AIR;
+    case SK_CONJURATIONS:    return spschool::conjuration;
+    case SK_HEXES:           return spschool::hexes;
+    case SK_CHARMS:          return spschool::charms;
+    case SK_FIRE_MAGIC:      return spschool::fire;
+    case SK_ICE_MAGIC:       return spschool::ice;
+    case SK_TRANSMUTATIONS:  return spschool::transmutation;
+    case SK_NECROMANCY:      return spschool::necromancy;
+    case SK_SUMMONINGS:      return spschool::summoning;
+    case SK_TRANSLOCATIONS:  return spschool::translocation;
+    case SK_POISON_MAGIC:    return spschool::poison;
+    case SK_EARTH_MAGIC:     return spschool::earth;
+    case SK_AIR_MAGIC:       return spschool::air;
 
     default:
-        return SPTYP_NONE;
+        return spschool::none;
     }
 }
 
@@ -1297,7 +1297,7 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         break;
     }
 
-    if (get_spell_disciplines(spell) & SPTYP_SUMMONING
+    if (get_spell_disciplines(spell) & spschool::summoning
         && spell != SPELL_AURA_OF_ABJURATION
         && you.get_mutation_level(MUT_NO_LOVE))
     {
@@ -1517,15 +1517,15 @@ static const mutation_type arcana_sacrifice_map[] = {
  * Are some subset of the given schools unusable by the player?
  * (Due to Sacrifice Arcana)
  *
- * @param schools   A bitfield containing a union of spschool_flag_types.
+ * @param schools   A bitfield containing a union of spschools.
  * @return          Whether the player is unable use any of the given schools.
  */
 bool cannot_use_schools(spschools_type schools)
 {
-    COMPILE_CHECK(ARRAYSZ(arcana_sacrifice_map) == SPTYP_LAST_EXPONENT + 1);
+    COMPILE_CHECK(ARRAYSZ(arcana_sacrifice_map) == SPSCHOOL_LAST_EXPONENT + 1);
 
     // iter over every school
-    for (int i = 0; i <= SPTYP_LAST_EXPONENT; i++)
+    for (int i = 0; i <= SPSCHOOL_LAST_EXPONENT; i++)
     {
         // skip schools not in the provided set
         const auto school = spschools_type::exponent(i);
@@ -1551,7 +1551,7 @@ bool cannot_use_schools(spschools_type schools)
  */
 skill_type arcane_mutation_to_skill(mutation_type mutation)
 {
-    for (int exp = 0; exp <= SPTYP_LAST_EXPONENT; exp++)
+    for (int exp = 0; exp <= SPSCHOOL_LAST_EXPONENT; exp++)
         if (arcana_sacrifice_map[exp] == mutation)
             return spell_type2skill(spschools_type::exponent(exp));
     return SK_NONE;

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -10,28 +10,30 @@
 #include "enum.h"
 #include "mon-info.h"
 
-enum spschool_flag_type
+enum class spschool
 {
-  SPTYP_NONE           = 0,
-  SPTYP_CONJURATION    = 1<<0,
-  SPTYP_HEXES          = 1<<1,
-  SPTYP_CHARMS         = 1<<2,
-  SPTYP_FIRE           = 1<<3,
-  SPTYP_ICE            = 1<<4,
-  SPTYP_TRANSMUTATION  = 1<<5,
-  SPTYP_NECROMANCY     = 1<<6,
-  SPTYP_SUMMONING      = 1<<7,
-  SPTYP_TRANSLOCATION  = 1<<8,
-  SPTYP_POISON         = 1<<9,
-  SPTYP_EARTH          = 1<<10,
-  SPTYP_AIR            = 1<<11,
-  SPTYP_LAST_SCHOOL    = SPTYP_AIR,
-  SPTYP_RANDOM         = SPTYP_LAST_SCHOOL << 1,
+  none           = 0,
+  conjuration    = 1<<0,
+  hexes          = 1<<1,
+  charms         = 1<<2,
+  fire           = 1<<3,
+  ice            = 1<<4,
+  transmutation  = 1<<5,
+  necromancy     = 1<<6,
+  summoning      = 1<<7,
+  translocation  = 1<<8,
+  poison         = 1<<9,
+  earth          = 1<<10,
+  air            = 1<<11,
+  LAST_SCHOOL    = spschool::air,
+  random         = spschool::LAST_SCHOOL << 1,
 };
-DEF_BITFIELD(spschools_type, spschool_flag_type, 11);
-const int SPTYP_LAST_EXPONENT = spschools_type::last_exponent;
-COMPILE_CHECK(spschools_type::exponent(SPTYP_LAST_EXPONENT)
-              == SPTYP_LAST_SCHOOL);
+DEF_BITFIELD(spschools_type, spschool, 11);
+const int SPSCHOOL_LAST_EXPONENT = spschools_type::last_exponent;
+COMPILE_CHECK(spschools_type::exponent(SPSCHOOL_LAST_EXPONENT)
+              == spschool::LAST_SCHOOL);
+// Moved from mapdef.cc:5318, needed to ensure randbook spschools are short ints
+COMPILE_CHECK(static_cast<int>(spschool::LAST_SCHOOL) < SHRT_MAX);
 
 struct bolt;
 class dist;
@@ -53,7 +55,7 @@ void init_spell_descs();
 void init_spell_name_cache();
 spell_type spell_by_name(string name, bool partial_match = false);
 
-spschool_flag_type school_by_name(string name);
+spschool school_by_name(string name);
 
 int get_spell_slot_by_letter(char letter);
 int get_spell_letter(spell_type spell);
@@ -81,7 +83,7 @@ int spell_levels_required(spell_type which_spell);
 
 spell_flags get_spell_flags(spell_type which_spell);
 
-bool spell_typematch(spell_type which_spell, spschool_flag_type which_disc);
+bool spell_typematch(spell_type which_spell, spschool which_disc);
 spschools_type get_spell_disciplines(spell_type which_spell);
 int count_bits(uint64_t bits);
 
@@ -92,8 +94,8 @@ int count_bits(enum_bitfield<E, Exp> bits)
 }
 
 const char *spell_title(spell_type which_spell);
-const char* spelltype_short_name(spschool_flag_type which_spelltype);
-const char* spelltype_long_name(spschool_flag_type which_spelltype);
+const char* spelltype_short_name(spschool which_spelltype);
+const char* spelltype_long_name(spschool which_spelltype);
 
 typedef function<int (coord_def where)> cell_func;
 typedef function<int (coord_def where, int pow, int spreadrate,
@@ -113,8 +115,8 @@ void apply_area_cloud(cloud_func func, const coord_def& where,
 bool spell_direction(dist &spelld, bolt &pbolt,
                      direction_chooser_args *args = nullptr);
 
-skill_type spell_type2skill(spschool_flag_type spelltype);
-spschool_flag_type skill2spell_type(skill_type spell_skill);
+skill_type spell_type2skill(spschool spelltype);
+spschool skill2spell_type(skill_type spell_skill);
 
 skill_type arcane_mutation_to_skill(mutation_type mutation);
 bool cannot_use_schools(spschools_type schools);

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -79,7 +79,7 @@ bool spell_harms_target(spell_type spell);
 bool spell_harms_area(spell_type spell);
 int spell_levels_required(spell_type which_spell);
 
-unsigned int get_spell_flags(spell_type which_spell);
+spell_flags get_spell_flags(spell_type which_spell);
 
 bool spell_typematch(spell_type which_spell, spschool_flag_type which_disc);
 spschools_type get_spell_disciplines(spell_type which_spell);

--- a/crawl-ref/source/spl-wpnench.cc
+++ b/crawl-ref/source/spl-wpnench.cc
@@ -95,7 +95,7 @@ spret cast_excruciating_wounds(int power, bool fail)
     if (dangerous_disto)
     {
         // Can't get out of it that easily...
-        MiscastEffect(&you, nullptr, WIELD_MISCAST, spschool::translocation,
+        MiscastEffect(&you, nullptr, {WIELD_MISCAST}, spschool::translocation,
                       9, 90, "rebranding a weapon of distortion");
     }
 

--- a/crawl-ref/source/spl-wpnench.cc
+++ b/crawl-ref/source/spl-wpnench.cc
@@ -95,8 +95,9 @@ spret cast_excruciating_wounds(int power, bool fail)
     if (dangerous_disto)
     {
         // Can't get out of it that easily...
-        MiscastEffect(&you, nullptr, {WIELD_MISCAST}, spschool::translocation,
-                      9, 90, "rebranding a weapon of distortion");
+        MiscastEffect(&you, nullptr, {miscast_source::wield},
+                      spschool::translocation, 9, 90,
+                      "rebranding a weapon of distortion");
     }
 
     noisy(spell_effect_noise(SPELL_EXCRUCIATING_WOUNDS), you.pos());

--- a/crawl-ref/source/spl-wpnench.cc
+++ b/crawl-ref/source/spl-wpnench.cc
@@ -95,7 +95,7 @@ spret cast_excruciating_wounds(int power, bool fail)
     if (dangerous_disto)
     {
         // Can't get out of it that easily...
-        MiscastEffect(&you, nullptr, WIELD_MISCAST, SPTYP_TRANSLOCATION,
+        MiscastEffect(&you, nullptr, WIELD_MISCAST, spschool::translocation,
                       9, 90, "rebranding a weapon of distortion");
     }
 

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -404,28 +404,28 @@ static bool _is_appropriate_spell(spell_type spell, const actor* target)
 {
     ASSERT(is_valid_spell(spell));
 
-    const unsigned int flags    = get_spell_flags(spell);
-    const bool         targeted = flags & SPFLAG_TARGETING_MASK;
+    const spell_flags  flags    = get_spell_flags(spell);
+    const bool         targeted = testbits(flags, spflag::targeting_mask);
 
     // All spells are blocked by transparent walls.
     if (targeted && !you.see_cell_no_trans(target->pos()))
         return false;
 
-    const bool helpful = flags & SPFLAG_HELPFUL;
+    const bool helpful = testbits(flags, spflag::helpful);
 
     if (target->is_player())
     {
-        if (flags & SPFLAG_NOT_SELF)
+        if (flags & spflag::not_self)
             return false;
 
-        return (flags & (SPFLAG_HELPFUL | SPFLAG_ESCAPE | SPFLAG_RECOVERY))
+        return (flags & (spflag::helpful | spflag::escape | spflag::recovery))
                || !targeted;
     }
 
     if (!targeted)
         return false;
 
-    if (flags & SPFLAG_NEUTRAL)
+    if (flags & spflag::neutral)
         return false;
 
     bool friendly = target->as_monster()->wont_attack();
@@ -525,7 +525,7 @@ static bool _evoke_item_on_target(actor* target)
 
 static bool _spell_in_range(spell_type spell, actor* target)
 {
-    if (!(get_spell_flags(spell) & SPFLAG_TARGETING_MASK))
+    if (!(get_spell_flags(spell) & spflag::targeting_mask))
         return true;
 
     int range = calc_spell_range(spell);
@@ -603,7 +603,7 @@ static bool _cast_spell_on_target(actor* target)
     macro_sendkeys_end_add_cmd(CMD_FORCE_CAST_SPELL);
     macro_buf_add(letter);
 
-    if (get_spell_flags(spell) & SPFLAG_TARGETING_MASK)
+    if (get_spell_flags(spell) & spflag::targeting_mask)
         _add_targeting_commands(target->pos());
 
     return true;

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -84,7 +84,7 @@ static void _random_hell_miscast()
                                  1, spschool::charms,
                                  1, spschool::hexes);
 
-    MiscastEffect(&you, nullptr, HELL_EFFECT_MISCAST, which_miscast,
+    MiscastEffect(&you, nullptr, {HELL_EFFECT_MISCAST}, which_miscast,
                   4 + random2(6), random2avg(97, 3),
                   "the effects of Hell");
 }
@@ -150,7 +150,7 @@ static void _themed_hell_summon_or_miscast()
     }
     else
     {
-        MiscastEffect(&you, nullptr, HELL_EFFECT_MISCAST, spec->miscast_type,
+        MiscastEffect(&you, nullptr, {HELL_EFFECT_MISCAST}, spec->miscast_type,
                       4 + random2(6), random2avg(97, 3),
                       "the effects of Hell");
     }

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -84,7 +84,7 @@ static void _random_hell_miscast()
                                  1, spschool::charms,
                                  1, spschool::hexes);
 
-    MiscastEffect(&you, nullptr, {HELL_EFFECT_MISCAST}, which_miscast,
+    MiscastEffect(&you, nullptr, {miscast_source::hell_effect}, which_miscast,
                   4 + random2(6), random2avg(97, 3),
                   "the effects of Hell");
 }
@@ -150,8 +150,8 @@ static void _themed_hell_summon_or_miscast()
     }
     else
     {
-        MiscastEffect(&you, nullptr, {HELL_EFFECT_MISCAST}, spec->miscast_type,
-                      4 + random2(6), random2avg(97, 3),
+        MiscastEffect(&you, nullptr, {miscast_source::hell_effect},
+                      spec->miscast_type, 4 + random2(6), random2avg(97, 3),
                       "the effects of Hell");
     }
 }

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -77,12 +77,12 @@ static void _hell_effect_noise()
  */
 static void _random_hell_miscast()
 {
-    const spschool_flag_type which_miscast
-        = random_choose_weighted(8, SPTYP_NECROMANCY,
-                                 4, SPTYP_SUMMONING,
-                                 2, SPTYP_CONJURATION,
-                                 1, SPTYP_CHARMS,
-                                 1, SPTYP_HEXES);
+    const spschool which_miscast
+        = random_choose_weighted(8, spschool::necromancy,
+                                 4, spschool::summoning,
+                                 2, spschool::conjuration,
+                                 1, spschool::charms,
+                                 1, spschool::hexes);
 
     MiscastEffect(&you, nullptr, HELL_EFFECT_MISCAST, which_miscast,
                   4 + random2(6), random2avg(97, 3),
@@ -95,7 +95,7 @@ struct hell_effect_spec
     /// The type of greater demon to spawn from hell effects.
     vector<monster_type> fiend_types;
     /// The appropriate theme of miscast effects to toss at the player.
-    spschool_flag_type miscast_type;
+    spschool miscast_type;
     /// A weighted list of lesser creatures to spawn.
     vector<pair<monster_type, int>> minor_summons;
 };
@@ -103,13 +103,13 @@ struct hell_effect_spec
 /// Hell effects for each branch of hell
 static map<branch_type, hell_effect_spec> hell_effects_by_branch =
 {
-    { BRANCH_DIS, { {RANDOM_DEMON_GREATER}, SPTYP_EARTH, {
+    { BRANCH_DIS, { {RANDOM_DEMON_GREATER}, spschool::earth, {
         { RANDOM_MONSTER, 100 }, // TODO
     }}},
-    { BRANCH_GEHENNA, { {MONS_BRIMSTONE_FIEND}, SPTYP_FIRE, {
+    { BRANCH_GEHENNA, { {MONS_BRIMSTONE_FIEND}, spschool::fire, {
         { RANDOM_MONSTER, 100 }, // TODO
     }}},
-    { BRANCH_COCYTUS, { {MONS_ICE_FIEND, MONS_SHARD_SHRIKE}, SPTYP_ICE, {
+    { BRANCH_COCYTUS, { {MONS_ICE_FIEND, MONS_SHARD_SHRIKE}, spschool::ice, {
         // total weight 100
         { MONS_ZOMBIE, 15 },
         { MONS_SKELETON, 10 },
@@ -123,7 +123,7 @@ static map<branch_type, hell_effect_spec> hell_effects_by_branch =
         { MONS_BLIZZARD_DEMON, 5 },
         { MONS_ICE_DEVIL, 5 },
     }}},
-    { BRANCH_TARTARUS, { {MONS_TZITZIMITL}, SPTYP_NECROMANCY, {
+    { BRANCH_TARTARUS, { {MONS_TZITZIMITL}, spschool::necromancy, {
         { RANDOM_MONSTER, 100 }, // TODO
     }}},
 };

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -750,7 +750,7 @@ void trap_def::trigger(actor& triggerer)
         {
             mpr("You enter the Zot trap.");
 
-            MiscastEffect(&you, nullptr, ZOT_TRAP_MISCAST, spschool::random,
+            MiscastEffect(&you, nullptr, {ZOT_TRAP_MISCAST}, spschool::random,
                            3, name(DESC_A));
         }
         else if (m)
@@ -780,8 +780,8 @@ void trap_def::trigger(actor& triggerer)
             {
                 mprf("The power of Zot is invoked against %s!",
                      targ->name(DESC_THE).c_str());
-                MiscastEffect(targ, nullptr, ZOT_TRAP_MISCAST, spschool::random,
-                              3, "the power of Zot");
+                MiscastEffect(targ, nullptr, {ZOT_TRAP_MISCAST},
+                              spschool::random, 3, "the power of Zot");
             }
         }
         break;

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -750,7 +750,7 @@ void trap_def::trigger(actor& triggerer)
         {
             mpr("You enter the Zot trap.");
 
-            MiscastEffect(&you, nullptr, ZOT_TRAP_MISCAST, SPTYP_RANDOM,
+            MiscastEffect(&you, nullptr, ZOT_TRAP_MISCAST, spschool::random,
                            3, name(DESC_A));
         }
         else if (m)
@@ -780,7 +780,7 @@ void trap_def::trigger(actor& triggerer)
             {
                 mprf("The power of Zot is invoked against %s!",
                      targ->name(DESC_THE).c_str());
-                MiscastEffect(targ, nullptr, ZOT_TRAP_MISCAST, SPTYP_RANDOM,
+                MiscastEffect(targ, nullptr, ZOT_TRAP_MISCAST, spschool::random,
                               3, "the power of Zot");
             }
         }

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -750,8 +750,8 @@ void trap_def::trigger(actor& triggerer)
         {
             mpr("You enter the Zot trap.");
 
-            MiscastEffect(&you, nullptr, {ZOT_TRAP_MISCAST}, spschool::random,
-                           3, name(DESC_A));
+            MiscastEffect(&you, nullptr, {miscast_source::zot_trap},
+                          spschool::random, 3, name(DESC_A));
         }
         else if (m)
         {
@@ -780,7 +780,7 @@ void trap_def::trigger(actor& triggerer)
             {
                 mprf("The power of Zot is invoked against %s!",
                      targ->name(DESC_THE).c_str());
-                MiscastEffect(targ, nullptr, {ZOT_TRAP_MISCAST},
+                MiscastEffect(targ, nullptr, {miscast_source::zot_trap},
                               spschool::random, 3, "the power of Zot");
             }
         }

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -914,7 +914,7 @@ static void _debug_acquirement_stats(FILE *ostat)
                 else if (item.sub_type == BOOK_RANDART_LEVEL)
                 {
                     const int level = item.plus;
-                    ego_quants[SPTYP_LAST_EXPONENT + level]++;
+                    ego_quants[SPSCHOOL_LAST_EXPONENT + level]++;
                 }
             }
         }
@@ -1012,8 +1012,8 @@ static void _debug_acquirement_stats(FILE *ostat)
     {
         // For spellbooks, for each spell discipline, list the number of
         // unseen and total spells available.
-        vector<int> total_spells(SPTYP_LAST_EXPONENT + 1);
-        vector<int> unseen_spells(SPTYP_LAST_EXPONENT + 1);
+        vector<int> total_spells(SPSCHOOL_LAST_EXPONENT + 1);
+        vector<int> unseen_spells(SPSCHOOL_LAST_EXPONENT + 1);
 
         for (int i = 0; i < NUM_SPELLS; ++i)
         {
@@ -1033,7 +1033,7 @@ static void _debug_acquirement_stats(FILE *ostat)
             const bool seen = you.spell_library[spell];
 
             const spschools_type disciplines = get_spell_disciplines(spell);
-            for (int d = 0; d <= SPTYP_LAST_EXPONENT; ++d)
+            for (int d = 0; d <= SPSCHOOL_LAST_EXPONENT; ++d)
             {
                 const auto disc = spschools_type::exponent(d);
 
@@ -1045,7 +1045,7 @@ static void _debug_acquirement_stats(FILE *ostat)
                 }
             }
         }
-        for (int d = 0; d <= SPTYP_LAST_EXPONENT; ++d)
+        for (int d = 0; d <= SPSCHOOL_LAST_EXPONENT; ++d)
         {
             const auto disc = spschools_type::exponent(d);
 
@@ -1197,9 +1197,9 @@ static void _debug_acquirement_stats(FILE *ostat)
                 "earth magic",
                 "air magic",
             };
-            COMPILE_CHECK(ARRAYSZ(names) == SPTYP_LAST_EXPONENT + 1);
+            COMPILE_CHECK(ARRAYSZ(names) == SPSCHOOL_LAST_EXPONENT + 1);
 
-            for (int i = 0; i <= SPTYP_LAST_EXPONENT; ++i)
+            for (int i = 0; i <= SPSCHOOL_LAST_EXPONENT; ++i)
             {
                 if (ego_quants[i] > 0)
                 {
@@ -1210,7 +1210,7 @@ static void _debug_acquirement_stats(FILE *ostat)
             // List levels for fixed level randarts.
             for (int i = 1; i < 9; ++i)
             {
-                const int k = SPTYP_LAST_EXPONENT + i;
+                const int k = SPSCHOOL_LAST_EXPONENT + i;
                 if (ego_quants[k] > 0)
                 {
                     fprintf(ostat, "%15s %d: %5.2f\n", "level", i,

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1149,22 +1149,22 @@ void debug_miscast(int target_index)
 
     if (spell != SPELL_NO_SPELL)
     {
-        miscast = new MiscastEffect(target, target, WIZARD_MISCAST, spell, pow,
-                                    fail, "", nothing);
+        miscast = new MiscastEffect(target, target, {WIZARD_MISCAST}, spell,
+                                    pow, fail, "", nothing);
     }
     else
     {
         if (level != -1)
         {
-            miscast = new MiscastEffect(target, target, WIZARD_MISCAST, school,
-                                        level, "wizard testing miscast",
+            miscast = new MiscastEffect(target, target, {WIZARD_MISCAST},
+                                        school, level, "wizard testing miscast",
                                         nothing);
         }
         else
         {
-            miscast = new MiscastEffect(target, target, WIZARD_MISCAST, school,
-                                        pow, fail, "wizard testing miscast",
-                                        nothing);
+            miscast = new MiscastEffect(target, target, {WIZARD_MISCAST},
+                                        school, pow, fail,
+                                        "wizard testing miscast", nothing);
         }
     }
     // Merely creating the miscast object causes one miscast effect to

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1043,30 +1043,30 @@ void debug_miscast(int target_index)
     }
 
     spell_type         spell  = spell_by_name(specs, true);
-    spschool_flag_type school = school_by_name(specs);
+    spschool school = school_by_name(specs);
 
     // Prefer exact matches for school name over partial matches for
     // spell name.
-    if (school != SPTYP_NONE
+    if (school != spschool::none
         && (strcasecmp(specs, spelltype_short_name(school)) == 0
             || strcasecmp(specs, spelltype_long_name(school)) == 0))
     {
         spell = SPELL_NO_SPELL;
     }
 
-    if (spell == SPELL_NO_SPELL && school == SPTYP_NONE)
+    if (spell == SPELL_NO_SPELL && school == spschool::none)
     {
         mpr("No matching spell or spell school.");
         return;
     }
-    else if (spell != SPELL_NO_SPELL && school != SPTYP_NONE)
+    else if (spell != SPELL_NO_SPELL && school != spschool::none)
     {
         mprf("Ambiguous: can be spell '%s' or school '%s'.",
             spell_title(spell), spelltype_short_name(school));
         return;
     }
 
-    spschools_type disciplines = SPTYP_NONE;
+    spschools_type disciplines = spschool::none;
     if (spell != SPELL_NO_SPELL)
     {
         disciplines = get_spell_disciplines(spell);

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1149,22 +1149,23 @@ void debug_miscast(int target_index)
 
     if (spell != SPELL_NO_SPELL)
     {
-        miscast = new MiscastEffect(target, target, {WIZARD_MISCAST}, spell,
-                                    pow, fail, "", nothing);
+        miscast = new MiscastEffect(target, target, {miscast_source::wizard},
+                                    spell, pow, fail, "", nothing);
     }
     else
     {
         if (level != -1)
         {
-            miscast = new MiscastEffect(target, target, {WIZARD_MISCAST},
-                                        school, level, "wizard testing miscast",
-                                        nothing);
+            miscast = new MiscastEffect(target, target,
+                                        {miscast_source::wizard}, school, level,
+                                        "wizard testing miscast", nothing);
         }
         else
         {
-            miscast = new MiscastEffect(target, target, {WIZARD_MISCAST},
-                                        school, pow, fail,
-                                        "wizard testing miscast", nothing);
+            miscast = new MiscastEffect(target, target,
+                                        {miscast_source::wizard}, school, pow,
+                                        fail, "wizard testing miscast",
+                                        nothing);
         }
     }
     // Merely creating the miscast object causes one miscast effect to

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -1141,9 +1141,9 @@ void debug_miscast(int target_index)
     // Suppress "nothing happens" message for monster miscasts which are
     // only harmless messages, since a large number of those are missing
     // monster messages.
-    nothing_happens_when_type nothing = NH_DEFAULT;
+    nothing_happens nothing = nothing_happens::DEFAULT;
     if (target_index != NON_MONSTER && level == 0)
-        nothing = NH_NEVER;
+        nothing = nothing_happens::NEVER;
 
     MiscastEffect *miscast;
 

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -193,7 +193,7 @@ void wizard_memorise_spec_spell()
         }
     }
 
-    if (get_spell_flags(static_cast<spell_type>(spell)) & SPFLAG_MONSTER)
+    if (get_spell_flags(static_cast<spell_type>(spell)) & spflag::monster)
         mpr("Spell is monster-only - unpredictable behavior may result.");
     if (!learn_spell(static_cast<spell_type>(spell), true))
         crawl_state.cancel_cmd_repeat();

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2222,7 +2222,7 @@ static void _xom_miscast(const int max_level, const bool nasty)
 
     god_speaks(GOD_XOM, _get_xom_speech(speech_str).c_str());
 
-    MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_XOM},
+    MiscastEffect(&you, nullptr, {miscast_source::god, GOD_XOM},
                   (spschool)school, level, cause_str, nothing_happens::DEFAULT,
                   lethality_margin, hand_str, can_plural);
 }

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2223,7 +2223,7 @@ static void _xom_miscast(const int max_level, const bool nasty)
     god_speaks(GOD_XOM, _get_xom_speech(speech_str).c_str());
 
     MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_XOM,
-                  (spschool)school, level, cause_str, NH_DEFAULT,
+                  (spschool)school, level, cause_str, nothing_happens::DEFAULT,
                   lethality_margin, hand_str, can_plural);
 }
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2202,7 +2202,7 @@ static void _xom_miscast(const int max_level, const bool nasty)
 
     // Take a note.
     const char* levels[4] = { "harmless", "mild", "medium", "severe" };
-    const auto school = spschools_type::exponent(random2(SPTYP_LAST_EXPONENT + 1));
+    const auto school = spschools_type::exponent(random2(SPSCHOOL_LAST_EXPONENT + 1));
     string desc = make_stringf("%s %s miscast", levels[level],
                                spelltype_short_name(school));
 #ifdef NOTE_DEBUG_XOM
@@ -2223,7 +2223,7 @@ static void _xom_miscast(const int max_level, const bool nasty)
     god_speaks(GOD_XOM, _get_xom_speech(speech_str).c_str());
 
     MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_XOM,
-                  (spschool_flag_type)school, level, cause_str, NH_DEFAULT,
+                  (spschool)school, level, cause_str, NH_DEFAULT,
                   lethality_margin, hand_str, can_plural);
 }
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2222,7 +2222,7 @@ static void _xom_miscast(const int max_level, const bool nasty)
 
     god_speaks(GOD_XOM, _get_xom_speech(speech_str).c_str());
 
-    MiscastEffect(&you, nullptr, GOD_MISCAST + GOD_XOM,
+    MiscastEffect(&you, nullptr, {GOD_MISCAST, GOD_XOM},
                   (spschool)school, level, cause_str, nothing_happens::DEFAULT,
                   lethality_margin, hand_str, can_plural);
 }


### PR DESCRIPTION
Following up on #927, convert five more enums to enum classes. Specifically:

* `enum spflag_type` becomes `enum class spflag` 
* `enum spschool_flag_type` becomes `enum class spschool`   
* `enum nothing_happens_when_type` becomes `enum class nothing_happens`   
* `enum miscast_source` becomes `enum class miscast_source`   
* `enum recall_t` becomes `enum class recall_t`.   

See individual commits for what each change involved; each commit message contains a detailed description of any special changes. Each commit contains one conversion and renaming, bundled together, since almost all of the lines changed by the conversion are subsequently changed by the renaming.

There are a couple of things I would like to do to make this better, but since the changes are mostly complete I am creating this PR for feedback purposes:
- [x] add a note to `docs/obsolete/cut_spells.txt` about the fact that enum values have changed since spells were cut
- [x] split the fourth commit into two parts: one dealing with the new struct, and a second dealing with the actual enum change—these were initially done in the opposite order so I made them 1 commit
- [x] change `spschool::RANDOM` to `spschool::random` for consistency with the rest of the enum class
- [x] resolve conflicts.

The result does compile on my machine; I'll let Travis check that more rigorously. I've done some very crude wizmode testing and everything seems to be working as intended—more specific testing around the areas where code logic has had to be changed is probably necessary.

I have reviewed my changes below to highlight some specific things I have questions on. 

Also feel free to suggest improvements to various things I have done here, not least including the new enum class names. I am trying to strike a balance between limiting the length of particular identifiers and the meaning of the type (when used for variable and argument type declarations for example) being clear.

This PR is up to date to the most recent commit at the time of most recently force-pushing, that is df2d5e0. I will force-push an update if any more conflicts arise in the meantime.

(The final commit does not have a commit message because its change is rather trivial.)