### PR TITLE
Let formicids dig statues (Yermak)

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -592,12 +592,8 @@ void move_player_action(coord_def move)
             you.digging = false;
             canned_msg(MSG_TOO_HUNGRY);
         }
-        else if (grd(targ) == DNGN_ROCK_WALL
-                 || grd(targ) == DNGN_CLEAR_ROCK_WALL
-                 || grd(targ) == DNGN_GRATE)
-        {
+        else if (feat_is_diggable(grd(targ)))
             targ_pass = true;
-        }
         else // moving or attacking ends dig
         {
             you.digging = false;


### PR DESCRIPTION
Previously, the types of walls that formicids could dig was hardcoded in
move_player_action. This commit changes the check to use the function
feat_is_diggable, the same check that is used for digging wands, to make
formicid digging exactly equivalent to the wand form.