### PR TITLE
Add missing loading images to webtiles.

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1196,7 +1196,10 @@ TITLEIMGS = denzi_dragon denzi_kitchen_duty denzi_summoner \
             psiweapon_kiku white_noise_entering_the_dungeon \
             white_noise_grabbing_the_orb pooryurik_knight \
             psiweapon_roxanne baconkid_gastronok baconkid_mnoleg \
-            peileppe_bloax_eye baconkid_duvessa_dowan
+            peileppe_bloax_eye baconkid_duvessa_dowan ploomutoo_ijyb \
+	    froggy_thunder_fist_nikola froggy_rune_and_run_failed_on_dis \
+	    froggy_natasha_and_boris froggy_jiyva_felid \
+	    froggy_goodgod_tengu_gold Cws_Minotauros
 
 STATICFILES = $(TILEIMAGEFILES:%=webserver/game_data/static/%.png) \
               webserver/static/stone_soup_icon-32x32.png \

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -207,6 +207,7 @@
         <img style="display:none;" alt="" src="{{ static_url("title_baconkid_duvessa_dowan.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_baconkid_gastronok.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_baconkid_mnoleg.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_Cws_Minotauros.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_denzi_dragon.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_denzi_evil_mage.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_denzi_invasion.png") }}">
@@ -214,8 +215,14 @@
         <img style="display:none;" alt="" src="{{ static_url("title_denzi_summoner.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_denzi_undead_warrior.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_firemage.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_froggy_goodgod_tengu_gold.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_froggy_jiyva_felid.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_froggy_natasha_and_boris.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_froggy_rune_and_run_failed_on_dis.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_froggy_thunder_fist_nikola.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_omndra_zot_demon.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_peileppe_bloax_eye.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_ploomutoo_ijyb.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_pooryurik_knight.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_psiweapon_kiku.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_psiweapon_roxanne.png") }}">


### PR DESCRIPTION
I heard someone mention they weren't ever seeing the newer title splash images on webtiles so I had a look at my test webtiles install and noticed they were completely missing. This fix seems to work at least tho perhaps it would've been better to refactor the makefile so the source folder is just scanned for images and client.html generated accordingly rather than having to explicitly add the images individually each time one is added. First time making a pull request here so apologies if I did anything incorrectly and if so please help me out with some tips. Thanks!