### PR TITLE
Autopickup usability improvements

### DIFF
--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -52,7 +52,7 @@ void adjust_item(int from_slot)
     if (from_slot == -1)
     {
         from_slot = prompt_invent_item("Adjust which item?",
-                                       menu_type::invlist, -1);
+                                       menu_type::invlist, OSEL_ANY);
         if (prompt_failed(from_slot))
             return;
 
@@ -61,7 +61,7 @@ void adjust_item(int from_slot)
 
     const int to_slot = prompt_invent_item("Adjust to which letter? ",
                                            menu_type::invlist,
-                                           -1, OPER_ANY,
+                                           OSEL_ANY, OPER_ANY,
                                            invprompt_flag::unthings_ok
                                             | invprompt_flag::manual_list);
     if (to_slot == PROMPT_ABORT

--- a/crawl-ref/source/butcher.cc
+++ b/crawl-ref/source/butcher.cc
@@ -365,7 +365,7 @@ void turn_corpse_into_chunks(item_def &item, bool bloodspatter)
     item.quantity  = stepdown_value(item.quantity, 4, 4, 12, 12);
 
     // Don't mark it as dropped if we are forcing autopickup of chunks.
-    if (you.force_autopickup[OBJ_FOOD][FOOD_CHUNK] <= 0
+    if (you.force_autopickup[OBJ_FOOD][FOOD_CHUNK] <= AP_FORCE_NONE
         && is_bad_food(item))
     {
         item.flags |= ISFLAG_DROPPED;

--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -24,6 +24,11 @@ You can quickly select items by type by pressing:
 Global selects:  <w>,</w>   select all     <w>*</w>   invert all      <w>-</w>   deselect all
 Note that for dropping, the <w>,</w> command uses the <w>drop_filter</w> option, which
 narrows the range of items to be (de)selected. The default are useless items.
+
+<h>Disabling autopickup via the drop menu</h>
+On the drop menu, items you select after pressing <w>\</w> will be marked with a <w>*</w>
+instead of the usual <w>+</w>. Autopickup for these items will be disabled when you
+leave the menu. To return to the normal selection mode, press <w>\</w> a second time.
 %%%%
 known-menu
 

--- a/crawl-ref/source/dat/defaults/menu_colours.txt
+++ b/crawl-ref/source/dat/defaults/menu_colours.txt
@@ -68,6 +68,7 @@ menu_colour += pickup:green:god gift
 # Highlight (partly) selected items
 menu_colour += inventory:white:\w \+\s
 menu_colour += inventory:white:\w \#\s
+menu_colour += inventory:white:\w \*\s
 
 
 # Not really menu.

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -18,6 +18,7 @@
 #include "colour.h"
 #include "command.h"
 #include "describe.h"
+#include "english.h"
 #include "env.h"
 #include "food.h"
 #include "god-item.h"
@@ -68,7 +69,7 @@ string InvTitle::get_text(const bool) const
 }
 
 InvEntry::InvEntry(const item_def &i)
-    : MenuEntry("", MEL_ITEM), item(&i)
+    : MenuEntry("", MEL_ITEM), item(&i), _has_star(false)
 {
     data = const_cast<item_def *>(item);
 
@@ -175,6 +176,11 @@ void InvEntry::select(int qty)
     MenuEntry::select(qty);
 }
 
+bool InvEntry::has_star() const
+{
+    return _has_star;
+}
+
 string InvEntry::get_filter_text() const
 {
     return item_prefix(*item) + " " + get_text();
@@ -204,6 +210,8 @@ string InvEntry::get_text(bool need_cursor) const
             tstr << '-';
         else if (selected_qty < quantity)
             tstr << '#';
+        else if (_has_star)
+            tstr << '*';
         else
             tstr << '+';
 
@@ -307,7 +315,7 @@ void InvEntry::set_show_glyph(bool doshow)
 
 InvMenu::InvMenu(int mflags)
     : Menu(mflags, "inventory"), type(menu_type::invlist), pre_select(nullptr),
-      title_annotate(nullptr)
+      title_annotate(nullptr), _mode_special_drop(false)
 {
 #ifdef USE_TILE_LOCAL
     if (Options.tile_menu_icons)
@@ -315,6 +323,11 @@ InvMenu::InvMenu(int mflags)
 #endif
 
     InvEntry::set_show_cursor(false);
+}
+
+bool InvMenu::mode_special_drop() const
+{
+    return _mode_special_drop;
 }
 
 void InvMenu::set_type(menu_type t)
@@ -347,6 +360,54 @@ void InvMenu::set_title(const string &s)
     set_title(new InvTitle(this, s.empty() ? "Inventory: " + slot_description()
                                            : s,
                            title_annotate));
+}
+
+int InvMenu::pre_process(int key)
+{
+    if (type == menu_type::drop && key == '\\')
+    {
+        _mode_special_drop = !_mode_special_drop;
+        key = CK_NO_KEY;
+    }
+    else if (key == '-')
+        _mode_special_drop = false;
+    return key;
+}
+
+static bool _item_is_permadrop_candidate(const item_def &item)
+{
+    // Known, non-artefact items of the types you see on the '\' menu proper.
+    // (No disabling autopickup for "green fizzy potion", "+3 whip", etc.)
+    if (item_type_unknown(item))
+        return false;
+    return item.base_type == OBJ_MISCELLANY
+        || is_stackable_item(item)
+        || item_type_has_ids(item.base_type);
+}
+
+void InvMenu::select_item_index(int idx, int qty, bool draw_cursor)
+{
+    if (type != menu_type::drop)
+        return Menu::select_item_index(idx, qty, draw_cursor);
+
+    InvEntry *ie = static_cast<InvEntry*>(items[idx]);
+
+    bool should_toggle_star = _item_is_permadrop_candidate(ie->item[0])
+        && (ie->has_star() || _mode_special_drop);
+
+    if (should_toggle_star)
+    {
+        // Toggle starred items back to selected-but-not-starred in this mode
+        // instead of turning them all the way off.
+        qty = _mode_special_drop ? -2 : 0;
+        ie->set_star(!ie->has_star());
+    }
+    Menu::select_item_index(idx, qty, draw_cursor);
+}
+
+void InvEntry::set_star(bool val)
+{
+    _has_star = val;
 }
 
 static bool _has_melded_armour()
@@ -878,7 +939,7 @@ vector<SelItem> InvMenu::get_selitems() const
     {
         InvEntry *inv = dynamic_cast<InvEntry*>(me);
         selected_items.emplace_back(inv->hotkeys[0], inv->selected_qty,
-                                    inv->item);
+                                    inv->item, inv->has_star());
     }
     return selected_items;
 }
