### PR TITLE
Add -branch-json and improve -playable-json

### DIFF
--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -851,6 +851,7 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;"
     <ClInclude Include="..\bloodspatter.h" />
     <ClInclude Include="..\book-data.h" />
     <ClInclude Include="..\book-type.h" />
+    <ClInclude Include="..\branch-data-json.h" />
     <ClInclude Include="..\branch-data.h" />
     <ClInclude Include="..\branch-type.h" />
     <ClInclude Include="..\branch.h" />

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -15,6 +15,7 @@ beam.o \
 behold.o \
 bitary.o \
 branch.o \
+branch-data-json.o \
 butcher.o \
 bloodspatter.o \
 chardump.o \

--- a/crawl-ref/source/android-project/jni/src/Android.mk
+++ b/crawl-ref/source/android-project/jni/src/Android.mk
@@ -34,6 +34,7 @@ LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
     $(CRAWL_PATH)/behold.cc \
     $(CRAWL_PATH)/bitary.cc \
     $(CRAWL_PATH)/branch.cc \
+    $(CRAWL_PATH)/branch-data-json.cc \
     $(CRAWL_PATH)/butcher.cc \
     $(CRAWL_PATH)/bloodspatter.cc \
     $(CRAWL_PATH)/chardump.cc \

--- a/crawl-ref/source/branch-data-json.cc
+++ b/crawl-ref/source/branch-data-json.cc
@@ -1,0 +1,38 @@
+/**
+ * @file
+ * @brief Provide branch data as JSON
+ */
+
+#include "AppHdr.h"
+
+#include "branch-data-json.h"
+
+#include "json.h"
+#include "json-wrapper.h"
+
+#include "branch.h"
+#include "stringutil.h" // to_string on Cygwin
+
+static JsonNode *_branch_info_array()
+{
+    JsonNode *br(json_mkarray());
+    for (branch_iterator it; it; ++it)
+    {
+        JsonNode *branch_info(json_mkobject());
+        json_append_member(branch_info, "name", json_mkstring(it->shortname));
+        json_append_member(branch_info, "long_name",
+            json_mkstring(it->longname));
+        json_append_member(branch_info, "levels", json_mknumber(it->numlevels));
+        json_append_member(branch_info, "has_rune",
+            json_mkbool(it->runes.size() > 0 ? true : false));
+        json_append_element(br, branch_info);
+    }
+    return br;
+}
+
+string branch_data_json()
+{
+    JsonWrapper json(json_mkobject());
+    json_append_member(json.node, "branches", _branch_info_array());
+    return json.to_string();
+}

--- a/crawl-ref/source/branch-data-json.h
+++ b/crawl-ref/source/branch-data-json.h
@@ -1,0 +1,3 @@
+#pragma once
+
+string branch_data_json();

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -22,6 +22,7 @@
 #include <set>
 #include <string>
 
+#include "branch-data-json.h"
 #include "chardump.h"
 #include "clua.h"
 #include "colour.h"
@@ -3828,6 +3829,7 @@ enum commandline_option_type
     CLO_THROTTLE,
     CLO_NO_THROTTLE,
     CLO_PLAYABLE_JSON, // JSON metadata for species, jobs, combos.
+    CLO_BRANCHES_JSON, // JSON metadata for branches.
     CLO_EDIT_BONES,
 #ifdef USE_TILE_WEB
     CLO_WEBTILES_SOCKET,
@@ -3846,7 +3848,7 @@ static const char *cmd_ops[] =
     "builddb", "help", "version", "seed", "save-version", "sprint",
     "extra-opt-first", "extra-opt-last", "sprint-map", "edit-save",
     "print-charset", "tutorial", "wizard", "explore", "no-save", "gdb",
-    "no-gdb", "nogdb", "throttle", "no-throttle", "playable-json",
+    "no-gdb", "nogdb", "throttle", "no-throttle", "playable-json", "branches-json",
     "bones",
 #ifdef USE_TILE_WEB
     "webtiles-socket", "await-connection", "print-webtiles-options",
@@ -4757,6 +4759,10 @@ bool parse_args(int argc, char **argv, bool rc_only)
 
         case CLO_PLAYABLE_JSON:
             fprintf(stdout, "%s", playable_metadata_json().c_str());
+            end(0);
+
+        case CLO_BRANCHES_JSON:
+            fprintf(stdout, "%s", branch_data_json().c_str());
             end(0);
 
         case CLO_TEST:

--- a/crawl-ref/source/jobs.cc
+++ b/crawl-ref/source/jobs.cc
@@ -186,3 +186,8 @@ bool is_starting_job(job_type job)
     return job < NUM_JOBS
         && !_job_def(job).recommended_species.empty();
 }
+
+vector<species_type> job_recommended_species(job_type job)
+{
+    return _job_def(job).recommended_species;
+}

--- a/crawl-ref/source/jobs.h
+++ b/crawl-ref/source/jobs.h
@@ -21,3 +21,4 @@ void job_stat_init(job_type job);
 void debug_jobdata();
 job_type random_starting_job();
 bool is_starting_job(job_type job);
