### PR TITLE
Fix Avatar Song displayed success rate

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -1077,6 +1077,7 @@ static int _mons_power_hd_factor(spell_type spell, bool random)
             return 10 * ENCH_POW_FACTOR;
 
         case SPELL_SIREN_SONG:
+        case SPELL_AVATAR_SONG:
             return 9 * ENCH_POW_FACTOR;
 
         case SPELL_MASS_CONFUSION:


### PR DESCRIPTION
Avatar song’s displayed success rate was incorrect, displaying 0% when the player could be vulnerable. This patch addresses the issue. 

*Editor’s note: the original pr message included unhelpful and unwelcome passive aggression.*