### PR TITLE
Add new message for re-corroding a corroded foe

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4348,9 +4348,10 @@ bool monster::corrode_equipment(const char* corrosion_source, int degree)
 
     if (you.see_cell(pos()))
     {
-        mprf("%s corrodes %s!",
-             corrosion_source,
-             name(DESC_THE).c_str());
+        if (!has_ench(ENCH_CORROSION))
+            mprf("%s corrodes %s!", corrosion_source, name(DESC_THE).c_str());
+        else
+            mprf("%s seems to be corroded for longer.", name(DESC_THE).c_str());
     }
 
     add_ench(mon_enchant(ENCH_CORROSION, 0));


### PR DESCRIPTION
When reapplying ENCH_CORROSION on a monster, make it clearer in the printed message that it's just a duration increase and not a stacking effect.

Old: zap wand of acid -> The acid corrodes the death yak! -> zap -> The acid corrodes the death yak!

New: zap wand of acid -> The acid corrodes the death yak! -> zap -> The death yak seems to be corroded for longer.