### PR TITLE
Remove throwables ammo brands(poison, steel)

### DIFF
--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -307,7 +307,6 @@ DEPTH:   D:4-, Depths
 MONS:    ball python w:5 / adder / water moccasin, place:Snake:1
 KFEAT:   v = general shop type:Serpentskin suffix:Sales count:7 ; \
          w:8 blowgun | w:8 needle ego:poisoned | w:4 needle ego:curare | \
-         w:14 tomahawk ego:poisoned | \
          w:3 ring of poison resistance | w:6 randbook disc:poison | \
          w:2 staff of poison | w:4 any weapon ego:venom | \
          w:4 any armour ego:poison_resistance | w:1 swamp dragon scales

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -884,8 +884,6 @@ ITEM:   Young Poisoner's Handbook / book of Changes / \
         spells:beastly_appendage&sting&sticks_to_snakes&spider_form
 KMASK:  'f = opaque
 : if crawl.coinflip() then
-KITEM:  f = javelin ego:poisoned q:4-6 / tomahawk ego:poisoned
-: else
 KITEM:  f = blowgun / w:5 nothing, needle ego:poisoned / needle ego:curare / needle ego:paralysis
 : end
 KITEM:  g = any potion q:2-3
@@ -939,8 +937,6 @@ ITEM:   Young Poisoner's Handbook / book of Changes / \
         randbook numspells:4 title:Nature \
         spells:beastly_appendage&sting&sticks_to_snakes&spider_form
 : if crawl.coinflip() then
-KITEM:  f = javelin ego:poisoned q:4-6 / tomahawk ego:poisoned
-: else
 KITEM:  f = blowgun / w:5 nothing, needle ego:poisoned / needle ego:curare / needle ego:paralysis
 : end
 KITEM:  g = any potion q:2 / any potion q:3

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1512,9 +1512,11 @@ static string _describe_ammo(const item_def &item)
                            "target, hitting an obstruction, or reaching its "
                            "maximum range.";
             break;
+#if TAG_MAJOR_VERSION == 34
         case SPMSL_STEEL:
             description += "It deals increased damage compared to normal ammo.";
             break;
+#endif
         case SPMSL_SILVER:
             description += "It deals substantially increased damage to chaotic "
                            "and magically transformed beings. It also inflicts "

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -367,8 +367,10 @@ const char* missile_brand_name(const item_def &item, mbn_type t)
         return t == MBN_NAME ? "curare-tipped" : "curare";
     case SPMSL_EXPLODING:
         return t == MBN_TERSE ? "explode" : "exploding";
+#if TAG_MAJOR_VERSION == 34
     case SPMSL_STEEL:
         return "steel";
+#endif
     case SPMSL_SILVER:
         return "silver";
     case SPMSL_PARALYSIS:

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -547,15 +547,11 @@ static special_missile_type _determine_missile_brand(const item_def& item,
     case MI_JAVELIN:
         rc = random_choose_weighted(30, SPMSL_RETURNING,
                                     32, SPMSL_PENETRATION,
-                                    32, SPMSL_POISONED,
-                                    21, SPMSL_STEEL,
                                     20, SPMSL_SILVER,
                                     nw, SPMSL_NORMAL);
         break;
     case MI_TOMAHAWK:
-        rc = random_choose_weighted(15, SPMSL_POISONED,
-                                    10, SPMSL_SILVER,
-                                    10, SPMSL_STEEL,
+        rc = random_choose_weighted(10, SPMSL_SILVER,
                                     12, SPMSL_DISPERSAL,
                                     28, SPMSL_RETURNING,
                                     15, SPMSL_EXPLODING,
@@ -635,7 +631,7 @@ bool is_missile_brand_ok(int type, int brand, bool strict)
     switch (brand)
     {
     case SPMSL_POISONED:
-        return type == MI_JAVELIN || type == MI_TOMAHAWK;
+        return false;
     case SPMSL_RETURNING:
         return type == MI_JAVELIN || type == MI_TOMAHAWK;
     case SPMSL_CHAOS:
@@ -647,6 +643,7 @@ bool is_missile_brand_ok(int type, int brand, bool strict)
     case SPMSL_EXPLODING:
         return type == MI_TOMAHAWK;
     case SPMSL_STEEL: // deliberate fall through
+		return false;
     case SPMSL_SILVER:
         return type == MI_JAVELIN || type == MI_TOMAHAWK;
     default: break;

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -298,7 +298,9 @@ unsigned int item_value(item_def item, bool ident)
             case SPMSL_PARALYSIS:
             case SPMSL_PENETRATION:
             case SPMSL_SILVER:
+#if TAG_MAJOR_VERSION == 34
             case SPMSL_STEEL:
+#endif
             case SPMSL_DISPERSAL:
                 valued *= 30;
                 break;


### PR DESCRIPTION
I think poison brand are enough for poison needles. And I'd also like to get rid of steel brands because I think they're nothing more than copying the top items.