### PR TITLE
Hepliaklqana Ancestor They/Them Pronouns

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -10,6 +10,7 @@
 #include "cio.h"
 #include "delay.h"
 #include "describe.h"
+#include "english.h"
 #include "externs.h"
 #include "invent.h"
 #include "libutil.h"
@@ -124,7 +125,7 @@ static string _describe_spell_filtering(mon_spell_slot_flag type, const char* pr
  *                          "possesses the following natural abilities:"
  */
 static string _booktype_header(mon_spell_slot_flag type, size_t num_books,
-                               bool has_silencable, bool has_filtered, const char* pronoun)
+                               bool has_silencable, bool has_filtered, const char* pronoun, bool pronoun_plural)
 {
     const string vulnerabilities =
         _ability_type_vulnerabilities(type, has_silencable);
@@ -133,7 +134,8 @@ static string _booktype_header(mon_spell_slot_flag type, size_t num_books,
 
     if (type == MON_SPELL_WIZARD)
     {
-        return make_stringf("has mastered %s%s%s:",
+        return make_stringf("%s mastered %s%s%s:",
+                            conjugate_verb("have", pronoun_plural).c_str(),
                             num_books > 1 ? "one of the following spellbooks"
                                           : "the following spells",
                             spell_filter_desc.c_str(),
@@ -142,7 +144,8 @@ static string _booktype_header(mon_spell_slot_flag type, size_t num_books,
 
     const string descriptor = _ability_type_descriptor(type);
 
-    return make_stringf("possesses the following %s abilities%s%s:",
+    return make_stringf("%s the following %s abilities%s%s:",
+                        conjugate_verb("possess", pronoun_plural).c_str(),
                         descriptor.c_str(),
                         spell_filter_desc.c_str(),
                         vulnerabilities.c_str());
@@ -261,7 +264,8 @@ static void _monster_spellbooks(const monster_info &mi,
                 uppercase_first(mi.pronoun(PRONOUN_SUBJECTIVE)) +
                 " " +
                 _booktype_header(type, valid_books.size(), has_silencable,
-                                 filtered_books, mi.pronoun(PRONOUN_OBJECTIVE));
+                                 filtered_books, mi.pronoun(PRONOUN_OBJECTIVE),
+                                 mi.pronoun_plurality());
         }
         else
         {

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4044,9 +4044,12 @@ static string _monster_stat_description(const monster_info& mi)
         }
         _add_energy_to_string(
             speed, me.spell,
-            mi.is_actual_spellcaster() ? conjugate_verb("cast", plural) + " spells" :
-            mi.is_priest()             ? conjugate_verb("use", plural) + " invocations"
-                                       : conjugate_verb("use", plural) + " natural abilities", fast, slow);
+            mi.is_actual_spellcaster() ? conjugate_verb("cast", plural)
+                                        + " spells" :
+            mi.is_priest()             ? conjugate_verb("use", plural)
+                                        + " invocations"
+                                       : conjugate_verb("use", plural)
+                                        + " natural abilities", fast, slow);
         _add_energy_to_string(speed, me.special,
                               conjugate_verb("use", plural) + " special abilities",
                               fast, slow);

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3931,16 +3931,19 @@ static string _monster_stat_description(const monster_info& mi)
     }
 
     const char* pronoun = mi.pronoun(PRONOUN_SUBJECTIVE);
+    const bool plural = mi.pronoun_plurality();
 
     if (mi.threat != MTHRT_UNDEF)
     {
-        result << uppercase_first(pronoun) << " looks "
-               << _get_threat_desc(mi.threat) << ".\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("look", plural) << " " 
+			   << _get_threat_desc(mi.threat) << ".\n";
     }
 
     if (!resist_descriptions.empty())
     {
-        result << uppercase_first(pronoun) << " is "
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
                << comma_separated_line(resist_descriptions.begin(),
                                        resist_descriptions.end(),
                                        "; and ", "; ")
@@ -3950,15 +3953,18 @@ static string _monster_stat_description(const monster_info& mi)
     // Is monster susceptible to anything? (On a new line.)
     if (!suscept.empty())
     {
-        result << uppercase_first(pronoun) << " is susceptible to "
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << "susceptible to "
                << comma_separated_line(suscept.begin(), suscept.end())
                << ".\n";
     }
 
     if (mi.is(MB_CHAOTIC))
     {
-        result << uppercase_first(pronoun) << " is vulnerable to silver and"
-                                              " hated by Zin.\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << "vulnerable to silver and hated by Zin.\n";
     }
 
     if (mons_class_flag(mi.type, M_STATIONARY)
@@ -3970,8 +3976,9 @@ static string _monster_stat_description(const monster_info& mi)
     if (mons_class_flag(mi.type, M_COLD_BLOOD)
         && get_resist(resist, MR_RES_COLD) <= 0)
     {
-        result << uppercase_first(pronoun) << " is cold-blooded and may be "
-                                              "slowed by cold attacks.\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << "cold-blooded and may be slowed by cold attacks.\n";
     }
 
     // Seeing invisible.
@@ -3980,7 +3987,9 @@ static string _monster_stat_description(const monster_info& mi)
 
     // Echolocation, wolf noses, jellies, etc
     if (!mons_can_be_blinded(mi.type))
-        result << uppercase_first(pronoun) << " is immune to blinding.\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << "immune to blinding.\n";
     // XXX: could mention "immune to dazzling" here, but that's spammy, since
     // it's true of such a huge number of monsters. (undead, statues, plants).
     // Might be better to have some place where players can see holiness &
@@ -3989,12 +3998,14 @@ static string _monster_stat_description(const monster_info& mi)
     if (mi.intel() <= I_BRAINLESS)
     {
         // Matters for Ely.
-        result << uppercase_first(pronoun) << " is mindless.\n";
+        result << uppercase_first(pronoun) << " " 
+			   << conjugate_verb("are", plural) << " mindless.\n";
     }
     else if (mi.intel() >= I_HUMAN)
     {
         // Matters for Yred, Gozag, Zin, TSO, Alistair....
-        result << uppercase_first(pronoun) << " is intelligent.\n";
+        result << uppercase_first(pronoun) << " "
+			   << conjugate_verb("are", plural) << " intelligent.\n";
     }
 
     // Unusual monster speed.
@@ -4003,7 +4014,9 @@ static string _monster_stat_description(const monster_info& mi)
     if (speed != 10 && speed != 0)
     {
         did_speed = true;
-        result << uppercase_first(pronoun) << " is " << mi.speed_description();
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << mi.speed_description();
     }
     const mon_energy_usage def = DEFAULT_ENERGY;
     if (!(mi.menergy == def))
@@ -4012,22 +4025,26 @@ static string _monster_stat_description(const monster_info& mi)
         vector<string> fast, slow;
         if (!did_speed)
             result << uppercase_first(pronoun) << " ";
-        _add_energy_to_string(speed, me.move, "covers ground", fast, slow);
+        _add_energy_to_string(speed, me.move,
+							  conjugate_verb("cover", plural) + " ground", fast, slow);
         // since MOVE_ENERGY also sets me.swim
         if (me.swim != me.move)
-            _add_energy_to_string(speed, me.swim, "swims", fast, slow);
-        _add_energy_to_string(speed, me.attack, "attacks", fast, slow);
+            _add_energy_to_string(speed, me.swim,
+								  conjugate_verb("swim", plural), fast, slow);
+        _add_energy_to_string(speed, me.attack,
+							  conjugate_verb("attack", plural), fast, slow);
         if (mons_class_itemuse(mi.type) >= MONUSE_STARTING_EQUIPMENT)
-            _add_energy_to_string(speed, me.missile, "shoots", fast, slow);
+            _add_energy_to_string(speed, me.missile,
+								  conjugate_verb("shoot", plural), fast, slow);
         _add_energy_to_string(
             speed, me.spell,
-            mi.is_actual_spellcaster() ? "casts spells" :
-            mi.is_priest()             ? "uses invocations"
-                                       : "uses natural abilities", fast, slow);
-        _add_energy_to_string(speed, me.special, "uses special abilities",
+            mi.is_actual_spellcaster() ? conjugate_verb("cast", plural) + " spells" :
+            mi.is_priest()             ? conjugate_verb("use", plural) + " invocations"
+                                       : conjugate_verb("use", plural) + " natural abilities", fast, slow);
+        _add_energy_to_string(speed, me.special, conjugate_verb("use", plural) + " special abilities",
                               fast, slow);
         if (mons_class_itemuse(mi.type) >= MONUSE_STARTING_EQUIPMENT)
-            _add_energy_to_string(speed, me.item, "uses items", fast, slow);
+            _add_energy_to_string(speed, me.item, conjugate_verb("use", plural) + " items", fast, slow);
 
         if (speed >= 10)
         {
@@ -4071,8 +4088,9 @@ static string _monster_stat_description(const monster_info& mi)
     if (mi.type == MONS_SHADOW)
     {
         // Cf. monster::action_energy() in monster.cc.
-        result << uppercase_first(pronoun) << " covers ground more"
-               << " quickly when invisible.\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("cover", plural)
+			   << " ground more quickly when invisible.\n";
     }
 
     if (mi.airborne())
@@ -4082,11 +4100,15 @@ static string _monster_stat_description(const monster_info& mi)
     if (!mi.can_regenerate())
         result << uppercase_first(pronoun) << " cannot regenerate.\n";
     else if (mons_class_fast_regen(mi.type))
-        result << uppercase_first(pronoun) << " regenerates quickly.\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("regenerate", plural)
+			   << " quickly.\n";
 
     const char* mon_size = get_size_adj(mi.body_size(), true);
     if (mon_size)
-        result << uppercase_first(pronoun) << " is " << mon_size << ".\n";
+        result << uppercase_first(pronoun)
+			   << " " << conjugate_verb("are", plural) << " "
+			   << mon_size << ".\n";
 
     if (in_good_standing(GOD_ZIN, 0) && !mi.pos.origin() && monster_at(mi.pos))
     {
@@ -4100,8 +4122,9 @@ static string _monster_stat_description(const monster_info& mi)
         }
         else if (eligibility == RE_TOO_STRONG)
         {
-            result << uppercase_first(pronoun) <<
-                    " is too strong to be affected by reciting Zin's laws.";
+            result << uppercase_first(pronoun)
+				   << " " << conjugate_verb("are", plural)
+				   << " too strong to be affected by reciting Zin's laws.";
         }
         else // RE_ELIGIBLE || RE_RECITE_TIMER
         {
@@ -4206,6 +4229,7 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
     const string it = mi.pronoun(PRONOUN_SUBJECTIVE);
     const string it_o = mi.pronoun(PRONOUN_OBJECTIVE);
     const string It = uppercase_first(it);
+	const string is = conjugate_verb("are", mi.pronoun_plurality());
 
     switch (mi.type)
     {
@@ -4316,7 +4340,7 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
     bool stair_use = false;
     if (!mons_class_can_use_stairs(mi.type))
     {
-        inf.body << It << " is incapable of using stairs.\n";
+        inf.body << It << " " << is << " incapable of using stairs.\n";
         stair_use = true;
     }
 
@@ -4326,14 +4350,14 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
                     "temporary. Killing " << it_o << " yields no experience, "
                     "nutrition or items";
         if (!stair_use)
-            inf.body << ", and " << it << " is incapable of using stairs";
+            inf.body << ", and " << it << " " << is << " incapable of using stairs";
         inf.body << ".\n";
     }
     else if (mi.is(MB_PERM_SUMMON))
     {
         inf.body << "\nThis monster has been summoned in a durable way. "
                     "Killing " << it_o << " yields no experience, nutrition "
-                    "or items, but " << it_o << " cannot be abjured.\n";
+                    "or items, but " << it << " cannot be abjured.\n";
     }
     else if (mi.is(MB_NO_REWARD))
     {
@@ -4342,7 +4366,7 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
     }
     else if (mons_class_leaves_hide(mi.type))
     {
-        inf.body << "\nIf " << it << " is slain, it may be possible to "
+        inf.body << "\nIf " << it << " " << is << " slain, it may be possible to "
                     "recover " << mi.pronoun(PRONOUN_POSSESSIVE)
                  << " hide, which can be used as armour.\n";
     }

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3935,15 +3935,15 @@ static string _monster_stat_description(const monster_info& mi)
 
     if (mi.threat != MTHRT_UNDEF)
     {
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("look", plural) << " " 
-			   << _get_threat_desc(mi.threat) << ".\n";
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("look", plural) << " "
+               << _get_threat_desc(mi.threat) << ".\n";
     }
 
     if (!resist_descriptions.empty())
     {
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural) << " "
                << comma_separated_line(resist_descriptions.begin(),
                                        resist_descriptions.end(),
                                        "; and ", "; ")
@@ -3953,18 +3953,17 @@ static string _monster_stat_description(const monster_info& mi)
     // Is monster susceptible to anything? (On a new line.)
     if (!suscept.empty())
     {
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << "susceptible to "
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural) << " susceptible to "
                << comma_separated_line(suscept.begin(), suscept.end())
                << ".\n";
     }
 
     if (mi.is(MB_CHAOTIC))
     {
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << "vulnerable to silver and hated by Zin.\n";
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural)
+               << " vulnerable to silver and hated by Zin.\n";
     }
 
     if (mons_class_flag(mi.type, M_STATIONARY)
@@ -3977,8 +3976,8 @@ static string _monster_stat_description(const monster_info& mi)
         && get_resist(resist, MR_RES_COLD) <= 0)
     {
         result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << "cold-blooded and may be slowed by cold attacks.\n";
+               << " " << conjugate_verb("are", plural)
+               << " cold-blooded and may be slowed by cold attacks.\n";
     }
 
     // Seeing invisible.
@@ -3987,9 +3986,11 @@ static string _monster_stat_description(const monster_info& mi)
 
     // Echolocation, wolf noses, jellies, etc
     if (!mons_can_be_blinded(mi.type))
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << "immune to blinding.\n";
+    {
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural)
+               << " immune to blinding.\n";
+    }
     // XXX: could mention "immune to dazzling" here, but that's spammy, since
     // it's true of such a huge number of monsters. (undead, statues, plants).
     // Might be better to have some place where players can see holiness &
@@ -3998,14 +3999,14 @@ static string _monster_stat_description(const monster_info& mi)
     if (mi.intel() <= I_BRAINLESS)
     {
         // Matters for Ely.
-        result << uppercase_first(pronoun) << " " 
-			   << conjugate_verb("are", plural) << " mindless.\n";
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural) << " mindless.\n";
     }
     else if (mi.intel() >= I_HUMAN)
     {
         // Matters for Yred, Gozag, Zin, TSO, Alistair....
         result << uppercase_first(pronoun) << " "
-			   << conjugate_verb("are", plural) << " intelligent.\n";
+               << conjugate_verb("are", plural) << " intelligent.\n";
     }
 
     // Unusual monster speed.
@@ -4014,9 +4015,9 @@ static string _monster_stat_description(const monster_info& mi)
     if (speed != 10 && speed != 0)
     {
         did_speed = true;
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << mi.speed_description();
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural) << " "
+               << mi.speed_description();
     }
     const mon_energy_usage def = DEFAULT_ENERGY;
     if (!(mi.menergy == def))
@@ -4026,25 +4027,35 @@ static string _monster_stat_description(const monster_info& mi)
         if (!did_speed)
             result << uppercase_first(pronoun) << " ";
         _add_energy_to_string(speed, me.move,
-							  conjugate_verb("cover", plural) + " ground", fast, slow);
+                              conjugate_verb("cover", plural) + " ground",
+                              fast, slow);
         // since MOVE_ENERGY also sets me.swim
         if (me.swim != me.move)
+        {
             _add_energy_to_string(speed, me.swim,
-								  conjugate_verb("swim", plural), fast, slow);
+                                  conjugate_verb("swim", plural), fast, slow);
+        }
         _add_energy_to_string(speed, me.attack,
-							  conjugate_verb("attack", plural), fast, slow);
+                              conjugate_verb("attack", plural), fast, slow);
         if (mons_class_itemuse(mi.type) >= MONUSE_STARTING_EQUIPMENT)
