### PR TITLE
Traps in full describe view

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -569,8 +569,7 @@ void full_describe_view()
     for (radius_iterator ri(you.pos(),
                             you.xray_vision ? LOS_NONE : LOS_DEFAULT); ri; ++ri)
     {
-        if (feat_stair_direction(grd(*ri)) != CMD_NO_CMD
-            || feat_is_altar(grd(*ri)))
+        if (feat_stair_direction(grd(*ri)) != CMD_NO_CMD)
         {
             list_features.push_back(*ri);
         }

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -557,7 +557,7 @@ public:
     void nextline() { cgotoxy(1, wherey() + 1); }
 };
 
-// Lists all the monsters and items currently in view by the player.
+// Lists monsters, items, and some interesting features in the player's view.
 // TODO: Allow sorting of items lists.
 void full_describe_view()
 {
@@ -569,7 +569,8 @@ void full_describe_view()
     for (radius_iterator ri(you.pos(),
                             you.xray_vision ? LOS_NONE : LOS_DEFAULT); ri; ++ri)
     {
-        if (feat_stair_direction(grd(*ri)) != CMD_NO_CMD)
+        if (feat_stair_direction(grd(*ri)) != CMD_NO_CMD
+            || (feat_is_trap(grd(*ri))))
         {
             list_features.push_back(*ri);
         }


### PR DESCRIPTION
This is a minor UI tweak and a bit of code cleanup in full_describe_view (which handles the ctrl-x screen).