### PR TITLE
Reduce monster glaciate damage by 20%

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2899,7 +2899,7 @@ spret cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
             beam.damage =
                 caster->is_player()
                     ? calc_dice(7, (66 + 3 * pow) / eff_range)
-                    : calc_dice(10, (54 + 3 * pow / 2) / eff_range);
+                    : calc_dice(8, (54 + 3 * pow / 2) / eff_range);
 
             if (actor_at(entry.first))
             {


### PR DESCRIPTION
On pandemonium lords during the orb run, glaciate is by far the most
common killer spell:

153 games for * (ckiller=pandemonium_lord ((d || depths || zot))
recent):
70x, 26x great icy blast, 9x great blast of fire, [...]

This is probably because the effective damage is higher than any other
spell in a pan lord's arsenal:
26 games for * (ckiller=pandemonium_lord ((d || depths || zot))
recent kaux=great_icy_blast): avg(dam)=56.69

Comparison: CBL 56, LCS 50, Firestorm 41. CBL gives at least a turn to
react, LCS has limited range, and Firestorm's damage is significantly
lower.

This reduction to glaciate damage will still give it a respectable 45
effective damage (80% of the above figure), which is still nothing to
sneeze at.