+        {
             _add_energy_to_string(speed, me.missile,
-								  conjugate_verb("shoot", plural), fast, slow);
+                                  conjugate_verb("shoot", plural), fast, slow);
+        }
         _add_energy_to_string(
             speed, me.spell,
             mi.is_actual_spellcaster() ? conjugate_verb("cast", plural) + " spells" :
             mi.is_priest()             ? conjugate_verb("use", plural) + " invocations"
                                        : conjugate_verb("use", plural) + " natural abilities", fast, slow);
-        _add_energy_to_string(speed, me.special, conjugate_verb("use", plural) + " special abilities",
+        _add_energy_to_string(speed, me.special,
+                              conjugate_verb("use", plural) + " special abilities",
                               fast, slow);
         if (mons_class_itemuse(mi.type) >= MONUSE_STARTING_EQUIPMENT)
-            _add_energy_to_string(speed, me.item, conjugate_verb("use", plural) + " items", fast, slow);
+        {
+            _add_energy_to_string(speed, me.item,
+                                  conjugate_verb("use", plural) + " items",
+                                  fast, slow);
+        }
 
         if (speed >= 10)
         {
@@ -4088,9 +4099,9 @@ static string _monster_stat_description(const monster_info& mi)
     if (mi.type == MONS_SHADOW)
     {
         // Cf. monster::action_energy() in monster.cc.
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("cover", plural)
-			   << " ground more quickly when invisible.\n";
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("cover", plural)
+               << " ground more quickly when invisible.\n";
     }
 
     if (mi.airborne())
@@ -4100,15 +4111,17 @@ static string _monster_stat_description(const monster_info& mi)
     if (!mi.can_regenerate())
         result << uppercase_first(pronoun) << " cannot regenerate.\n";
     else if (mons_class_fast_regen(mi.type))
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("regenerate", plural)
-			   << " quickly.\n";
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("regenerate", plural)
+               << " quickly.\n";
 
     const char* mon_size = get_size_adj(mi.body_size(), true);
     if (mon_size)
-        result << uppercase_first(pronoun)
-			   << " " << conjugate_verb("are", plural) << " "
-			   << mon_size << ".\n";
+    {
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural) << " "
+               << mon_size << ".\n";
+    }
 
     if (in_good_standing(GOD_ZIN, 0) && !mi.pos.origin() && monster_at(mi.pos))
     {
@@ -4122,9 +4135,9 @@ static string _monster_stat_description(const monster_info& mi)
         }
         else if (eligibility == RE_TOO_STRONG)
         {
-            result << uppercase_first(pronoun)
-				   << " " << conjugate_verb("are", plural)
-				   << " too strong to be affected by reciting Zin's laws.";
+            result << uppercase_first(pronoun) << " "
+                   << conjugate_verb("are", plural)
+                   << " too strong to be affected by reciting Zin's laws.";
         }
         else // RE_ELIGIBLE || RE_RECITE_TIMER
         {
@@ -4229,7 +4242,7 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
     const string it = mi.pronoun(PRONOUN_SUBJECTIVE);
     const string it_o = mi.pronoun(PRONOUN_OBJECTIVE);
     const string It = uppercase_first(it);
-	const string is = conjugate_verb("are", mi.pronoun_plurality());
+    const string is = conjugate_verb("are", mi.pronoun_plurality());
 
     switch (mi.type)
     {

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3086,7 +3086,9 @@ static string _mon_enchantments_string(const monster_info& mi)
     if (!enchant_descriptors.empty())
     {
         return uppercase_first(mi.pronoun(PRONOUN_SUBJECTIVE))
-            + " is "
+            + " "
+            + conjugate_verb("are", mi.pronoun_plurality())
+            + " "
             + comma_separated_line(enchant_descriptors.begin(),
                                    enchant_descriptors.end())
             + ".";
@@ -3183,7 +3185,8 @@ static string _get_monster_desc(const monster_info& mi)
     string pronoun = uppercase_first(mi.pronoun(PRONOUN_SUBJECTIVE));
 
     if (mi.is(MB_CLINGING))
-        text += pronoun + " is clinging to the wall.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " clinging to the wall.\n";
 
     if (mi.is(MB_MESMERIZING))
     {
@@ -3193,49 +3196,61 @@ static string _get_monster_desc(const monster_info& mi)
 
     if (mi.is(MB_SLEEPING) || mi.is(MB_DORMANT))
     {
-        text += pronoun + " appears to be "
+        text += pronoun + " "
+                + conjugate_verb("appear", mi.pronoun_plurality()) + " to be "
                 + (mi.is(MB_CONFUSED) ? "sleepwalking"
                         : "resting")
                           + ".\n";
     }
     // Applies to both friendlies and hostiles
     else if (mi.is(MB_FLEEING))
-        text += pronoun + " is fleeing.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " fleeing.\n";
     // hostile with target != you
     else if (mi.attitude == ATT_HOSTILE && (mi.is(MB_UNAWARE) || mi.is(MB_WANDERING)))
-        text += pronoun + " doesn't appear to have noticed you.\n";
+        text += pronoun + " " + conjugate_verb("don't", mi.pronoun_plurality())
+                + " appear to have noticed you.\n";
 
     if (mi.attitude == ATT_FRIENDLY)
-        text += pronoun + " is friendly.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " friendly.\n";
     else if (mi.attitude == ATT_GOOD_NEUTRAL)
-        text += pronoun + " seems to be peaceful towards you.\n";
+        text += pronoun + " " + conjugate_verb("seem", mi.pronoun_plurality())
+                + " to be peaceful towards you.\n";
     else if (mi.attitude != ATT_HOSTILE && !mi.is(MB_INSANE))
     {
         // don't differentiate between permanent or not
-        text += pronoun + " is indifferent to you.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " indifferent to you.\n";
     }
 
     if (mi.is(MB_SUMMONED) || mi.is(MB_PERM_SUMMON))
     {
-        text += pronoun + " has been summoned";
+        text += pronoun + " " + conjugate_verb("have", mi.pronoun_plurality())
+                + " been summoned";
         if (mi.is(MB_SUMMONED_CAPPED))
-            text += ", and is expiring";
+            text += ", and " + conjugate_verb("are", mi.pronoun_plurality())
+                    + " expiring";
         else if (mi.is(MB_PERM_SUMMON))
             text += " but will not time out";
         text += ".\n";
     }
 
     if (mi.is(MB_HALOED))
-        text += pronoun + " is illuminated by a divine halo.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " illuminated by a divine halo.\n";
 
     if (mi.is(MB_UMBRAED))
-        text += pronoun + " is wreathed by an umbra.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " wreathed by an umbra.\n";
 
     if (mi.intel() <= I_BRAINLESS)
-        text += pronoun + " is mindless.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " mindless.\n";
 
     if (mi.is(MB_CHAOTIC))
-        text += pronoun + " is chaotic.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " chaotic.\n";
 
     if (mi.is(MB_POSSESSABLE))
     {
@@ -3243,13 +3258,16 @@ static string _get_monster_desc(const monster_info& mi)
                 + " soul is ripe for the taking.\n";
     }
     else if (mi.is(MB_ENSLAVED))
-        text += pronoun + " is a disembodied soul.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " a disembodied soul.\n";
 
     if (mi.is(MB_MIRROR_DAMAGE))
-        text += pronoun + " is reflecting injuries back at attackers.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " reflecting injuries back at attackers.\n";
 
     if (mi.is(MB_INNER_FLAME))
-        text += pronoun + " is filled with an inner flame.\n";
+        text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
+                + " filled with an inner flame.\n";
 
     if (mi.fire_blocker)
     {
@@ -3580,8 +3598,9 @@ static void _describe_cell(const coord_def& where, bool in_range)
 
         if (!in_range)
         {
-            mprf(MSGCH_EXAMINE_FILTER, "%s is out of range.",
-                 mon->pronoun(PRONOUN_SUBJECTIVE).c_str());
+            mprf(MSGCH_EXAMINE_FILTER, "%s %s out of range.",
+                 mon->pronoun(PRONOUN_SUBJECTIVE).c_str(),
+                 conjugate_verb("are", mi.pronoun_plurality()).c_str());
         }
 #ifndef DEBUG_DIAGNOSTICS
         monster_described = true;

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3185,8 +3185,10 @@ static string _get_monster_desc(const monster_info& mi)
     string pronoun = uppercase_first(mi.pronoun(PRONOUN_SUBJECTIVE));
 
     if (mi.is(MB_CLINGING))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " clinging to the wall.\n";
+    }
 
     if (mi.is(MB_MESMERIZING))
     {
@@ -3212,8 +3214,10 @@ static string _get_monster_desc(const monster_info& mi)
                 + " appear to have noticed you.\n";
 
     if (mi.attitude == ATT_FRIENDLY)
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " friendly.\n";
+    }
     else if (mi.attitude == ATT_GOOD_NEUTRAL)
         text += pronoun + " " + conjugate_verb("seem", mi.pronoun_plurality())
                 + " to be peaceful towards you.\n";
@@ -3229,28 +3233,38 @@ static string _get_monster_desc(const monster_info& mi)
         text += pronoun + " " + conjugate_verb("have", mi.pronoun_plurality())
                 + " been summoned";
         if (mi.is(MB_SUMMONED_CAPPED))
+        {
             text += ", and " + conjugate_verb("are", mi.pronoun_plurality())
                     + " expiring";
+        }
         else if (mi.is(MB_PERM_SUMMON))
             text += " but will not time out";
         text += ".\n";
     }
 
     if (mi.is(MB_HALOED))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " illuminated by a divine halo.\n";
+    }
 
     if (mi.is(MB_UMBRAED))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " wreathed by an umbra.\n";
+    }
 
     if (mi.intel() <= I_BRAINLESS)
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " mindless.\n";
+    }
 
     if (mi.is(MB_CHAOTIC))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " chaotic.\n";
+    }
 
     if (mi.is(MB_POSSESSABLE))
     {
@@ -3262,12 +3276,16 @@ static string _get_monster_desc(const monster_info& mi)
                 + " a disembodied soul.\n";
 
     if (mi.is(MB_MIRROR_DAMAGE))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " reflecting injuries back at attackers.\n";
+    }
 
     if (mi.is(MB_INNER_FLAME))
