### PR TITLE
Merge Piercer into the storm bow

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -539,6 +539,7 @@ BRAND:    SPWPN_VORPAL
 BOOL:     seeinv
 INSCRIP:  Acc+∞
 
+# TAG_MAJOR_VERSION == 34
 NAME:    longbow "Piercer"
 OBJ:     OBJ_WEAPONS/WPN_LONGBOW
 PLUS:    +7
@@ -547,6 +548,7 @@ TILE:    urand_piercer
 TILE_EQ: great_bow
 BRAND:   SPWPN_PENETRATION
 EV:      -2
+BOOL:    nogen
 
 # TAG_MAJOR_VERSION == 34
 ENUM:    BLOWGUN_ASSASSIN
@@ -654,6 +656,7 @@ COLOUR:   BLUE
 TILE:     urand_storm_bow
 TILE_EQ:  storm_bow
 BRAND:    SPWPN_ELECTROCUTION
+INSCRIP:  penet
 
 NAME:    large shield of Ignorance
 OBJ:     OBJ_ARMOUR/ARM_LARGE_SHIELD

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -281,12 +281,8 @@ relieve opponents of their weapons, dealing extra damage in the process.
 %%%%
 storm bow
 
-A longbow with the colour of dark rain clouds.
-{{
-    if you.can_smell() then
-        return "It smells like a storm just past, or one about to begin."
-    end
-}}
+A longbow with the colour of dark rain clouds that fires arrows like
+lightning.
 %%%%
 large shield of Ignorance
 

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <sstream>
 
+#include "art-enum.h"
 #include "artefact.h"
 #include "chardump.h"
 #include "command.h"
@@ -60,7 +61,8 @@ bool is_penetrating_attack(const actor& attacker, const item_def* weapon,
             && get_ammo_brand(projectile) == SPMSL_PENETRATION
            || weapon
               && is_launched(&attacker, weapon, projectile) == launch_retval::LAUNCHED
-              && get_weapon_brand(*weapon) == SPWPN_PENETRATION;
+              && (get_weapon_brand(*weapon) == SPWPN_PENETRATION
+                  || is_unrandom_artefact(*weapon, UNRAND_STORM_BOW));
 }
 
 bool item_is_quivered(const item_def &item)


### PR DESCRIPTION
The storm bow is functionally the same as a +8 elec longbow; fairly
strong, but unremarkable. Piercer is a little better since it's a bow
user's only way to get a penetration weapon, but that's still not too
special.

Adding a penetration effect to the storm bow makes it much more
exciting, fits the electric/lightning theme, and puts it almost on par
with the other unrand bow Zephyr. This also makes Piercer obsolete.