### PR TITLE
Remove troves asking for scrolls of identify

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -97,7 +97,6 @@ function trove.get_trove_item(e, value, base_item)
   -- currently 20% armour, 15% weapon, 50% consumable, 15% miscellaneous
   local prices = {
        {base="scroll", type="acquirement", quant=2},
-       {base="scroll", type="identify", quant=12+d(4)+d(4)+d(4)},
        {base="miscellaneous", type="rune of Zot", quant=3, name="slimy rune of Zot"},
        {base="miscellaneous", type="rune of Zot", quant=11, name="abyssal rune of Zot"},
        {base="miscellaneous", type="horn of Geryon"} }


### PR DESCRIPTION
Beyond the early game, once almost all the potions and scrolls in the
game are identified, scrolls of identify become a convenience tool more
than anything else; it is simply easier and faster for the player to
identify this unknown ring on the floor using a scroll than to find
something to drop, pick the ring up, put it on, decide it's useless,
drop it, and pick up the other thing. This especially applies when the
player has 5+ spare identify scrolls in their inventory, which is fairly
common around the time of Vaults and Depths.

Troves asking for identify scrolls encouraged players to employ the
tedious second behaviour, and to some extent take risks with
wear-identifying artefacts, in order to horde the scrolls and eventually
enter the trove. Additionally, being reduced to 0 identify scrolls by a
trove hardly makes a significant difference to the strength of a
character - rather it simply means once again that the tedious
wear-identification process is required.

Note that the wear-identification of artefacts that is encouraged by
this isn't particularly dangerous beyond the early game anyway; the only
bad effects are *Drain and *Contam; *Drain is unlikely to have a
significant impact, and *Contam may cause 1 malmutate before wearing
off that the player can probably eliminate by using a mutation potion.

Hence, remove troves asking for scrolls of identify, because they
encouraged tedious behaviour instead of meaningful decision making.