@@ -1243,6 +1304,30 @@ static string _drop_selitem_text(const vector<MenuEntry*> *s)
                         s->size() > 1? "s" : "");
 }
 
+static string _drop_prompt(bool as_menu_title, bool menu_autopickup_mode)
+{
+    string prompt_base;
+
+    if (as_menu_title && menu_autopickup_mode)
+        prompt_base = "Drop (and turn off autopickup for) what? ";
+    else if (as_menu_title)
+        prompt_base = "Drop what?                               ";
+    else
+        prompt_base = "Drop what? ";
+    return prompt_base + slot_description()
+#ifdef TOUCH_UI
+                          + " (<Enter> or tap header to drop)";
+#else
+                          + " (_ for help)";
+#endif
+}
+
+static string _drop_menu_titlefn(const Menu *m, const string &)
+{
+    const InvMenu *invmenu = static_cast<const InvMenu *>(m);
+    return _drop_prompt(true, invmenu->mode_special_drop());
+}
+
 /**
  * Prompt the player to select zero or more items to drop.
  * TODO: deduplicate/merge with prompt_invent_item().
@@ -1252,14 +1337,6 @@ static string _drop_selitem_text(const vector<MenuEntry*> *s)
  */
 vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
 {
-    const string prompt = "Drop what? " + slot_description()
-#ifdef TOUCH_UI
-                          + " (<Enter> or tap header to drop)"
-#else
-                          + " (_ for help)"
-#endif
-    ;
-
     unsigned char  keyin = '?';
     int            ret = PROMPT_ABORT;
 
@@ -1279,6 +1356,7 @@ vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
 
         if (need_prompt)
         {
+            const string prompt = _drop_prompt(false, false);
             mprf(MSGCH_PROMPT, "%s (<w>?</w> for menu, <w>Esc</w> to quit)",
                  prompt.c_str());
         }
@@ -1290,17 +1368,18 @@ vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
         need_prompt = true;
         need_getch  = true;
 
-        // Note:  We handle any "special" character first, so that
-        //        it can be used to override the others.
-        if (keyin == '?' || keyin == '*' || keyin == ',')
+        if (keyin == '_')
+            show_specific_help("pick-up");
+        else if (keyin == '?' || keyin == '*' || keyin == ',')
         {
             // The "view inventory listing" mode.
-            const int ch = _invent_select(prompt.c_str(),
+            const int ch = _invent_select("",
                                           menu_type::drop,
                                           OSEL_ANY,
                                           -1,
                                           MF_MULTISELECT | MF_ALLOW_FILTER,
-                                          nullptr, &items,
+                                          _drop_menu_titlefn,
+                                          &items,
                                           &Options.drop_filter,
                                           _drop_selitem_text,
                                           &preselected_items);
@@ -1370,10 +1449,7 @@ vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
     }
 
     if (ret != PROMPT_ABORT)
-    {
-        items.emplace_back(ret, count,
-                           ret != PROMPT_GOT_SPECIAL ? &you.inv[ret] : nullptr);
-    }
+        items.emplace_back(ret, count, &you.inv[ret]);
     return items;
 }
 

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -70,7 +70,6 @@ DEF_BITFIELD(invent_prompt_flags, invprompt_flag);
 #define PROMPT_ABORT         -1
 #define PROMPT_GOT_SPECIAL   -2
 #define PROMPT_NOTHING       -3
-#define PROMPT_INAPPROPRIATE -4
 
 #define SLOT_BARE_HANDS      PROMPT_GOT_SPECIAL
 
@@ -81,10 +80,10 @@ struct SelItem
     int slot;
     int quantity;
     const item_def *item;
-
-    SelItem() : slot(0), quantity(0), item(nullptr) { }
-    SelItem(int s, int q, const item_def *it = nullptr)
-        : slot(s), quantity(q), item(it)
+    bool has_star;
+    SelItem() : slot(0), quantity(0), item(nullptr), has_star(false) { }
+    SelItem(int s, int q, const item_def *it = nullptr, bool do_star = false)
+        : slot(s), quantity(q), item(it), has_star(do_star)
     {
     }
 };
