### PR TITLE
Support profile-guided optimisation (PGO)

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -65,6 +65,14 @@
 #    ANDROID       -- perform an Android build (see docs/develop/android.txt)
 #    TOUCH_UI      -- enable UI behaviour more compatible with touch-screens
 #
+# Profile Guided Optimisation parameters:
+#
+# To generate a PGO build, you should probably use util/build-pgo.sh.
+# (Note: PGO support has only been tested with OSX built-in Clang.)
+#
+#    PGO_GENERATE  -- set to build PGO instrumentation.
+#    PGO_USE       -- set to build with PGO data.
+#
 #
 # Requirements:
 #    For tile builds, you need pkg-config.
@@ -501,12 +509,7 @@ ifdef HURRY
 NO_AUTO_OPT = YesPlease
 endif
 
-ifdef AUTO_OPT
-ifndef NO_AUTO_OPT
-CFOPTIMIZE += -march=native
-endif
-endif
-
+# Set base compiler optimisation flags
 ifdef USE_ICC
 # If you have a Core 2 processor, this _really_ makes things fly:
 #CFOPTIMIZE := -O2 -parallel -xT
@@ -526,6 +529,21 @@ else
   else
     CFOPTIMIZE := -O2
   endif
+endif
+
+ifdef AUTO_OPT
+ifndef NO_AUTO_OPT
+CFOPTIMIZE += -march=native
+endif
+endif
+
+ifdef PGO_GENERATE
+	CFOPTIMIZE_L += -fprofile-instr-generate
+	LDFLAGS += -fprofile-instr-generate
+endif
+
+ifdef PGO_USE
+	CFOPTIMIZE_L += -fprofile-instr-use=$(PGO_USE)
 endif
 
 ifdef LTO

--- a/crawl-ref/source/util/pgo-build.sh
+++ b/crawl-ref/source/util/pgo-build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+if [[ $(uname) != Darwin ]] ; then
+    echo "error: This script only works on OSX for now." >&2
+    exit 1
+fi
+
+NPROC=$(sysctl -n hw.ncpu)
+QW_RC="../../../qw/qw.rc" # separate checkout
+QW_START_SEED=1 # What seed should qw start at. Use $RANDOM
+QW_NUM_RUNS=1 # How many runs should qw complete
+CLEANUP_TEMP_DIRS="true" # "" disables cleanup, anything else enables it
+
+######################
+# Make sure we're running niced
+renice -n 10 $$
+
+######################
+echo '=> Build the instrumented binary'
+make -j "$NPROC" PGO_GENERATE=y
+
+######################
+echo '=> Generate some profile data'
+
+CRAWL_TEMP_DIR=$(mktemp -d)
+LLVM_TEMP_DIR=$(mktemp -d)
+
+function cleanup() {
+  echo '=> Cleaning up temporary directories'
+  rm -rf "$CRAWL_TEMP_DIR"
+  rm -rf "$LLVM_TEMP_DIR"
+}
+if [[ -n $CLEANUP_TEMP_DIRS ]] ; then
+  trap cleanup EXIT
+fi
+
+export LLVM_PROFILE_FILE="$LLVM_TEMP_DIR/%m-%p.profraw"
+
+echo '===> qw'
+# TODO parallel processes
+# This doesn't work though, the crawl processes hang when qw dies
+# seq $START_SEED $((START_SEED+10)) | LLVM_PROFILE_FILE="%m-%p.profraw" xargs -t -P$NPROC -n 1 -I {} script -qr qw{}.ttyrec ./crawl -rc "$QW_RC" -seed {} -name qw{} >/dev/null
+for i in $(seq 1 "$QW_NUM_RUNS") ; do
+  seed=$((QW_START_SEED + i - 1))
+  echo "=====> run $i/$QW_NUM_RUNS"
+  time script -qr /dev/null ./crawl -rc "$QW_RC" -seed "$seed" >/dev/null
+done
+
+echo '===> stress tests (to be implemented)'
+
+######################
+echo '=> Process raw profile data'
+PROFDATA_PATH="$LLVM_TEMP_DIR/crawl.profdata"
+llvm-profdata merge -output="$PROFDATA_PATH" "$LLVM_TEMP_DIR"/*.profraw
+
+######################
+echo '=> Build the PGO-optimised binary'
+CCACHE_DISABLE=1 make -j "$NPROC" "PGO_USE=$PROFDATA_PATH"
+
+######################
+if [[ -n $CLEANUP_TEMP_DIRS ]] ; then
+  cleanup
+  trap - EXIT
+fi


### PR DESCRIPTION
PGO produces (slightly) faster binaries. In the best case I've been able
to benchmark (re-running an idential short qw run) with and without PGO,
there is a 8% benefit. Real world benefit is likely to be much smaller,
of course.

TODO:
* Support GCC PGO
* Support Linux
* Use a broader test corpus, and run tests in parallel
* Improve the interface for creating a PGO build (currently it's a shell
  script, but could this be folded back into a Makefile target...?)