### PR TITLE
Turn off skill targets when aptitudes change from level up (11943)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2912,7 +2912,7 @@ void level_change(bool skip_attribute_increase)
                     // do_level_up = false) but save the old values; then when
                     // we want the messages later, we restore the old skill
                     // levels and call check_skill_level_change() again, this
-                    // time passing do_update = true.
+                    // time passing do_level_up = true.
 
                     uint8_t saved_skills[NUM_SKILLS];
                     for (skill_type sk = SK_FIRST_SKILL; sk < NUM_SKILLS; ++sk)

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -399,6 +399,8 @@ void check_skill_level_change(skill_type sk, bool do_level_up)
         else
             you.skills[sk] = new_level;
     }
+
+    check_training_targets();
 }
 
 // Fill a queue in random order with the values of the array.


### PR DESCRIPTION
Add a call to check_training_targets() into the function
check_skill_level_change(). Also, update an inaccurate comment about
this function.