### PR TITLE
feat: further distinguish skill drain <= 100 in status

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -526,12 +526,19 @@ bool fill_status_info(int status, status_info& inf)
             inf.short_text   = "heavily drained";
             inf.long_text    = "Your life force is heavily drained.";
         }
+        else if (you.attribute[ATTR_XP_DRAIN] > 50)
+        {
+            inf.light_colour = BROWN;
+            inf.light_text   = "Drain";
+            inf.short_text   = "drained";
+            inf.long_text    = "Your life force is drained.";
+        }
         else if (you.attribute[ATTR_XP_DRAIN])
         {
             inf.light_colour = YELLOW;
             inf.light_text   = "Drain";
-            inf.short_text   = "drained";
-            inf.long_text    = "Your life force is drained.";
+            inf.short_text   = "lightly drained";
+            inf.long_text    = "Your life force is lightly drained.";
         }
         break;
 


### PR DESCRIPTION
This should make it easier for the player to judge how heavily he
is drained in the early game, and when using Ru's powers.

For monsters, the drain of a wraith is 25, and a hit from a draining
wand is a minimum of 75, but currently both give you the same status.

The same is true for Ru's Draw out power and Apocalypse: 30 vs 100,
but both give you the same status (and have the same "skill drain"
description in the god ability menu). For Ru it's quite important to
manage your skill drain, and introducing a new threshold should help
with that.

Unfortunately, there is no orange so I had to settle on brown.

I also considered using the old "You are drained" for < 50 and introduce a new wording for >= 50 but I couldn't think of anything that works.

I also thought about handling the difference in skill drain for Ru in the ability menu, by introducing a new "light skill drain" flag https://github.com/crawl/crawl/blob/dc03e01af6270c8ad31b42f997966e0998785fa6/crawl-ref/source/ability.cc#L112 but I the bitwise operators made me refrain. If this is issue is acknowleged and this should be the preferred way to handle it, I can work on it further.