### PR TITLE
Fix death channel duration leak when cast at max duration (11828)

### DIFF
--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -71,12 +71,6 @@ spret cast_sublimation_of_blood(int pow, bool fail)
 
 spret cast_death_channel(int pow, god_type god, bool fail)
 {
-    if (you.duration[DUR_DEATH_CHANNEL] >= 60 * BASELINE_DELAY)
-    {
-        canned_msg(MSG_NOTHING_HAPPENS);
-        return spret::abort;
-    }
-
     fail_check();
     mpr("Malign forces permeate your being, awaiting release.");
 


### PR DESCRIPTION
Simply remove the check in cast_death_channel for returning spret::abort
when at max duration. The information that the player has maxed out
their duration is not given to the player for other spells, and so
should not be given for death channel.