### PR TITLE
Let barachim use grand finale at range 8 (11917)

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -6674,7 +6674,7 @@ spret uskayaw_grand_finale(bool fail)
         args.needs_path = false;
         args.top_prompt = "Aiming: <white>Grand Finale</white>";
         args.self = CONFIRM_CANCEL;
-        targeter_smite tgt(&you, 7, 0, 0);
+        targeter_smite tgt(&you);
         args.hitfunc = &tgt;
         direction(beam, args);
         if (crawl_state.seen_hups)


### PR DESCRIPTION
The range of grand finale was hardcoded as 7 rather than using
LOS_RADIUS, so when barachim were added, this wasn't updated.
This commit changes the grand finale targeter to use targeter_smite's
default parameters, which include range = LOS_RADIUS.