+    {
         text += pronoun + " " + conjugate_verb("are", mi.pronoun_plurality())
                 + " filled with an inner flame.\n";
+    }
 
     if (mi.fire_blocker)
     {

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3210,8 +3210,8 @@ static string _get_monster_desc(const monster_info& mi)
                 + " fleeing.\n";
     // hostile with target != you
     else if (mi.attitude == ATT_HOSTILE && (mi.is(MB_UNAWARE) || mi.is(MB_WANDERING)))
-        text += pronoun + " " + conjugate_verb("don't", mi.pronoun_plurality())
-                + " appear to have noticed you.\n";
+        text += pronoun + " " + conjugate_verb("have", mi.pronoun_plurality())
+                + " not noticed you.\n";
 
     if (mi.attitude == ATT_FRIENDLY)
     {

--- a/crawl-ref/source/english.cc
+++ b/crawl-ref/source/english.cc
@@ -269,7 +269,7 @@ static const char * const _pronoun_declension[][NUM_PRONOUN_CASES] =
     { "he",  "his",  "himself",  "him" }, // masculine
     { "she", "her",  "herself",  "her" }, // feminine
     { "you", "your", "yourself", "you" }, // 2nd person
-	{ "they", "their", "themself", "them" }, // neutral
+    { "they", "their", "themself", "them" }, // neutral
 };
 
 const char *decline_pronoun(gender_type gender, pronoun_type variant)

--- a/crawl-ref/source/english.cc
+++ b/crawl-ref/source/english.cc
@@ -202,7 +202,7 @@ string apostrophise(const string &name)
     if (name == "herself")
         return "her own";
 
-    if (name == "themselves")
+    if (name == "themselves" || name == "themself")
         return "their own";
 
     if (name == "yourself")
@@ -269,6 +269,7 @@ static const char * const _pronoun_declension[][NUM_PRONOUN_CASES] =
     { "he",  "his",  "himself",  "him" }, // masculine
     { "she", "her",  "herself",  "her" }, // feminine
     { "you", "your", "yourself", "you" }, // 2nd person
+	{ "they", "their", "themself", "them" }, // neutral
 };
 
 const char *decline_pronoun(gender_type gender, pronoun_type variant)

