### PR TITLE
Re-enable stat shifting for Gnolls worshipping Jiyva

### DIFF
--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -376,11 +376,9 @@ static void _jiyva_effects(int /*time_delta*/)
         }
     }
 
-    // Gnolls can't shift stats
     if (have_passive(passive_t::fluid_stats)
         && x_chance_in_y(you.piety / 4, MAX_PIETY)
-        && !player_under_penance() && one_chance_in(4)
-        && you.species != SP_GNOLL)
+        && !player_under_penance() && one_chance_in(4))
     {
         jiyva_stat_action();
     }


### PR DESCRIPTION
Re-enables the stat shifting passive for Gnolls who are worshipping
Jiyva. This is a leftover fragment from the static attribute iteration
of Gnolls.