### PR TITLE
Don't place shafts in ebering_ghost_disaster_area (11926)

### DIFF
--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -256,14 +256,9 @@ ENDMAP
 NAME:   ebering_vaults_ghost_disaster_area
 TAGS:   vaults_orient_s
 KMONS:  O = player ghost
-NSUBST: ' = d / e / 8=wWlr / .
+NSUBST: ' = d / e / 8=wWl / .
 : lone_ghost_guarded_loot(_G, "O")
 : lone_ghost_extra_loot(_G, ".")
-: if you.depth() < dgn.br_depth(you.branch()) then
-KFEAT:  r = known shaft trap
-: else
-SUBST:  r = wWl
-: end
 SUBST:  P = GTV
 : vaults_ghost_setup(_G)
 MAP

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -451,14 +451,9 @@ ENDMAP
 NAME:   ebering_ghost_disaster_area
 ORIENT: float
 KMONS:  O = player ghost
-NSUBST: ' = d / e / 8=wWlr / -
+NSUBST: ' = d / e / 8=wWl / -
 : lone_ghost_guarded_loot(_G, "O")
 : lone_ghost_extra_loot(_G, "-")
-: if you.depth() < dgn.br_depth(you.branch()) then
-KFEAT:  r = known shaft trap
-: else
-SUBST:  r = wWl
-: end
 SUBST: P = GTV
 : ghost_setup(_G)
 MAP


### PR DESCRIPTION
This commit prevents the vaults ebering_ghost_disaster_area and
ebering_vaults_ghost_disaster_area from placing shaft traps, instead
placing only water and lava tiles, implementing option 2 in 11926.
This change is to prevent ghosts in these vaults from being shafted
immediately when they enter line of sight of the player, before the
player can do anything to stop this.

These vaults were introduced by commits bb431e2 and a6a7277
respectively, and appear to have been introduced with the idea that
ghosts cannot be shafted. Ghosts can now be shafted, as of 8c2e593, and
this means that these vaults in particular could cause ghosts to be
shafted to lower floors, leaving behind an empty (or mostly empty) ghost
vault for the player to raid, and allowing the ghost to be encountered
outside of its vault on a lower floor, with the player then unable to
choose whether to fight the ghost.

I suggested three other courses of action in 11926: revert 8c2e593, remove these vaults altogether, and come up with some special-cased solution to prevent these ghosts being shafted. I came to the conclusion that the option to remove the shafts from these vaults was the most appropriate solution, and hence I have implemented it in this PR. If you prefer another option, I am happy to implement that instead, with the exception of option 4.