### PR TITLE
Remove weapon gifting from Trog

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1188,18 +1188,6 @@ static string _why_reject(const item_def &item, int agent)
         return "Destroying unusable weapon or armour!";
     }
 
-    // Trog does not gift the Wrath of Trog, nor weapons of pain
-    // (which work together with Necromantic magic).
-    // nor fancy magic staffs (wucad mu, majin-bo)
-    if (agent == GOD_TROG
-        && (get_weapon_brand(item) == SPWPN_PAIN
-            || is_unrandom_artefact(item, UNRAND_TROG)
-            || is_unrandom_artefact(item, UNRAND_WUCAD_MU)
-            || is_unrandom_artefact(item, UNRAND_MAJIN)))
-    {
-        return "Destroying a weapon Trog hates!";
-    }
-
     // Pain brand is useless if you've sacrificed Necromacy.
     if (you.get_mutation_level(MUT_NO_NECROMANCY_MAGIC)
         && get_weapon_brand(item) == SPWPN_PAIN)
@@ -1239,7 +1227,6 @@ int acquirement_create_item(object_class_type class_wanted,
     ASSERT(class_wanted != OBJ_RANDOM);
 
     const bool divine = (agent == GOD_OKAWARU || agent == GOD_XOM
-                         || agent == GOD_TROG
 #if TAG_MAJOR_VERSION == 34
                          || agent == GOD_PAKELLAS
 #endif
@@ -1263,8 +1250,6 @@ int acquirement_create_item(object_class_type class_wanted,
         // Don't generate randart books in items(), we do that
         // ourselves.
         bool want_arts = (class_wanted != OBJ_BOOKS);
-        if (agent == GOD_TROG && !one_chance_in(3))
-            want_arts = false;
 
         thing_created = items(want_arts, class_wanted, type_wanted,
                               ITEM_LEVEL, 0, agent);
@@ -1327,14 +1312,6 @@ int acquirement_create_item(object_class_type class_wanted,
                     continue;
                 }
             }
-        }
-
-        if (agent == GOD_TROG && coinflip()
-            && acq_item.base_type == OBJ_WEAPONS && !is_range_weapon(acq_item)
-            && !is_unrandom_artefact(acq_item))
-        {
-            // ... but Trog loves the antimagic brand specially.
-            set_item_ego_type(acq_item, OBJ_WEAPONS, SPWPN_ANTIMAGIC);
         }
 
         const string rejection_reason = _why_reject(acq_item, agent);
@@ -1426,14 +1403,9 @@ int acquirement_create_item(object_class_type class_wanted,
                 make_item_randart(acq_item, true);
             }
 
-            if (agent == GOD_TROG || agent == GOD_OKAWARU)
-            {
-                if (agent == GOD_TROG)
-                    acq_item.plus += random2(3);
-
-                // On a weapon, an enchantment of less than 0 is never viable.
+            // On a weapon, an enchantment of less than 0 is never viable.
+            if (agent == GOD_OKAWARU)
                 acq_item.plus = max(static_cast<int>(acq_item.plus), random2(2));
-            }
         }
 
         // Last check: don't acquire items your god hates.

--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -171,8 +171,8 @@ Trog
 
 Trog is an ancient god of anger and violence. Followers are expected to kill in
 Trog's name, and especially to slay wizards. In return, worshippers of Trog
-gain the ability to go berserk at will in combat, and will be granted
-assistance in the form of powerful weapons and mighty allies. Followers are
+gain the ability to go berserk at will in combat, and can request assistance in
+the form of powerful weapons and mighty allies. Followers are absolutely
 absolutely forbidden the use of spell magic.
 %%%%
 Uskayaw

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -203,10 +203,7 @@ const vector<god_power> god_powers[NUM_GODS] =
       { 3, "Trog will now gift you ammunition as you gain piety.",
            "Trog will no longer gift you ammunition.",
            "Trog will gift you ammunition as you gain piety." },
-      { 4, ABIL_TROG_BROTHERS_IN_ARMS, "call in reinforcements" },
-      { 5, "Trog will now gift you weapons as you gain piety.",
-           "Trog will no longer gift you weapons.",
-           "Trog will gift you weapons as you gain piety." },
+      { 4, ABIL_TROG_BROTHERS_IN_ARMS, "call in reinforcements" }
     },
 
     // Nemelex
@@ -1372,25 +1369,19 @@ static bool _give_trog_oka_gift(bool forced)
     if (you.species == SP_FELID)
         return false;
 
-    const bool need_missiles = _need_missile_gift(forced);
-    object_class_type gift_type;
+    const bool enough_piety = you.piety >= piety_breakpoint(4);
+    if (!enough_piety)
+        return false;
 
-    if (forced && coinflip()
-        || (!forced && you.piety >= piety_breakpoint(4)
-            && random2(you.piety) > 120
-            && one_chance_in(4)))
+    // What sort of gift?
+    object_class_type gift_type = OBJ_MISSILES;
+    const bool can_get_item = random2(you.piety) > 120 && one_chance_in(4);
+    if (you_worship(GOD_OKAWARU))
     {
-        if (you_worship(GOD_TROG)
-            || (you_worship(GOD_OKAWARU) && coinflip()))
-        {
-            gift_type = OBJ_WEAPONS;
-        }
-        else
-            gift_type = OBJ_ARMOUR;
+        if (forced || can_get_item)
+            gift_type = coinflip() ? OBJ_WEAPONS : OBJ_ARMOUR;
     }
-    else if (need_missiles)
-        gift_type = OBJ_MISSILES;
-    else
+    if (gift_type == OBJ_MISSILES && !_need_missile_gift(forced))
         return false;
 
     success = acquirement(gift_type, you.religion);


### PR DESCRIPTION
There are a few reasons for this change:

1) Weapon gifting overlaps with Okawaru. It's not an exact overlap --
   Okawaru also gifts armour, and the more subtle stats of gifted
   weapons (enchantment & brand distribution) differ between the gods
   too. But it's nevertheless a very same-y god feature.
   a) Okawaru's thematic connection to item gifting is stronger than
      Trog's.
   b) Okawaru is a weaker god overall, and removing / nerfing weapon
      gifting would result in a very mediocre god.
2) Trog is a fantastically strong god for the early and mid game, but
   falls off a little as the game goes on. This change emphasises that
   power curve by cutting out a god feature with zero impact on the
   early game, and relatively little on the mid game.
   a) Even with this change, Trog will remain a very strong god, but
      perhaps less overwhelmingly strong at all points in the game.