### PR TITLE
Webtiles: Disallow user login when account has been banned

### DIFF
--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -429,9 +429,17 @@ function (exports, $, key_conversion, chat, comm) {
         return false;
     }
 
-    function login_failed()
+    function login_failed(data)
     {
-        $("#login_message").html("Login failed.");
+        var reason = data.reason;
+        if (reason)
+        {
+            $("#login_message").html(reason);
+        }
+        else
+        {
+            $("#login_message").html("Login failed.");
+        }
         $("#login_form").show();
         $("#reg_link").show();
         $("#forgot_link").show();

--- a/crawl-ref/source/webserver/userdb.py
+++ b/crawl-ref/source/webserver/userdb.py
@@ -147,7 +147,7 @@ def user_passwd_match(username, passwd):  # type: (str, str) -> Optional[Tuple[s
         result = db.c.fetchone()  # type: Optional[Tuple[str, str, str]]
 
     if dgl_is_banned(result[2]):
-	    return result[0], 'Account is disabled.'
+        return result[0], 'Account is disabled.'
     elif result and crypt.crypt(passwd, result[1]) == result[1]:
         return result[0], None
     else:

--- a/crawl-ref/source/webserver/userdb.py
+++ b/crawl-ref/source/webserver/userdb.py
@@ -132,24 +132,26 @@ def get_user_info(username):  # type: (str) -> Optional[Tuple[int, str, int]]
         return None
 
 
-def user_passwd_match(username, passwd):  # type: (str, str) -> Optional[str]
-    """Returns the correctly cased username."""
+def user_passwd_match(username, passwd):  # type: (str, str) -> Optional[Tuple[str, str]]
+    """Returns the correctly cased username and a reason for failure."""
     passwd = passwd[0:max_passwd_length]
 
     with crawl_db(password_db) as db:
         query = """
-            SELECT username, password
+            SELECT username, password, flags
             FROM dglusers
             WHERE username=?
             COLLATE NOCASE
         """
         db.c.execute(query, (username,))
-        result = db.c.fetchone()  # type: Optional[Tuple[str, str]]
+        result = db.c.fetchone()  # type: Optional[Tuple[str, str, str]]
 
-    if result and crypt.crypt(passwd, result[1]) == result[1]:
-        return result[0]
+    if dgl_is_banned(result[2]):
+	    return result[0], 'Account is disabled.'
+    elif result and crypt.crypt(passwd, result[1]) == result[1]:
+        return result[0], None
     else:
-        return None
+        return None, None
 
 
 def ensure_user_db_exists():  # type: () -> None

--- a/crawl-ref/source/webserver/ws_handler.py
+++ b/crawl-ref/source/webserver/ws_handler.py
@@ -579,11 +579,14 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
         self.init_user(login_callback)
 
     def login(self, username, password):
-        real_username = userdb.user_passwd_match(username, password)
-        if real_username:
+        real_username, fail_reason = userdb.user_passwd_match(username, password)
+        if real_username and fail_reason is None:
             self.logger.info("User %s logging in from %s.",
                                         real_username, self.request.remote_ip)
             self.do_login(real_username)
+        elif fail_reason:
+            self.logger.warning("Failed login for user %s: %s", real_username, fail_reason)
+            self.send_message("login_fail", reason = fail_reason)
         else:
             self.logger.warning("Failed login for user %s.", username)
             self.send_message("login_fail")


### PR DESCRIPTION
This PR changes webtiles login code to look at the user flags in the DGL database. If the banned flag is set, webtiles will not allow the user to log in. Previously, these flags were not used in the webtiles server.

I'm looking for feedback in the following areas:

1. Code review on the current changes
2. A user who holds a valid login token can bypass the normal login procedure. This would allow a banned user to login, as long as they hold on to a valid token.
3. I'm not aware of any existing script or other nice way of banning a user. Manually setting the account flag to 'banned' will not kick off any user who is currently logged in on an active connection.

Looking for solutions for 2 and 3 above.