### PR TITLE
Don't ignore autopickup settings after autobutcher

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -3214,10 +3214,8 @@ static void _do_autopickup()
                 if (you_are_delayed() && current_delay()->want_autoeat())
                     butchery(&mi);
                 else
-                {
                     o = next;
-                    continue;
-                }
+                continue;
             }
 
             // Do this before it's picked up, otherwise the picked up


### PR DESCRIPTION
Food generated by autobutchery was being allowed to re-use the item_needs_autopickup result from back when it was a corpse. Force it to be re-checked after creation instead.