### PR TITLE
Don't try to generate any removed branches in mapstat

### DIFF
--- a/crawl-ref/source/dbg-maps.cc
+++ b/crawl-ref/source/dbg-maps.cc
@@ -190,7 +190,7 @@ static void _dungeon_places()
             continue;
 #if TAG_MAJOR_VERSION == 34
         // Don't want to include branches that no longer generate.
-        if (it->id == BRANCH_FOREST || it->id == BRANCH_LABYRINTH)
+        if (branch_is_unfinished(it->id))
             continue;
 #endif
 


### PR DESCRIPTION
As a followup to 17bec22d, this commit prevents mapstat from generating
the other removed branches: the Dwarven Hall and Hall of Blades.

It affects only the latter though, because the Dwarven Hall doesn't have
any maps and cannot be generated anyway.

Before this change, the Hall of Blade's info could be found between the Vaults:5's and Crypt:1's data in mapstat.log.