### PR TITLE
Fix AC calculation in item description with deformed body (Monsterracer)

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1631,7 +1631,7 @@ static string _describe_armour(const item_def &item, bool verbose)
             {
                 description += make_stringf("\nWearing mundane armour of this type "
                                             "will give the following: %d AC",
-                                             you.base_ac_from(item));
+                                             you.base_ac_from(item, 100) / 100);
             }
         }
     }


### PR DESCRIPTION
Previously, the AC granted by armour when the player has deformed body
was sometimes lower than that indicated in the item description's
"Wearing mundane armour of this type will grant the following:" line.

This was because:
  - player::base_ac_from calculates the AC reduction from
    deformed body as `AC - baseAC / 2`;
  - the description called the player::base_ac_from method with scale
    parameter 1, resulting in the AC being rounded up;
  - the actual AC calculation called the method with scale parameter 100
    and then performed integer division on the final result, resulting
    in the overall AC being rounded down.

Fix this by calling base_ac_from with scale parameter 100 and then
dividing by 100, so that the maths here is equivalent to that in the
real AC calculation.