### PR TITLE
Fix display of detected gold on the minimap (11950)

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1099,13 +1099,19 @@ void gozag_detect_level_gold(bool count)
                 || env.map_knowledge(pos).item()->base_type != OBJ_GOLD)
             {
                 detected = true;
+                update_item_at(pos, true);
             }
-            update_item_at(pos, true);
             // the pile can still remain undetected if it is not in
             // you.visible_igrd, for example if it is under deep water and the
             // player will not be able to see it.
             if (detected && env.map_knowledge(pos).item())
+            {
                 env.map_knowledge(pos).flags |= MAP_DETECTED_ITEM;
+#ifdef USE_TILE
+                // force an update for gold generated during Abyss shifts
+                tiles.update_minimap(pos);
+#endif
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, there are several Gold Sense-related bugs:
* on webtiles, detected gold is not displayed on the minimap;
* on local tiles, it disappears from the minimap after reloading the
  game and after reentering a floor;
* on console, it's not possible to scroll the map in the X mode to see
  all detected piles of gold on a new level.

This happens because now update_item_at() runs more than once for each
pile of gold.

Prior to 063869c, the gold detection code from files.cc:_count_gold(),
which contains update_item_at(), run only once for each new level.
After that commit and after 4488db6, the gold detection code, which is
now in god-passive.cc:gozag_detect_level_gold(), runs twice when the
player enters a new floor. First, it runs as a delayed action, then it
runs for counting the generated gold (both calls come from
files.cc:load_level()).

When it's called the first time, gozag_detect_level_gold() sets the
MAP_DETECTED_ITEM flag for each pile of gold, so they would appear on
the minimap. When gozag_detect_level_gold() called after that,
clear_item() removes this flag from the piles, and, since
env.map_knowledge() already knows about those piles,
gozag_detect_level_gold() won't set the flag again.

The code path is god-passive.cc:gozag_detect_level_gold() ->
show.cc:update_item_at() -> map-cell.h:set_item() ->
map-cell.h:clear_item().

Unlike webtiles, local tiles update the minimap only after the first
call, so detected gold appears on the minimap, but only until a current
level is reloaded.

This commit makes it safe to call gozag_detect_level_gold() multiple
times: update_item_at() will be called only for undetected piles of
gold.

Also, force update of the minimap so piles of gold generated in new
Abyss regions are displayed too.