### PR TITLE
Fix dancing weapon description when multiple monsters enter LOS (11843)

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3001,6 +3001,8 @@ static string _describe_monster_weapon(const monster_info& mi, bool ident)
 
     if (mi.type == MONS_PANDEMONIUM_LORD)
         desc += " armed with ";
+    else if (mi.type == MONS_DANCING_WEAPON)
+        desc += " ";
     else
         desc += " wielding ";
     desc += name1;
@@ -3297,7 +3299,7 @@ string get_monster_equipment_desc(const monster_info& mi,
 
     string weap = "";
 
-    if (mi.type != MONS_DANCING_WEAPON && mi.type != MONS_SPECTRAL_WEAPON)
+    if (mi.type != MONS_SPECTRAL_WEAPON)
         weap = _describe_monster_weapon(mi, level == DESC_IDENTIFIED);
 
     // Print the rest of the equipment only for full descriptions.


### PR DESCRIPTION
When multiple enemies entered line of sight at once including at least
one dancing weapon, the message "There is." was being printed. This is
because there was an unnecessary check for enemies not being dancing
weapons in get_monster_equipment_desc. Remove this check, and add a
special case to the helper function _describe_monster_weapon to prevent
these messages being printed as "There is wielding a +4 trident."

These messages should now properly print as e.g.
"There is a +4 executioner's axe of electrocution."