### PR TITLE
Fix yellow draconians' rAcid mutation not being applied (malacante)

### DIFF
--- a/crawl-ref/source/dat/species/draconian-yellow.yaml
+++ b/crawl-ref/source/dat/species/draconian-yellow.yaml
@@ -31,6 +31,7 @@ levelup_stat_frequency: 4
 mutations:
   1:
     MUT_COLD_BLOODED: 1
+  7:
     MUT_ACID_RESISTANCE: 1
   14:
     MUT_ACIDIC_BITE: 1


### PR DESCRIPTION
This apparently needs to be set at XL 7 not XL 1.