### PR TITLE
Use OR instead of equal for holiness check (11909)

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1716,7 +1716,7 @@ static void _fire_kill_conducts(monster &mons, killer_type killer,
 
     mon_holy_type holiness = mons.holiness();
 
-    if (holiness == MH_DEMONIC)
+    if (holiness & MH_DEMONIC)
         did_kill_conduct(DID_KILL_DEMON, mons);
     else if (holiness & (MH_NATURAL | MH_PLANT))
     {


### PR DESCRIPTION
Fixes bug 11909

Affects hell rats because they get the MH_EVIL flag applied as well as MH_DEMONIC, the bug would also affect any demonic monster with more than one holiness flag.

Probably just overlooked in c932079a4eb94c70e47aebf39e9aad417afd7f93 back in 2014 but I didn't do a lot of digging.

Thanks!