### PR TITLE
Simplify missile description cases

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1512,7 +1512,8 @@ static string _describe_ammo(const item_def &item)
     }
 
     const int dam = property(item, PWPN_DAMAGE);
-    if (can_throw)
+    const bool player_throwable = is_throwable(&you, item, false);
+    if (player_throwable)
     {
         const int throw_delay = (10 + dam / 2);
         const int target_skill = _item_training_target(item);

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -937,7 +937,7 @@ static int _item_training_target(const item_def &item)
         return weapon_min_delay_skill(item) * 10;
     else if (is_shield(item))
         return round(you.get_shield_skill_to_offset_penalty(item) * 10);
-    else if (item.base_type == OBJ_MISSILES && throw_dam)
+    else if (item.base_type == OBJ_MISSILES && is_throwable(&you, item, false))
         return (((10 + throw_dam / 2) - FASTEST_PLAYER_THROWING_SPEED) * 2) * 10;
     else
         return 0;
@@ -950,14 +950,13 @@ static int _item_training_target(const item_def &item)
  */
 static skill_type _item_training_skill(const item_def &item)
 {
-    const int throw_dam = property(item, PWPN_DAMAGE);
     if (item.base_type == OBJ_WEAPONS || item.base_type == OBJ_STAVES)
         return item_attack_skill(item);
     else if (is_shield(item))
         return SK_SHIELDS; // shields are armour, so do shields before armour
     else if (item.base_type == OBJ_ARMOUR)
         return SK_ARMOUR;
-    else if (item.base_type == OBJ_MISSILES && throw_dam)
+    else if (item.base_type == OBJ_MISSILES && is_throwable(&you, item, false))
         return SK_THROWING;
     else if (item_is_evokable(item)) // not very accurate
         return SK_EVOCATIONS;
@@ -1513,7 +1512,7 @@ static string _describe_ammo(const item_def &item)
     }
 
     const int dam = property(item, PWPN_DAMAGE);
-    if (dam || item.sub_type == MI_DART)
+    if (can_throw)
     {
         const int throw_delay = (10 + dam / 2);
         const int target_skill = _item_training_target(item);


### PR DESCRIPTION
Previously, descriptions for projectiles were based largely around
whether they had a damage value associated with them, under the logic
that "inherent missile damage => throwable missile". This made life easy
in dealing with the old needles and with regular launcher missiles.

However, it led to:
* the sling bullet description having lots of throwing information
  (despite sling bullets not being throwable) and
* the throwing net description lacking the fact that a net's delay is
  lowered with Throwing skill

With the changes to throwing missiles, we can now just focus on
throwable-ness to fix these issues and more.