--- a/crawl-ref/source/gender-type.h
+++ b/crawl-ref/source/gender-type.h
@@ -6,5 +6,6 @@ enum gender_type
     GENDER_MALE,
     GENDER_FEMALE,
     GENDER_YOU, // A person, not a gender, but close enough.
+	GENDER_NEUTRAL,
     NUM_GENDERS
 };

--- a/crawl-ref/source/gender-type.h
+++ b/crawl-ref/source/gender-type.h
@@ -6,6 +6,6 @@ enum gender_type
     GENDER_MALE,
     GENDER_FEMALE,
     GENDER_YOU, // A person, not a gender, but close enough.
-	GENDER_NEUTRAL,
+    GENDER_NEUTRAL,
     NUM_GENDERS
 };

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -7061,9 +7061,9 @@ static void _hepliaklqana_choose_gender()
         canned_msg(MSG_OK);
         return;
     }
-    
+
     const int new_gender = choice == 2 ? 4 : choice + 1;
-	   const int hep_new_gender = (choice + 1) % 3;
+    const int hep_new_gender = (choice + 1) % 3;
 
     if (new_gender == current_gender)
     {

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -7040,12 +7040,13 @@ static void _hepliaklqana_choose_gender()
     static const string gender_names[] = { "neither", "male", "female" };
     const int current_gender
         = you.props[HEPLIAKLQANA_ALLY_GENDER_KEY].get_int();
-    ASSERT(size_t(current_gender) < ARRAYSZ(gender_names));
+    const int hep_current_gender = current_gender == 4 ? 0 : current_gender;
+    ASSERT(size_t(hep_current_gender) < ARRAYSZ(gender_names));
 
     mprf(MSGCH_PROMPT,
          "Was %s a) male, b) female, or c) neither? (Currently %s.)",
          hepliaklqana_ally_name().c_str(),
-         gender_names[current_gender].c_str());
+         gender_names[hep_current_gender].c_str());
 
     int keyin = toalower(get_ch());
     if (!isaalpha(keyin))
