### PR TITLE
Use high-res app icon on all platforms

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -351,11 +351,7 @@ bool TilesFramework::initialise()
     DATA_DIR_PATH
 #endif
 #endif
-#ifdef TARGET_OS_MACOSX
     "dat/tiles/stone_soup_icon-512x512.png";
-#else
-    "dat/tiles/stone_soup_icon-32x32.png";
-#endif
 
     string title = string(CRAWL " ") + Version::Long;
 


### PR DESCRIPTION
Previously the 512x512 app icon was only used on MacOS, and all other
platforms used the 32x32 icon. This change is to use the 512x512 icon on
all platforms.

Note that I only have access to Linux, so that is all I've tested this on.