@@ -141,6 +140,8 @@ public:
     }
 
     virtual void select(int qty = -1) override;
+    void set_star(bool);
+    bool has_star() const;
 
     virtual string get_filter_text() const override;
 
@@ -149,6 +150,7 @@ public:
 
 private:
     void add_class_hotkeys(const item_def &i);
+    bool _has_star;
 };
 
 class InvMenu : public Menu
@@ -194,8 +196,13 @@ public:
     const menu_sort_condition *find_menu_sort_condition() const;
     void sort_menu(vector<InvEntry*> &items, const menu_sort_condition *cond);
 
+    // Drop menu only: if true, dropped items are removed from autopickup.
+    bool mode_special_drop() const;
+
 protected:
     void do_preselect(InvEntry *ie);
+    void select_item_index(int idx, int qty, bool draw_cursor = true) override;
+    int pre_process(int key) override;
     virtual bool is_selectable(int index) const override;
     virtual string help_key() const override;
 
@@ -205,6 +212,9 @@ protected:
 
     invtitle_annotator title_annotate;
     string temp_title;
+
+private:
+    bool _mode_special_drop;
 };
 
 void get_class_hotkeys(const int type, vector<char> &glyphs);

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2388,9 +2388,12 @@ public:
         else
             selected_qty = 0;
 
