### PR TITLE
Traps in stash search

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -110,12 +110,13 @@ that contain the spell.
 You can search for artefact item properties (such as <w>/prevents.*teleport</w>)
 to find artefacts that have the property.
 
-You can search by some additional item properties: <w>artefact</w> or <w>artifact</w> will
-find identified artefacts, <w>ego</w> or <w>branded</w> will find non-artefacts with a
-brand and unidentified items which may be branded, <w>throwable</w> will find things
-you can throw, <w>dropped</w> will find items you have dropped, <w>in_shop</w> will find
-items in shops, and (if the autopickup_search option is enabled) <w>autopickup</w> will find
-items that would be automatically picked up.
+You can search by some additional item properties: <w>artefact</w> or
+<w>artifact</w> will find identified artefacts, <w>ego</w> or <w>branded</w>
+will find non-artefacts with a brand and unidentified items which may be
+branded, <w>throwable</w> will find things you can throw, <w>dropped</w> will
+find items you have dropped, <w>in_shop</w> will find items in shops, and (if
+the autopickup_search option is enabled) <w>autopickup</w> will find items that
+would be automatically picked up.
 
 Skill names (such as <w>Polearms</w> or <w>Long Blades</w>) will find all weapons that
 train that skill. You can also look for <w>melee weapon</w> and <w>ranged weapon</w>.
@@ -126,10 +127,10 @@ Use <w>armour && !!body</w> to list all armour pieces except for body armour.
 
 <h>Finding Dungeon Features:</h>
 
-You can search for dungeon features by name: all shops will be found by a
-search for <w>shop</w> (including shops that do not have "shop" in their name);
-other dungeon features can also be found by name: <w>fountain</w>, <w>spear trap</w>,
-<w>altar</w>, etc. You can also search for altars by deity name: <w>Zin</w>.
+You can search for dungeon features by name: all shops will be found by a search
+for <w>shop</w> (including shops that do not have "shop" in their name); other
+dungeon features can also be found by name: <w>dispersal trap</w>, <w>altar</w>,
+etc. You can also search for altars by deity name: <w>Zin</w>.
 
 <h>Non-regex operators:</h>
 

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -471,7 +471,7 @@ vector<stash_search_result> Stash::matches_search(
     if (feat != DNGN_FLOOR)
     {
         const string fdesc = feature_description();
-        if (!fdesc.empty() && search.matches(fdesc))
+        if (!fdesc.empty() && search.matches(prefix + " " + fdesc))
         {
             stash_search_result res;
             res.match = fdesc;

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1251,7 +1251,9 @@ static bool _is_potentially_boring(stash_search_result res)
            && (item_type_known(res.item) || !item_is_branded(res.item));
 }
 
-static bool _is_duplicate_for_search(stash_search_result l, stash_search_result r, bool ignore_missile_stacks=true)
+static bool _is_duplicate_for_search(stash_search_result l,
+                                     stash_search_result r,
+                                     bool ignore_missile_stacks=true)
 {
     if (l.in_inventory || r.in_inventory)
         return false;
@@ -1387,7 +1389,8 @@ static vector<stash_search_result> _stash_filter_duplicates(vector<stash_search_
     for (const stash_search_result &res : in)
     {
         if (out.size() && !out.back().in_inventory &&
-            _is_potentially_boring(res) && _is_duplicate_for_search(out.back(), res))
+            _is_potentially_boring(res) && _is_duplicate_for_search(out.back(),
+                                                                    res))
         {
             // don't push_back the duplicate
             out.back().duplicate_piles++;
@@ -1521,24 +1524,24 @@ void StashTracker::search_stashes()
         {
             // use the deduplicated results if we are filtering useless items
             again = display_search_results(dedup_results,
-                                                      sort_by_dist,
-                                                      filter_useless,
-                                                      default_execute,
-                                                      search,
-                                                      csearch == "."
-                                                      || csearch == "..",
-                                                      results.size());
+                                           sort_by_dist,
+                                           filter_useless,
+                                           default_execute,
+                                           search,
+                                           csearch == "."
+                                           || csearch == "..",
+                                           results.size());
         }
         else
         {
             again = display_search_results(results,
-                                                      sort_by_dist,
-                                                      filter_useless,
-                                                      default_execute,
-                                                      search,
-                                                      csearch == "."
-                                                      || csearch == "..",
-                                                      dedup_results.size());
+                                           sort_by_dist,
+                                           filter_useless,
+                                           default_execute,
+                                           search,
+                                           csearch == "."
+                                           || csearch == "..",
+                                           dedup_results.size());
         }
         if (!again)
             break;
@@ -1624,7 +1627,8 @@ formatted_string StashSearchMenu::calc_title()
             menu_action == ACT_EXECUTE ? "travel" : "view  ",
             sort_style, filtered));
     }
-    fs.cprintf(string(max(0, strwidth(prefixes[!f])-strwidth(prefixes[f])), ' '));
+    fs.cprintf(string(max(0, strwidth(prefixes[!f])-strwidth(prefixes[f])),
+                      ' '));
     return fs;
 }
 
