### PR TITLE
Webserver: Enhance lobby_remove message

### DIFF
--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -40,7 +40,10 @@ def update_all_lobbys(game):
 def remove_in_lobbys(process):
     for socket in list(sockets):
         if socket.is_in_lobby():
-            socket.send_message("lobby_remove", id=process.id)
+            socket.send_message("lobby_remove", id=process.id,
+                                reason=process.exit_reason,
+                                message=process.exit_message,
+                                dump=process.exit_dump_url)
 
 
 def write_dgl_status_file():


### PR DESCRIPTION
Hi, iam currently writing https://github.com/syranez/dcss-lobby which connects to a dcss server and listens to lobby-messages. dcss-lobby parses the messages and gives them in an edited form for further processing. The lobby_remove message does not give any information, why some player got removed from the lobby, thus:

The lobby_remove message contains now additionaly this three attributes:

* reason: the players cause for exiting the game ("saved", "bailed out", "dead")
* message: exit message if the reason is not "saved". Otherwise it is
null.
* dump: contains an url to the final morgue file or player morgue
directory if game is not finished yet.