### PR TITLE
Don't allow the player to cancel monster spells with OTR (11990)

### DIFF
--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -279,7 +279,7 @@ spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 
 spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 {
-    if (otr_stop_summoning_prompt())
+    if (caster->is_player() && otr_stop_summoning_prompt())
         return spret::abort;
 
     fail_check();


### PR DESCRIPTION
The monster spell Monstrous Menagerie and monsters using scrolls of
summoning use the same functions in spl-summoning.cc as the player
versions of the spell; this is not the case for any other summoning
spells.

This was allowing the player to cancel casting a monster's monstrous
menagerie or using their scroll of summoning if they had OTR up. We add
special checks to these two functions to avoid calling
otr_stop_summoning_prompt with monster casters.