### PR TITLE
Fix CMD_MAP_UNFORGET in colemak keybindings

### DIFF
--- a/crawl-ref/settings/colemak_command_keys.txt
+++ b/crawl-ref/settings/colemak_command_keys.txt
@@ -63,6 +63,9 @@ bindkey = [U] CMD_MAP_FIND_EXCLUDED
 bindkey = [^U] CMD_TOGGLE_TRAVEL_SPEED
 bindkey = [^U] CMD_MAP_CLEAR_EXCLUDES
 
+# fix overwrite on ^U
+bindkey = [F] CMD_MAP_UNFORGET
+
 # replace (i) with (y)
 bindkey = [y] CMD_DISPLAY_INVENTORY
 bindkey = [Y] CMD_DISPLAY_SPELLS


### PR DESCRIPTION
CMD_MAP_UNFORGET is overwritten in colemak_command_keys.txt
I propose setting it to F since it is similar to CMD_MAP_FORGET [^F]