### PR TITLE
Mention draining gaze's healing effect

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -500,7 +500,8 @@ antimagic weapon.
 Draining Gaze spell
 
 Causes the target's magic to leak into the air, as though they were hit by an
-antimagic weapon, with no direct line of fire required.
+antimagic weapon, and heals the caster for the amount of magic drained,
+with no direct line of fire required.
 %%%%
 Dream Dust spell
 


### PR DESCRIPTION
Draining gaze heals ghost moths and eyes of draining for the amount of
MP drained by the gaze. This commit adds a note to this effect to the
draining gaze spell description.

Note: orange crystal statues also cast this spell, but they don't get
healed from it because they cannot regenerate HP.