### PR TITLE
Always display the duration of the last action on the HUD (Yermak)

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1454,12 +1454,13 @@ show_game_time = true
         By default, the counter in the stat area displays elapsed game time.
         Most actions take one unit of time, but some are quicker (putting on a
         ring, wielding a weapon, ...) and others are slower (swinging a weapon
-        with low skill, changing armour, ...). The duration of the last action
-        is displayed in parenthesis, after the time display.
+        with low skill, changing armour, ...).
         When set to false, the counter will display player turns instead, which
         is the number of actions taken regardless of their duration. It is this
         turn count which is used for scoring (and this turn count is always
         visible on the % overview screen).
+        The duration of the last action is displayed in parenthesis, after the
+        time/player turns display.
 
 equip_bar = false
         When set to true, this option replaces the noise bar with an

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -550,14 +550,14 @@ void update_turn_count()
     // Show the turn count starting from 1. You can still quit on turn 0.
     textcolour(HUD_VALUE_COLOUR);
     if (Options.show_game_time)
-    {
-        CPRINTF("%.1f (%.1f)%s", you.elapsed_time / 10.0,
-                (you.elapsed_time - you.elapsed_time_at_last_input) / 10.0,
-                // extra spaces to erase excess if previous output was longer
-                "    ");
-    }
+        CPRINTF("%.1f", you.elapsed_time / 10.0);
     else
         CPRINTF("%d", you.num_turns);
+
+    CPRINTF(" (%.1f)%s",
+            (you.elapsed_time - you.elapsed_time_at_last_input) / 10.0,
+            // extra spaces to erase excess if previous output was longer
+            "    ");
     textcolour(LIGHTGREY);
 }
 

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -406,14 +406,15 @@ function ($, comm, enums, map_knowledge, messages, options) {
         {
             $("#stats_time_caption").text("Time:");
             $("#stats_time").text((player.time / 10.0).toFixed(1));
-            if (player.time_delta)
-                $("#stats_time").append(" (" + (player.time_delta / 10.0).toFixed(1) + ")");
         }
         else
         {
             $("#stats_time_caption").text("Turn:");
             $("#stats_time").text(player.turn);
         }
+
+        if (player.time_delta)
+            $("#stats_time").append(" (" + (player.time_delta / 10.0).toFixed(1) + ")");
 
         var place_desc = player.place;
         if (player.depth) place_desc += ":" + player.depth;


### PR DESCRIPTION
Because of how the score is calculated, it might be more useful to have
player turns instead of elapsed time on the HUD.
`show_game_time = false` replaces time with player turns, but also
hides the duration of the last action. The HUD is the only place that
shows this duration, so players who care about their score have to use
the default value for show_game_time and have to regularly check their
turns via the E or % commands.

After this commit, the HUD will display the duration regardless of the
show_game_time's value.

This change was suggested on ##crawl-dev on 2018-08-30.