### PR TITLE
Make the polymorph targeter more informative (11706)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6237,6 +6237,7 @@ bool bolt::nasty_to(const monster* mon) const
         case BEAM_SLOW:
         case BEAM_PARALYSIS:
         case BEAM_PETRIFY:
+        case BEAM_POLYMORPH:
         case BEAM_DISPEL_UNDEAD:
         case BEAM_PAIN:
         case BEAM_AGONY:

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1267,12 +1267,23 @@ int hex_success_chance(const int mr, int powc, int scale, bool round_up)
 vector<string> desc_success_chance(const monster_info& mi, int pow, bool evoked,
                                    targeter* hitfunc)
 {
+    targeter_beam* beam_hitf = dynamic_cast<targeter_beam*>(hitfunc);
     vector<string> descs;
     const int mr = mi.res_magic();
     if (mr == MAG_IMMUNE)
         descs.push_back("magic immune");
     else if (hitfunc && !hitfunc->affects_monster(mi))
         descs.push_back("not susceptible");
+    // Polymorph has a special effect on ugly things and shapeshifters that
+    // does not require passing an MR check.
+    else if (beam_hitf && beam_hitf->beam.flavour == BEAM_POLYMORPH
+             && (mi.type == MONS_UGLY_THING || mi.type == MONS_VERY_UGLY_THING
+                 || mi.is(MB_SHAPESHIFTER)))
+    {
+        descs.push_back(make_stringf("will change %s",
+                                     mi.is(MB_SHAPESHIFTER) ? "shape"
+                                     /* ugly things */      : "colour"));
+    }
     else
     {
         const int adj_pow = evoked ? pakellas_effective_hex_power(pow)


### PR DESCRIPTION
This commit changes the polymorph targeter to display "not susceptible"
for undead and nonliving monsters that cannot be polymorphed. It also
now displays "will change shape" and "will change colour" instead of the
chance to hex, when targeting known shapeshifters and (very) ugly
things, respectively, to make this special effect somewhat better
described.