@@ -7055,14 +7056,15 @@ static void _hepliaklqana_choose_gender()
     }
 
     const uint32_t choice = keyin - 'a';
-    if (choice > ARRAYSZ(gender_names))
+    if (choice >= ARRAYSZ(gender_names))
     {
         canned_msg(MSG_OK);
         return;
     }
+    
+    const int new_gender = choice == 2 ? 4 : choice + 1;
+	   const int hep_new_gender = (choice + 1) % 3;
 
-    // fun trick
-    const int new_gender = (choice + 1) % 3;
     if (new_gender == current_gender)
     {
         canned_msg(MSG_OK);
@@ -7072,7 +7074,7 @@ static void _hepliaklqana_choose_gender()
     you.props[HEPLIAKLQANA_ALLY_GENDER_KEY] = new_gender;
     mprf("%s was always %s, you're pretty sure.",
          hepliaklqana_ally_name().c_str(),
-         gender_names[new_gender].c_str());
+         gender_names[hep_new_gender].c_str());
     upgrade_hepliaklqana_ancestor(true);
 }
 

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1841,3 +1841,12 @@ const char *monster_info::pronoun(pronoun_type variant) const
     }
     return mons_pronoun(type, variant, true);
 }
+
+const bool monster_info::pronoun_plurality() const
+{
+	if (props.exists(MON_GENDER_KEY))
+	{
+		return props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL ? true : false;
+	}
+	return false;
+}

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1844,9 +1844,7 @@ const char *monster_info::pronoun(pronoun_type variant) const
 
 const bool monster_info::pronoun_plurality() const
 {
-	if (props.exists(MON_GENDER_KEY))
-	{
-		return props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL ? true : false;
-	}
-	return false;
+    if (props.exists(MON_GENDER_KEY))
+        return props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL ? true : false;
+    return false;
 }

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1551,7 +1551,11 @@ string monster_info::wounds_description_sentence() const
     if (wounds.empty())
         return "";
     else
