### PR TITLE
Improve OTR's behaviour around allies and god conducts (11181, 11913)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4189,6 +4189,20 @@ void bolt::handle_stop_attack_prompt(monster* mon)
         beam_cancelled = true;
         finish_beam();
     }
+    // Handle enslaving monsters when OTR is up: give a prompt for attempting
+    // to enslave monsters that don't have rPois with Toxic status.
+    else if (flavour == BEAM_ENSLAVE && you.duration[DUR_TOXIC_RADIANCE]
+             && mon->res_poison() <= 0)
+    {
+        string verb = make_stringf("enslave %s", mon->name(DESC_THE).c_str());
+        if (otr_stop_summoning_prompt(true, verb,
+                                      mons_genus(mon->type) == MONS_ORC))
+        {
+            beam_cancelled = true;
+            finish_beam();
+            prompted = true;
+        }
+    }
 
     if (prompted)
     {

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4195,8 +4195,7 @@ void bolt::handle_stop_attack_prompt(monster* mon)
              && mon->res_poison() <= 0)
     {
         string verb = make_stringf("enslave %s", mon->name(DESC_THE).c_str());
-        if (otr_stop_summoning_prompt(true, verb,
-                                      mons_genus(mon->type) == MONS_ORC))
+        if (otr_stop_summoning_prompt(verb))
         {
             beam_cancelled = true;
             finish_beam();

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -873,8 +873,6 @@ int mons_usable_missile(monster* mons, item_def **launcher)
     }
 }
 
-
-
 bool bad_attack(const monster *mon, string& adj, string& suffix,
                 bool& would_cause_penance, coord_def attack_pos)
 {
@@ -1070,6 +1068,42 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
 
     if (prompted)
         *prompted = true;
+
+    if (yesno(prompt.c_str(), false, 'n'))
+        return false;
+    else
+    {
+        canned_msg(MSG_OK);
+        return true;
+    }
+}
+
+/**
+ * Does the player have Olgreb's Toxic Radiance up that would/could cause
+ * a hostile summon to be created? If so, prompt the player as to whether they
+ * want to continue to create their summon. Note that this prompt is never a
+ * penance prompt, because we don't cause penance when monsters enter line of
+ * sight when OTR is active, regardless of how they entered LOS.
+ *
+ * @param always  True if the spell always creates monsters that do not resist
+ *                poison, false if the spell only creates non-rPois monsters
+ *                sometimes.
+ * @param verb    The verb to be used in the prompt. Defaults to "summon".
+ * @return        True if the player wants to abort.
+ */
+bool otr_stop_summoning_prompt(bool always, string verb)
+{
+    if (!you.duration[DUR_TOXIC_RADIANCE])
+        return false;
+
+    if (crawl_state.disables[DIS_CONFIRMATIONS])
+        return false;
+
+    if (crawl_state.which_god_acting() == GOD_XOM)
+        return false;
+
+    string prompt = make_stringf("Really %s while emitting a toxic aura?",
+                                 verb.c_str());
 
     if (yesno(prompt.c_str(), false, 'n'))
         return false;

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1085,13 +1085,10 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
  * penance prompt, because we don't cause penance when monsters enter line of
  * sight when OTR is active, regardless of how they entered LOS.
  *
- * @param always  True if the spell always creates monsters that do not resist
- *                poison, false if the spell only creates non-rPois monsters
- *                sometimes.
  * @param verb    The verb to be used in the prompt. Defaults to "summon".
  * @return        True if the player wants to abort.
  */
-bool otr_stop_summoning_prompt(bool always, string verb)
+bool otr_stop_summoning_prompt(string verb)
 {
     if (!you.duration[DUR_TOXIC_RADIANCE])
         return false;

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -73,3 +73,6 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
                         function<bool(const actor *victim)> affects = nullptr,
                         bool *prompted = nullptr,
                         const monster *mons = nullptr);
+
+bool otr_stop_summoning_prompt(bool always = true, string verb = "summon",
+                               bool orcs = false);

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -74,5 +74,4 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
                         bool *prompted = nullptr,
                         const monster *mons = nullptr);
 
-bool otr_stop_summoning_prompt(bool always = true, string verb = "summon",
-                               bool orcs = false);
+bool otr_stop_summoning_prompt(string verb = "summon");

