### PR TITLE
Fix holy word scroll (11821)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2780,6 +2780,42 @@ void read(item_def* scroll)
         return;
     }
 
+    if (scroll->sub_type == SCR_HOLY_WORD && item_type_known(*scroll))
+    {
+        if (you_worship(GOD_YREDELEMNUL)
+            && !yesno("This action would place you under penance -"
+                      " continue anyway?", false, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return;
+        }
+
+        bool friendlies = false;
+        const coord_def& where = you.pos();
+        for (radius_iterator ri(where, LOS_SOLID); ri; ++ri) {
+            const monster_info* m = env.map_knowledge(*ri).monsterinfo();
+            monster* mons = monster_at(*ri);
+
+            if (!m || !mons || !mons->alive() || !mons->undead_or_demonic())
+                continue;
+
+            if (mons_att_wont_attack(m->attitude)
+                && !mons_is_projectile(m->type))
+            {
+                friendlies = true;
+                break;
+            }
+        }
+
+        if (friendlies
+        && !yesno("There are friendly unholy creatures around -"
+                  " continue anyway?", true, 'n'))
+        {
+            canned_msg(MSG_OK);
+            return;
+        }
+    }
+
     if (you.get_mutation_level(MUT_BLURRY_VISION)
         && !i_feel_safe(false, false, true)
         && !yesno("Really read with blurry vision while enemies are nearby?",

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -32,7 +32,6 @@ bool puton_ring(int slot = -1, bool allow_prompt = true,
 void read(item_def* scroll = nullptr);
 void read_scroll(item_def& scroll);
 bool player_can_read();
-bool scroll_will_harm(const scroll_type scr, const monster &m);
 string cannot_read_item_reason(const item_def &item);
 
 bool remove_ring(int slot = -1, bool announce = false);

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "enum.h"
+#include "item-prop-enum.h"
 #include "operation-types.h"
 
 item_def* use_an_item(int item_type, operation_types oper, const char* prompt,
@@ -31,6 +32,7 @@ bool puton_ring(int slot = -1, bool allow_prompt = true,
 void read(item_def* scroll = nullptr);
 void read_scroll(item_def& scroll);
 bool player_can_read();
+bool scroll_will_harm(const scroll_type scr, const monster &m);
 string cannot_read_item_reason(const item_def &item);
 
 bool remove_ring(int slot = -1, bool announce = false);

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1261,11 +1261,22 @@ void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
         // XXX: attacker isn't passed through "int torment()".
         behaviour_event(mons, ME_ALERT, attacker);
 
-        if (attacker && attacker->is_player()
-            && taux == TORMENT_SCROLL
-            && item_type_known(OBJ_SCROLLS, SCR_TORMENT))
+        if (attacker && attacker->is_player())
         {
-            set_attack_conducts(conducts, *mons, you.can_see(*mons));
+            bool set_conducts = false;
+            switch (taux)
+            {
+                case TORMENT_SCROLL:
+                    set_conducts = item_type_known(OBJ_SCROLLS, SCR_TORMENT);
+                    break;
+                case TORMENT_SCEPTRE:
+                    set_conducts = true;
+                    break;
+                default: break;
+            }
+
+            if (set_conducts)
+                set_attack_conducts(conducts, *mons, you.can_see(*mons));
         }
     }
 

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1077,6 +1077,7 @@ void holy_word_monsters(coord_def where, int pow, holy_word_source_type source,
     if (!mons || !mons->alive() || !mons->undead_or_demonic())
         return;
 
+    god_conduct_trigger conducts[3];
     int hploss = roll_dice(3, 15) + (random2(pow) / 5);
 
     if (hploss)
@@ -1085,6 +1086,13 @@ void holy_word_monsters(coord_def where, int pow, holy_word_source_type source,
             simple_monster_message(*mons, " is blasted by Zin's holy word!");
         else
             simple_monster_message(*mons, " convulses!");
+
+        if (attacker && attacker->is_player()
+            && source == HOLY_WORD_SCROLL
+            && item_type_known(OBJ_SCROLLS, SCR_HOLY_WORD))
+        {
+            set_attack_conducts(conducts, *mons, you.can_see(*mons));
+        }
     }
     mons->hurt(attacker, hploss, BEAM_MISSILE);
 
@@ -1239,6 +1247,7 @@ void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
         return;
     }
 
+    god_conduct_trigger conducts[3];
     int hploss = max(0, mons->hit_points *
                         (50 - mons->res_negative_energy() * 5) / 100 - 1);
 
@@ -1251,6 +1260,13 @@ void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
         // it. It does alert them, though.
         // XXX: attacker isn't passed through "int torment()".
         behaviour_event(mons, ME_ALERT, attacker);
+
+        if (attacker && attacker->is_player()
+            && taux == TORMENT_SCROLL
+            && item_type_known(OBJ_SCROLLS, SCR_TORMENT))
+        {
+            set_attack_conducts(conducts, *mons, you.can_see(*mons));
+        }
     }
 
     mons->hurt(attacker, hploss, BEAM_TORMENT_DAMAGE);


### PR DESCRIPTION
When reading the holy word scroll, the player is now warned in
case there are friendly unholy creatures around. Also, another
warning dialogue is spawned if reading the scroll would put the
player under penance.