### PR TITLE
Include petrification information in death messages (11374)

### DIFF
--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -2800,15 +2800,21 @@ string scorefile_entry::death_description(death_desc_verbosity verbosity) const
                 if (you.duration[DUR_PARALYSIS])
                 {
                     desc += "... while paralysed";
-                    if (you.props.exists("paralysed_by"))
-                        desc += " by " + you.props["paralysed_by"].get_string();
+                    if (you.props.exists(PARALYSED_BY_KEY))
+                    {
+                        desc += " by "
+                                + you.props[PARALYSED_BY_KEY].get_string();
+                    }
                     desc += _hiscore_newline_string();
                 }
                 else if (you.duration[DUR_PETRIFIED])
                 {
                     desc += "... while petrified";
-                    if (you.props.exists("petrified_by"))
-                        desc += " by " + you.props["petrified_by"].get_string();
+                    if (you.props.exists(PETRIFIED_BY_KEY))
+                    {
+                        desc += " by "
+                                + you.props[PETRIFIED_BY_KEY].get_string();
+                    }
                     desc += _hiscore_newline_string();
                 }
 

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -2804,6 +2804,13 @@ string scorefile_entry::death_description(death_desc_verbosity verbosity) const
                         desc += " by " + you.props["paralysed_by"].get_string();
                     desc += _hiscore_newline_string();
                 }
+                else if (you.duration[DUR_PETRIFIED])
+                {
+                    desc += "... while petrified";
+                    if (you.props.exists("petrified_by"))
+                        desc += " by " + you.props["petrified_by"].get_string();
+                    desc += _hiscore_newline_string();
+                }
 
             }
         }

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -220,8 +220,8 @@ static void _decrement_petrification(int delay)
         mprf(MSGCH_DURATION, "You turn to %s and can move again.",
              flesh_equiv.c_str());
 
-        if (you.props.exists("petrified_by"))
-            you.props.erase("petrified_by");
+        if (you.props.exists(PETRIFIED_BY_KEY))
+            you.props.erase(PETRIFIED_BY_KEY);
     }
 
     if (you.duration[DUR_PETRIFYING])
@@ -257,8 +257,8 @@ static void _decrement_paralysis(int delay)
             you.redraw_evasion = true;
             you.duration[DUR_PARALYSIS_IMMUNITY] = roll_dice(1, 3)
             * BASELINE_DELAY;
-            if (you.props.exists("paralysed_by"))
-                you.props.erase("paralysed_by");
+            if (you.props.exists(PARALYSED_BY_KEY))
+                you.props.erase(PARALYSED_BY_KEY);
         }
     }
 }

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -219,6 +219,9 @@ static void _decrement_petrification(int delay)
 
         mprf(MSGCH_DURATION, "You turn to %s and can move again.",
              flesh_equiv.c_str());
+
+        if (you.props.exists("petrified_by"))
+            you.props.erase("petrified_by");
     }
 
     if (you.duration[DUR_PETRIFYING])

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6747,6 +6747,9 @@ void player::petrify(actor *who, bool force)
 
     duration[DUR_PETRIFYING] = 3 * BASELINE_DELAY;
 
+    if (who)
+        props["petrified_by"] = who->name(DESC_A, true);
+
     redraw_evasion = true;
     mprf(MSGCH_WARN, "You are slowing down.");
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6700,7 +6700,7 @@ void player::paralyse(actor *who, int str, string source)
     {
         take_note(Note(NOTE_PARALYSIS, str, 0, source));
         // use the real name here even for invisible monsters
-        props["paralysed_by"] = use_actor_name ? who->name(DESC_A, true)
+        props[PARALYSED_BY_KEY] = use_actor_name ? who->name(DESC_A, true)
                                                : source;
     }
 
@@ -6748,7 +6748,7 @@ void player::petrify(actor *who, bool force)
     duration[DUR_PETRIFYING] = 3 * BASELINE_DELAY;
 
     if (who)
-        props["petrified_by"] = who->name(DESC_A, true);
+        props[PETRIFIED_BY_KEY] = who->name(DESC_A, true);
 
     redraw_evasion = true;
     mprf(MSGCH_WARN, "You are slowing down.");

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -50,6 +50,8 @@
 #define SAP_MAGIC_KEY "sap_magic_amount"
 #define TEMP_WATERWALK_KEY "temp_waterwalk"
 #define EMERGENCY_FLIGHT_KEY "emergency_flight"
+#define PARALYSED_BY_KEY "paralysed_by"
+#define PETRIFIED_BY_KEY "petrified_by"
 
 // display/messaging breakpoints for penalties from Ru's MUT_HORROR
 #define HORROR_LVL_EXTREME  3


### PR DESCRIPTION
Display "Slain by X ... while petrified [by X]" on the death screen when
the player was killed while petrified, in the same way as paralysis.

This applies only when fully petrified, not when petrifying, and the
monster that first applied the petrifying status is used in the death
message, even if the player is hit again with the petrify spell by a
different source on the following turn and this accelerated the
petrification process.