### PR TITLE
Improve shaft messaging

### DIFF
--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -540,13 +540,10 @@ static level_id _travel_destination(const dungeon_feature_type how,
                                     + shaft_dest.describe() + ".");
         }
 
-        string howfar;
-        if (shaft_depth > 1)
-            howfar = make_stringf(" for %d floors", shaft_depth);
-
-        mprf("You %s a shaft%s!", you.airborne() ? "are sucked into"
-                                                 : "fall through",
-                                  howfar.c_str());
+        mprf("You %s a shaft and drop %d floor%s!",
+             you.airborne() ? "are sucked" : "fall",
+             shaft_depth,
+             shaft_depth > 1 ? "s" : "");
 
         // Shafts are one-time-use.
         mpr("The shaft crumbles and collapses.");


### PR DESCRIPTION
Always print the number of floors, so the message is consistent between falling one or multiple levels.