### PR TITLE
Only generate one of Spider/Snake/Swamp/Shoals

### DIFF
--- a/crawl-ref/source/branch.cc
+++ b/crawl-ref/source/branch.cc
@@ -105,14 +105,6 @@ static const branch_type danger_branch_order[] = {
 };
 COMPILE_CHECK(ARRAYSZ(danger_branch_order) == NUM_BRANCHES);
 
-static const int number_of_branch_swap_pairs = 2;
-
-static const branch_type swap_branches[number_of_branch_swap_pairs][2] =
-{
-    {BRANCH_SHOALS, BRANCH_SWAMP},
-    {BRANCH_SPIDER, BRANCH_SNAKE}
-};
-
 branch_iterator::branch_iterator(branch_iterator_type type) :
     iter_type(type), i(0)
 {
@@ -159,14 +151,23 @@ branch_iterator branch_iterator::operator++(int)
 
 vector<branch_type> random_choose_disabled_branches()
 {
-    // You will get one of Shoals/Swamp and one of Spider/Snake.
-    // This way you get one "water" branch and one "poison" branch.
-    vector<branch_type> disabled_branch;
+    vector<branch_type> disabled_branches;
+    // You will get one of Shoals/Swamp/Spider/Snake
+    branch_type enabled_s_branch = random_choose(
+        BRANCH_SWAMP,
+        BRANCH_SNAKE,
+        BRANCH_SHOALS,
+        BRANCH_SPIDER);
+    for (branch_type disabled : {BRANCH_SWAMP, BRANCH_SNAKE, BRANCH_SHOALS, BRANCH_SPIDER})
+    {
+        if (disabled != enabled_s_branch)
+        {
+            dprf("Disabling branch: %s", branches[disabled].shortname);
+            disabled_branches.push_back(disabled);
+        }
+    }
 
-    for (int i=0; i < number_of_branch_swap_pairs; i++)
-        disabled_branch.push_back(swap_branches[i][random_choose(0,1)]);
-
-    return disabled_branch;
+    return disabled_branches;
 }
 
 const Branch& your_branch()
@@ -202,16 +203,8 @@ bool is_hell_branch(branch_type branch)
 
 bool is_random_subbranch(branch_type branch)
 {
-    for (int i=0; i < number_of_branch_swap_pairs; i++)
-    {
-        for (int j=0; j < 2; j++)
-        {
-            if (branch == swap_branches[i][j])
-                return true;
-        }
-    }
-
-    return false;
+    return branch == BRANCH_SWAMP || branch == BRANCH_SNAKE
+           || branch == BRANCH_SPIDER || branch == BRANCH_SHOALS;
 }
 
 bool is_connected_branch(const Branch *branch)

--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -1084,12 +1084,12 @@ void unmarshallUniqueAnnotations(reader& inf)
 */
 bool connected_branch_can_exist(branch_type br)
 {
-    if (br == BRANCH_SPIDER && stair_level.count(BRANCH_SNAKE)
-        || br == BRANCH_SNAKE && stair_level.count(BRANCH_SPIDER)
-        || br == BRANCH_SWAMP && stair_level.count(BRANCH_SHOALS)
-        || br == BRANCH_SHOALS && stair_level.count(BRANCH_SWAMP))
+    if (br == BRANCH_SPIDER
+        || br == BRANCH_SNAKE
+        || br == BRANCH_SWAMP
+        || br == BRANCH_SHOALS)
     {
-        return false;
+        return stair_level.count(br);
     }
 
     return true;


### PR DESCRIPTION
This is a pretty big change, I think there are some other things to do if this is merged:

- [ ] does the scoring algorithm need an update?
- [ ] should other branches roulette? In the past there has been discussion of elf/crypt and hell/pan
- [ ] should the difficulty of certain S branches be tweaked? Specifically making Swamp a little harder and Shoals a little easier.

--

* The first branch of these the player enters is typically a reasonable
  challenge, but the second is usually too easy. (There are exceptions,
  for example games where the player is poison immune and shoals
  generates.)
* Without the second branch, choice of where to go after getting first
  rune becomes much more difficult for the player. At the moment,
  completing the second branch is easier than anywhere else the player
  can go in the dungeon.

Alternate approaches:

* Make one of the S branch pairs much harder. The new harder branch
would overlap in difficulty with existing rune branches.
* Once you enter one S branch, close the other. Harder to implement, and
would probably result in a no-brainer decision where there is always an
optimal choice.