### PR TITLE
C++ Cloud Generators

### DIFF
--- a/crawl-ref/source/cloud.h
+++ b/crawl-ref/source/cloud.h
@@ -60,3 +60,66 @@ const cloud_tile_info& cloud_type_tile_info(cloud_type type);
 
 void start_still_winds();
 void end_still_winds();
+
+
+// XXX: move CloudGenerator stuff into its own file
+class CloudGenerator
+{
+public:
+    CloudGenerator(coord_def _loc, cloud_type _type,
+                   int _pow_max, int _delay_max, int _size_max)
+        : loc(_loc), type(_type), walk_dist(0),
+          pow_min(1), pow_max(_pow_max), pow_rolls(1),
+          delay_min(_delay_max), delay_max(_delay_max),
+          size_min(_size_max), size_max(_size_max),
+          size_buildup_amnt(0), size_buildup_max(0),
+          initial_clouds(0), exclusion_radius(0), aut_extant(0), delay(0)
+    { }
+
+    // TODO: setter functions for pow, delay, size, buildup, initial, exclrad
+
+    void run();
+
+private:
+    /// Center of cloud generation.
+    coord_def loc;
+    /// Type of cloud to generate (e.g. CLOUD_BLUE_SMOKE)
+    cloud_type type;
+    /// The distance to move over the course of one random walk.
+    int walk_dist;
+    /// Cloud lifetime: [pow_min, pow_max]. More pow_rolls decrease variance.
+    int pow_min, pow_max, pow_rolls;
+    /// Delay between each cloud placement: [delay_min, delay_max].
+    int delay_min, delay_max;
+    /// # of clouds that are generated with each firing: [size_min, size_max].
+    int size_min, size_max;
+    /**
+     * If nonzero, adds
+     * (size_buildup_amnt / size_buildup_max * aut_extant)
+     * to size_min and size_max, maxing out at size_buildup_amnt.
+     */
+    int size_buildup_amnt, size_buildup_max;
+    /// Rate at which clouds spread; -1 is default for type, otherwise [0-100].
+    int spread_rate;
+    /**
+     * The number of clouds to lay when the level containing the cloud machine
+     * is entered. (Clouds are cleared when the player leaves a level.)
+     */
+    int initial_clouds;
+    /**
+     * Size of exclusions automatically placed around clouds from this
+     * generator. If 0, no exclusion will be placed.
+     */
+    int exclusion_radius;
+    /// How long has this generator existed?
+    int aut_extant;
+    /// How long until the next cloud generation event?
+    int delay;
+    // XXX: listener?
+    // XXX: kill_cat?
+    // XXX: spread_rate_buildup/amnt?
+
+    pair<int, int> get_size_range() const;
+};
+
+#endif

--- a/crawl-ref/source/dat/dlua/lm_trig.lua
+++ b/crawl-ref/source/dat/dlua/lm_trig.lua
@@ -298,7 +298,7 @@ function Triggerable:do_trigger(triggerer, marker, ev)
   for _, slave_marker in ipairs(slaves) do
     self.want_remove = false
 
-    self:on_trigger(triggerer, slave_marker, ev)
+    self:on_trigger(triggerer, slave_marker, ev, slaves)
 
     if self.want_remove then
       num_want_remove = num_want_remove + 1

--- a/crawl-ref/source/env.h
+++ b/crawl-ref/source/env.h
@@ -6,6 +6,8 @@
 #include "coord.h"
 #include "fprop.h"
 #include "map-cell.h"
+#include "cloud.h"
+#include "map_knowledge.h"
 #include "monster.h"
 #include "trap-def.h"
 
@@ -108,6 +110,9 @@ struct crawl_environment
     int density;
     int absdepth0;
     vector<pair<coord_def, int> > sunlight;
+
+    /// Invisible generators that create clouds over time.
+    vector<CloudGenerator> cloud_generators;
 
     // Remaining fields not marshalled:
 

--- a/crawl-ref/source/env.h
+++ b/crawl-ref/source/env.h
@@ -3,11 +3,10 @@
 #include <set>
 #include <memory> // unique_ptr
 
+#include "cloud.h"
 #include "coord.h"
 #include "fprop.h"
 #include "map-cell.h"
-#include "cloud.h"
-#include "map_knowledge.h"
 #include "monster.h"
 #include "trap-def.h"
 
@@ -111,7 +110,7 @@ struct crawl_environment
     int absdepth0;
     vector<pair<coord_def, int> > sunlight;
 
-    /// Invisible generators that create clouds over time.
+    bool special_clouds;
     vector<CloudGenerator> cloud_generators;
 
     // Remaining fields not marshalled:

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1388,6 +1388,9 @@ bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,
     if (make_changes)
         delete_all_clouds();
 
+    env.cloud_generators.clear();
+    env.special_clouds = 0;
+
     // Lose all listeners.
     dungeon_events.clear();
 


### PR DESCRIPTION
Edit 3-17-19: 
This patch has been finished/tested for months. Whenever the Crawl dev team feels like looking at it, they're free to.

C++ Cloud Generators!

Entry point is on_trigger at lm_fog.lua:209; after the level builder has
loaded everything, when it first calls the fog machines, it'll instead create
the C++ fog machines. The other fog-machine-related functions have been
commented out, but the markers will still be triggered and still fire, just
with no payload. This is done partly out of discomfort and partly in the
interest of save compatability.

The fog machines can run every time world_reacts() is triggered. Fog machines
in desolation are strange, and run with delay = 0; I've simulated this by
running them 20 times, and it's pretty close to the current effect.

Other fog-machine types defined in lm_fog.lua seem to be unused, other than
one vault which uses chained fog machines, hangedman_minor_magic. This
works as intended.

All parameters inside lm_fog.lua are re-used. Since it's easy to check, fog
machines won't fire if they're not visible (and their fog can't be visible),
with a distance check I guesstimated at 10.

Inspiration was taken from PleasingFungus' branch, cloud_gen, which is
referenced as a previous commit.

Synchronized generators (i.e. firing in specific order) would be a neat
addition, for future work.

Help wanted:

- [X] Test effects on webserver/desolation performance
- [X] Fix hangedman_minor_magic by implementing chained fog machines (in C++) 
- [X] Add other types of fog machines (presently unutilized)
- [X] Gut unused lua/clean up

I've tested these personally, but, recommended testing for reviewers:
Test desolation
Test hangedman_minor_magic
Test any other cloud-generator-heavy maps, such as Sprint 2