-        return string(pronoun(PRONOUN_SUBJECTIVE)) + " is " + wounds + ".";
+    {
+        return string(pronoun(PRONOUN_SUBJECTIVE)) + " "
+                + conjugate_verb("are", pronoun_plurality())
+                + " " + wounds + ".";
+    }
 }
 
 string monster_info::wounds_description(bool use_colour) const

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -305,6 +305,7 @@ struct monster_info : public monster_info_base
     vector<string> attributes() const;
 
     const char *pronoun(pronoun_type variant) const;
+    const bool pronoun_plurality() const;
 
     string wounds_description_sentence() const;
     string wounds_description(bool colour = false) const;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2353,7 +2353,17 @@ string monster::pronoun(pronoun_type pro, bool force_visible) const
 
 string monster::conj_verb(const string &verb) const
 {
-    return conjugate_verb(verb, false);
+    const monster_info mi(this);
+	bool plural_conj = false;
+	// Conjugate neutral (not neuter) gender monsters as if they were plural.
+	if (mi.props.exists(MON_GENDER_KEY))
+	{
+		if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
+		{
+			plural_conj = true;
+		}
+	}
+    return conjugate_verb(verb, plural_conj);
 }
 
 string monster::hand_name(bool plural, bool *can_plural) const

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2353,15 +2353,7 @@ string monster::pronoun(pronoun_type pro, bool force_visible) const
 
 string monster::conj_verb(const string &verb) const
 {
-    const monster_info mi(this);
-    bool plural_conj = false;
-    // Conjugate neutral (not neuter) gender monsters as if they were plural.
-    if (mi.props.exists(MON_GENDER_KEY))
-    {
-        if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
-            plural_conj = true;
-    }
-    return conjugate_verb(verb, plural_conj);
+    return conjugate_verb(verb, false);
 }
 
 string monster::hand_name(bool plural, bool *can_plural) const

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2354,14 +2354,7 @@ string monster::pronoun(pronoun_type pro, bool force_visible) const
 string monster::conj_verb(const string &verb) const
 {
     const monster_info mi(this);
-    bool plural_conj = false;
-    // Conjugate neutral (not neuter) gender monsters as if they were plural.
-    if (mi.props.exists(MON_GENDER_KEY))
-    {
-        if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
-            plural_conj = true;
-    }
-    return conjugate_verb(verb, plural_conj);
+    return conjugate_verb(verb, mi.pronoun_plurality());
 }
 
 string monster::hand_name(bool plural, bool *can_plural) const

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2354,15 +2354,13 @@ string monster::pronoun(pronoun_type pro, bool force_visible) const
 string monster::conj_verb(const string &verb) const
 {
     const monster_info mi(this);
-	bool plural_conj = false;
-	// Conjugate neutral (not neuter) gender monsters as if they were plural.
-	if (mi.props.exists(MON_GENDER_KEY))
-	{
-		if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
-		{
-			plural_conj = true;
-		}
-	}
+    bool plural_conj = false;
+    // Conjugate neutral (not neuter) gender monsters as if they were plural.
+    if (mi.props.exists(MON_GENDER_KEY))
+    {
+        if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
+            plural_conj = true;
+    }
     return conjugate_verb(verb, plural_conj);
 }
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2354,7 +2354,14 @@ string monster::pronoun(pronoun_type pro, bool force_visible) const
 string monster::conj_verb(const string &verb) const
 {
     const monster_info mi(this);
-    return conjugate_verb(verb, mi.pronoun_plurality());
+    bool plural_conj = false;
+    // Conjugate neutral (not neuter) gender monsters as if they were plural.
+    if (mi.props.exists(MON_GENDER_KEY))
+    {
+        if (mi.props[MON_GENDER_KEY].get_int() == GENDER_NEUTRAL)
+            plural_conj = true;
+    }
+    return conjugate_verb(verb, plural_conj);
 }
 
 string monster::hand_name(bool plural, bool *can_plural) const