-        // Set the force_autopickup values
-        const int forceval = (selected_qty == 2 ? -1 : selected_qty);
-        you.force_autopickup[item->base_type][item->sub_type] = forceval;
+        if (selected_qty == 2)
+            set_item_autopickup(*item, AP_FORCE_OFF);
+        else if (selected_qty == 1)
+            set_item_autopickup(*item, AP_FORCE_ON);
+        else
+            set_item_autopickup(*item, AP_FORCE_NONE);
     }
 };
 
@@ -2462,9 +2465,9 @@ static void _add_fake_item(object_class_type base, int sub,
 
     items.push_back(ptmp);
 
-    if (you.force_autopickup[base][sub] == 1)
+    if (you.force_autopickup[base][sub] == AP_FORCE_ON)
         selected.emplace_back(0, 1, ptmp);
-    else if (you.force_autopickup[base][sub] == -1)
+    else if (you.force_autopickup[base][sub] == AP_FORCE_OFF)
         selected.emplace_back(0, 2, ptmp);
 }
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2918,8 +2918,6 @@ static int _autopickup_subtype(const item_def &item)
     case OBJ_POTIONS:
     case OBJ_STAVES:
         return item_type_known(item) ? item.sub_type : max_type;
-    case OBJ_MISCELLANY:
-        return max_type;
     case OBJ_BOOKS:
         if (item.sub_type == BOOK_MANUAL || item_type_known(item))
             return item.sub_type;

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -29,6 +29,13 @@ enum item_source_type
     AQ_WIZMODE    = 200,
 };
 
+enum autopickup_level_type
+{
+    AP_FORCE_OFF = -1,
+    AP_FORCE_NONE = 0,
+    AP_FORCE_ON = 1,
+};
+
 /// top-priority item override colour
 #define FORCED_ITEM_COLOUR_KEY "forced_item_colour"
 
@@ -134,6 +141,9 @@ bool can_autopickup();
 
 bool need_to_autopickup();
 void autopickup();
+
+void set_item_autopickup(const item_def &item, autopickup_level_type ap);
+int item_autopickup_level(const item_def &item);
 
 int find_free_slot(const item_def &i);
 

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -438,7 +438,7 @@ protected:
 
     void deselect_all(bool update_view = true);
     virtual void select_items(int key, int qty = -1);
