### PR TITLE
Add a menu shortcut to select last unequipped item

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -2644,7 +2644,7 @@ will deselect it (except for ',' and '-', obviously).
 &amp;
   Select all carrion and inedible food.
 
-\+ or :
+:
   Select all books.
 
 /

--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -737,6 +737,10 @@ In order to get a description of what an item does, bring up the inventory (with
 of armours and weapons, but don't expect too much information from examining
 unidentified items.
 
+In most equipment-related prompts and menus, the ';' key is a shortcut for
+"last unequipped item," meaning the armour, jewellery or weapon you most
+recently took off or unwielded.
+
 Another useful command is the '{' key, which lets you inscribe items with a
 comment. You can also inscribe items when looking at your inventory with 'i',
 simply by pressing the letter of an item. For more details, and how to automate
@@ -2675,6 +2679,10 @@ will deselect it (except for ',' and '-', obviously).
   Selects next item. (If you have pressed the key of an item in the list, '.'
   will toggle the next item. This can be repeated, quickly selecting several
   subsequent items).
+
+;
+  Select last unequipped. Selects the equipment (armour, jewellery, or weapon)
+  you last took off or unwielded.
 
 Level map ('X')
 ========================================

--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -239,4 +239,6 @@ void swap_inv_slots(int from_slot, int to_slot, bool verbose)
         if (to_count > 0)
             last_pickup[from_slot] = to_count;
     }
+    if (you.last_unequip == from_slot)
+        you.last_unequip = to_slot;
 }

--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -22,8 +22,9 @@ You can quickly select items by type by pressing:
 <w>/</w>   wands        <w>|</w>   magical staves <w>?</w>   scrolls         <w>:</w>   books
 <w>"</w>   amulets      <w>=</w>   rings          <w>}</w>   miscellaneous   <w>%</w>   food
 Global selects:  <w>,</w>   select all     <w>*</w>   invert all      <w>-</w>   deselect all
+                 <w>;</w>   select last unequipped
 Note that for dropping, the <w>,</w> command uses the <w>drop_filter</w> option, which
-narrows the range of items to be (de)selected. The default are useless items.
+narrows the range of items to be (de)selected. The default is to select useless items.
 %%%%
 known-menu
 

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -351,9 +351,14 @@ void InvMenu::set_title(const string &s)
 
 int InvMenu::pre_process(int key)
 {
-    if (type == menu_type::drop || type == menu_type::invlist)
-        if (key == ';' && you.last_unequip != -1)
-            key = index_to_letter(you.last_unequip);
+    if (key == '-' && minus_is_pageup())
+        key = CK_PGUP;
+    else if (key == ';'
+             && you.last_unequip != -1
+             && (type == menu_type::drop || type == menu_type::invlist))
+    {
+        key = index_to_letter(you.last_unequip);
+    }
     return key;
 }
 
@@ -1888,12 +1893,15 @@ int prompt_invent_item(const char *prompt,
             // The "view inventory listing" mode.
             vector< SelItem > items;
             current_type_expected = keyin == '*' ? OSEL_ANY : type_expect;
+            int mflags = MF_SINGLESELECT | MF_ANYPRINTABLE | MF_NO_SELECT_QTY;
+            if (other_valid_char == '-')
+                mflags |= MF_SPECIAL_MINUS;
             keyin = _invent_select(
                         prompt,
                         mtype,
                         current_type_expected,
                         -1,
-                        MF_SINGLESELECT | MF_ANYPRINTABLE | MF_NO_SELECT_QTY,
+                        mflags,
                         nullptr,
                         &items);
 

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -349,6 +349,14 @@ void InvMenu::set_title(const string &s)
                            title_annotate));
 }
 
+int InvMenu::pre_process(int key)
+{
+    if (type == menu_type::drop || type == menu_type::invlist)
+        if (key == ';' && you.last_unequip != -1)
+            key = index_to_letter(you.last_unequip);
+    return key;
+}
+
 static bool _has_melded_armour()
 {
     for (int e = EQ_CLOAK; e <= EQ_BODY_ARMOUR; e++)
@@ -1357,6 +1365,11 @@ vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
             else
                 break;
         }
