### PR TITLE
Rework storm card (minmay, ebering)

### DIFF
--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -58,7 +58,8 @@ the Storm card
 
 The card depicts a ship at sea sinking in a thunderstorm.
 
-Drawing this card unleashes a storm of wind and thunder clouds.
+Drawing this card unleashes a storm of wind and electrical discharges. Increasing
+card power will result in a stronger wind force and more numerous discharges.
 %%%%
 Pain card
 


### PR DESCRIPTION
Storm's old effect (wind blast + storm cloud ring + air elemental)
didn't fit in well with the rest of the deck of desctruction, and wasn't
that great anyway. Rework to be more purely about AoE electrical damage.

New effects are: wind blast, up to twelve electrical explosions
(depending on power), and a few lingering storm clouds (mostly for
flavour).

The number of orb of electricity explosions depends on how open your
surrounding terrain is, to reward using this card in the open. (In a
corridor, you will probably not even see one.)

In terms of balance, it may be neccessary to play with the number of
explosions. Specifically, perhaps guaranteeing some number of explosions
even in corridors (or when the only space is too close to the
player...?), and reducing the maximum number of explosions based on card
power.