### PR TITLE
Mark some runed door vaults as no_tele_into

### DIFF
--- a/crawl-ref/source/dat/des/variable/float.des
+++ b/crawl-ref/source/dat/des/variable/float.des
@@ -8502,6 +8502,7 @@ DEPTH:  D:8-, Depths
 ORIENT: float
 KMONS:  8 = 8
 KITEM:  8 = |
+KPROP:  8 = no_tele_into
 SUBST:  c : cvb, x : xcvb
 MAP
  xxxxxx@xx

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -4831,6 +4831,7 @@ ENDMAP
 NAME:   minmay_hidden_floor
 DEPTH:  D:12-, Depths
 SUBST:  9 = 9999., 8 = 8888.
+KPROP:  8*$ = no_tele_into
 MAP
      @
 cccccnccccc
@@ -4838,7 +4839,7 @@ c.........c
 c.ccc9ccc.c
 c.c8ncn8c.c
 c.cn***nc.c
-@.9c*.*c9.n@
+@.9c*$*c9.n@
 cncn***nc.c
 c.=8ncn8c.c
 c.ccc9ccc.c


### PR DESCRIPTION
Replace an empty square in one with $ to simplify the KPROP logic.