### PR TITLE
Add bolt range behaviour to bolt spell descriptions

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -14,7 +14,8 @@ Randomly translocates the user a short distance.
 Breathe Dispelling Energy ability
 
 Breathes a bolt of dispelling energy at a targeted creature, possibly removing
-some of its enchantments.
+some of its enchantments. The range of the bolt is decreased by one for every
+creature it strikes.
 %%%%
 Breathe Fire ability
 
@@ -51,11 +52,13 @@ for a short time. It may also splash onto other nearby creatures on impact.
 Breathe Steam ability
 
 Breathes a jet of steam at a targeted location, which will scald any creatures
-it hits and will also obscure vision.
+it hits and will also obscure vision. The range of the jet is decreased by one
+for every creature it strikes.
 %%%%
 Breathe Noxious Fumes ability
 
-Breathes a blast of noxious fumes at a targeted creature.
+Breathes a blast of noxious fumes at a targeted creature. The range of the blast
+is decreased by one for every creature it strikes.
 %%%%
 Bat Form ability
 

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -176,21 +176,25 @@ the bolt's destination.
 %%%%
 Bolt of Cold spell
 
-Fires a penetrating bolt of frost.
+Fires a penetrating bolt of frost. The range of the bolt is decreased by one for
+every creature it strikes.
 %%%%
 Bolt of Draining spell
 
 Fires a penetrating bolt of negative energy, which drains any living creature
-it strikes.
+it strikes. The range of the bolt is decreased by one for every creature it
+hits.
 %%%%
 Bolt of Fire spell
 
-Fires a penetrating bolt of flames.
+Fires a penetrating bolt of flames. The range of the bolt is decreased by one
+for every creature it strikes.
 %%%%
 Bolt of Magma spell
 
 Fires a penetrating bolt of molten rock. A portion of its damage bypasses
-fire resistance.
+fire resistance. The range of the bolt is decreased by one for every creature
+it strikes.
 %%%%
 Borgnjor's Revivification spell
 
@@ -270,7 +274,8 @@ Exhales a large cloud of fumes filled with the very essence of chaos.
 %%%%
 Chilling Breath spell
 
-Exhales a blast of frost that may knock back airborne targets.
+Exhales a blast of frost that may knock back airborne targets. The range of the
+blast is decreased by one for every creature it strikes.
 %%%%
 Cleansing Flame spell
 
@@ -287,6 +292,7 @@ become available.
 Cold Breath spell
 
 Exhales a focused blast of icy-cold air. It may knock back airborne targets.
+The range of the blast is decreased by one for every creature it strikes.
 %%%%
 Confuse spell
 
@@ -338,7 +344,8 @@ force of any creature it envelops.
 %%%%
 Corrosive Bolt spell
 
-Fires a penetrating bolt of acid.
+Fires a penetrating bolt of acid. The range of the bolt is decreased by one for
+every creature it strikes.
 %%%%
 Corrupting Pulse spell
 
@@ -350,7 +357,8 @@ Crystal Bolt spell
 
 Projects a penetrating projectile with peculiar magical properties. It is
 randomly imbued with either fire or ice, and additionally will reflect from
-walls of any material due to the crystal embedded in the shot.
+walls of any material due to the crystal embedded in the shot. The range of the
+bolt is decreased by one for every creature it strikes.
 %%%%
 Darkness spell
 
@@ -509,7 +517,8 @@ Throws a bolt of electricity at the target, with high accuracy.
 %%%%
 Energy Bolt spell
 
-Fires a bolt of highly destructive energy.
+Fires a bolt of highly destructive energy. The range of the bolt is decreased
+by one for every creature it strikes.
 %%%%
 Enslavement spell
 
@@ -541,7 +550,8 @@ ineffective against unnatural targets.
 %%%%
 Fire Breath spell
 
-Breathes a blast of fire at a targeted creature.
+Breathes a blast of fire at a targeted creature. The range of the blast is
+decreased by one for every creature it strikes.
 %%%%
 Fire Storm spell
 
@@ -882,7 +892,8 @@ shorter time.
 Metal Splinters spell
 
 Fires a directed stream of sharp metal splinters. Its damage is strongly
-reduced by armour.
+reduced by armour. The range of the stream is decreased by one for every
+creature it strikes.
 %%%%
 Miasma Breath spell
 
@@ -1280,7 +1291,8 @@ While transformed, any equipped body armour, gloves and boots are melded.
 %%%%
 Steam Ball spell
 
-Throws a ball of hot steam towards a targeted creature.
+Throws a ball of hot steam towards a targeted creature. The range of the ball
+is decreased by one for every creature it strikes.
 %%%%
 Sticks to Snakes spell
 
@@ -1557,7 +1569,8 @@ Life will not be drained in excess of what the caster can capably absorb.
 %%%%
 Venom Bolt spell
 
-Fires a penetrating bolt of poison.
+Fires a penetrating bolt of poison. The range of the bolt is decreased by one
+for every creature it strikes.
 %%%%
 Virulence spell
 


### PR DESCRIPTION
Add a one-line description of how bolt spells' range is reduced by one
for each monster the bolt strikes, to all relevant bolt and bolt-like
spells and abilities. The description is:

"The range of the [bolt/blast/jet/ball] is decreased by one for every
creature it strikes."

The spells whose descriptions are changed by this commit are:
  Breathe Dispelling Energy
  Breathe Frost
  Breathe Steam
  Breathe Noxious Fumes
  Bolt of Cold
  Bolt of Draining
  Bolt of Fire
  Bolt of Magma
  Chilling Breath
  Cold Breath
  Corrosive Bolt
  Crystal Bolt
  Energy Bolt
  Fire Breath
  Metal Splinters
  Quicksilver Bolt
  Steam Ball
  Venom Bolt

The bolt-like spells and abilities whose descriptions are not affected
by this commit are:
  Breathe Fire (I'm not actually sure what uses this ability, apart from
                red draconian players, for whom the ability is
		different anyway.)
  Random Bolt
  Shadow Bolt (used for Dithmenos worshippers).