### PR TITLE
Remove possible placement of blowgun from vault

### DIFF
--- a/crawl-ref/source/dat/des/variable/arcadia.des
+++ b/crawl-ref/source/dat/des/variable/arcadia.des
@@ -36,7 +36,7 @@ KMONS:   N = spriggan ; robe . quarterstaff
 KMONS:   O = dire elephant / death yak / emperor scorpion / anaconda w:5
 KMONS:   Q = bush
 KMONS:   R = plant
-ITEM:    dagger / short sword / rapier / flail / whip / blowgun / shortbow
+ITEM:    dagger / short sword / rapier / flail / whip / shortbow
 ITEM:    robe / cloak / hat / buckler / steam dragon scales w:1
 ITEM:    ration q:3
 KFEAT:   _ = altar_trog


### PR DESCRIPTION
Should fix a bug where this vault places an item marked as removed.