### PR TITLE
Don't scale EV bonuses when a flying Te/swimming Mf/petrifying/held (11463)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2241,11 +2241,8 @@ static int _player_evasion(ev_ignore_type evit)
 
     const int evasion_bonuses = _player_evasion_bonuses() * scale;
 
-    const int prescaled_evasion =
-        poststepdown_evasion + evasion_bonuses;
-
     const int final_evasion =
-        _player_scale_evasion(prescaled_evasion, scale);
+        _player_scale_evasion(poststepdown_evasion, scale) + evasion_bonuses;
 
     return unscale_round_up(final_evasion, scale);
 }


### PR DESCRIPTION
Previously, the effects of flat evasion bonuses such as rings of
evasion, the amulet of the acrobat, mutations, and potions of agility,
were scaled up by the effects of flying as a tengu, and swimming as a
merfolk, and halved by the petrifying and held statuses.

This led to weird behaviour where flying as a tengu meant acrobat
actually gave 18 EV, and other oddities, which are inconsistent with how
flat bonuses generally function.

Therefore, this commit makes it so that the evasion bonuses are added to
the post-scale evasion, rather than the pre-scale evasion.

There is a remaining inconsistency in paralysis, full petrification,
tree form, and most notably, dexterity stat zero, where these evasion
bonuses are not accounted for at all. In the case of paralysis and full
petrification this probably makes sense, whereas for clumsy and tree
form, where you can still act, this behaviour is somewhat arguable,
because it is not obvious here that rings of evasion etc are rendered
useless.