### PR TITLE
Fix hint for item description

### DIFF
--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -2933,7 +2933,7 @@ static string _hints_throw_stuff(const item_def &item)
     string result;
 
     result  = "To do this, type <w>%</w> to fire, then ";
-    if (!item.slot)
+    if (item.slot)
     {
         result += "<w>";
         result += item.slot;


### PR DESCRIPTION
In #766 (and 2b1cce4), I made a mistake in the conditional expression. Sorry.