+vector<species_type> job_recommended_species(job_type job);

--- a/crawl-ref/source/json.cc
+++ b/crawl-ref/source/json.cc
@@ -550,6 +550,11 @@ JsonNode *json_mkstring(const char *s)
     return mkstring(json_strdup(s));
 }
 
+JsonNode *json_mkstring(string s)
+{
+    return json_mkstring(s.c_str());
+}
+
 JsonNode *json_mknumber(double n)
 {
     JsonNode *node = mknode(JSON_NUMBER);

--- a/crawl-ref/source/json.h
+++ b/crawl-ref/source/json.h
@@ -98,6 +98,7 @@ JsonNode   *json_first_child    (const JsonNode *node);
 JsonNode *json_mknull();
 JsonNode *json_mkbool(bool b);
 JsonNode *json_mkstring(const char *s);
+JsonNode *json_mkstring(string s);
 JsonNode *json_mknumber(double n);
 JsonNode *json_mkarray();
 JsonNode *json_mkobject();

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -555,6 +555,7 @@ static void _show_commandline_options_help()
     puts("  -gdb/-no-gdb     produce gdb backtrace when a crash happens (default:on)");
 #endif
     puts("  -playable-json   list playable species, jobs, and character combos.");
+    puts("  -branches-json   list branch data.");
 
 #if defined(TARGET_OS_WINDOWS) && defined(USE_TILE_LOCAL)
     text_popup(help, L"Dungeon Crawl command line help");

--- a/crawl-ref/source/playable.cc
+++ b/crawl-ref/source/playable.cc
@@ -92,6 +92,14 @@ static JsonNode *_species_apts(species_type sp)
     return apts;
 }
 
+static JsonNode *_species_recommended_jobs(species_type sp)
+{
+    JsonNode *jobs(json_mkarray());
+    for (const auto job : get_species_def(sp).recommended_jobs)
+        json_append_element(jobs, json_mkstring(get_job_name(job)));
+    return jobs;
+}
+
 static JsonNode *_species_modifiers(species_type sp)
 {
     JsonNode *modifiers(json_mkobject());
@@ -115,6 +123,8 @@ static JsonNode *_species_metadata(species_type sp,
     }
     json_append_member(species, "apts", _species_apts(sp));
     json_append_member(species, "modifiers", _species_modifiers(sp));
+    json_append_member(species, "recommended_jobs",
+                       _species_recommended_jobs(sp));
     return species;
 }
 
@@ -142,11 +152,21 @@ static JsonNode *_species_metadata_array()
     return species;
 }
 
+static JsonNode *_job_recommended_species(job_type job)
+{
+    JsonNode *species(json_mkarray());
+    for (const auto sp : job_recommended_species(job))
+        json_append_element(species, json_mkstring(species_name(sp)));
+    return species;
+}
+
 static JsonNode *_job_metadata(job_type job)
 {
     JsonNode *job_json(json_mkobject());
     json_append_member(job_json, "name", json_mkstring(get_job_name(job)));
     json_append_member(job_json, "abbr", json_mkstring(get_job_abbrev(job)));
+    json_append_member(job_json, "recommended_species",
+                       _job_recommended_species(job));
     return job_json;
 }
 

--- a/crawl-ref/source/playable.cc
+++ b/crawl-ref/source/playable.cc
@@ -106,12 +106,12 @@ static JsonNode *_species_metadata(species_type sp,
                                    species_type derives = SP_UNKNOWN)
 {
     JsonNode *species(json_mkobject());
-    json_append_member(species, "name", json_mkstring(species_name(sp).c_str()));
+    json_append_member(species, "name", json_mkstring(species_name(sp)));
     json_append_member(species, "abbr", json_mkstring(get_species_abbrev(sp)));
     if (derives != SP_UNKNOWN)
     {
         json_append_member(species, "derives",
-                           json_mkstring(species_name(derives).c_str()));
+                           json_mkstring(species_name(derives)));
     }
     json_append_member(species, "apts", _species_apts(sp));
     json_append_member(species, "modifiers", _species_modifiers(sp));
@@ -162,7 +162,7 @@ static JsonNode *_combo_array()
 {
     JsonNode *array(json_mkarray());
     for (const string &combo_abbr : playable_combo_names())
-        json_append_element(array, json_mkstring(combo_abbr.c_str()));
+        json_append_element(array, json_mkstring(combo_abbr));
     return array;
 }
 


### PR DESCRIPTION
Dump basic branch information as JSON.

The key use of this is knowing how to refer to branches when talking
about morgues. Depending on the branch, you might describe a place in
the following ways:

* the Temple
* a Sewer
* an Ice Cave
* Pandemonium
* level 1 of the Dungeon
* level 1 of the Depths
* level 1 of a Ziggurat

Without this data being accessible, figuring out the above
programatically required a hardcoded lookup table, which is duplicated
work and bitrots over time as the Dungeon's layout changes.

---

Also, put recommended jobs/species in `-playable-json` output.