--- a/crawl-ref/source/god-blessing.cc
+++ b/crawl-ref/source/god-blessing.cc
@@ -581,6 +581,11 @@ static void _beogh_reinf_callback(const mgen_data &mg, monster *&mon, int placed
 // you out.
 static void _beogh_blessing_reinforcements()
 {
+    // Don't gift orcs if Toxic radiance is up, to avoid the player being
+    // penanced through no fault of their own.
+    if (you.duration[DUR_TOXIC_RADIANCE])
+        return;
+
     // Possible reinforcement.
     const monster_type followers[] =
     {

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2617,7 +2617,8 @@ spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
         else
             mpr("Your toxic radiance grows in intensity.");
 
-        you.increase_duration(DUR_TOXIC_RADIANCE, 3 + random2(pow/20), 15);
+        you.increase_duration(DUR_TOXIC_RADIANCE, 2 + random2(pow/20), 15);
+        toxic_radiance_effect(&you, 1, true);
 
         flash_view_delay(UA_PLAYER, GREEN, 300, &hitfunc);
 
@@ -2643,7 +2644,8 @@ spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
                                " begins to radiate toxic energy.");
 
         mon_agent->add_ench(mon_enchant(ENCH_TOXIC_RADIANCE, 1, mon_agent,
-                                        (5 + random2avg(pow/15, 2)) * BASELINE_DELAY));
+                                        (4 + random2avg(pow/15, 2)) * BASELINE_DELAY));
+        toxic_radiance_effect(agent, 1);
 
         targeter_los hitfunc(mon_agent, LOS_NO_TRANS);
         flash_view_delay(UA_MONSTER, GREEN, 300, &hitfunc);
@@ -2652,7 +2654,20 @@ spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
     }
 }
 
-void toxic_radiance_effect(actor* agent, int mult)
+/*
+ * Attempt to poison all monsters in line of sight of the caster.
+ *
+ * @param agent   The caster.
+ * @param mult    A number to multiply the damage by.
+ *                This is the time taken for the player's action in turns,
+ *                or 1 if the spell was cast this turn.
+ * @param on_cast Whether the spell was cast this turn. This only matters
+ *                if the player cast the spell. If true, we trigger conducts
+ *                if the player hurts allies; if false, we don't, to avoid
+ *                the player being accidentally put under penance.
+ *                Defaults to false.
+ */
+void toxic_radiance_effect(actor* agent, int mult, bool on_cast)
 {
     int pow;
     if (agent->is_player())
@@ -2689,7 +2704,20 @@ void toxic_radiance_effect(actor* agent, int mult)
         }
         else
         {
+            // We need to deal with conducts before damaging the monster,
+            // because otherwise friendly monsters that are one-shot won't
+            // trigger conducts. Only trigger conducts on the turn the player
+            // casts the spell (see PR #999).
+            if (on_cast && agent->is_player())
+            {
+                god_conduct_trigger conducts[3];
+                set_attack_conducts(conducts, *ai->as_monster());
+                if (is_sanctuary(ai->pos()))
+                    break_sanctuary = true;
+            }
+
             ai->hurt(agent, dam, BEAM_POISON);
+
             if (ai->alive())
             {
                 behaviour_event(ai->as_monster(), ME_ANNOY, agent,
@@ -2697,9 +2725,6 @@ void toxic_radiance_effect(actor* agent, int mult)
                 if (coinflip() || !ai->as_monster()->has_ench(ENCH_POISON))
                     poison_monster(ai->as_monster(), agent, 1);
             }
-
-            if (agent->is_player() && is_sanctuary(ai->pos()))
-                break_sanctuary = true;
         }
     }
 

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -57,7 +57,7 @@ spret cast_dazzling_spray(int pow, coord_def aim, bool fail);
 
 spret cast_toxic_radiance(actor *caster, int pow, bool fail = false,
                                bool mon_tracer = false);
