### PR TITLE
Don't ignore torment damage for Jiyva jelly spawns

### DIFF
--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -533,18 +533,13 @@ static void _maybe_ru_retribution(int dam, mid_t death_source)
     }
 }
 
-static void _maybe_spawn_monsters(int dam, const bool is_torment,
-                                  kill_method_type death_type,
+static void _maybe_spawn_monsters(int dam, kill_method_type death_type,
                                   mid_t death_source)
 {
     monster* damager = monster_by_mid(death_source);
     // We need to exclude acid damage and similar things or this function
     // will crash later.
     if (!damager)
-        return;
-
-    // Exclude torment damage. Ugh.
-    if (is_torment)
         return;
 
     monster_type mon;
@@ -797,10 +792,6 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
 
     int drain_amount = 0;
 
-    const bool is_torment = (aux && (strstr(aux, "torment")
-                || strstr(aux, "Torment")
-                || strstr(aux, "exploding lurking horror")));
-
     // Multiply damage if amulet of harm is in play
     if (dam != INSTANT_DEATH)
         dam = _apply_extra_harm(dam, source);
@@ -958,7 +949,7 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
             _deteriorate(dam);
             _yred_mirrors_injury(dam, source);
             _maybe_ru_retribution(dam, source);
-            _maybe_spawn_monsters(dam, is_torment, death_type, source);
+            _maybe_spawn_monsters(dam, death_type, source);
             _maybe_fog(dam);
             _powered_by_pain(dam);
             if (sanguine_armour_valid())


### PR DESCRIPTION
And also Xom butterfly spawns.

This exception dates back to when Jiyva was first introduced (in
[0.6.0-a0-258-g6d7627cb65](https://github.com/crawl/crawl/commit/6d7627cb65e54dae22237da82ea076bf17b1f9b7)).

It's an exception which isn't mentioned anywhere to the player and
probably unnecessary in terms of balance for both gods.