+        else if (keyin == ';')
+        {
+            ret = you.last_unequip;
+            break;
+        }
         else if (!isspace(keyin))
         {
             // We've got a character we don't understand...
@@ -1942,6 +1955,11 @@ int prompt_invent_item(const char *prompt,
             }
             else if (!do_warning || check_warning_inscriptions(you.inv[ret], oper))
                 break;
+        }
+        else if (keyin == ';')
+        {
+            ret = you.last_unequip;
+            break;
         }
         else if (!isspace(keyin))
         {

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -196,6 +196,7 @@ public:
 
 protected:
     void do_preselect(InvEntry *ie);
+    int pre_process(int key) override;
     virtual bool is_selectable(int index) const override;
     virtual string help_key() const override;
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2629,6 +2629,8 @@ bool drop_item(int item_dropped, int quant_drop)
     you.turn_is_over = true;
 
     you.last_pickup.erase(item_dropped);
+    if (you.last_unequip == item.link)
+        you.last_unequip = -1;
 
     return true;
 }

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -1194,7 +1194,7 @@ bool Menu::process_key(int keyin)
         if (!page_down() && is_set(MF_WRAP))
             m_ui.scroller->set_scroll(0);
         break;
-    case CK_PGUP: case '<': case ';':
+    case CK_PGUP: case '<':
         page_up();
         break;
     case CK_UP:

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -912,6 +912,11 @@ void Menu::set_flags(int new_flags, bool use_options)
 #endif
 }
 
+bool Menu::minus_is_pageup() const
+{
+    return !is_set(MF_MULTISELECT) && !is_set(MF_SPECIAL_MINUS);
+}
+
 void Menu::set_more(const formatted_string &fs)
 {
     m_keyhelp_more = false;
@@ -922,9 +927,10 @@ void Menu::set_more(const formatted_string &fs)
 void Menu::set_more()
 {
     m_keyhelp_more = true;
+    string pageup_keys = minus_is_pageup() ? "<w>-</w>|<w><<</w>" : "<w><<</w>";
     more = formatted_string::parse_string(
         "<lightgrey>[<w>+</w>|<w>></w>|<w>Space</w>]: page down        "
-        "[<w>-</w>|<w><<</w>]: page up        "
+        "[" + pageup_keys + "]: page up        "
         "[<w>Esc</w>]: close        [<w>XXX</w>]</lightgrey>"
     );
     update_more();
@@ -1188,7 +1194,7 @@ bool Menu::process_key(int keyin)
         sel.clear();
         lastch = keyin;
         return is_set(MF_UNCANCEL) && !crawl_state.seen_hups;
-    case ' ': case CK_PGDN: case '>':
+    case ' ': case CK_PGDN: case '>': case '+':
     case CK_MOUSE_B1:
     case CK_MOUSE_CLICK:
         if (!page_down() && is_set(MF_WRAP))

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -274,6 +274,7 @@ enum MenuFlag
 
     MF_USE_TWO_COLUMNS  = 0x08000,   ///< Only valid for tiles menus
     MF_UNCANCEL         = 0x10000,   ///< Menu is uncancellable
+    MF_SPECIAL_MINUS    = 0x20000,   ///< '-' isn't PGUP or clear multiselect
 };
 
 class UIMenu;
@@ -308,6 +309,7 @@ public:
     virtual bool is_set(int flag) const;
     void set_tag(const string& t) { tag = t; }
 
+    bool minus_is_pageup() const;
     // Sets a replacement for the default -more- string.
     void set_more(const formatted_string &more);
     // Shows a stock message about scrolling the menu instead of -more-

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -83,6 +83,7 @@ bool unequip_item(equipment_type slot, bool msg)
         else
             you.melded.set(slot, false);
         ash_check_bondage();
+        you.last_unequip = item_slot;
         return true;
     }
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5090,6 +5090,7 @@ player::player()
     equip.init(-1);
     melded.reset();
     unrand_reacts.reset();
+    last_unequip = -1;
 
     symbol          = MONS_PLAYER;
     form            = transformation::none;

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -396,7 +396,7 @@ public:
     // The last spell cast by the player.
     spell_type last_cast_spell;
     map<int,int> last_pickup;
-
+    int last_unequip;
 
     // ---------------------------
     // Volatile (same-turn) state:


### PR DESCRIPTION
In equipment-related menus and prompts, make ';' (semicolon) an alias
for the letter of the player's most recently unequipped item. The goal
of this change is to reduce the amount of time the player spends
scanning through menus to remember which item is where. Examples:

* Wear-IDing a good cloak ('f') and dropping your old one: Wfd;<Enter>
* Wear-IDing a bad cloak ('f') and re-equipping the old: WfW;d;<Enter>
* Swapping to a utility ring ('g') for a certain enemy, then going back
to your usual ring: Pg<P;<

In those examples, we saved a little mental effort by not having to keep
track of the location in inventory of the old cloak and ring.

Notes/possible issues:

The semicolon key is losing existing, though undocumented, behavior as
one of several ways send a page-up key (besides '<', PGUP itself, and
inconsistently '-').

The fact that this alias is usable on the (d)rop menu is documented both
in crawl_manual.txt and on the d_ help screen, but for i, w, W, and P
it's manual-only. (Those other help screens don't yet exist.)