-    void select_item_index(int idx, int qty, bool draw_cursor = true);
+    virtual void select_item_index(int idx, int qty, bool draw_cursor = true);
     void select_index(int index, int qty = -1);
 
     bool is_hotkey(int index, int key);

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -71,7 +71,7 @@ static void _give_bonus_items()
 static void _autopickup_ammo(missile_type missile)
 {
     if (Options.autopickup_starting_ammo)
-        you.force_autopickup[OBJ_MISSILES][missile] = 1;
+        you.force_autopickup[OBJ_MISSILES][missile] = AP_FORCE_ON;
 }
 
 /**

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -3958,7 +3958,7 @@ static void tag_read_you_items(reader &th)
 
         // If fruit pickup was not set explicitly during the time between
         // FOOD_PURGE and FOOD_PURGE_AP_FIX, copy the old exemplar FOOD_PEAR.
-        if (food_pickups[FOOD_FRUIT] == 0)
+        if (food_pickups[FOOD_FRUIT] == AP_FORCE_NONE)
             food_pickups[FOOD_FRUIT] = food_pickups[FOOD_PEAR];
     }
     if (you.species == SP_FORMICID)

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -392,7 +392,7 @@ void wizard_tweak_object()
     char specs[50];
     int keyin;
 
-    int item = prompt_invent_item("Tweak which item? ", menu_type::invlist, -1);
+    int item = prompt_invent_item("Tweak which item? ", menu_type::invlist, OSEL_ANY);
 
     if (prompt_failed(item))
         return;
@@ -522,7 +522,7 @@ static bool _make_book_randart(item_def &book)
 void wizard_value_item()
 {
     const int i = prompt_invent_item("Value of which item?",
-                                     menu_type::invlist, -1);
+                                     menu_type::invlist, OSEL_ANY);
 
     if (prompt_failed(i))
         return;
@@ -592,7 +592,7 @@ void wizard_create_all_artefacts()
 void wizard_make_object_randart()
 {
     int i = prompt_invent_item("Make an artefact out of which item?",
-                                menu_type::invlist, -1);
+                                menu_type::invlist, OSEL_ANY);
 
     if (prompt_failed(i))
         return;
@@ -683,7 +683,7 @@ static bool _item_type_can_be_cursed(int type)
 void wizard_uncurse_item()
 {
     const int i = prompt_invent_item("(Un)curse which item?",
-                                     menu_type::invlist, -1);
+                                     menu_type::invlist, OSEL_ANY);
 
     if (!prompt_failed(i))
     {
@@ -1302,7 +1302,7 @@ static void _debug_rap_stats(FILE *ostat)
 {
     const int inv_index
         = prompt_invent_item("Generate randart stats on which item?",
-                             menu_type::invlist, -1);
+                             menu_type::invlist, OSEL_ANY);
 
     if (prompt_failed(inv_index))
         return;

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -709,7 +709,7 @@ void wizard_give_monster_item(monster* mon)
     }
 
     int player_slot = prompt_invent_item("Give which item to monster?",
-                                          menu_type::drop, -1);
+                                          menu_type::drop, OSEL_ANY);
 
     if (prompt_failed(player_slot))
         return;


### PR DESCRIPTION
These changes are aimed at making the in-game autopickup settings more convenient to use.

* Misc. evocables (fan of gales etc.) definitely belonged on the '\\' menu but were only present as one "all misc items" toggle, so they've been given their own section. The same commit also removes the (recognized) books section, which is fairly pointless now that spellbooks no longer take up inventory space.
* A new hotkey is added to the drop menu: pressing '\\' before selecting items will cause those items to be both dropped from inventory and removed from autopickup. I'm usually a heavy user of the item knowledge menu ('\\'), but now I hardly touch it -- it turns out that 90% of what I did with it was turn off autopickup for the thing I just dropped. This is a much easier way to do that, so I'm hoping this will be a big usability win.

Possible issues:
* This adds a field to InvEntry/InvMenu/SelItem. Many things are InvMenus, but this field only gets used on the drop menu. Perhaps new subclasses would have been better? I liked it better the "just add a field" way, but I'm not married to it.
* The existence of this hotkey isn't exposed in a blatantly obvious way -- it's just kind of there if you happen to open the help screen. That's true of many hotkeys, but generally the ones that change a menu mode are shown all the time. Currently, that's not happening.
* Changing check_item_knowledge() to add a new section was painful. It's kind of crying out for a refactor. I tried, but what I ended up with wasn't good enough to justify the diff, so I went for the minimal possible change instead. Not ideal -- I'm hoping to take another crack at it later, probably break it into its own file. For now, I think the quality of life improvement of having the misc. items toggleable outweighs the added cruft.
* The difference between selected-for-autopickup-toggle items and normally-selected items might not be visually obvious enough. Right now it's just '*' vs '+'.

This is my first contribution of more than a few lines, so I hope I didn't screw anything up too badly, procedure-wise. I left it as three separate commits because it seemed clearer that way -- I figure I can always rebase them later if this gets merged.

Edit: maybe affects https://github.com/crawl/crawl/pull/1015