### PR TITLE
Fix cut-off ability cost description for Sac Purity (11893)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3220,9 +3220,9 @@ int choose_ability_menu(const vector<talent>& talents)
         // Hack like the one in spl-cast.cc:list_spells() to align the title.
         ToggleableMenuEntry* me =
             new ToggleableMenuEntry("Ability - do what?                  "
-                                    "Cost                          Failure",
+                                    "Cost                            Failure",
                                     "Ability - describe what?            "
-                                    "Cost                          Failure",
+                                    "Cost                            Failure",
                                     MEL_ITEM);
         me->colour = BLUE;
         abil_menu.set_title(me, true, true);
@@ -3230,9 +3230,9 @@ int choose_ability_menu(const vector<talent>& talents)
 #else
     abil_menu.set_title(
         new ToggleableMenuEntry("Ability - do what?                  "
-                                "Cost                          Failure",
+                                "Cost                            Failure",
                                 "Ability - describe what?            "
-                                "Cost                          Failure",
+                                "Cost                            Failure",
                                 MEL_TITLE), true, true);
 #endif
     abil_menu.set_tag("ability");
@@ -3355,7 +3355,7 @@ string describe_talent(const talent& tal)
     ostringstream desc;
     desc << left
          << chop_string(ability_name(tal.which), 32)
-         << chop_string(make_cost_description(tal.which), 30)
+         << chop_string(make_cost_description(tal.which), 32)
          << chop_string(failure, 12);
     return trimmed_string(desc.str());
 }


### PR DESCRIPTION
When the Sacrifice Purity ability was granted to the player with the
inhibited regeneration mutation, the ability's cost description is
  Purity (inhibited regeneration)
which is 31 characters, however the cost string is only allocated 30
characters, so the last parenthesis was being cut off.

Hence, extend the string length for the ability cost description to 32
characters, and adjust the ability screen's title line accordingly.

I am fairly confident inhibited regeneration is the longest of all the ability cost descriptions. If anyone finds one longer, please tell me.