### PR TITLE
Run GDB from /usr/local/bin on OSX

### DIFF
--- a/crawl-ref/source/AppHdr.h
+++ b/crawl-ref/source/AppHdr.h
@@ -191,6 +191,13 @@ static inline double pow(int x, double y) { return std::pow((double)x, y); }
 # define IMMUTABLE
 #endif
 
+// /usr/bin is not writable on OSX 10.11+ due to System Integrity Protection
+#ifdef TARGET_OS_MACOSX
+# define GDB_PATH "/usr/local/bin/gdb"
+#else
+# define GDB_PATH "/usr/bin/gdb"
+#endif
+
 
 // =========================================================================
 //  Defines for dgamelaunch-specific things.

--- a/crawl-ref/source/crash.cc
+++ b/crawl-ref/source/crash.cc
@@ -425,7 +425,7 @@ void call_gdb(FILE *file)
                 "-ex", "bt full",
                 0
             };
-            execv("/usr/bin/gdb", (char* const*)argv);
+            execv(GDB_PATH, (char* const*)argv);
             printf("Failed to start gdb: %s\n", strerror(errno));
             fflush(stdout);
             _exit(0);

--- a/crawl-ref/source/state.cc
+++ b/crawl-ref/source/state.cc
@@ -68,7 +68,7 @@ game_state::game_state()
 #ifdef TARGET_OS_WINDOWS
     no_gdb = "Non-UNIX Platform -> not running gdb.";
 #else
-    no_gdb = access("/usr/bin/gdb", 1) ? "/usr/bin/gdb not executable." : 0;
+    no_gdb = access(GDB_PATH, 1) ? "gdb not executable." : 0;
 #endif
 }
 


### PR DESCRIPTION
/usr/bin is no longer writable on OSX 10.11+ due to System Integrity Protection