-void toxic_radiance_effect(actor* agent, int mult);
+void toxic_radiance_effect(actor* agent, int mult, bool on_cast = false);
 
 spret cast_searing_ray(int pow, bolt &beam, bool fail);
 void handle_searing_ray();

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -92,6 +92,9 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
 
 spret cast_summon_butterflies(int pow, god_type god, bool fail)
 {
+    if (otr_stop_summoning_prompt())
+        return spret::abort;
+
     fail_check();
     bool success = false;
 
@@ -114,6 +117,9 @@ spret cast_summon_butterflies(int pow, god_type god, bool fail)
 
 spret cast_summon_small_mammal(int pow, god_type god, bool fail)
 {
+    if (otr_stop_summoning_prompt())
+        return spret::abort;
+
     fail_check();
 
     monster_type mon = MONS_PROGRAM_BUG;
@@ -157,6 +163,10 @@ spret cast_sticks_to_snakes(int pow, god_type god, bool fail)
         mpr("You don't have anything to turn into a snake.");
         return spret::abort;
     }
+
+    if (otr_stop_summoning_prompt(false, "create snakes"))
+        return spret::abort;
+
     // Sort by the quantity if the player has no bow skill; this will
     // put arrows with the smallest quantity first in line
     // If the player has bow skill, we will already have plain arrows
@@ -227,6 +237,9 @@ spret cast_sticks_to_snakes(int pow, god_type god, bool fail)
 
 spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 {
+    if (otr_stop_summoning_prompt(false))
+        return spret::abort;
+
     fail_check();
     monster_type mon = MONS_PROGRAM_BUG;
 
@@ -266,6 +279,9 @@ spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 
 spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 {
+    if (otr_stop_summoning_prompt(false))
+        return spret::abort;
+
     fail_check();
     monster_type type = MONS_PROGRAM_BUG;
 
@@ -381,6 +397,9 @@ spret cast_dragon_call(int pow, bool fail)
         mpr("You cannot issue another dragon's call so soon.");
         return spret::abort;
     }
+
+    if (otr_stop_summoning_prompt(false, "call dragons"))
+        return spret::abort;
 
     fail_check();
 
@@ -1148,6 +1167,10 @@ bool summon_demon_type(monster_type mon, int pow, god_type god,
 
 spret cast_summon_demon(int pow, god_type god, bool fail)
 {
+    // Chaos spawn, orange demons and sixfirhies are not rPois
+    if (otr_stop_summoning_prompt(false))
+        return spret::abort;
+
     fail_check();
     mpr("You open a gate to Pandemonium!");
 
@@ -1159,6 +1182,9 @@ spret cast_summon_demon(int pow, god_type god, bool fail)
 
 spret cast_summon_greater_demon(int pow, god_type god, bool fail)
 {
+    if (otr_stop_summoning_prompt(false)) // Hell beasts are not rPois
+        return spret::abort;
+
     fail_check();
     mpr("You open a gate to Pandemonium!");
 
@@ -1171,6 +1197,13 @@ spret cast_summon_greater_demon(int pow, god_type god, bool fail)
 spret cast_shadow_creatures(int st, god_type god, level_id place,
                                  bool fail)
 {
+    bool can_summon_orcs = place.branch == BRANCH_DUNGEON
+                           || place.branch == BRANCH_BAILEY
+                           || place.branch == BRANCH_ORC
+                           || place.branch == BRANCH_VAULTS;
+    if (otr_stop_summoning_prompt(false, "summon", can_summon_orcs))
+        return spret::abort;
+
     fail_check();
     const bool scroll = (st == MON_SUMM_SCROLL);
     mpr("Wisps of shadow whirl around you...");
@@ -1409,6 +1442,9 @@ spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 
     if (success)
     {
+        if (otr_stop_summoning_prompt(true, "summon a forest"))
+            return spret::abort;
+
         fail_check();
         // Replace some rock walls with trees, then scatter a smaller number
         // of trees on unoccupied floor (such that they do not break connectivity)

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -164,7 +164,7 @@ spret cast_sticks_to_snakes(int pow, god_type god, bool fail)
         return spret::abort;
     }
 
-    if (otr_stop_summoning_prompt(false, "create snakes"))
+    if (otr_stop_summoning_prompt("create snakes"))
         return spret::abort;
 
     // Sort by the quantity if the player has no bow skill; this will
@@ -237,7 +237,7 @@ spret cast_sticks_to_snakes(int pow, god_type god, bool fail)
 
 spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 {
-    if (otr_stop_summoning_prompt(false))
+    if (otr_stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -279,7 +279,7 @@ spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 
 spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 {
-    if (otr_stop_summoning_prompt(false))
+    if (otr_stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -398,7 +398,7 @@ spret cast_dragon_call(int pow, bool fail)
         return spret::abort;
     }
 
-    if (otr_stop_summoning_prompt(false, "call dragons"))
+    if (otr_stop_summoning_prompt("call dragons"))
         return spret::abort;
 
     fail_check();
@@ -1168,7 +1168,7 @@ bool summon_demon_type(monster_type mon, int pow, god_type god,
 spret cast_summon_demon(int pow, god_type god, bool fail)
 {
     // Chaos spawn, orange demons and sixfirhies are not rPois
-    if (otr_stop_summoning_prompt(false))
+    if (otr_stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -1182,7 +1182,7 @@ spret cast_summon_demon(int pow, god_type god, bool fail)
 
 spret cast_summon_greater_demon(int pow, god_type god, bool fail)
 {
-    if (otr_stop_summoning_prompt(false)) // Hell beasts are not rPois
+    if (otr_stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -1197,11 +1197,7 @@ spret cast_summon_greater_demon(int pow, god_type god, bool fail)
 spret cast_shadow_creatures(int st, god_type god, level_id place,
                                  bool fail)
 {
-    bool can_summon_orcs = place.branch == BRANCH_DUNGEON
-                           || place.branch == BRANCH_BAILEY
-                           || place.branch == BRANCH_ORC
-                           || place.branch == BRANCH_VAULTS;
-    if (otr_stop_summoning_prompt(false, "summon", can_summon_orcs))
+    if (otr_stop_summoning_prompt("summon"))
         return spret::abort;
 
     fail_check();
@@ -1442,7 +1438,7 @@ spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail)
 
     if (success)
     {
-        if (otr_stop_summoning_prompt(true, "summon a forest"))
+        if (otr_stop_summoning_prompt("summon a forest"))
             return spret::abort;
 
         fail_check();


### PR DESCRIPTION
This pull request has now been updated to reflect the current consensus.

This pull request adds a warning for summoning non-rPois monsters while the Toxic status is active, lets OTR deal damage on the turn it is cast in addition to subsequent turns, and lets OTR trigger god conducts but only on the turn it is cast.

See the commit messages for more details, and the discussion below for what led to this solution.