### PR TITLE
Remove sling bullet. And sling weapons's damage increase one.

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -549,6 +549,7 @@ static int _acquirement_missile_subtype(bool /*divine*/, int & /*quantity*/)
 
     switch (skill)
     {
+	case SK_SLINGS:    result = MI_STONE; break;
     case SK_BOWS:      result = MI_ARROW; break;
     case SK_CROSSBOWS: result = MI_BOLT; break;
 

--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -549,7 +549,6 @@ static int _acquirement_missile_subtype(bool /*divine*/, int & /*quantity*/)
 
     switch (skill)
     {
-    case SK_SLINGS:    result = MI_SLING_BULLET; break;
     case SK_BOWS:      result = MI_ARROW; break;
     case SK_CROSSBOWS: result = MI_BOLT; break;
 

--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -549,7 +549,7 @@ static int _acquirement_missile_subtype(bool /*divine*/, int & /*quantity*/)
 
     switch (skill)
     {
-	case SK_SLINGS:    result = MI_STONE; break;
+    case SK_SLINGS:    result = MI_STONE; break;
     case SK_BOWS:      result = MI_ARROW; break;
     case SK_CROSSBOWS: result = MI_BOLT; break;
 

--- a/crawl-ref/source/dat/des/branches/geh.des
+++ b/crawl-ref/source/dat/des/branches/geh.des
@@ -155,7 +155,7 @@ KMONS:   34 = ice devil
 KMONS:   56 = reaper ; scythe ego:freezing ident:type / shard shrike w:5
 KMONS:   7 = alligator snapping turtle skeleton / anaconda simulacrum / \
          golden dragon simulacrum w:5 / iron troll simulacrum w:5 / hydra simulacrum
-KMONS:   0 = skeletal warrior ; hunting sling ego:freezing ident:type . sling bullet
+KMONS:   0 = skeletal warrior ; hunting sling ego:freezing ident:type . stone
 SUBST:   l = w, W = .
 :  else
 KMONS:   1 = shard shrike

--- a/crawl-ref/source/dat/des/branches/shoals.des
+++ b/crawl-ref/source/dat/des/branches/shoals.des
@@ -959,7 +959,7 @@ ORIENT: float
 SHUFFLE: 1Ww / 2DD
 MONS: merfolk, faun
 MONS: merfolk impaler ; demon trident good_item | trident good_item . gold
-MONS: satyr ; fustibalus good_item . sling bullet good_item . gold / \
+MONS: satyr ; fustibalus good_item . stone good_item . gold / \
       satyr ; longbow good_item . arrow good_item . gold
 COLOUR:   c = white
 COLOUR:   1234'D = cyan

--- a/crawl-ref/source/dat/des/branches/zot.des
+++ b/crawl-ref/source/dat/des/branches/zot.des
@@ -1100,10 +1100,10 @@ KMONS:   1 = guardian mummy ; randart dire flail ego:chaos | \
              randart scythe ego:chaos | randart dire flail | \
              randart great mace | randart battleaxe | randart great sword | \
              randart glaive | randart scythe
-KMONS:   3 = guardian mummy ; randart fustibalus ego:chaos . sling bullet / \
+KMONS:   3 = guardian mummy ; randart fustibalus ego:chaos . stone / \
              guardian mummy ; randart longbow ego:chaos . arrow / \
              guardian mummy ; randart triple crossbow . bolt / \
-             guardian mummy ; randart fustibalus . sling bullet / \
+             guardian mummy ; randart fustibalus . stone / \
              guardian mummy ; randart longbow . arrow / \
              guardian mummy ; randart arbalest . bolt
 KMONS:   5 = guardian mummy ; wand of acid | scroll of summoning
@@ -2340,7 +2340,7 @@ MONS:    very ugly thing w:20 / deep elf annihilator w:15 / \
 MONS:    curse skull w:15 / apocalypse crab / lorocyproca / acid blob
 MONS:    butterfly
 ITEM:    stone q:1 no_pickup, large rock q:1 no_pickup
-ITEM:    sling bullet q:1 no_pickup, crystal ball of energy no_pickup
+ITEM:    stone q:1 no_pickup, crystal ball of energy no_pickup
 # Altars obliquely refer to those temple maps.
 KFEAT:   D = altar_lugonu / altar_jiyva / altar_beogh w:5 / C w:20
 KFEAT:   ~ = known zot trap

--- a/crawl-ref/source/dat/des/builder/alphashops.des
+++ b/crawl-ref/source/dat/des/builder/alphashops.des
@@ -149,7 +149,7 @@
        "wand of random effects" }
 
       elseif s == "S" then i = { "scarf", "scimitar", "short sword",
-       "sling bullet", "scale mail", "book of summonings", "book of the sky",
+       "scale mail", "book of summonings", "book of the sky",
        "ring of see invisible", "ring of slaying", "spear", "ring of stealth",
        "ring of strength", "manual of stealth", "sack of spiders",
        "scroll of summoning", "scythe", "book of spatial translocations",

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -333,7 +333,7 @@ KMONS:   2 = stone giant / catoblepas w:20 / deep troll earth mage /\
 ITEM:    stone
 KFEAT:   v = general shop type:Pet suffix:Rocks count:7 ; \
          w:15 stone | w:15 large rock | w:8 hunting sling | w:1 fustibalus | \
-         w:8 sling bullet | w:7 crystal ball of energy | \
+         w:7 crystal ball of energy | \
          w:8 wand of digging | w:5 randbook disc:earth | \
          w:2 book of the earth | w:2 book of geomancy | w:4 staff of earth | \
          w:1 crystal plate armour

--- a/crawl-ref/source/dat/des/sprint/arena_sprint.des
+++ b/crawl-ref/source/dat/des/sprint/arena_sprint.des
@@ -1084,7 +1084,7 @@ KFEAT:  Q = weapon shop type:Weapon suffix:Rack count:17 use_all greed:30 ; \
             mundane not_cursed lajatang | mundane not_cursed longbow |\
             mundane not_cursed fustibalus | mundane not_cursed triple crossbow \
                 |\
-            mundane bolt q:50 | mundane sling bullet q:50 |\
+            mundane bolt q:50 | mundane stone q:50 |\
             mundane arrow q:50
 KFEAT:  H = distillery shop type:Bottled suffix:Wisdom count:5 use_all greed:6 ; \
             potion of experience q:1 | potion of experience q:1 |\

--- a/crawl-ref/source/dat/des/sprint/zigsprint.des
+++ b/crawl-ref/source/dat/des/sprint/zigsprint.des
@@ -759,7 +759,7 @@ KITEM:    J = hand crossbow mundane not_cursed ident:all plus:5, \
               longbow mundane not_cursed ident:all plus:5, \
               hunting sling mundane not_cursed ident:all plus:5, \
               fustibalus mundane not_cursed ident:all plus:5, \
-              sling bullet q:1000 mundane ident:all
+              stone q:1000 mundane ident:all
 KITEM:    K = potion of curing q:9 ident:all, \
               potion of heal wounds q:9 ident:all, \
               potion of berserk rage q:2 ident:all, \

--- a/crawl-ref/source/dat/des/variable/large_themed.des
+++ b/crawl-ref/source/dat/des/variable/large_themed.des
@@ -57,8 +57,8 @@ NAME:    minmay_goblin_kobold_castle
 TAGS:    no_rotate
 ORIENT:  north
 DEPTH:   D:3-6
-MONS:    goblin; hunting sling . stone / hobgoblin w:2; hunting sling . sling \
-         bullet / nothing
+MONS:    goblin; hunting sling . stone / hobgoblin w:2; hunting sling . stone \
+         / nothing
 MONS:    goblin; club / hobgoblin; club / gnoll w:3; club | spear / nothing
 MONS:    kobold; stone / nothing
 MONS:    kobold; club / big kobold w:1; club | short sword w:2 / nothing
@@ -1161,7 +1161,7 @@ KFEAT:   _ = altar_okawaru
 # Lots of loot in this one. In true Okawaru fashion, most of it is junk!
 ITEM:    any armour, any armour good_item
 ITEM:    any weapon, any weapon good_item
-ITEM:    arrow, bolt, sling bullet, gold
+ITEM:    arrow, bolt, stone, gold
 SHUFFLE: df, hi, jk, eg
 NSUBST:  d = 1:e / *:d, f = 1:g / *:f
 SUBST:   n = nv, 5 = 2221'

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -1338,7 +1338,7 @@ NAME:   minmay_ruffians
 TAGS:   transparent
 DEPTH:  D:6-10
 MONS:   human; club | mace w:3 . animal skin | leather armour
-MONS:   human; hunting sling . stone | sling bullet w:3 . animal skin | \
+MONS:   human; hunting sling . stone w:3 . animal skin | \
         leather armour
 SUBST:  1 = 112.
 KMONS:  3 = human; flail . ring mail | scale mail
@@ -5605,7 +5605,7 @@ COLOUR:  F = lightred
 : elseif you.in_branch("Coc") then
 KMONS:   9 = ice devil w:15 / ice dragon / simulacrum w:5 / \
              skeletal warrior ; hunting sling ego:freezing ident:type . \
-             mundane sling bullet . mace ego:freezing ident:type
+             mundane stone . mace ego:freezing ident:type
 KMONS:   8 = blizzard demon / lich / shard shrike / \
              reaper ; scythe ego:freezing ident:type
 KMONS:   7 = ice fiend

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1035,11 +1035,6 @@ short sword
 
 A personal stabbing weapon with a short grip.
 %%%%
-sling bullet
-
-A small, heavy projectile specially shaped for use with slings. It is more
-effective as ammunition than simple stones.
-%%%%
 spear
 
 A hunting weapon consisting of a wooden shaft with a pointed metal head

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1094,7 +1094,6 @@ static void _append_weapon_stats(string &description, const item_def &item)
 
     const bool could_set_target = _could_set_training_target(item, true);
 
-    if (skill == SK_SLINGS)
     description += make_stringf(
     "\nBase accuracy: %+d  Base damage: %d  Base attack delay: %.1f"
     "\nThis weapon's minimum attack delay (%.1f) is reached at skill level %d.",

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1095,12 +1095,6 @@ static void _append_weapon_stats(string &description, const item_def &item)
     const bool could_set_target = _could_set_training_target(item, true);
 
     if (skill == SK_SLINGS)
-    {
-        description += make_stringf("\nFiring bullets:    Base damage: %d",
-                                    base_dam +
-                                    ammo_type_damage(MI_SLING_BULLET));
-    }
-
     description += make_stringf(
     "\nBase accuracy: %+d  Base damage: %d  Base attack delay: %.1f"
     "\nThis weapon's minimum attack delay (%.1f) is reached at skill level %d.",

--- a/crawl-ref/source/god-blessing.cc
+++ b/crawl-ref/source/god-blessing.cc
@@ -170,7 +170,7 @@ void gift_ammo_to_orc(monster* orc, bool initial_gift)
     else
         ammo.sub_type = fires_ammo_type(*launcher);
 
-    if (ammo.sub_type = MI_STONE);
+    ammo.sub_type = MI_STONE;
 
     ammo.quantity = 30 + random2(10);
     if (initial_gift || !launcher)

--- a/crawl-ref/source/god-blessing.cc
+++ b/crawl-ref/source/god-blessing.cc
@@ -170,8 +170,7 @@ void gift_ammo_to_orc(monster* orc, bool initial_gift)
     else
         ammo.sub_type = fires_ammo_type(*launcher);
 
-    if (ammo.sub_type == MI_STONE)
-        ammo.sub_type = MI_SLING_BULLET; // ugly special case
+    if (ammo.sub_type = MI_STONE);
 
     ammo.quantity = 30 + random2(10);
     if (initial_gift || !launcher)

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2515,7 +2515,7 @@ void check_item_knowledge(bool unknown_items)
         for (int i = 0; i < NUM_MISSILES; i++)
         {
 #if TAG_MAJOR_VERSION == 34
-            if (i == MI_NEEDLE)
+            if (i == MI_NEEDLE || i == MI_SLING_BULLET)
                 continue;
 #endif
             _add_fake_item(OBJ_MISSILES, i, selected_items, items_missile);

--- a/crawl-ref/source/item-prop-enum.h
+++ b/crawl-ref/source/item-prop-enum.h
@@ -335,7 +335,9 @@ enum missile_type
 
     MI_STONE,
     MI_LARGE_ROCK,
+#if TAG_MAJOR_VERSION == 34
     MI_SLING_BULLET,
+#endif
     MI_THROWING_NET,
     MI_BOOMERANG,
 

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -616,10 +616,10 @@ static const weapon_def Weapon_prop[] =
         DAMV_NON_MELEE, 0, 0, 0, {}, },
 #endif
 
-    { WPN_HUNTING_SLING,     "hunting sling",       5,  2, 12,
+    { WPN_HUNTING_SLING,     "hunting sling",       6,  2, 12,
         SK_SLINGS,       SIZE_LITTLE, SIZE_LITTLE, MI_STONE,
         DAMV_NON_MELEE, 8, 10, 15, RANGED_BRANDS },
-    { WPN_FUSTIBALUS,        "fustibalus",          8, -1, 14,
+    { WPN_FUSTIBALUS,        "fustibalus",          9, -1, 14,
         SK_SLINGS,       SIZE_LITTLE, SIZE_LITTLE, MI_STONE,
         DAMV_NON_MELEE, 2, 2, 150, RANGED_BRANDS },
 
@@ -662,7 +662,9 @@ static const missile_def Missile_prop[] =
     { MI_ARROW,         "arrow",         0, 8,  2,  false },
     { MI_BOLT,          "bolt",          0, 8,  2,  false },
     { MI_LARGE_ROCK,    "large rock",   20, 25, 7,  true  },
+#if TAG_MAJOR_VERSION == 34
     { MI_SLING_BULLET,  "sling bullet",  4, 8,  5,  false },
+#endif
     { MI_JAVELIN,       "javelin",      10, 20, 8,  true  },
     { MI_THROWING_NET,  "throwing net",  0, 0,  30, true  },
     { MI_BOOMERANG,     "boomerang",     6, 20, 5,  true  },

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -795,7 +795,7 @@ const set<pair<object_class_type, int> > removed_items =
     { OBJ_FOOD,      FOOD_ROYAL_JELLY },
     { OBJ_FOOD,      FOOD_UNUSED },
     { OBJ_FOOD,      FOOD_FRUIT },
-	{ OBJ_MISSILES,  MI_SLING_BULLET },
+    { OBJ_MISSILES,  MI_SLING_BULLET },
 #endif
     // Outside the #if because we probably won't remove these.
     { OBJ_RUNES,     RUNE_ELF },

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -795,6 +795,7 @@ const set<pair<object_class_type, int> > removed_items =
     { OBJ_FOOD,      FOOD_ROYAL_JELLY },
     { OBJ_FOOD,      FOOD_UNUSED },
     { OBJ_FOOD,      FOOD_FRUIT },
+	{ OBJ_MISSILES,  MI_SLING_BULLET },
 #endif
     // Outside the #if because we probably won't remove these.
     { OBJ_RUNES,     RUNE_ELF },

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -3375,7 +3375,7 @@ bool item_def::launched_by(const item_def &launcher) const
     if (base_type != OBJ_MISSILES)
         return false;
     const missile_type mt = fires_ammo_type(launcher);
-    return sub_type == mt || (mt == MI_STONE && sub_type == MI_SLING_BULLET);
+    return sub_type == mt || (mt == MI_STONE);
 }
 
 int item_def::index() const
@@ -3499,8 +3499,10 @@ colour_t item_def::missile_colour() const
     {
         case MI_STONE:
             return BROWN;
+#if TAG_MAJOR_VERSION == 34
         case MI_SLING_BULLET:
             return CYAN;
+#endif
         case MI_LARGE_ROCK:
             return LIGHTGREY;
         case MI_ARROW:

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -519,7 +519,6 @@ static special_missile_type _determine_missile_brand(const item_def& item,
     case MI_THROWING_NET:
     case MI_STONE:
     case MI_LARGE_ROCK:
-    case MI_SLING_BULLET:
     case MI_ARROW:
     case MI_BOLT:
         rc = SPMSL_NORMAL;
@@ -557,7 +556,6 @@ bool is_missile_brand_ok(int type, int brand, bool strict)
     // Launcher ammo can never be branded.
     if ((type == MI_STONE
         || type == MI_LARGE_ROCK
-        || type == MI_SLING_BULLET
         || type == MI_ARROW
         || type == MI_BOLT)
         && brand != SPMSL_NORMAL
@@ -640,7 +638,6 @@ static void _generate_missile_item(item_def& item, int force_type,
             random_choose_weighted(50, MI_STONE,
                                    20, MI_ARROW,
                                    12, MI_BOLT,
-                                   12, MI_SLING_BULLET,
                                    10, MI_DART,
                                    3,  MI_BOOMERANG,
                                    2,  MI_JAVELIN,

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -635,7 +635,7 @@ static void _generate_missile_item(item_def& item, int force_type,
     else
     {
         item.sub_type =
-            random_choose_weighted(50, MI_STONE,
+            random_choose_weighted(62, MI_STONE,
                                    20, MI_ARROW,
                                    12, MI_BOLT,
                                    10, MI_DART,

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -1323,10 +1323,7 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
             && (mon->type == MONS_JOSEPH
                 || mon->type == MONS_SATYR
                 || (mon->type == MONS_FAUN && one_chance_in(3))
-                || one_chance_in(15)))
-        {
-            xitt = MI_SLING_BULLET;
-        }
+                || one_chance_in(15)));
 
         const int thing_created = items(false, xitc, xitt, level);
 

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -1319,12 +1319,6 @@ static void _give_ammo(monster* mon, int level, bool mons_summoned)
         const object_class_type xitc = OBJ_MISSILES;
         int xitt = fires_ammo_type(*launcher);
 
-        if (xitt == MI_STONE
-            && (mon->type == MONS_JOSEPH
-                || mon->type == MONS_SATYR
-                || (mon->type == MONS_FAUN && one_chance_in(3))
-                || one_chance_in(15)));
-
         const int thing_created = items(false, xitc, xitt, level);
 
         if (thing_created == NON_ITEM)

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -1955,8 +1955,7 @@ bool monster::pickup_missile(item_def &item, bool msg, bool force)
                 // Don't drop huge stacks for tiny stacks.
                 if (item.launched_by(*launch)
                     && (!miss->launched_by(*launch)
-                        || item.sub_type == MI_SLING_BULLET
-                           && miss->sub_type == MI_STONE
+                        || item.sub_type == MI_STONE
                         || get_ammo_brand(*miss) == SPMSL_NORMAL
                            && item_brand != SPMSL_NORMAL)
                     && item.quantity * 2 > miss->quantity)

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -1670,7 +1670,7 @@ static void _construct_weapon_menu(const newgame_def& ng,
             if (is_ranged_weapon_type(wpn_type))
             {
                 text += " and ";
-                text += wpn_type == WPN_HUNTING_SLING ? ammo_name(MI_SLING_BULLET)
+                text += wpn_type == WPN_HUNTING_SLING ? ammo_name(MI_STONE)
                                                       : ammo_name(wpn_type);
                 text += "s";
             }

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -1670,8 +1670,7 @@ static void _construct_weapon_menu(const newgame_def& ng,
             if (is_ranged_weapon_type(wpn_type))
             {
                 text += " and ";
-                text += wpn_type == WPN_HUNTING_SLING ? ammo_name(MI_STONE)
-                                                      : ammo_name(wpn_type);
+                text += ammo_name(wpn_type);
                 text += "s";
             }
             break;

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -165,9 +165,6 @@ item_def* newgame_make_item(object_class_type base,
         _autopickup_ammo(MI_STONE);
     else if (item.base_type == OBJ_BOOKS && item.sub_type == BOOK_CHANGES)
         _autopickup_ammo(MI_ARROW);
-    // You probably want to pick up both.
-    if (item.is_type(OBJ_MISSILES, MI_STONE))
-        _autopickup_ammo(MI_STONE);
 
     origin_set_startequip(item);
 

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -166,7 +166,7 @@ item_def* newgame_make_item(object_class_type base,
     else if (item.base_type == OBJ_BOOKS && item.sub_type == BOOK_CHANGES)
         _autopickup_ammo(MI_ARROW);
     // You probably want to pick up both.
-    if (item.is_type(OBJ_MISSILES, MI_SLING_BULLET))
+    if (item.is_type(OBJ_MISSILES, MI_STONE))
         _autopickup_ammo(MI_STONE);
 
     origin_set_startequip(item);
@@ -225,7 +225,7 @@ static void _give_ammo(weapon_type weapon, int plus)
         newgame_make_item(OBJ_MISSILES, MI_BOLT, 20);
         break;
     case WPN_HUNTING_SLING:
-        newgame_make_item(OBJ_MISSILES, MI_SLING_BULLET, 20);
+        newgame_make_item(OBJ_MISSILES, MI_STONE, 20);
         break;
     default:
         break;

--- a/crawl-ref/source/quiver.h
+++ b/crawl-ref/source/quiver.h
@@ -15,7 +15,7 @@ enum ammo_t
 {
     AMMO_THROW,           // no launcher wielded -> darts, stones, ...
     AMMO_BOW,             // wielded bow -> arrows
-    AMMO_SLING,           // wielded sling -> stones, sling bullets
+    AMMO_SLING,           // wielded sling -> stones
     AMMO_CROSSBOW,        // wielded crossbow -> bolts
     // Used to be hand crossbows
 #if TAG_MAJOR_VERSION == 34

--- a/crawl-ref/source/rltiles/dc-item.txt
+++ b/crawl-ref/source/rltiles/dc-item.txt
@@ -231,7 +231,7 @@ i-blinding BRAND_BLINDING
 stone MI_STONE
 # flying stone
 effect/stone0 MI_STONE0
-
+# Remove sling bullets when TAG_MAJOR_VERSION > 34
 sling_bullet1 MI_SLING_BULLET
 sling_bullet2
 steel_sling_bullet1 MI_SLING_BULLET_STEEL

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2185,15 +2185,6 @@ static tileidx_t _tileidx_missile_base(const item_def &item)
         case SPMSL_SILVER:   return TILE_MI_BOLT_SILVER;
         }
 
-    case MI_SLING_BULLET:
-        switch (brand)
-        {
-        default:             return TILE_MI_SLING_BULLET + 1;
-        case 0:              return TILE_MI_SLING_BULLET;
-        case SPMSL_STEEL:    return TILE_MI_SLING_BULLET_STEEL;
-        case SPMSL_SILVER:   return TILE_MI_SLING_BULLET_SILVER;
-        }
-
     case MI_JAVELIN:
         switch (brand)
         {
@@ -2760,20 +2751,6 @@ tileidx_t tileidx_item_throw(const item_def &item, int dx, int dy)
         {
             case MI_STONE:
                 ch = TILE_MI_STONE0;
-                break;
-            case MI_SLING_BULLET:
-                switch (item.brand)
-                {
-                default:
-                    ch = TILE_MI_SLING_BULLET0;
-                    break;
-                case SPMSL_STEEL:
-                    ch = TILE_MI_SLING_BULLET_STEEL0;
-                    break;
-                case SPMSL_SILVER:
-                    ch = TILE_MI_SLING_BULLET_SILVER0;
-                    break;
-                }
                 break;
             case MI_LARGE_ROCK:
                 ch = TILE_MI_LARGE_ROCK0;


### PR DESCRIPTION
Sling bullet is removed to reduce inventory pressure. As the stone became the only sling bullet, the damage from the slings increased by one.