### PR TITLE
Remove dump_book_spells option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -122,7 +122,7 @@ The contents of this text are:
 4-b     Items and Kills.
                 kill_map, dump_kill_places, dump_kill_breakdowns,
                 dump_item_origins, dump_item_origin_price, dump_message_count,
-                dump_order, dump_book_spells
+                dump_order
 4-c     Notes.
                 user_note_prefix, note_items, note_monsters, note_hp_percent,
                 note_skill_levels, note_all_skill_levels, note_skill_max,
@@ -2272,11 +2272,6 @@ dump_order += monlist,kills,notes,skill_gains,action_counts
         while in wizard mode). The "vaults" section is enabled by default
         in trunk builds of Crawl (not releases or pre-release betas),
         appearing between "notes" and "skill_gains".
-
-dump_book_spells = true
-        By default all randart spellbooks in inventory will have all their
-        spells listed in the dump. If this option is set to true, spells will
-        also be dumped for non-randart spellbooks.
 
 4-c     Notes.
 --------------

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -809,12 +809,8 @@ static void _sdump_inventory(dump_params &par)
                 if (origin_describable(item) && _dump_item_origin(item))
                     text += "\n" "   (" + origin_desc(item) + ")";
 
-                if (is_dumpable_artefact(item)
-                    || Options.dump_book_spells
-                       && item.base_type == OBJ_BOOKS)
-                {
+                if (is_dumpable_artefact(item))
                     text += chardump_desc(item);
-                }
                 else
                     text += "\n";
             }

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1982,8 +1982,7 @@ string get_item_description(const item_def &item, bool verbose,
         break;
 
     case OBJ_BOOKS:
-        if (!verbose
-            && (Options.dump_book_spells || is_random_artefact(item)))
+        if (!verbose && is_random_artefact(item))
         {
             desc += describe_item_spells(item);
             if (desc.empty())

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -216,7 +216,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(wall_jump_prompt), false),
         new BoolGameOption(SIMPLE_NAME(wall_jump_move), false),
         new BoolGameOption(SIMPLE_NAME(darken_beyond_range), true),
-        new BoolGameOption(SIMPLE_NAME(dump_book_spells), true),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs), false),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs_all), false),
         new BoolGameOption(SIMPLE_NAME(arena_list_eq), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -401,7 +401,6 @@ public:
 
     int         dump_item_origins;  // Show where items came from?
     int         dump_item_origin_price;
-    bool        dump_book_spells;
 
     // Order of sections in the character dump.
     vector<string> dump_order;


### PR DESCRIPTION
Obsolete since the introduction of the spell library.