@@ -1665,7 +1669,8 @@ bool StashTracker::display_search_results(
                               filter_useless ? "hide" : "show");
     stashmenu.set_tag("stash");
     stashmenu.action_cycle = Menu::CYCLE_TOGGLE;
-    stashmenu.menu_action  = default_execute ? Menu::ACT_EXECUTE : Menu::ACT_EXAMINE;
+    stashmenu.menu_action  = default_execute ? Menu::ACT_EXECUTE
+                                             : Menu::ACT_EXAMINE;
     string title = "match";
 
     MenuEntry *mtitle = new MenuEntry(title, MEL_TITLE);
@@ -1687,7 +1692,8 @@ bool StashTracker::display_search_results(
         matchtitle << res.match;
         if (res.duplicates > 0)
         {
-            matchtitle << " (" << res.duplicates << " further duplicate" << (res.duplicates == 1 ? "" : "s");
+            matchtitle << " (" << res.duplicates << " further duplicate" <<
+                (res.duplicates == 1 ? "" : "s");
             if (res.duplicates != res.duplicate_piles)
             {
                 matchtitle << " in " << res.duplicate_piles

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -225,7 +225,8 @@ bool Stash::needs_stop() const
 bool Stash::is_boring_feature(dungeon_feature_type feature)
 {
     // Count shops as boring features, because they are handled separately.
-    return !is_notable_terrain(feature) || feature == DNGN_ENTER_SHOP;
+    return !is_notable_terrain(feature) && !feat_is_trap(feature)
+        || feature == DNGN_ENTER_SHOP;
 }
 
 static bool _grid_has_perceived_item(const coord_def& pos)

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -468,7 +468,7 @@ vector<stash_search_result> Stash::matches_search(
         }
     }
 
-    if (results.empty() && feat != DNGN_FLOOR)
+    if (feat != DNGN_FLOOR)
     {
         const string fdesc = feature_description();
         if (!fdesc.empty() && search.matches(fdesc))

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1402,7 +1402,7 @@ static vector<stash_search_result> _stash_filter_duplicates(vector<stash_search_
         // don't push_back duplicates
         {
             stash_match_type mtype = out.back().match_type;
-            switch(mtype)
+            switch (mtype)
             {
             case MATCH_ITEM:
                 out.back().duplicate_piles++;

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -110,6 +110,15 @@ private:
     friend class ST_ItemIterator;
 };
 
+enum stash_match_type
+{
+    MATCH_UNKNOWN,
+    MATCH_ITEM,
+    MATCH_SHOP,
+    MATCH_FEATURE,
+    MATCH_NUM_MATCH_TYPE
+};
+
 struct stash_search_result
 {
     // Where's this thingummy of interest.
@@ -118,6 +127,9 @@ struct stash_search_result
     // Number of levels the player must cross to reach the level the stash/shop
     // is on.
     int player_distance;
+
+    // Type of thing found.
+    stash_match_type match_type;
 
     // Text that describes this search result - usually the name of
     // the first matching item in the stash or the name of the shop.
@@ -132,6 +144,9 @@ struct stash_search_result
     // The shop in question, if this result is for a shop name.
     const ShopInfo *shop;
 
+    // Type of feature, if this result is for a feature.
+    dungeon_feature_type feat;
+
     // Whether the found items are in the player's inventory.
     bool in_inventory;
 
@@ -139,9 +154,10 @@ struct stash_search_result
     int duplicates;
     int duplicate_piles;
 
-    stash_search_result() : pos(), player_distance(0), match(), primary_sort(),
-                            item(), shop(nullptr), in_inventory(false),
-                            duplicates(0), duplicate_piles(0)
+    stash_search_result() : pos(), player_distance(0), match_type(), match(),
+                            primary_sort(), item(), shop(nullptr), feat(),
+                            in_inventory(false), duplicates(0),
+                            duplicate_piles(0)
     {
     }
 

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -129,7 +129,7 @@ struct stash_search_result
     // Item that was matched.
     item_def item;
 
-    // The shop in question, if this is result is for a shop name.
+    // The shop in question, if this result is for a shop name.
     const ShopInfo *shop;
 
     // Whether the found items are in the player's inventory.
@@ -139,8 +139,9 @@ struct stash_search_result
     int duplicates;
     int duplicate_piles;
 
-    stash_search_result() : pos(), player_distance(0), match(), primary_sort(), item(),
-                            shop(nullptr), in_inventory(false), duplicates(0), duplicate_piles(0)
+    stash_search_result() : pos(), player_distance(0), match(), primary_sort(),
+                            item(), shop(nullptr), in_inventory(false),
+                            duplicates(0), duplicate_piles(0)
     {
     }
 
@@ -249,7 +250,7 @@ public:
     // Mark nets at (x,y) on current level as no longer trapping an actor.
     bool unmark_trapping_nets(const coord_def &c);
 
-    void  add_stash(coord_def p);
+    void add_stash(coord_def p);
 
     void save(writer&) const;
     void load(reader&);


### PR DESCRIPTION
The main effect here should be to allow stash searching to work for traps as well as for items. (Excluding web traps.) Some of these commits fix (what I take to be) bugs and clean up the code in stash.cc and stash.h as well.

I tried to keep things fairly fine-grained in terms of commit size, but I am happy to squash some together if it's desired.