### PR TITLE
Player ghosts aren't immune to shafts

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5601,9 +5601,8 @@ bool monster::do_shaft()
     if (!is_valid_shaft_level())
         return false;
 
-    // Tentacles & player ghosts are immune to shafting
-    if (mons_is_tentacle_or_tentacle_segment(type)
-        || type == MONS_PLAYER_GHOST)
+    // Tentacles are immune to shafting
+    if (mons_is_tentacle_or_tentacle_segment(type))
     {
         return false;
     }


### PR DESCRIPTION
This is an artifact from when player ghosts were totally unable to leave the floor they started on by any means. Now that they don't have this trait, and don't broadcast it in their descriptions, there isn't any reason for them to be special-case immune to shafts, or for them to destroy shafts uselessly on moving over them.