### PR TITLE
Fix monsters not being woken when hit by animated trees (11819)

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2371,6 +2371,8 @@ void forest_damage(const actor *mon)
                             "@foe@ @is@ scraped by a branch!",
                             "A tree reaches out and scrapes @foe@!",
                             "A root barely touches @foe@ from below.");
+                    if (foe->is_monster())
+                        behaviour_event(foe->as_monster(), ME_WHACK);    
                 }
                 else
                 {
@@ -2378,6 +2380,8 @@ void forest_damage(const actor *mon)
                         "@foe@ @is@ hit by a branch!",
                         "A tree reaches out and hits @foe@!",
                         "A root smacks @foe@ from below.");
+                    if (foe->is_monster())
+                        behaviour_event(foe->as_monster(), ME_WHACK);    
                 }
 
                 msg = replace_all(replace_all(msg,


### PR DESCRIPTION
This commit adds a call to behaviour_event to, among other things, wake
sleeping monsters, when they are attacked by an animated tree from
summon forest as long as the attack hits.

Reproducing this bug is difficult: I recommend the method Yermak talked about in his bug report: that is, place monsters behind a closed door, cast the spell, then open the door.