### PR TITLE
Start new wanderers with weapon in slot 'a'

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -545,6 +545,9 @@ static void _setup_generic(const newgame_def& ng)
         item_colour(item);  // set correct special and colour
     }
 
+    if (you.equip[EQ_WEAPON] > 0)
+        swap_inv_slots(0, you.equip[EQ_WEAPON], false);
+
     // A second pass to apply the item_slot option.
     for (auto &item : you.inv)
     {


### PR DESCRIPTION
After this commit, all new characters who start with a weapon wielded
will find that weapon in slot 'a'. This was already true for all
backgrounds except wanderer.