### PR TITLE
Webtiles: Log IPs correctly when behind a reverse proxy

### DIFF
--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -153,6 +153,10 @@ use_gzip = True
 # This needs a patch currently not in mainline tornado.
 http_connection_timeout = None
 
+# Set this to true if you are behind a reverse proxy
+# Your proxy must set header X-Real-IP
+http_xheaders = None
+
 kill_timeout = 10 # Seconds until crawl is killed after HUP is sent
 
 nick_regex = r"^[a-zA-Z0-9]{3,20}$"

--- a/crawl-ref/source/webserver/server.py
+++ b/crawl-ref/source/webserver/server.py
@@ -136,6 +136,8 @@ def bind_server():
     kwargs = {}
     if http_connection_timeout is not None:
         kwargs["connection_timeout"] = http_connection_timeout
+    if getattr(config, "http_xheaders", False):
+        kwargs["xheaders"] = http_xheaders
 
     servers = []
 


### PR DESCRIPTION
This change has been tested on a local dev environment with and without a reverse proxy. Tested with Tornado 2.4.1 and trunk webtiles server. I used getattr so this will not crash when config.py is missing the new option.

See below for relevant Tornado documentation.

http://www.tornadoweb.org/en/stable/httpserver.html#http-server
http://www.tornadoweb.org/en/stable/httputil.html#tornado.httputil.HTTPServerRequest.remote_ip

Commit message reproduced below:

> This change allows webtiles to accurately log IP addresses when it is
> running behind a reverse proxy.
> 
> Webtiles logs IP addresses when users connect to the server. This is
> done by looking at the value of 'request.remote_ip', provided by
> Tornado. When webtiles is running behind a reverse proxy, the value
> returned by Tornado is the IP address of the proxy itself. This does not
> uniquely identify users and results in a mostly useless log file.
> 
> This commit looks for the new setting 'http_xheaders' in config.py and,
> if it is found, passes it along to Tornado.HTTPServer. When HTTPServer
> is initialized with this setting, request.remote_ip will instead return
> the value of header X-Real-IP if it is present. This header can be set
> by a reverse proxy to indicate the actual IP of the real client.
> 
> Be warned that enabling this option when webtiles is NOT protected
> behind a reverse proxy introduces a security risk. An attacker could
> inject a false address into the X-Real-IP header. Do not enable this
> option if the webtiles server is directly exposed to users.
> 
