### PR TITLE
Don't add unique annotations for an illusory unique (u/kitchen_ace)

### DIFF
--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -823,6 +823,7 @@ void set_unique_annotation(monster* mons, const level_id level)
     if (!mons_is_or_was_unique(*mons)
         && mons->type != MONS_PLAYER_GHOST
         || testbits(mons->flags, MF_SPECTRALISED)
+        || mons->is_illusion()
         || mons->props.exists("no_annotate")
             && mons->props["no_annotate"].get_bool())
 


### PR DESCRIPTION
After commit eddfa9bf, if an illusionary unique created by phantom
mirror outlives the original, the corresponding unique annotation
won't be removed.
Fix this by not adding annotations for illusions.