### PR TITLE
Allow travelling to altars, shops, and branches in ^O

### DIFF
--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -606,6 +606,11 @@ void show_interlevel_travel_depth_help()
     show_specific_help("interlevel-travel.depth.prompt");
 }
 
+void show_interlevel_travel_altar_help()
+{
+    show_specific_help("interlevel-travel.altar.prompt");
+}
+
 void show_stash_search_help()
 {
     show_specific_help("stash-search.prompt");

--- a/crawl-ref/source/command.h
+++ b/crawl-ref/source/command.h
@@ -21,6 +21,7 @@ void show_levelmap_help();
 void show_targeting_help();
 void show_interlevel_travel_branch_help();
 void show_interlevel_travel_depth_help();
+void show_interlevel_travel_altar_help();
 void show_stash_search_help();
 void show_butchering_help();
 void show_skill_menu_help();

--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -209,6 +209,7 @@ interlevel-travel.branch.prompt
  <w>Ctrl-P</w> : Travel to a level in the branch above this one.
  <w>*</w>      : Show available waypoints (if any are set).
  <w>0</w>-<w>9</w>    : Go to the numbered waypoint.
+ <w>_</w>      : Show available altars (if any are discovered).
 %%%%
 interlevel-travel.depth.prompt
 
@@ -221,6 +222,16 @@ interlevel-travel.depth.prompt
  <w>-</w> or <w>p</w> : Change default to the branch above this one.
  <w>$</w>      : Change default to deepest visited level in this branch.
  <w>^</w>      : Change default to the entrance to the current branch.
+%%%%
+interlevel-travel.altar.prompt
+
+<h>Interlevel Travel (go to an altar):
+ Use the shortcut letter (the initial of a god, with TSO being replaced by 1)
+ to select the altar for travel.
+
+ Once you select a god, you will begin travelling to the nearst altar.
+
+ <w>Enter</w>  : Repeat last interlevel travel.
 %%%%
 butchering
 

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1433,43 +1433,45 @@ static vector<stash_search_result> _stash_filter_duplicates(vector<stash_search_
     return out;
 }
 
-void StashTracker::search_stashes()
+void StashTracker::search_stashes(string search_term)
 {
     char buf[400];
 
     update_corpses();
     update_identification();
 
-    stash_search_reader reader(buf, sizeof buf);
-
-    bool validline = false;
-    msgwin_prompt(stash_search_prompt());
-    while (true)
+    if (search_term.empty())
     {
-        int ret = reader.read_line();
-        if (!ret)
-        {
-            validline = true;
-            break;
-        }
-        else if (ret == '?')
-        {
-            show_stash_search_help();
-            redraw_screen();
-        }
-        else
-            break;
-    }
-    msgwin_reply(validline ? buf : "");
+        stash_search_reader reader(buf, sizeof buf);
 
-    clear_messages();
-    if (!validline || (!*buf && lastsearch.empty()))
-    {
-        canned_msg(MSG_OK);
-        return;
-    }
+        bool validline = false;
+        msgwin_prompt(stash_search_prompt());
+        while (true)
+        {
+            int ret = reader.read_line();
+            if (!ret)
+            {
+                validline = true;
+                break;
+            }
+            else if (ret == '?')
+            {
+                show_stash_search_help();
+                redraw_screen();
+            }
+            else
+                break;
+        }
+        msgwin_reply(validline ? buf : "");
 
-    string csearch_literal = *buf? buf : lastsearch;
+        clear_messages();
+        if (!validline || (!*buf && lastsearch.empty()))
+        {
+            canned_msg(MSG_OK);
+            return;
+        }
+    }
+    string csearch_literal = search_term.empty() ? (*buf? buf : lastsearch) : search_term;
     string csearch = csearch_literal;
 
     bool curr_lev = (csearch[0] == '@' || csearch == ".");

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -240,7 +240,7 @@ public:
     {
     }
 
-    void search_stashes();
+    void search_stashes(string search_term = "");
 
     LevelStashes &get_current_level();
     LevelStashes *find_current_level();

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -2214,6 +2214,42 @@ static int _prompt_travel_branch(int prompt_flags)
     }
 }
 
+static god_type _god_from_initial(const char god_initial)
+{
+    switch (toupper_safe(god_initial))
+    {
+        case '1': return GOD_SHINING_ONE;
+        case 'A': return GOD_ASHENZARI;
+        case 'B': return GOD_BEOGH;
+        case 'C': return GOD_CHEIBRIADOS;
+        case 'D': return GOD_DITHMENOS;
+        case 'E': return GOD_ELYVILON;
+        case 'F': return GOD_FEDHAS;
+        case 'G': return GOD_GOZAG;
+        case 'H': return GOD_HEPLIAKLQANA;
+        case 'J': return GOD_JIYVA;
+        case 'K': return GOD_KIKUBAAQUDGHA;
+        case 'L': return GOD_LUGONU;
+        case 'M': return GOD_MAKHLEB;
+        case 'N': return GOD_NEMELEX_XOBEH;
+        case 'O': return GOD_OKAWARU;
+#if TAG_MAJOR_VERSION == 34
+        case 'P': return GOD_PAKELLAS;
+#endif
+        case 'Q': return GOD_QAZLAL;
+        case 'R': return GOD_RU;
+        case 'S': return GOD_SIF_MUNA;
+        case 'T': return GOD_TROG;
+        case 'U': return GOD_USKAYAW;
+        case 'V': return GOD_VEHUMET;
+        case 'W': return GOD_WU_JIAN;
+        case 'X': return GOD_XOM;
+        case 'Y': return GOD_YREDELEMNUL;
+        case 'Z': return GOD_ZIN;
+        default:  return GOD_NO_GOD;
+    }
+}
+
 level_id find_up_level(level_id curr, bool up_branch)
 {
     --curr.depth;


### PR DESCRIPTION
Currently, players need to use `Ctrl+O` to check discovered altars, but then have to use `Ctrl+F` to travel to the desired one.

This change makes it possible to travel to the nearest discovered altar within the Dungeon Overview
1. Within Dungeon Overview, press `_`.
2. Players will then be asked to enter the initial of a god. 
(`A/a` for Ashenzari except for TSO, which is replaced by `1`.)
3. Auto-travel to the nearest (level distance -wise) altar is then started.

This is done by modifying `G` such that `G_` can now be used to select the desired altar for travel, and `_` in dungeon overview is made a shortcut to `G_`.

However, this introduces UI inconsistencies now that `_` can only be pressed in dungeon overview while G only works in the main UI.

Therefore, `G` and `$` keypresses in dungeon overview are made shortcuts to G prompts and `^F "shop"`, respectively.

To do so, `StashTracker::search_stashes()` is modified to accept an optional predefined keyword. `StashTracker::search_stashes()` now directly return search results without asking what to search for when the keyword is specified.