### PR TITLE
Reduce troll starting mutations

### DIFF
--- a/crawl-ref/source/dat/species/troll.yaml
+++ b/crawl-ref/source/dat/species/troll.yaml
@@ -48,12 +48,18 @@ levelup_stats:
   - str
 mutations:
   1:
-    MUT_TOUGH_SKIN: 3
     MUT_REGENERATION: 1
-    MUT_CLAWS: 3
+    MUT_CLAWS: 2
     MUT_GOURMAND: 1
-    MUT_FAST_METABOLISM: 3
+    MUT_FAST_METABOLISM: 2
     MUT_SHAGGY_FUR: 1
+    MUT_TOUGH_SKIN: 1
+  9:
+    MUT_TOUGH_SKIN: 1
+    MUT_CLAWS: 1
+  14:
+    MUT_TOUGH_SKIN: 1
+    MUT_FAST_METABOLISM: 1
 recommended_jobs:
   - JOB_FIGHTER
   - JOB_MONK


### PR DESCRIPTION
Old: 3 levels of claws, tough skin and fast metabolism at XL 1.

New:
```
XL      1   9  14
======+===+===+==
Claws | 2 | 3 |
Skin  | 1 | 2 | 3
Metab | 2 |   | 3
```

Even with these mutations coming later, trolls still have (and should
have) a very strong early game. However, it's hopefully a reduction from
nigh-invincible to something with at least a little uncertainty.

Claws upgrade to XL9 rather than later so there's no possibility of
avoiding XP to deal with hydrae.