### PR DESCRIPTION
Now your ancestors that were "always neither, you're pretty sure" use "they" instead of "it"!

I think it makes the ancestor feel more like a person and less like a thing. It's not like your ancestor was a jelly or something. (And it's cool to be able to have my nonbinary friends help me beat up some gnolls without having to call them "it".)

The code to add "GENDER_NEUTRAL" to the gender list and the god ability was pretty simple, but I had to fix a lot of verb conjugations in the monster descriptions because they were all (reasonably-- the way singular they/them still conjugates verbs as plural is weird) hard coded as the singular conjugation.

This is my first time contributing to a project this big, git still really confuses me, and I'm pretty new to C++, so I have no idea what I'm doing right now. Please help me learn!

I tried my best to follow the conventions the existing code uses, but I haven't actually sat down and made sure I'm following the style guide yet. There are a couple places I want to refactor before this is 100% ready, such as monster::conj_verb and using the gender enums instead of hard coding the integers. I also would like to do a larger-scale test. Maybe temporarily change the gender of all the generic monsters in the dungeon in order to catch anything I missed? Would that be difficult to do?

Also, do I have to change anything to keep translations from breaking with these changes?

This was my intro project to get comfortable with Crawl's codebase, but if this is a change people would consider actually adding to the game, I'll put in the time to make it perfect.

<img width="466" alt="AllyDescription" src="https://user-images.githubusercontent.com/8132415/59155059-f7b0c380-8a34-11e9-9a4f-4ac484acf094.png">
