### PR TITLE
Fix a default force_more_message

### DIFF
--- a/crawl-ref/source/dat/defaults/messages.txt
+++ b/crawl-ref/source/dat/defaults/messages.txt
@@ -91,7 +91,7 @@ msc += mute:Uskayaw will no longer force your foes to share their pain\.
 
 force_more_message += You have reached level
 force_more_message += Your scales start
-force_more_message += You (fall through|are sucked into) a shaft
+force_more_message += You (fall|are sucked) into a shaft
 force_more_message += You fall into the water!
 force_more_message += You fall into the lava!
 force_more_message += You focus on prolonging your flight

--- a/crawl-ref/source/dat/defaults/misc.txt
+++ b/crawl-ref/source/dat/defaults/misc.txt
@@ -12,5 +12,5 @@ sort_menus += inv: true : equipped, charged
 note_items    += acquirement, running, of Zot
 note_messages += Your scales start
 note_messages += protects you from harm
-note_messages += You (fall through|are sucked into) a shaft
+note_messages += You (fall|are sucked) into a shaft
 note_monsters += orb of fire, ancient lich, Sigmund


### PR DESCRIPTION
This was broken by the shaft message change in 52ca42d.