### PR TITLE
Update tutorial, fix tutorial/hints mode skill menu text (11851)

### DIFF
--- a/crawl-ref/source/dat/descript/tutorial.txt
+++ b/crawl-ref/source/dat/descript/tutorial.txt
@@ -371,9 +371,10 @@ of the screen. </localtiles>Rereading old messages with
 tutorial3 trap
 
 Traps can have a variety of unpleasant effects, such as alerting monsters or
-teleporting you into danger. They will often be hidden until you discover them
-by stepping on them. If there's no way around, you'll have to trigger the trap
-and deal with the consequences.
+teleporting you into danger. Some traps are permanent and will always be
+revealed as part of the map, but other traps can be triggered by exploring new
+tiles, and won't exist after being triggered. If there's no way around, you'll
+have to trigger the trap and deal with the consequences.
 %%%%
 tutorial3 potion
 
@@ -701,8 +702,8 @@ again.
 %%%%
 tutorial5 hunger
 
-Berserking also causes a large amount of hunger. You cannot berserk while very
-hungry, so you should always carry some food with you.
+Berserking also causes a large amount of hunger. You cannot berserk while near
+starving, so you should always carry some food with you.
 %%%%
 tutorial5 berserk2
 

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -1440,7 +1440,7 @@ void SkillMenu::refresh_button_row()
     const string helpstring = "[<yellow>?</yellow>] ";
     const string azstring = "[<yellow>a</yellow>-<yellow>z</yellow>] ";
 
-    string legend = is_set(SKMF_SIMPLE) ? "Read skill descriptions" : "Help";
+    string legend = is_set(SKMF_SIMPLE) ? "Skill descriptions" : "Help";
     string midlegend = "";
     string clearlegend = "";
     if (is_set(SKMF_HELP))


### PR DESCRIPTION
Update a traps message that stated traps aren't always revealed, and a
berserk hunger message that stated you can't berserk while very hungry;
this restriction is now limited to near starving or worse.

Shorten the "Read skill descriptions" button description to "Skill
descriptions" to avoid this overlapping the text on the following line.

I have completely played through the tutorial; these were the only issues I found.