### PR TITLE
Incremental pregen

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,7 +18,7 @@ These include:
 	   resize-observer-polyfill, and scrollbarwidth
        worley.{cc,h}
 * zlib: webserver/static/scripts/contrib/inflate.js
-* Apache v2: pcg.cc
+* Apache v2, MIT (see comments in the file for details): pcg.cc
 
 The majority of Crawl's tiles and artwork are released under the CC0 license
 (https://creativecommons.org/publicdomain/zero/1.0/), and new submissions are

--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -471,31 +471,30 @@ Seeded play
 ========================================
 
 Crawl dungeons are determined by a "seed" number used to initialise the game's
-random number generator. If you initialise the game, keeping the game version
-constant, then the same seed should (within certain parameters) lead to the same
-dungeon. In offline games you can view your game's seed with '?V' as well as in
-a character file; in online games you normally must finish a game in order to
-see the game's seed. There are two seeded modes:
+random number generator. You may either let the game choose a seed randomly,
+or specify a seed; if you choose a seed this puts the game in "Seeded" mode,
+which is scored separately. Playing games with the same seed value, as long as
+the game version is constant, should (within certain parameters) lead to the
+same dungeon. The entire connected dungeon will be determined by the game
+seed, including dungeon layout, monster placement, and items. Portal vaults
+and chaotic zones such as the abyss are not guaranteed to be the same, and the
+placement of rare unique artefacts may vary depending on certain player
+actions.
 
-Without dungeon pregeneration ('pregen_dungeon = false')
-  If dungeon pregeneration is turned off (the default), every game with the
-  same seed will have at least the same initial dungeon level and temple
-  layout. However, the order in which you explore levels after the first one
-  can lead to multiple possible dungeon layouts, depending on your choices. This
-  is implicitly how dungeon generation always worked before version 0.23.
-
-With dungeon pregeneration ('pregen_dungeon = true')
-  If dungeon pregeneration is turned on, the entire connected dungeon will be
-  determined by the game seed. Portal vaults and chaotic zones such as the
-  abyss are not guaranteed to be the same, though.
-
-To set a game seed, use the 'game_seed' rc file option, or the '-seed' command
-line option.
+To set a game seed, use the "Choose game seed" option from the main menu; you
+can also use the 'game_seed' rc file option, or the '-seed' command line
+option. In offline games you can view your game's seed with '?V' as well as in
+a character file; in online games a randomly chosen seed will only be shown to
+you after finishing the game.
 
 If you find that the same seed generates distinct parts of a dungeon on the
 same or different devices, please report it as a bug. However, keep in mind
-that upgrading your save game between multiple versions of crawl, or traversing
-dungeon levels in different orders, will naturally lead to seed divergence.
+that upgrading your save game between multiple versions of crawl will
+naturally lead to seed divergence. When playing offline, if you would like to
+ensure that your game can be upgraded without divergence, you can set
+'pregen_dungeon = true' in your options file. (This will also ensure
+completely stable unique artefact placement.) On the other hand, to completely
+disable incremental pregeneration, you can set 'incremental_pregen = false'.
 
 Further Help
 ========================================

--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -492,9 +492,9 @@ same or different devices, please report it as a bug. However, keep in mind
 that upgrading your save game between multiple versions of crawl will
 naturally lead to seed divergence. When playing offline, if you would like to
 ensure that your game can be upgraded without divergence, you can set
-'pregen_dungeon = true' in your options file. (This will also ensure
+'pregen_dungeon = full' in your options file. (This will also ensure
 completely stable unique artefact placement.) On the other hand, to completely
-disable incremental pregeneration, you can set 'incremental_pregen = false'.
+disable incremental pregeneration, you can set 'pregen_dungeon = false'.
 
 Further Help
 ========================================

--- a/crawl-ref/docs/develop/levels/advanced.txt
+++ b/crawl-ref/docs/develop/levels/advanced.txt
@@ -275,10 +275,14 @@ a. Abyssal vaults must be small: no larger than 28x23. 23x23 or
    smaller vaults are best so that they can be rotated and fit in
    anywhere on the level.
 
-b. The player may never get a chance to explore unique abyss vaults
-   (vaults without the "allow_dup" tag). The player may be teleported
-   away to a different area of the abyss, or never notice your vault
-   before it shifts away.
+b. Unique vaults (vaults without the "allow_dup" tag) are tracked
+   separately for the abyss, so if a map's DEPTH spec allows it to
+   place both inside and outside of the abyss, it may appear up to
+   two times even if unique. The same applies to unique tags.
+
+c. The player may never get a chance to explore unique abyss vaults.
+   The player may be teleported away to a different area of the abyss,
+   or never notice your vault before it shifts away.
 
    Unique vaults that the player never sees will be reused by the
    abyss builder, but it is still possible for the player to see an
@@ -287,9 +291,9 @@ b. The player may never get a chance to explore unique abyss vaults
    can finish exploring it.
 
    Once any square of a unique vault has been seen by the player in
-   the abyss, that vault cannot be reused.
+   the abyss, that vault cannot be reused within the abyss.
 
-c. Timers and other listeners in an abyssal vault may be discarded at
+d. Timers and other listeners in an abyssal vault may be discarded at
    any time when the abyss shifts and the vault is destroyed. You can
    still use timers to modify your vaults, but be aware that the timer
    may be removed at any time as the abyss shifts away from your

--- a/crawl-ref/docs/develop/levels/syntax.txt
+++ b/crawl-ref/docs/develop/levels/syntax.txt
@@ -634,9 +634,9 @@ ITEM:     (list of items, separated by comma)
           will be created instead. Staff unrands, since they have no
           corresponding type that can be transformed into a randart, are
           replaced by an appropriate magical staff. (E.g. a staff of poison.)
-          The lua function you.unrands() ('you.unrands("scythe of curses")')
-          can be used to check whether an unrand has already been seen, if
-          you don't want to use the default fallback.
+          You should not use `you.unrands` to check whether an unrand has been
+          seen in normal levelgen scenarios, as it will impact seeding. Some
+          details about default fallbacks can be specified in art-data.txt.
 
           Randart spell books
           -------------------

--- a/crawl-ref/docs/develop/levels/syntax.txt
+++ b/crawl-ref/docs/develop/levels/syntax.txt
@@ -327,7 +327,8 @@ TAGS:     Tags go on a TAGS: line and are space-separated. You can have several
              property to every square of the vault. See KPROP: below.
           * "allow_dup": Vaults are normally used only once per game. If you
              have a vault that can be used more than once, use allow_dup to tell
-             the dungeon builder that the vault can be reused.
+             the dungeon builder that the vault can be reused. This is tracked
+             separately for the abyss and the rest of the dungeon.
           * "chance_FOO": Maps can be tagged chance_ with any unique suffix
              to indicate that if the map's CHANCE roll is made, one of the maps
              tagged chance_FOO should be picked.
@@ -379,7 +380,8 @@ TAGS:     Tags go on a TAGS: line and are space-separated. You can have several
           * "uniq_BAR": (uniq_ with any suffix) specifies that only one of
              the vaults with this tag can be used in a game. In particular,
              late-Dungeon encompass vaults have the tag uniq_d_encompass, so
-             that only one will occur per game.
+             that only one will occur per game. This is tracked separately
+             for the abyss and the rest of the dungeon.
           * "luniq": specifies that this vault can be used only once on a
              given level. "luniq" is only relevant when used with "allow_dup".
           * "luniq_BAR": (luniq_ with any suffix) specifies that only one

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -410,14 +410,17 @@ game_seed = none
         "-seed", which will override any rc file setting. This value is an
         unsigned 64 bit integer.
 
-pregen_dungeon = false
-        When set to true, the game will pregenerate the entire connected dungeon
-        when starting a new character. This leads to more deterministic dungeon
-        generation relative to a particular game seed. If this is false, levels
-        will be generated as you enter them, and the order in which you traverse
-        the dungeon will lead to different dungeons for the same game seed. With
-        this set to true, you still may encounter variation in portal vaults,
-        the abyss, pandemonium, and ziggurats.
+pregen_dungeon = classic
+        When set to `true` or `full`, the game will pregenerate the entire
+        connected dungeon when starting a new character. This leads to
+        deterministic dungeon generation relative to a particular game seed, at
+        the cost of a slow game start. If set to `incremental`, the game will
+        generate levels as needed so that it always generates them in the same
+        order, also producing a deterministic dungeon. You still may encounter
+        variation in bazaars, the abyss, pandemonium, and ziggurats, and for
+        incremental pregeneration, artefacts. When set to `false` or `classic`,
+        the game will generate all levels on level entry, as was the rule before
+        0.23. Some servers may disallow full pregeneration.
 
 2-  File System.
 ================

--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -1437,11 +1437,11 @@ static void _generate_area(const map_bitmask &abyss_genlevel_mask)
 
 static void _initialize_abyss_state()
 {
-    abyssal_state.major_coord.x = get_uint32() & 0x7FFFFFFF;
-    abyssal_state.major_coord.y = get_uint32() & 0x7FFFFFFF;
-    abyssal_state.seed = get_uint32() & 0x7FFFFFFF;
+    abyssal_state.major_coord.x = rng::get_uint32() & 0x7FFFFFFF;
+    abyssal_state.major_coord.y = rng::get_uint32() & 0x7FFFFFFF;
+    abyssal_state.seed = rng::get_uint32() & 0x7FFFFFFF;
     abyssal_state.phase = 0.0;
-    abyssal_state.depth = get_uint32() & 0x7FFFFFFF;
+    abyssal_state.depth = rng::get_uint32() & 0x7FFFFFFF;
     abyssal_state.destroy_all_terrain = false;
     abyssal_state.level = _get_random_level();
     abyss_sample_queue = sample_queue(ProceduralSamplePQCompare());
@@ -1451,7 +1451,7 @@ void set_abyss_state(coord_def coord, uint32_t depth)
 {
     abyssal_state.major_coord = coord;
     abyssal_state.depth = depth;
-    abyssal_state.seed = get_uint32() & 0x7FFFFFFF;
+    abyssal_state.seed = rng::get_uint32() & 0x7FFFFFFF;
     abyssal_state.phase = 0.0;
     abyssal_state.destroy_all_terrain = true;
     abyss_sample_queue = sample_queue(ProceduralSamplePQCompare());

--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -20,6 +20,7 @@
 #include "colour.h"
 #include "coordit.h"
 #include "dbg-scan.h"
+#include "dbg-util.h"
 #include "delay.h"
 #include "dgn-overview.h"
 #include "dgn-proclayouts.h"
@@ -1493,6 +1494,15 @@ static void abyss_area_shift()
     // And allow monsters in transit another chance to return.
     place_transiting_monsters();
 
+    auto &vault_list =  you.vault_list[level_id::current()];
+#ifdef DEBUG
+    vault_list.push_back("[shift]");
+#endif
+    const auto &level_vaults = level_vault_names();
+    vault_list.insert(vault_list.end(),
+                        level_vaults.begin(), level_vaults.end());
+
+
     check_map_validity();
     // TODO: should dactions be rerun at this point instead? That would cover
     // this particular case...
@@ -1721,6 +1731,14 @@ void abyss_teleport()
     forget_map(false);
     clear_excludes();
     gozag_detect_level_gold(false);
+    auto &vault_list =  you.vault_list[level_id::current()];
+#ifdef DEBUG
+    vault_list.push_back("[tele]");
+#endif
+    const auto &level_vaults = level_vault_names();
+    vault_list.insert(vault_list.end(),
+                        level_vaults.begin(), level_vaults.end());
+
     more();
 }
 

--- a/crawl-ref/source/areas.cc
+++ b/crawl-ref/source/areas.cc
@@ -145,6 +145,9 @@ static void _actor_areas(actor *a)
  */
 static void _update_agrid()
 {
+    // sanitize rng in case this gets indirectly called by the builder.
+    rng::generator gameplay(rng::GAMEPLAY);
+
     if (no_areas)
     {
         _agrid_valid = true;

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -123,6 +123,11 @@
 
 # PLUS: The pluses of the artefact.
 
+# FALLBACK: if an artifact has already generated, the builder instead usually
+# creates a randart with the same base type. This field allows overriding the
+# base type for certain special cases (e.g. if a randart's special properties
+# put it on par with a much stronger base type).
+
 #####
 
 # Explanation of normal fields:
@@ -160,6 +165,7 @@
 ENUM:   DUMMY1
 NAME:   DUMMY UNRANDART 1
 OBJ:    OBJ_UNASSIGNED/250
+FALLBACK: OBJ_UNASSIGNED/250
 PLUS:   250
 COLOUR: BLACK
 
@@ -177,6 +183,7 @@ BRAND:   SPWPN_VORPAL
 
 NAME:    Wrath of Trog
 OBJ:     OBJ_WEAPONS/WPN_BATTLEAXE
+FALLBACK: OBJ_WEAPONS/WPN_EXECUTIONERS_AXE
 PLUS:    +8
 COLOUR:  ETC_BLOOD
 TILE:    spwpn_wrath_of_trog
@@ -187,6 +194,7 @@ BRAND:   SPWPN_ANTIMAGIC
 
 NAME:    mace of Variability
 OBJ:     OBJ_WEAPONS/WPN_GREAT_MACE
+FALLBACK: OBJ_WEAPONS/OBJ_RANDOM
 INSCRIP: chain chaos
 PLUS:    +7
 COLOUR:  ETC_RANDOM
@@ -207,6 +215,7 @@ BRAND:   SPWPN_VORPAL
 
 NAME:    sword of Power
 OBJ:     OBJ_WEAPONS/WPN_GREAT_SWORD
+FB_BRAND: SPWPN_VORPAL
 PLUS:    +0 # Set on wield
 COLOUR:  RED
 TILE:    spwpn_sword_of_power
@@ -235,6 +244,7 @@ VALUE:   1000
 NAME:    Vampire's Tooth
 OBJ:     OBJ_WEAPONS/WPN_QUICK_BLADE
 # it's a quick blade made from a tooth -> no TYPE
+FB_BRAND: SPWPN_VAMPIRISM
 PLUS:    +12
 COLOUR:  ETC_BONE
 TILE:    spwpn_vampires_tooth
@@ -270,6 +280,7 @@ COLOUR:  ETC_BONE
 TILE:    spwpn_sword_of_zonguldrok
 TILE_EQ: zonguldrok
 BRAND:   SPWPN_REAPING
+FB_BRAND: SPWPN_PAIN
 VALUE:   800
 BOOL:    evil, corpse_violating
 
@@ -405,6 +416,8 @@ COLOUR:  ETC_SLIME
 TILE:    urand_punk
 TILE_EQ: punk
 BRAND:   SPWPN_ACID
+# random fallback brand
+FB_BRAND: SPWPN_NORMAL
 BOOL:    rCorr
 
 NAME:     longbow "Zephyr"
@@ -428,6 +441,7 @@ STR:     7
 
 NAME:     glaive of the Guard
 OBJ:      OBJ_WEAPONS/WPN_GLAIVE
+FALLBACK: OBJ_WEAPONS/WPN_BARDICHE
 PLUS:     +8
 COLOUR:   ETC_ELECTRICITY
 TILE:     urand_guard
@@ -443,6 +457,7 @@ PLUS:     +10
 COLOUR:   ETC_HOLY
 TILE:     unrand_zealot_sword
 TILE_EQ:  zealot_sword
+# fallback places a randart eudemon blade!
 BRAND:    SPWPN_HOLY_WRATH
 EV:       3
 ANGRY:    5
@@ -451,6 +466,7 @@ LIFE:     1
 NAME:    arbalest "Damnation"
 INSCRIP: damnation,
 OBJ:     OBJ_WEAPONS/WPN_ARBALEST
+FB_BRAND: SPWPN_FLAMING
 PLUS:    +6
 COLOUR:  ETC_FIRE
 TILE:    urand_damnation
@@ -492,6 +508,7 @@ COLOUR:   ETC_UNHOLY
 TILE:     urand_botono
 TILE_EQ:  botono
 BRAND:    SPWPN_REAPING
+FB_BRAND: SPWPN_PAIN
 HP:       -6
 LIFE:     1
 BOOL:     poison, nogen
@@ -517,6 +534,8 @@ MAGIC:   1
 
 NAME:     Elemental Staff
 OBJ:      OBJ_WEAPONS/WPN_STAFF
+FALLBACK: OBJ_WEAPONS/WPN_LAJATANG
+FB_BRAND: SPWPN_FREEZING
 PLUS:     +3
 COLOUR:   DARKGREY
 TILE:     urand_elemental
@@ -555,6 +574,8 @@ ENUM:    BLOWGUN_ASSASSIN
 NAME:    blowgun of the Assassin
 INSCRIP: stab,
 OBJ:     OBJ_WEAPONS/WPN_BLOWGUN
+# fallback is just to prevent errors
+FALLBACK: OBJ_WEAPONS/WPN_LONGBOW
 PLUS:    +6
 COLOUR:  ETC_DEATH
 TILE:    urand_blowgun
@@ -564,6 +585,8 @@ BOOL:    inv, tilerim, nogen
 
 NAME:    lance "Wyrmbane"
 OBJ:     OBJ_WEAPONS/WPN_SPEAR
+FALLBACK: OBJ_WEAPONS/WPN_DEMON_TRIDENT
+FB_BRAND: SPWPN_VORPAL
 INSCRIP: slay drac,
 TYPE:    lance
 BASE_DAM: +2
@@ -589,6 +612,7 @@ STEALTH:  1
 
 NAME:    plutonium sword
 OBJ:     OBJ_WEAPONS/WPN_TRIPLE_SWORD
+FB_BRAND: SPWPN_CHAOS
 PLUS:    +11
 COLOUR:  ETC_MUTAGENIC
 TILE:    urand_plutonium
@@ -600,6 +624,7 @@ VALUE:   1000
 NAME:     great mace "Undeadhunter"
 INSCRIP:  disrupt,
 OBJ:      OBJ_WEAPONS/WPN_GREAT_MACE
+FB_BRAND: SPWPN_HOLY_WRATH
 PLUS:     +7
 COLOUR:   LIGHTGREY
 TILE:     urand_undeadhunter
@@ -608,6 +633,7 @@ LIFE:     1
 
 NAME:    whip "Snakebite"
 OBJ:     OBJ_WEAPONS/WPN_WHIP
+FALLBACK: OBJ_WEAPONS/WPN_DEMON_WHIP
 INSCRIP: curare,
 PLUS:    +8
 COLOUR:  DARKGREY
@@ -679,6 +705,7 @@ DEX:     4
 
 NAME:     cloak of the Thief
 OBJ:      OBJ_ARMOUR/ARM_CLOAK
+FB_BRAND: SPARM_INVISIBILITY
 INSCRIP:  +Fog
 PLUS:     +2
 COLOUR:   ETC_DARK
@@ -700,6 +727,7 @@ BOOL:    nogen
 
 NAME:    crown of Dyrovepreva
 OBJ:     OBJ_ARMOUR/ARM_HAT
+FB_BRAND: SPARM_SEE_INVISIBLE
 PLUS:    +3
 COLOUR:  ETC_JEWEL
 TILE:    urand_dyrovepreva
@@ -713,6 +741,7 @@ PLUS:     +2
 COLOUR:   DARKGREY
 TILE:     urand_bear
 TILE_EQ:  bear
+# TODO: why isn't this brand working on the fallback?
 BRAND:    SPARM_SPIRIT_SHIELD
 BOOL:     berserk
 MAGIC:    2
@@ -720,6 +749,8 @@ LIFE:     1
 
 NAME:     robe of Misfortune
 OBJ:      OBJ_ARMOUR/ARM_ROBE
+# try to make it bad, this is the only bad SPARM:
+FB_BRAND: SPARM_PONDEROUSNESS
 PLUS:     5
 COLOUR:   LIGHTMAGENTA
 TILE:     urand_misfortune
@@ -740,6 +771,7 @@ BOOL:     fly, nogen
 ENUM:     BOOTS_ASSASSIN
 NAME:     boots of the Assassin
 OBJ:      OBJ_ARMOUR/ARM_BOOTS
+FB_BRAND: SPARM_STEALTH
 INSCRIP:  Detection Stab+
 PLUS:     +2
 COLOUR:   BROWN
@@ -751,6 +783,7 @@ VALUE:    600
 ENUM:    LEAR
 NAME:    Lear's hauberk
 OBJ:     OBJ_ARMOUR/ARM_CHAIN_MAIL
+FALLBACK: OBJ_ARMOUR/ARM_PLATE_ARMOUR
 PLUS:    27
 COLOUR:  ETC_GOLD
 TILE:    urand_lear
@@ -759,6 +792,9 @@ BOOL:    special
 
 NAME:    skin of Zhor
 OBJ:     OBJ_ARMOUR/ARM_ANIMAL_SKIN
+# because animal skins count as "mundane" use something else to ensure a randart
+# is generated; this isn't a great match:
+FALLBACK: OBJ_ARMOUR/ARM_STEAM_DRAGON_ARMOUR
 PLUS:    +4
 COLOUR:  BROWN
 TILE:    urand_zhor
@@ -770,6 +806,7 @@ INSCRIP: Hibernate
 ENUM:    SALAMANDER
 NAME:    salamander hide armour
 OBJ:     OBJ_ARMOUR/ARM_LEATHER_ARMOUR
+FB_BRAND: SPARM_FIRE_RESISTANCE
 PLUS:    +3
 COLOUR:  ETC_FIRE
 TILE:    urand_salamander
@@ -827,6 +864,7 @@ BOOL:    seeinv
 
 NAME:     robe of Night
 OBJ:      OBJ_ARMOUR/ARM_ROBE
+# there's not a very appropriate fallback brand that works on robes...
 PLUS:     +5
 INSCRIP:  Dark
 COLOUR:   ETC_DARK
@@ -893,6 +931,7 @@ BOOL:     poison
 
 NAME:     shield of the Gong
 OBJ:      OBJ_ARMOUR/ARM_SHIELD
+FALLBACK: OBJ_ARMOUR/ARM_LARGE_SHIELD
 PLUS:     +18
 COLOUR:   ETC_GOLD
 TILE:     urand_gong
@@ -999,6 +1038,7 @@ COLOUR:   ETC_UNHOLY
 TILE:     spwpn_demon_axe
 TILE_EQ:  demon_axe
 BRAND:    SPWPN_VORPAL
+FB_BRAND: SPWPN_PAIN
 BOOL:     evil, seeinv, fly, curse
 
 NAME:     lightning scales
@@ -1029,6 +1069,7 @@ TILE:     urand_vitality
 
 NAME:     autumn katana
 OBJ:      OBJ_WEAPONS/WPN_LONG_SWORD
+FALLBACK: OBJ_WEAPONS/WPN_DOUBLE_SWORD
 TYPE:     katana
 TILE:     urand_katana
 TILE_EQ:  katana_slant
@@ -1043,6 +1084,8 @@ BRAND:    SPWPN_VORPAL
 NAME:     shillelagh "Devastator"
 INSCRIP:  shatter
 OBJ:      OBJ_WEAPONS/WPN_CLUB
+FALLBACK: OBJ_WEAPONS/WPN_EVENINGSTAR
+FB_BRAND: SPWPN_VORPAL
 TYPE:     shillelagh
 TILE:     urand_shillelagh
 TILE_EQ:  shillelagh
@@ -1145,6 +1188,8 @@ BOOL:    nogen
 NAME:     arc blade
 INSCRIP:  discharge,
 OBJ:      OBJ_WEAPONS/WPN_RAPIER
+FALLBACK: OBJ_WEAPONS/WPN_QUICK_BLADE
+FB_BRAND: SPWPN_ELECTROCUTION
 PLUS:     +8
 COLOUR:   ETC_ELECTRICITY
 TILE:     urand_arc_blade
@@ -1165,6 +1210,8 @@ MAGIC:    1
 NAME:    lajatang of Order
 INSCRIP: silver,
 OBJ:     OBJ_WEAPONS/WPN_LAJATANG
+# not really comparable...
+FB_BRAND: SPWPN_HOLY_WRATH
 COLOUR:  ETC_SILVER
 TILE:    urand_order
 TILE_EQ: order
@@ -1191,12 +1238,14 @@ TILE_EQ:  orange_crystal
 PLUS:     8
 INT:      3
 BRAND:    SPARM_ARCHMAGI
+FB_BRAND: SPWPN_NORMAL
 BOOL:     clarity
 
 ENUM:    MAJIN
 NAME:    Majin-Bo
 INSCRIP: Archmagi
 OBJ:     OBJ_WEAPONS/WPN_QUARTERSTAFF
+FALLBACK: OBJ_WEAPONS/WPN_LAJATANG
 PLUS:    +6
 COLOUR:  ETC_UNHOLY
 TILE:    spwpn_majin
@@ -1214,6 +1263,7 @@ TILE:    urand_gyre
 TILE_EQ: gyre
 PLUS:    7
 BRAND:   SPWPN_PROTECTION
+FB_BRAND: SPWPN_VORPAL
 
 ENUM:    ETHERIC_CAGE
 NAME:    Maxwell's etheric cage

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -460,6 +460,12 @@ static void _add_randart_weapon_brand(const item_def &item,
 {
     const int item_type = item.sub_type;
 
+    if (!is_weapon_brand_ok(item_type, item_props[ARTP_BRAND], true))
+        item_props[ARTP_BRAND] = SPWPN_NORMAL;
+
+    if (item_props[ARTP_BRAND] != SPWPN_NORMAL)
+        return;
+
     if (is_range_weapon(item))
     {
         item_props[ARTP_BRAND] = random_choose_weighted(

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -52,6 +52,9 @@ struct unrandart_entry
 
     object_class_type base_type;
     uint8_t           sub_type;
+    object_class_type fallback_base_type;
+    uint8_t           fallback_sub_type;
+    int               fallback_brand;
     short             plus;
     short             plus2;
     colour_t          colour;

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -381,7 +381,8 @@ void attack::init_attack(skill_type unarmed_skill, int attack_number)
     if (attacker->is_monster())
     {
         mon_attack_def mon_attk = mons_attack_spec(*attacker->as_monster(),
-                                                   attack_number);
+                                                   attack_number,
+                                                   false);
 
         attk_type       = mon_attk.type;
         attk_flavour    = mon_attk.flavour;

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -214,7 +214,9 @@ static void _sdump_header(dump_params &par)
 
     if (you.game_is_seeded
 #ifdef DGAMELAUNCH
-        && par.se // for online games, only show seed for a dead char
+        && (par.se // for online games, show seed for a dead char
+            || you.wizard
+            || crawl_state.type == GAME_TYPE_CUSTOM_SEED)
 #endif
         )
     {

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -95,7 +95,7 @@ static string _get_version_features()
     string result;
     if (crawl_state.need_save
 #ifdef DGAMELAUNCH
-        && you.wizard
+        && (you.wizard || crawl_state.type == GAME_TYPE_CUSTOM_SEED)
 #endif
        )
     {

--- a/crawl-ref/source/dat/des/branches/elf.des
+++ b/crawl-ref/source/dat/des/branches/elf.des
@@ -1275,11 +1275,7 @@ ENDMAP
 NAME:    minmay_guarded_unrand_folly
 DEPTH:   Elf
 ORIENT:  float
-: if you.unrands("robe_of_folly") then
-ITEM:    robe randart no_pickup
-: else
 ITEM:    robe_of_folly no_pickup
-: end
 MONS:    deep elf sorcerer / deep elf annihilator
 NSUBST:  1 = 2:2 / 5=1.. / .
 SUBST:   2 = 1.

--- a/crawl-ref/source/dat/des/branches/lair.des
+++ b/crawl-ref/source/dat/des/branches/lair.des
@@ -2379,13 +2379,7 @@ NAME:    minmay_guarded_unrand_snakebite
 TAGS:    ruin
 DEPTH:   Lair
 ORIENT:  southeast
-: if you.unrands("snakebite") then
-# A randart venom demon whip is unlikely to be useful
-# for someone with snakebite, so just do this
-ITEM:    demon whip good_item
-: else
 ITEM:    snakebite no_pickup
-: end
 KMONS:   A = adder
 KMONS:   B = water moccasin
 KMONS:   C = black mamba

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
@@ -1276,11 +1276,7 @@ ENDMAP
 NAME:    minmay_guarded_unrand_guard_vaults
 TAGS:    vaults_hard vaults_orient_n
 WEIGHT:  3
-: if you.unrands("glaive_of_the_guard") then
-ITEM:    bardiche randart no_pickup
-: else
 ITEM:    glaive_of_the_guard no_pickup
-: end
 SUBST:   b : bxcmG.T
 NSUBST:  3:9 / 4=9. / ., 8 = 2:8 / 6=8.. / .
 MAP
@@ -1304,15 +1300,9 @@ ENDMAP
 NAME:    minmay_guarded_unrand_secular_launcher
 TAGS:    vaults_hard vaults_orient_s
 WEIGHT:  3
-: if you.unrands("sniper") and you.unrands("storm_bow") then
-ITEM:    triple crossbow randart no_pickup / longbow randart no_pickup
-: elseif you.unrands("sniper") then
-ITEM:    storm_bow no_pickup
-: elseif you.unrands("storm_bow") then
-ITEM:    sniper no_pickup
-: else
+# n.b. if one of these has generated, this may fall back on a randart. If both
+# have generated, it is guaranteed to.
 ITEM:    storm_bow no_pickup / sniper no_pickup
-: end
 NSUBST:  3:9 / 6=9. / ., 8 = 2:8 / 6=8.. / .
 MAP
      vvvvv

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -709,7 +709,7 @@ local kstr =
 local i = 0
 while i < itemCount do
     local itm = items[crawl.random2(#items) + 1]
-    if not (chosen[itm] or you.unrands(itm)) then
+    if not (chosen[itm]) then
         i = i + 1
         chosen[itm] = true
         kstr = kstr .. itm

--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -194,7 +194,10 @@ function trove.get_toll_nopiety()
 end
 
 function trove.portal(e)
-    local toll = trove.get_trove_toll(e)
+    -- dependent on player stats (skills, race, etc) so needs to be isolated
+    -- from gameplay rng.
+    local toll = crawl.rng_wrap(function () return trove.get_trove_toll(e) end,
+                                "subgenerator")
 
     local function stair ()
         return trove_marker  {

--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -881,11 +881,7 @@ KMONS:      & = col:mutagenic primal ox-sting-weird mutant beast \
                 name:Cigotuvi's_Monster name_replace tile:mons_cigotuvis_monster
 ITEM:       potion of mutation
 ITEM:       potion of mutation q:1, potion of mutation
-: if you.unrands("hat of the alchemist") then
-ITEM:       any jewellery randart
-: else
 ITEM:       any jewellery randart / w:5 hat_of_the_alchemist
-: end
 ITEM:       randbook disc:transmutation disc2:necromancy owner:Cigotuvi
 ITEM:       book of transfigurations / randbook disc:transmutation
 ITEM:       staff of death, scroll of summoning

--- a/crawl-ref/source/dat/des/variable/float.des
+++ b/crawl-ref/source/dat/des/variable/float.des
@@ -3245,11 +3245,7 @@ KMONS:  2 = shock serpent / storm dragon
 ITEM:   book of air / book of the sky / manual of air magic / \
         staff of air ident:type / lightning rod w:15 / fan of gales w:15 / \
         storm dragon scales w:5
-: if you.unrands("arc blade") then
-KITEM:  2 = quick blade ego:electrocution randart ident:type
-: else
-KITEM:  2 = arc_blade
-: end
+KITEM:  2 = arc_blade ident:type
 : minmay_elemental_octagon_setup(_G)
 MAP
     xxx@xxx
@@ -3277,11 +3273,7 @@ KMONS:  2 = stone giant / iron dragon
 ITEM:   book of geomancy / book of the earth / manual of earth magic / \
         staff of earth ident:type / ring of protection ident:type / \
         wand of scattershot ident:type / crystal plate armour w:5
-: if you.unrands("devastator") then
-KITEM:  2 = eveningstar randart
-: else
 KITEM:  2 = devastator
-: end
 : minmay_elemental_octagon_setup(_G)
 MAP
     xxx@xxx
@@ -3309,15 +3301,9 @@ KMONS:  2 = frost giant / ice dragon
 ITEM:   book of frost / book of ice / manual of ice magic / \
         wand of iceblast ident:type / staff of cold ident:type / \
         ring of ice ident:type / phial of floods / ice dragon scales w:5
-: if you.unrands("frostbite") then
-KITEM:  2 = executioner's axe ego:freezing randart ident:type / \
+KITEM:  2 = frostbite ident:type / \
             battleaxe ego:freezing randart ident:type / \
             broad axe ego:freezing randart ident:type
-: else
-KITEM:  2 = frostbite / \
-            battleaxe ego:freezing randart ident:type / \
-            broad axe ego:freezing randart ident:type
-: end
 : minmay_elemental_octagon_setup(_G)
 MAP
     xxx@xxx
@@ -3345,11 +3331,7 @@ KMONS:  2 = fire giant / fire dragon
 ITEM:   book of flames / book of fire / manual of fire magic / \
         staff of fire ident:type / ring of fire ident:type / lamp of fire / \
         fire dragon scales w:5
-: if you.unrands("firestarter") then
-KITEM:  2 = great mace ego:flaming randart ident:type
-: else
-KITEM:  2 = firestarter
-: end
+KITEM:  2 = firestarter ident:type
 : minmay_elemental_octagon_setup(_G)
 MAP
     xxx@xxx
@@ -3374,12 +3356,7 @@ ORIENT:  float
 DEPTH:   Depths, Crypt
 MONS:    necromancer / vampire mage
 MONS:    lich / ancient lich w:5
-: if you.unrands("majin-bo") then
-ITEM:    quarterstaff randart ego:vampirism ident:type no_pickup \
-         / good_item lajatang no_pickup
-: else
-ITEM:    majin-bo no_pickup
-: end
+ITEM:    majin-bo no_pickup ident:type
 ITEM:    any magical staff / any book
 NSUBST:  d = 1:d / *:e
 NSUBST:  1 = 4:1 / 8=1... / .
@@ -3408,11 +3385,7 @@ NAME:    minmay_guarded_unrand_sceptre_of_torment
 ORIENT:  float
 DEPTH:   Depths, Crypt
 MONS:    mummy priest, greater mummy
-: if you.unrands("sceptre_of_torment") then
-KITEM:   d = any weapon good_item randart no_pickup
-: else
-KITEM:   d = sceptre_of_torment no_pickup
-: end
+KITEM:   d = sceptre_of_torment no_pickup ident:type
 KMONS:   d = greater mummy
 MAP
 ccccccccccc@ccccccccccc
@@ -3432,11 +3405,7 @@ NAME:    minmay_guarded_unrand_sword_of_power
 ORIENT:  float
 DEPTH:   D:13-
 MONS:    vault guard
-: if you.unrands("sword_of_power") then
-ITEM:    any weapon good_item randart no_pickup
-: else
 ITEM:    sword_of_power no_pickup
-: end
 MAP
  vvvvvvvv
 vv......vv
@@ -3454,11 +3423,7 @@ ENDMAP
 NAME:    minmay_guarded_unrand_guard
 DEPTH:   D:12-, Depths:1-4
 ORIENT:  float
-: if you.unrands("glaive_of_the_guard") then
-ITEM:    bardiche randart no_pickup
-: else
 ITEM:    glaive_of_the_guard no_pickup
-: end
 SUBST:   b : bxcmG.T
 NSUBST:  3:9 / 4=9. / ., 8 = 2:8 / 6=8.. / .
 MAP
@@ -9109,13 +9074,7 @@ NAME:    emtedronai_trogs_sanctum
 TAGS:    no_monster_gen no_trap_gen no_tele_into no_item_gen
 DEPTH:   D:13-, Depths
 ORIENT:  float
-: if not you.unrands("necklace_of_bloodlust") then
-KITEM:   _ = necklace of bloodlust no_pickup
-: elseif not you.unrands("wrath_of_trog") then
-KITEM:   _ = wrath of trog no_pickup
-: else
-KITEM:   _ = nothing
-: end
+KITEM:   _ = necklace of bloodlust no_pickup / wrath of trog no_pickup
 ITEM:    manual of armour w:30 / manual of fighting w:30 / \
          manual of long blades / manual of axes / manual of maces & flails / \
          manual of polearms / manual of dodging / manual of shields

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -6709,11 +6709,7 @@ DEPTH:   D:12-
 MONS:    deep elf mage / ogre mage / wizard / \
          kobold demonologist w:2 / vampire mage w:2 / naga mage w:2
 NSUBST:  1 = 6:1 / 10=1.... / .
-: if you.unrands("glaive of prune") then
-ITEM:    any weapon good_item randart no_pickup
-: else
 ITEM:    glaive_of_prune no_pickup
-: end
 SUBST:   " : .:50 cvbnG
 SUBST:   ' : .:50 cvbnG
 SUBST:   ? : .:50 cvbnG
@@ -6748,12 +6744,7 @@ TAGS:    transparent
 DEPTH:   D:8-
 MONS:    chaos spawn
 KFEAT:   _ = altar_xom
-: if you.unrands("mace of variability") then
-# could be a launcher!
-ITEM:    any weapon good_item randart ego:chaos ident:type no_pickup
-: else
-ITEM:    mace_of_variability no_pickup
-: end
+ITEM:    mace_of_variability no_pickup ident:type
 # walls are carefully placed and guarantee no islands
 SUBST:   x = xcvbmGwWlTUVYt+ <:4 >:4 A:2 1:160
 NSUBST:  1 = 2:1 / 2:% / 3=1%...... / .
@@ -6777,12 +6768,8 @@ TAGS:    no_monster_gen no_trap_gen transparent
 MONS:    worker ant / soldier ant
 MONS:    killer bee
 MONS:    adder / water moccasin
-: if you.unrands("staff_of_olgreb") then
-ITEM:    young poisoner's handbook / ring of poison resistance ident:type / \
-         staff of poison ident:type / swamp dragon scales
-: else
-ITEM:    staff_of_olgreb no_pickup
-: end
+# TODO: built in fallback for staff of olgreb is kind of dumb
+ITEM:    staff_of_olgreb no_pickup ident:type
 NSUBST:  1 = 5:1 / 6=1.. / ., 2 = 5:2 / 9=2.. / ., 3 = 5:3 / 6=1.. / .
 MAP
       ...
@@ -6820,11 +6807,7 @@ MONS:    vampire mosquito / tyrant leech / vampire, vampire knight
 : else
 MONS:    vampire knight, vampire mage
 : end
-: if you.unrands("vampires_tooth") then
-ITEM:    quick blade randart no_pickup
-: else
 ITEM:    vampires_tooth no_pickup
-: end
 MAP
 .........
 .ccc.ccc.
@@ -6842,11 +6825,7 @@ TAGS:    transparent
 DEPTH:   D:14-, Depths
 MONS:    spriggan berserker
 NSUBST:  1 = 3:1 / 9=1...... / .
-: if you.unrands("wrath_of_trog") then
-ITEM:    executioner's axe randart ego:antimagic ident:type no_pickup
-: else
-ITEM:    wrath_of_trog no_pickup
-: end
+ITEM:    wrath_of_trog no_pickup ident:type
 MAP
     .......
    .."""""..
@@ -6874,12 +6853,7 @@ NSUBST:  d = 1:d / *:*
 MONS:    skeletal warrior
 NSUBST:  d = 1:d / *:%
 : end
-: if you.unrands("skullcrusher") then
-ITEM:    giant club randart ego:speed ident:type no_pickup / \
-         giant spiked club randart no_pickup
-: else
-ITEM:    skullcrusher no_pickup
-: end
+ITEM:    skullcrusher no_pickup ident:type
 NSUBST:  ' = 12:1 / 14=1...... / .
 SUBST:   " = 1., ! = 2.
 MAP
@@ -6913,11 +6887,7 @@ NAME:    minmay_guarded_unrand_finisher
 TAGS:    transparent
 DEPTH:   D:7-13
 MONS:    wraith
-: if you.unrands("finisher") then
-ITEM:    scythe randart ego:speed ident:type no_pickup
-: else
-ITEM:    finisher no_pickup
-: end
+ITEM:    finisher no_pickup ident:type
 SUBST:   1 = 1.
 NSUBST:  A = 1:. / *:c, B = 1:. / *:c
 SUBST:   c = c .:2
@@ -6941,12 +6911,7 @@ NAME:    minmay_guarded_unrand_resistance
 DEPTH:   D:9-14
 TAGS:    no_monster_gen no_trap_gen transparent
 KMASK:   lw = opaque
-: if you.unrands("shield_of_resistance") then
-ITEM:    buckler randart no_pickup / shield randart no_pickup / \
-         large shield randart no_pickup
-: else
 ITEM:    shield_of_resistance no_pickup
-: end
 MONS:    fire dragon, ice dragon
 MAP
 ...........
@@ -6965,11 +6930,7 @@ ENDMAP
 NAME:    chequers_guarded_unrand_ignorance
 DEPTH:   D:7-12, Orc
 TAGS:    no_monster_gen no_trap_gen transparent
-: if you.unrands("large_shield_of_ignorance") then
-ITEM:    large shield randart no_pickup
-: else
 ITEM:    large_shield_of_ignorance no_pickup
-: end
 MONS:    orange crystal statue
 KPROP:   .d1 = no_tele_into
 SUBST:   - = .
@@ -6990,11 +6951,7 @@ ENDMAP
 NAME:    chequers_guarded_unrand_mask_of_the_dragon
 DEPTH:   Zot, !Zot:$
 TAGS:    no_monster_gen no_trap_gen
-: if you.unrands("mask_of_the_dragon") then
-ITEM:    hat randart no_pickup
-: else
 ITEM:    mask_of_the_dragon no_pickup
-: end
 # Shuffle one transporter destination location
 NSUBST:  r = 1:R / *:-
 # Randomly swap which transporter is the entrance and the loot locations.
@@ -7040,11 +6997,7 @@ ENDMAP
 NAME:   brannock_guarded_unrand_thermic_engine
 DEPTH:  Depths
 TAGS:   no_monster_gen no_item_gen transparent
-: if you.unrands("maxwell's_thermic_engine") then
-ITEM:   demon blade randart no_pickup
-: else
 ITEM:   maxwell's_thermic_engine no_pickup
-: end
 MONS:   ice devil, blizzard demon, ice fiend
 MONS:   sun demon, balrug, brimstone fiend
 # 6-2-1, 9 total demons for each side
@@ -7068,11 +7021,7 @@ TAGS:   no_monster_gen no_item_gen transparent
 DEPTH:  D:5-8
 ORIENT: float
 MONS:   rat, river rat, hell rat
-: if you.unrands("ratskin_cloak") then
-ITEM:   cloak randart
-: else
 ITEM: ratskin_cloak
-:end
 NSUBST: - = 8:1 / *:.
 NSUBST: ' = 6:1 / 4:2 / 2:23 / 1:3 / *:.
 MAP

--- a/crawl-ref/source/dat/dlua/ghost.lua
+++ b/crawl-ref/source/dat/dlua/ghost.lua
@@ -312,11 +312,10 @@ function setup_xom_dancing_weapon(e)
         quality = crawl.coinflip() and "good_item"
                   or crawl.coinflip() and "randart"
                   or ""
-        -- do  this check independently of global state so that the effect
-        -- on the rng is the same either way
-        local can_try_variability = crawl.one_chance_in(100)
-        variability = not you.unrands("mace of Variability")
-                      and can_try_variability and "mace of Variability"
+
+        -- if variability has already generated, this will end up with a
+        -- chaos branded great mace as a backup.
+        variability = crawl.one_chance_in(100) and "mace of Variability"
     end
 
     -- Make one weapons table with each weapon getting weight by class.

--- a/crawl-ref/source/dat/dlua/test.lua
+++ b/crawl-ref/source/dat/dlua/test.lua
@@ -44,7 +44,7 @@ function test.regenerate_level(place, use_random_maps)
   if place then
     debug.goto_place(place)
   end
-  debug.flush_map_memory()
+  debug.flush_map_memory() -- TODO: this is overkill for a single level
   dgn.reset_level()
   debug.generate_level(use_random_maps)
 end

--- a/crawl-ref/source/dbg-maps.cc
+++ b/crawl-ref/source/dbg-maps.cc
@@ -263,6 +263,8 @@ bool mapstat_build_levels()
         dlua.callfn("dgn_clear_data", "");
         you.uniq_map_tags.clear();
         you.uniq_map_names.clear();
+        you.uniq_map_tags_abyss.clear();
+        you.uniq_map_names_abyss.clear();
         you.unique_creatures.reset();
         initialise_branch_depths();
         init_level_connectivity();
@@ -303,6 +305,8 @@ static void _report_available_random_vaults(FILE *outf)
 {
     you.uniq_map_tags.clear();
     you.uniq_map_names.clear();
+    you.uniq_map_tags_abyss.clear();
+    you.uniq_map_names_abyss.clear();
 
     fprintf(outf, "\n\nRandom vaults available by dungeon level:\n");
     for (auto lvl : generated_levels)

--- a/crawl-ref/source/dgn-shoals.cc
+++ b/crawl-ref/source/dgn-shoals.cc
@@ -1018,6 +1018,13 @@ void shoals_apply_tides(int turns_elapsed, bool force, bool incremental_tide)
         return;
     }
 
+    // isolate from main levelgen rng if called from there; the behavior of
+    // this function is dependent on global state (tide direction, etc) that
+    // may impact the number of rolls depending on when the player changes
+    // shoals levels, so doing this with the levelgen rng has downstream
+    // effects.
+    rng::generator tide_rng(rng::GAMEPLAY);
+
     CrawlHashTable &props(you.props);
     _shoals_init_tide();
 

--- a/crawl-ref/source/domino.h
+++ b/crawl-ref/source/domino.h
@@ -441,7 +441,7 @@ class DominoSet
                     tiling[pt] = choices[0];
                 }
                 else
-                    tiling[pt] = rng() % adjacencies_.size();
+                    tiling[pt] = rng(adjacencies_.size());
 
                 has_conflicts |= Conflicts(pt, tiling);
             }
@@ -475,7 +475,7 @@ class DominoSet
                                 tiling[pt] = choices[0];
                             }
                             else
-                                tiling[pt] = rng() % adjacencies_.size();
+                                tiling[pt] = rng(adjacencies_.size());
 
                             int after = Conflicts(pt, tiling);
                             if (after >= conflicts)
@@ -574,13 +574,13 @@ class DominoSet
                         for (int y = -sz; y <= sz; ++y)
                         {
                             Point nb = {pt.x + x, pt.y + y};
-                            if (tiling.find(nb) != tiling.end() && rng() % 2)
+                            if (tiling.find(nb) != tiling.end() && rng(2))
                                 shuffle.insert(nb);
                         }
                     }
                 }
                 for (auto itr : shuffle)
-                    tiling[itr] = rng() % adjacencies_.size();
+                    tiling[itr] = rng(adjacencies_.size());
             }
 
         int Conflicts(Point pt, const std::map<Point, uint32_t>& tiling) const

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5746,6 +5746,7 @@ static void _stock_shop_item(int j, shop_type shop_type_,
  */
 void place_spec_shop(const coord_def& where, shop_spec &spec, int shop_level)
 {
+    rng::subgenerator shop_rng; // isolate shop rolls from levelgen
     no_notes nx;
 
     shop_struct& shop = env.shop[where];

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -612,6 +612,7 @@ void dgn_flush_map_memory()
     you.zig_max = 0;
     you.exploration = 0;
     you.seen_portals = 0; // should be just cosmetic
+    reset_portal_entrances();
     // would it be safe to just clear you.props?
     you.props.erase(TEMPLE_SIZE_KEY);
     you.props.erase(TEMPLE_MAP_KEY);
@@ -1332,6 +1333,8 @@ void dgn_reset_level(bool enable_random_maps)
     tile_init_default_flavour();
     tile_clear_flavour();
     env.tile_names.clear();
+
+    update_portal_entrances();
 }
 
 static int _num_items_wanted(int absdepth0)

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -259,7 +259,7 @@ bool builder(bool enable_random_maps)
     temp_unique_items = you.unique_items;
 
     unwind_bool levelgen(crawl_state.generating_level, true);
-    rng_generator levelgen_rng(you.where_are_you);
+    rng::generator levelgen_rng(you.where_are_you);
 
 #ifdef DEBUG_DIAGNOSTICS // no point in enabling unless dprf works
     CrawlHashTable &debug_logs = you.props["debug_builder_logs"].get_table();

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -3831,13 +3831,14 @@ static void _randomly_place_item(int item)
     }
     if (!found)
     {
+        dprf(DIAG_DNGN, "Builder failed to place %s",
+            mitm[item].name(DESC_PLAIN, false, true).c_str());
         // Couldn't find a single good spot!
         destroy_item(item);
     }
     else
     {
-        dprf(DIAG_DNGN, "builder placing %s (%s) at %d,%d",
-            mitm[item].name(DESC_PLAIN).c_str(),
+        dprf(DIAG_DNGN, "Builder placing %s at %d,%d",
             mitm[item].name(DESC_PLAIN, false, true).c_str(),
             itempos.x, itempos.y);
         move_item_to_grid(&item, itempos);
@@ -4579,8 +4580,7 @@ int dgn_place_item(const item_spec &spec,
 
             if (_apply_item_props(item, spec, (useless_tries >= 10), false))
             {
-                dprf(DIAG_DNGN, "vault spec: placing %s (%s) at %d,%d",
-                    mitm[item_made].name(DESC_PLAIN).c_str(),
+                dprf(DIAG_DNGN, "vault spec: placing %s at %d,%d",
                     mitm[item_made].name(DESC_PLAIN, false, true).c_str(),
                     where.x, where.y);
                 env.level_map_mask(where) |= MMT_NO_TRAP;
@@ -5111,8 +5111,7 @@ static void _vault_grid_glyph(vault_placement &place, const coord_def& where,
         {
             mitm[item_made].pos = where;
             env.level_map_mask(where) |= MMT_NO_TRAP;
-            dprf(DIAG_DNGN, "vault grid: placing %s (%s) at %d,%d",
-                mitm[item_made].name(DESC_PLAIN).c_str(),
+            dprf(DIAG_DNGN, "vault grid: placing %s at %d,%d",
                 mitm[item_made].name(DESC_PLAIN, false, true).c_str(),
                 mitm[item_made].pos.x, mitm[item_made].pos.y);
         }
@@ -5736,6 +5735,8 @@ static void _stock_shop_item(int j, shop_type shop_type_,
     item.pos = shop.pos;
     item.link = ITEM_IN_SHOP;
     shop.stock.push_back(item);
+    dprf(DIAG_DNGN, "shop spec: placing %s",
+                    item.name(DESC_PLAIN, false, true).c_str());
 }
 
 /**

--- a/crawl-ref/source/dungeon.h
+++ b/crawl-ref/source/dungeon.h
@@ -190,6 +190,9 @@ extern vector<vault_placement> Temp_Vaults;
 
 extern const map_bitmask *Vault_Placement_Mask;
 
+set<string> &get_uniq_map_tags();
+set<string> &get_uniq_map_names();
+
 void init_level_connectivity();
 void read_level_connectivity(reader &th);
 void write_level_connectivity(writer &th);

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -599,7 +599,7 @@ int apply_chunked_AC(int dam, int ac)
 
     int hurt = 0;
     for (int i = 0; i < dam; i++)
-        if (get_uint32() < cr)
+        if (rng::get_uint32() < cr)
             hurt++;
 
     return hurt;

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1385,7 +1385,7 @@ static const vector<branch_type> portal_generation_order =
 #if TAG_MAJOR_VERSION == 34
     BRANCH_LABYRINTH,
 #endif
-    BRANCH_BAZAAR,
+    // do not pregenerate bazaar (TODO: this is non-ideal)
     // do not pregenerate trove
     BRANCH_WIZLAB,
     BRANCH_DESOLATION,
@@ -1403,8 +1403,12 @@ void update_portal_entrances()
         if (feat_is_portal_entrance(feat))
         {
             level_id whither = stair_destination(feat, "", false);
-            if (whither.branch == BRANCH_ZIGGURAT || whither.branch == BRANCH_TROVE)
+            if (whither.branch == BRANCH_ZIGGURAT // not (quite) pregenerated
+                || whither.branch == BRANCH_TROVE // not pregenerated
+                || whither.branch == BRANCH_BAZAAR) // multiple bazaars possible
+            {
                 continue; // handle these differently
+            }
             dprf("Setting up entry for %s.", whither.describe().c_str());
             ASSERT(count(portal_generation_order.begin(),
                          portal_generation_order.end(),

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1391,7 +1391,7 @@ static const vector<branch_type> portal_generation_order =
     BRANCH_DESOLATION,
 };
 
-static void _update_portal_entrances()
+void update_portal_entrances()
 {
     for (rectangle_iterator ri(0); ri; ++ri)
     {
@@ -1485,7 +1485,7 @@ bool generate_level(const level_id &l)
     env.sanctuary_time = 0;
     env.markers.init_all(); // init first, activation happens when entering
     show_update_emphasis(); // Clear map knowledge stair emphasis in env.
-    _update_portal_entrances();
+    update_portal_entrances();
 
     // save the level and associated env state
     _save_level(level_id::current());

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1393,6 +1393,9 @@ static const vector<branch_type> portal_generation_order =
 
 void update_portal_entrances()
 {
+    unordered_set<branch_type, std::hash<int>> seen_portals;
+    auto const cur_level = level_id::current();
+    // add any portals not currently registered
     for (rectangle_iterator ri(0); ri; ++ri)
     {
         dungeon_feature_type feat = env.grid(*ri);
@@ -1407,9 +1410,22 @@ void update_portal_entrances()
                          portal_generation_order.end(),
                          whither.branch) == 1);
             ASSERT(brentry[whither.branch] == level_id()); // violated by multiple portals
-            brentry[whither.branch] = level_id::current();
+            brentry[whither.branch] = cur_level;
+            seen_portals.insert(whither.branch);
         }
     }
+    // clean up any portals that aren't actually here -- comes up for wizmode
+    // and test mode cases.
+    for (auto b : portal_generation_order)
+        if (!seen_portals.count(b) && brentry[b] == cur_level)
+            brentry[b] = level_id();
+}
+
+void reset_portal_entrances()
+{
+    for (auto b : portal_generation_order)
+        if (brentry[b].is_valid())
+            brentry[b] = level_id();
 }
 
 static bool _generate_portal_levels()

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2422,7 +2422,7 @@ static vector<ghost_demon> _load_permastore_ghosts(bool backup_on_upgrade=false)
  */
 bool define_ghost_from_bones(monster& mons)
 {
-    rng_generator rng(RNG_SYSTEM_SPECIFIC);
+    rng::generator rng(rng::SYSTEM_SPECIFIC);
 
     bool used_permastore = false;
 
@@ -3037,7 +3037,7 @@ static size_t _ghost_permastore_size()
 
 static vector<ghost_demon> _update_permastore(const vector<ghost_demon> &ghosts)
 {
-    rng_generator rng(RNG_SYSTEM_SPECIFIC);
+    rng::generator rng(rng::SYSTEM_SPECIFIC);
     if (ghosts.empty())
         return ghosts;
 

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1462,6 +1462,7 @@ static const vector<branch_type> branch_generation_order =
     BRANCH_COCYTUS,
     BRANCH_DIS,
     BRANCH_GEHENNA,
+    BRANCH_PANDEMONIUM,
     NUM_BRANCHES,
 };
 
@@ -1501,17 +1502,18 @@ bool pregen_dungeon(const level_id &stopping_point)
     {
         // TODO: why is dungeon invalid? it's not set up properly in
         // `initialise_branch_depths` for some reason. The vestibule is invalid
-        // because its depth isn't set until the player actually enters a portal.
+        // because its depth isn't set until the player actually enters a
+        // portal, similarly for other portal branches.
         if (br < NUM_BRANCHES &&
             (brentry[br].is_valid()
-             || br == BRANCH_DUNGEON || br == BRANCH_VESTIBULE))
+             || br == BRANCH_DUNGEON || br == BRANCH_VESTIBULE
+             || !is_connected_branch(br)))
         {
             for (int i = 1; i <= branches[br].numlevels; i++)
             {
                 level_id new_level = level_id(br, i);
                 if (you.save->has_chunk(new_level.describe()))
                     continue;
-
                 to_generate.push_back(new_level);
 
                 if (br == stopping_point.branch
@@ -1528,7 +1530,10 @@ bool pregen_dungeon(const level_id &stopping_point)
     }
 
     if (to_generate.size() == 0)
+    {
+        dprf("levelgen: No valid levels to generate.");
         return false;
+    }
     else if (to_generate.size() == 1)
         return generate_level(to_generate[0]); // no popup for this case
     else

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1467,6 +1467,8 @@ static const vector<branch_type> branch_generation_order =
 
 static bool _branch_pregenerates(branch_type b)
 {
+    if (!Options.incremental_pregen)
+        return false;
     return count(branch_generation_order.begin(),
         branch_generation_order.end(), b) > 0;
 }

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1497,7 +1497,21 @@ bool generate_level(const level_id &l)
     dprf("Generating new level for '%s'.", level_name.c_str());
     builder(true);
 
-    you.vault_list[level_id::current()] = level_vault_names();
+    auto &vault_list =  you.vault_list[level_id::current()];
+#ifdef DEBUG
+    // places where a level can generate multiple times.
+    // could add portals to this list for debugging purposes?
+    if (   you.where_are_you == BRANCH_ABYSS
+        || you.where_are_you == BRANCH_PANDEMONIUM
+        || you.where_are_you == BRANCH_BAZAAR
+        || you.where_are_you == BRANCH_ZIGGURAT)
+    {
+        vault_list.push_back("[gen]");
+    }
+#endif
+    const auto &level_vaults = level_vault_names();
+    vault_list.insert(vault_list.end(),
+                        level_vaults.begin(), level_vaults.end());
 
     // initialize env for a new level
     env.turns_on_level = 0;

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -82,6 +82,7 @@ class level_id;
 void trackers_init_new_level(bool transit);
 
 bool generate_level(const level_id &l);
+bool pregen_dungeon(const level_id &stopping_point);
 bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,
                 const level_id& old_level);
 void delete_level(const level_id &level);

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -81,6 +81,7 @@ class level_id;
 
 void trackers_init_new_level(bool transit);
 
+void update_portal_entrances();
 bool generate_level(const level_id &l);
 bool pregen_dungeon(const level_id &stopping_point);
 bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -82,6 +82,7 @@ class level_id;
 void trackers_init_new_level(bool transit);
 
 void update_portal_entrances();
+void reset_portal_entrances();
 bool generate_level(const level_id &l);
 bool pregen_dungeon(const level_id &stopping_point);
 bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -296,8 +296,7 @@ const vector<GameOption*> game_options::build_options_list()
 #ifndef DGAMELAUNCH
         new BoolGameOption(SIMPLE_NAME(pregen_dungeon), false),
 #endif
-        // TODO: should setting this to false be allowed outside of debug builds?
-        new BoolGameOption(SIMPLE_NAME(incremental_pregen), true),
+        new BoolGameOption(SIMPLE_NAME(incremental_pregen), false),
 
 
 #ifdef DGL_SIMPLE_MESSAGING

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -296,6 +296,9 @@ const vector<GameOption*> game_options::build_options_list()
 #ifndef DGAMELAUNCH
         new BoolGameOption(SIMPLE_NAME(pregen_dungeon), false),
 #endif
+        // TODO: should setting this to false be allowed outside of debug builds?
+        new BoolGameOption(SIMPLE_NAME(incremental_pregen), true),
+
 
 #ifdef DGL_SIMPLE_MESSAGING
         new BoolGameOption(SIMPLE_NAME(messaging), false),

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2758,8 +2758,8 @@ const size_t RCS_END = RCS_EM;
  */
 string make_name(uint32_t seed, makename_type name_type)
 {
-    uint64_t sarg[1] = { static_cast<uint64_t>(seed) };
-    rng::PcgRNG rng = rng::PcgRNG(sarg, ARRAYSZ(sarg));
+    // TODO: better conversion of the seed to 64 bits
+    rng::PcgRNG rng = rng::PcgRNG(static_cast<uint64_t>(seed));
 
     string name;
 

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2759,7 +2759,7 @@ const size_t RCS_END = RCS_EM;
 string make_name(uint32_t seed, makename_type name_type)
 {
     uint64_t sarg[1] = { static_cast<uint64_t>(seed) };
-    PcgRNG rng = PcgRNG(sarg, ARRAYSZ(sarg));
+    rng::PcgRNG rng = rng::PcgRNG(sarg, ARRAYSZ(sarg));
 
     string name;
 
@@ -3035,10 +3035,10 @@ static void _test_jiyva_names(const string& fname)
         sysfail("can't write test output");
 
     string longest;
-    seed_rng(27);
+    rng::seed(27);
     for (int i = 0; i < 1000000; i++)
     {
-        const string name = make_name(get_uint32(), MNAME_JIYVA);
+        const string name = make_name(rng::get_uint32(), MNAME_JIYVA);
         ASSERT(name[0] == 'J');
         if (name.length() > longest.length())
             longest = name;
@@ -3060,7 +3060,7 @@ void make_name_tests()
     _test_jiyva_names("jiyva_names.out");
     _test_scroll_names("scroll_names.out");
 
-    seed_rng(27);
+    rng::seed(27);
     for (int i = 0; i < 1000000; ++i)
         make_name();
 }

--- a/crawl-ref/source/item-name.h
+++ b/crawl-ref/source/item-name.h
@@ -121,7 +121,7 @@ bool is_bad_item(const item_def &item, bool temp = false);
 bool is_dangerous_item(const item_def& item, bool temp = false);
 bool is_useless_item(const item_def &item, bool temp = false);
 
-string make_name(uint32_t seed = get_uint32(),
+string make_name(uint32_t seed = rng::get_uint32(),
                  makename_type name_type = MNAME_DEFAULT);
 void make_name_tests();
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4241,6 +4241,8 @@ static bool _book_from_spell(const char* specs, item_def &item)
 bool get_item_by_name(item_def *item, const char* specs,
                       object_class_type class_wanted, bool create_for_real)
 {
+    // used only for wizmode and item lookup
+
     int            type_wanted    = -1;
     int            special_wanted = 0;
 

--- a/crawl-ref/source/jobs.cc
+++ b/crawl-ref/source/jobs.cc
@@ -68,6 +68,8 @@ job_type get_job_by_name(const char *name)
 // Must be called after species_stat_init for the wanderer formula to work.
 void job_stat_init(job_type job)
 {
+    rng::subgenerator stat_rng;
+
     you.hp_max_adj_perm = 0;
 
     you.base_stats[STAT_STR] += _job_def(job).s;

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -413,7 +413,7 @@ LUAFN(debug_reset_rng)
         unsigned int seed = (unsigned int) luaL_safe_checkint(ls, 1);
         Options.seed = (uint64_t) seed;
     }
-    reset_rng();
+    rng::reset();
     const string ret = make_stringf("%" PRIu64, Options.seed);
     lua_pushstring(ls, ret.c_str());
     return 1;
@@ -423,7 +423,7 @@ LUAFN(debug_get_rng_state)
 {
     string r = make_stringf("seed: %" PRIu64 ", generator states: ",
         Options.seed);
-    vector<uint64_t> states = get_rng_states();
+    vector<uint64_t> states = rng::get_states();
     for (auto i : states)
         r += make_stringf("%" PRIu64 " ", i);
     lua_pushstring(ls, r.c_str());

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -105,6 +105,7 @@ LUAFN(debug_generate_level)
     tile_clear_flavour();
     tile_new_level(true);
     builder(lua_isboolean(ls, 1)? lua_toboolean(ls, 1) : true);
+    update_portal_entrances();
     return 0;
 }
 

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -816,6 +816,24 @@ int getch_with_command_macros()
     return macro_buf_get();
 }
 
+static string _buffer_to_string()
+{
+    string s;
+    for (const int k : Buffer)
+    {
+        if (k > 0 && k <= numeric_limits<unsigned char>::max())
+        {
+            char c = static_cast<unsigned char>(k);
+            if (c == '[' || c == ']')
+                s += "\\";
+            s += c;
+        }
+        else
+            s += make_stringf("[%d]", k);
+    }
+    return s;
+}
+
 /*
  * Flush the buffer. Later we'll probably want to give the player options
  * as to when this happens (ex. always before command input, casting failed).
@@ -845,11 +863,16 @@ void flush_input_buffer(int reason)
         || reason == FLUSH_REPLAY_SETUP_FAILURE
         || reason == FLUSH_REPEAT_SETUP_DONE)
     {
-        if (crawl_state.nonempty_buffer_flush_errors)
+        if (crawl_state.nonempty_buffer_flush_errors && !Buffer.empty())
         {
             if (you.wizard) // crash -- intended for tests
+            {
+                mprf(MSGCH_ERROR,
+                    "Flushing non-empty key buffer (Buffer is '%s')",
+                    _buffer_to_string().c_str());
                 ASSERT(Buffer.empty());
-            else if (!Buffer.empty())
+            }
+            else
                 mprf(MSGCH_ERROR, "Flushing non-empty key buffer");
         }
         while (!Buffer.empty())

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1115,10 +1115,26 @@ static void _generate_armour_item(item_def& item, bool allow_uniques,
     // Forced randart.
     if (item_level == ISPEC_RANDART)
     {
+        int ego = item.brand;
         for (int i = 0; i < 100; ++i)
             if (_try_make_armour_artefact(item, force_type, 0, true, agent)
                 && is_artefact(item))
             {
+                // borrowed from similar code for weapons -- is this really the
+                // best way to force an ego??
+                if (ego > SPARM_NORMAL)
+                {
+                    item.props[ARTEFACT_PROPS_KEY].get_vector()[ARTP_BRAND].get_short() = ego;
+                    if (randart_is_bad(item)) // recheck, the brand changed
+                    {
+                        force_type = item.sub_type;
+                        item.clear();
+                        item.quantity = 1;
+                        item.base_type = OBJ_ARMOUR;
+                        item.sub_type = force_type;
+                        continue;
+                    }
+                }
                 return;
             }
         // fall back to an ordinary item
@@ -1738,6 +1754,102 @@ void squash_plusses(int item_slot)
     set_equip_desc(item, ISFLAG_NO_DESC);
 }
 
+static bool _ego_unrand_only(int base_type, int ego)
+{
+    if (base_type == OBJ_WEAPONS)
+    {
+        switch (static_cast<brand_type>(ego))
+        {
+        case SPWPN_REAPING:
+        case SPWPN_ACID:
+            return true;
+        default:
+            return false;
+        }
+    }
+    // all armours are ok?
+    return false;
+}
+
+// Make a corresponding randart instead as a fallback.
+// Attempts to use base type, sub type, and ego (for armour/weapons).
+// Artefacts can explicitly specify a base type and fallback type.
+
+// Could be even more flexible: maybe allow an item spec to describe
+// complex fallbacks?
+static void _setup_fallback_randart(const int unrand_id,
+                                    item_def &item,
+                                    int &force_type,
+                                    int &item_level)
+{
+    ASSERT(get_unrand_entry(unrand_id));
+    const unrandart_entry &unrand = *get_unrand_entry(unrand_id);
+    dprf("Placing fallback randart for %s", unrand.name);
+
+    uint8_t fallback_sub_type;
+    if (unrand.fallback_base_type != OBJ_UNASSIGNED)
+    {
+        item.base_type = unrand.fallback_base_type;
+        fallback_sub_type = unrand.fallback_sub_type;
+    }
+    else
+    {
+        item.base_type = unrand.base_type;
+        fallback_sub_type = unrand.sub_type;
+    }
+
+    if (item.base_type == OBJ_WEAPONS
+        && fallback_sub_type == WPN_STAFF)
+    {
+        item.base_type = OBJ_STAVES;
+        if (unrand_id == UNRAND_WUCAD_MU)
+            force_type = STAFF_ENERGY;
+        else if (unrand_id == UNRAND_OLGREB)
+            force_type = STAFF_POISON;
+        else
+            force_type = OBJ_RANDOM;
+        // XXX: small chance of the other unrand...
+        // (but we won't hit this case until a new staff unrand is added)
+    }
+    else if (item.base_type == OBJ_JEWELLERY
+             && fallback_sub_type == AMU_NOTHING)
+    {
+        force_type = NUM_JEWELLERY;
+    }
+    else
+        force_type = fallback_sub_type;
+
+    // import some brand information from the unrand. TODO: I'm doing this for
+    // the sake of vault designers who make themed vaults. But it also often
+    // makes the item more redundant with the unrand; maybe add a bit more
+    // flexibility in item specs so that this part is optional? However, from a
+    // seeding perspective, it also makes sense if the item generated is
+    // very comparable.
+
+    // unset fallback_brand is -1. In that case it will try to use the regular
+    // brand if there is one. If the end result here is 0, the brand (for
+    // weapons) will be chosen randomly. So to force randomness, use
+    // SPWPN_NORMAL on the fallback ego, or set neither. (Randarts cannot be
+    // unbranded.)
+    item.brand = unrand.fallback_brand; // no type checking here...
+
+    if (item.brand < 0
+        && !_ego_unrand_only(item.base_type, unrand.prpty[ARTP_BRAND])
+        && item.base_type == unrand.base_type // brand isn't well-defined for != case
+        && ((item.base_type == OBJ_WEAPONS
+             && is_weapon_brand_ok(item.sub_type, unrand.prpty[ARTP_BRAND], true))
+            || (item.base_type == OBJ_ARMOUR
+             && is_armour_brand_ok(item.sub_type, unrand.prpty[ARTP_BRAND], true))))
+    {
+        // maybe do jewellery too?
+        item.brand = unrand.prpty[ARTP_BRAND];
+    }
+    if (item.brand < 0)
+        item.brand = 0;
+
+    item_level = ISPEC_RANDART;
+}
+
 /**
  * Create an item.
  *
@@ -1766,6 +1878,8 @@ int items(bool allow_uniques,
           int force_ego,
           int agent)
 {
+    rng::subgenerator item_rng;
+
     ASSERT(force_ego <= 0
            || force_class == OBJ_WEAPONS
            || force_class == OBJ_ARMOUR
@@ -1848,34 +1962,8 @@ int items(bool allow_uniques,
             return p;
         }
 
-        // make a corresponding randart instead.
-        const unrandart_entry* unrand = get_unrand_entry(unrand_id);
-        ASSERT(unrand);
-        item.base_type = unrand->base_type;
-
-        if (unrand->base_type == OBJ_WEAPONS
-            && unrand->sub_type == WPN_STAFF)
-        {
-            item.base_type = OBJ_STAVES;
-            if (unrand_id == UNRAND_WUCAD_MU)
-                force_type = STAFF_ENERGY;
-            else if (unrand_id == UNRAND_OLGREB)
-                force_type = STAFF_POISON;
-            else
-                force_type = OBJ_RANDOM;
-            // XXX: small chance of the other unrand...
-            // (but we won't hit this case until a new staff unrand is added)
-        }
-        else if (unrand->base_type == OBJ_JEWELLERY
-                 && unrand->sub_type == AMU_NOTHING)
-        {
-            force_type = NUM_JEWELLERY;
-        }
-        else
-            force_type = unrand->sub_type;
-
-        item_level = ISPEC_RANDART;
-        item.brand = 0;
+        _setup_fallback_randart(unrand_id, item, force_type, item_level);
+        allow_uniques = false;
     }
 
     // Determine sub_type accordingly. {dlb}

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -2267,13 +2267,13 @@ void map_def::reinit()
 
 bool map_def::map_already_used() const
 {
-    return you.uniq_map_names.count(name)
+    return get_uniq_map_names().count(name)
            || env.level_uniq_maps.find(name) !=
                env.level_uniq_maps.end()
            || env.new_used_subvault_names.find(name) !=
                env.new_used_subvault_names.end()
-           || has_any_tag(you.uniq_map_tags.begin(),
-                          you.uniq_map_tags.end())
+           || has_any_tag(get_uniq_map_tags().begin(),
+                          get_uniq_map_tags().end())
            || has_any_tag(env.level_uniq_map_tags.begin(),
                           env.level_uniq_map_tags.end())
            || has_any_tag(env.new_used_subvault_tags.begin(),

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -680,7 +680,7 @@ public:
      */
     void more(bool full, bool user=false)
     {
-        rng_generator rng(RNG_UI);
+        rng::generator rng(rng::UI);
 
         if (_pre_more())
             return;
@@ -1402,7 +1402,7 @@ static int _last_msg_turn = -1; // Turn of last message.
 static void _mpr(string text, msg_channel_type channel, int param, bool nojoin,
                  bool cap)
 {
-    rng_generator rng(RNG_UI);
+    rng::generator rng(rng::UI);
 
     if (_msg_dump_file != nullptr)
         fprintf(_msg_dump_file, "%s\n", text.c_str());
@@ -1819,7 +1819,7 @@ static bool _pre_more()
 
 void more(bool user_forced)
 {
-    rng_generator rng(RNG_UI);
+    rng::generator rng(rng::UI);
 
     if (!crawl_state.io_inited)
         return;

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -285,6 +285,8 @@ static bool _apply_weapon_spec(const mon_weapon_spec &spec, item_def &item,
  */
 int make_mons_weapon(monster_type type, int level, bool melee_only)
 {
+    rng::subgenerator item_rng;
+
     static const weapon_list GOBLIN_WEAPONS = // total 10
     {   { WPN_DAGGER,           3 },
         { WPN_CLUB,             3 },

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1510,7 +1510,7 @@ static monster* _place_pghost_aux(const mgen_data &mg, const monster *leader,
     // since depending on the ghost, the aux call can trigger variation in
     // things like whether an enchantment (with a random duration) is
     // triggered.
-    rng_generator rng(RNG_SYSTEM_SPECIFIC);
+    rng::generator rng(rng::SYSTEM_SPECIFIC);
     return _place_monster_aux(mg, leader, place, force_pos, dont_place);
 }
 

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -578,6 +578,10 @@ static bool _valid_monster_generation_location(const mgen_data &mg,
         || monster_at(mg_pos)
         || you.pos() == mg_pos && !fedhas_passthrough_class(mg.cls))
     {
+        ASSERT(!crawl_state.generating_level
+                || !in_bounds(mg_pos)
+                || you.pos() != mg_pos
+                || you.where_are_you == BRANCH_ABYSS);
         return false;
     }
 
@@ -594,6 +598,7 @@ static bool _valid_monster_generation_location(const mgen_data &mg,
     if (mg.proximity == PROX_AWAY_FROM_PLAYER && close_to_player
         || mg.proximity == PROX_CLOSE_TO_PLAYER && !close_to_player)
     {
+        ASSERT(!crawl_state.generating_level || you.where_are_you == BRANCH_ABYSS);
         return false;
     }
     // Check that the location is not proximal to level stairs.
@@ -828,6 +833,8 @@ monster* place_monster(mgen_data mg, bool force_pos, bool dont_place)
                 member->props["kirke_band"] = true;
         }
     }
+    dprf(DIAG_DNGN, "Placing %s at %d,%d", mon->name(DESC_PLAIN, true).c_str(),
+                mon->pos().x, mon->pos().y);
 
     // Placement of first monster, at least, was a success.
     return mon;

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -2023,14 +2023,19 @@ mon_attack_def mons_attack_spec(const monster& m, int attk_number,
             attk.damage = max(1, you.skill_rdiv(SK_UNARMED_COMBAT, 10, 20));
     }
 
-    if (attk.type == AT_RANDOM)
-        attk.type = random_choose(AT_HIT, AT_GORE);
+    if (!base_flavour)
+    {
+        // TODO: randomization here is not the greatest way of doing any of
+        // these...
+        if (attk.type == AT_RANDOM)
+            attk.type = random_choose(AT_HIT, AT_GORE);
 
-    if (attk.type == AT_CHERUB)
-        attk.type = random_choose(AT_HIT, AT_BITE, AT_PECK, AT_GORE);
+        if (attk.type == AT_CHERUB)
+            attk.type = random_choose(AT_HIT, AT_BITE, AT_PECK, AT_GORE);
 
-    if (attk.flavour == AF_DRAIN_STAT)
-        attk.flavour = random_choose(AF_DRAIN_STR, AF_DRAIN_INT,AF_DRAIN_DEX);
+        if (attk.flavour == AF_DRAIN_STAT)
+            attk.flavour = random_choose(AF_DRAIN_STR, AF_DRAIN_INT,AF_DRAIN_DEX);
+    }
 
     // Slime creature attacks are multiplied by the number merged.
     if (mon.type == MONS_SLIME_CREATURE && mon.blob_size > 1)
@@ -2088,12 +2093,12 @@ string mon_attack_name(attack_type attack, bool with_object)
 #if TAG_MAJOR_VERSION == 34
         "sting",
 #endif
-        "hit", // AT_CHERUB
+        "hit, bite, peck, or gore", // AT_CHERUB
 #if TAG_MAJOR_VERSION == 34
         "hit", // AT_SHOOT
 #endif
         "hit", // AT_WEAP_ONLY,
-        "hit", // AT_RANDOM
+        "hit or gore", // AT_RANDOM
     };
     COMPILE_CHECK(ARRAYSZ(attack_types) == NUM_ATTACK_TYPES - AT_FIRST_ATTACK);
 

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -245,7 +245,7 @@ bool mons_class_sees_invis(monster_type type, monster_type base);
 
 bool mons_immune_magic(const monster& mon);
 
-mon_attack_def mons_attack_spec(const monster& mon, int attk_number, bool base_flavour = false);
+mon_attack_def mons_attack_spec(const monster& mon, int attk_number, bool base_flavour = true);
 string mon_attack_name(attack_type attack, bool with_object = true);
 bool flavour_triggers_damageless(attack_flavour flavour);
 int flavour_damage(attack_flavour flavour, int HD, bool random = true);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3533,6 +3533,8 @@ void monster::suicide(int hp_target)
 
 mon_holy_type monster::holiness(bool /*temp*/) const
 {
+    rng::ASSERT_stable rng_check;
+
     // zombie kraken tentacles
     if (testbits(flags, MF_FAKE_UNDEAD))
         return MH_UNDEAD;

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2540,6 +2540,12 @@ _schedule_ds_mutations(vector<mutation_type> muts)
 
 void roll_demonspawn_mutations()
 {
+    // intentionally create the subgenerator either way, so that this has the
+    // same impact on the current main rng for all chars.
+    rng::subgenerator ds_rng;
+
+    if (you.species != SP_DEMONSPAWN)
+        return;
     you.demonic_traits = _schedule_ds_mutations(
                          _order_ds_mutations(
                          _select_ds_mutations()));

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -585,9 +585,6 @@ void validate_mutations(bool debug_msg)
         }
     }
     ASSERT(total_temp == you.attribute[ATTR_TEMP_MUTATIONS]);
-    ASSERT(you.attribute[ATTR_TEMP_MUT_XP] >=0);
-    if (total_temp > 0)
-        ASSERT(you.attribute[ATTR_TEMP_MUT_XP] > 0);
 }
 
 string describe_mutations(bool drop_title)

--- a/crawl-ref/source/ng-init.cc
+++ b/crawl-ref/source/ng-init.cc
@@ -540,6 +540,6 @@ void initialise_item_descriptions()
 
 void fix_up_jiyva_name()
 {
-    you.jiyva_second_name = make_name(get_uint32(), MNAME_JIYVA);
+    you.jiyva_second_name = make_name(rng::get_uint32(), MNAME_JIYVA);
     ASSERT(you.jiyva_second_name[0] == 'J');
 }

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -462,7 +462,7 @@ static void _free_up_slot(char letter)
 
 void initial_dungeon_setup()
 {
-    rng_generator levelgen_rng(BRANCH_DUNGEON);
+    rng::generator levelgen_rng(BRANCH_DUNGEON);
 
     initialise_branch_depths();
     initialise_temples();
@@ -472,7 +472,7 @@ void initial_dungeon_setup()
 
 static void _setup_generic(const newgame_def& ng)
 {
-    reset_rng(); // initialize rng from Options.seed
+    rng::reset(); // initialize rng from Options.seed
     _init_player();
     you.game_seed = crawl_state.seed;
 

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -234,6 +234,8 @@ static void _give_ammo(weapon_type weapon, int plus)
 
 static void _give_items_skills(const newgame_def& ng)
 {
+    create_wanderer();
+
     switch (you.char_class)
     {
     case JOB_BERSERKER:
@@ -275,10 +277,6 @@ static void _give_items_skills(const newgame_def& ng)
         else
             you.skills[SK_ARMOUR]++;
 
-        break;
-
-    case JOB_WANDERER:
-        create_wanderer();
         break;
 
     default:
@@ -508,8 +506,7 @@ static void _setup_generic(const newgame_def& ng)
     // This function depends on stats and mutations being finalised.
     _give_items_skills(ng);
 
-    if (you.species == SP_DEMONSPAWN)
-        roll_demonspawn_mutations();
+    roll_demonspawn_mutations();
 
     _give_starting_food();
 

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -683,6 +683,12 @@ static void _wanderer_cover_equip_holes()
 // levels/equipment, but pretty randomised.
 void create_wanderer()
 {
+    // intentionally create the subgenerator either way, so that this has the
+    // same impact on the current main rng for all chars.
+    rng::subgenerator wn_rng;
+    if (you.char_class != JOB_WANDERER)
+        return;
+
     // Decide what our character roles are.
     stat_type primary_role   = _wanderer_choose_role();
     stat_type secondary_role = _wanderer_choose_role();

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -173,7 +173,8 @@ public:
 
     uint64_t    seed;           // Non-random games.
     uint64_t    seed_from_rc;
-    bool        pregen_dungeon; // Is the dungeon generated at the beginning?
+    bool        pregen_dungeon; // Is the dungeon completely generated at the beginning?
+    bool        incremental_pregen; // Does the dungeon always generate in a specified order?
 
 #ifdef DGL_SIMPLE_MESSAGING
     bool        messaging;      // Check for messages.

--- a/crawl-ref/source/pcg.cc
+++ b/crawl-ref/source/pcg.cc
@@ -10,56 +10,59 @@
 
 #include "pcg.h"
 
-uint32_t
-PcgRNG::get_uint32()
+namespace rng
 {
-    count_++;
-    uint64_t oldstate = state_;
-    // Advance internal state
-    state_ = oldstate * static_cast<uint64_t>(6364136223846793005ULL) + (inc_|1);
-    // Calculate output function (XSH RR), uses old state for max ILP
-    uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
-    uint32_t rot = oldstate >> 59u;
-    return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
-}
+    uint32_t
+    PcgRNG::get_uint32()
+    {
+        count_++;
+        uint64_t oldstate = state_;
+        // Advance internal state
+        state_ = oldstate * static_cast<uint64_t>(6364136223846793005ULL) + (inc_|1);
+        // Calculate output function (XSH RR), uses old state for max ILP
+        uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
+        uint32_t rot = oldstate >> 59u;
+        return (xorshifted >> rot) | (xorshifted << ((-rot) & 31));
+    }
 
-uint64_t
-PcgRNG::get_uint64()
-{
-    return static_cast<uint64_t>(get_uint32()) << 32 | get_uint32();
-}
+    uint64_t
+    PcgRNG::get_uint64()
+    {
+        return static_cast<uint64_t>(get_uint32()) << 32 | get_uint32();
+    }
 
-PcgRNG::PcgRNG()
-      // Choose base state arbitrarily. There's nothing up my sleeve.
-    : state_(static_cast<uint64_t>(18446744073709551557ULL)), // Largest 64-bit prime.
-      inc_(static_cast<uint64_t>(2305843009213693951ULL)),    // Largest Mersenne prime under 64-bits.
-      count_(0)
+    PcgRNG::PcgRNG()
+          // Choose base state arbitrarily. There's nothing up my sleeve.
+        : state_(static_cast<uint64_t>(18446744073709551557ULL)), // Largest 64-bit prime.
+          inc_(static_cast<uint64_t>(2305843009213693951ULL)),    // Largest Mersenne prime under 64-bits.
+          count_(0)
 
-{ }
+    { }
 
-PcgRNG::PcgRNG(uint64_t init_key[], int key_length)
-    : PcgRNG()
-{
-    if (key_length > 0)
-        state_ = init_key[0];
-    if (key_length > 1)
-        inc_ = init_key[1];
-    else
-        inc_ ^= get_uint32();
-}
+    PcgRNG::PcgRNG(uint64_t init_key[], int key_length)
+        : PcgRNG()
+    {
+        if (key_length > 0)
+            state_ = init_key[0];
+        if (key_length > 1)
+            inc_ = init_key[1];
+        else
+            inc_ ^= get_uint32();
+    }
 
-PcgRNG::PcgRNG(const CrawlVector &v)
-    : PcgRNG()
-{
-    ASSERT(v.size() == 2);
-    state_ = static_cast<uint64_t>(v[0].get_int64());
-    inc_ = static_cast<uint64_t>(v[1].get_int64());
-}
+    PcgRNG::PcgRNG(const CrawlVector &v)
+        : PcgRNG()
+    {
+        ASSERT(v.size() == 2);
+        state_ = static_cast<uint64_t>(v[0].get_int64());
+        inc_ = static_cast<uint64_t>(v[1].get_int64());
+    }
 
-CrawlVector PcgRNG::to_vector()
-{
-    CrawlVector store;
-    store.push_back(static_cast<int64_t>(state_));
-    store.push_back(static_cast<int64_t>(inc_));
-    return store;
+    CrawlVector PcgRNG::to_vector()
+    {
+        CrawlVector store;
+        store.push_back(static_cast<int64_t>(state_));
+        store.push_back(static_cast<int64_t>(inc_));
+        return store;
+    }
 }

--- a/crawl-ref/source/pcg.h
+++ b/crawl-ref/source/pcg.h
@@ -15,6 +15,7 @@ namespace rng
         uint32_t get_bounded_uint32(uint32_t bound);
         uint64_t get_uint64();
         uint32_t operator()() { return get_uint32(); }
+        uint32_t operator()(uint32_t bound) { return get_bounded_uint32(bound); }
 
         typedef uint32_t result_type;
         static constexpr uint32_t min() { return 0; }

--- a/crawl-ref/source/pcg.h
+++ b/crawl-ref/source/pcg.h
@@ -1,27 +1,30 @@
 #pragma once
 class CrawlVector;
 
-class PcgRNG
+namespace rng
 {
-    public:
-        PcgRNG();
-        PcgRNG(uint64_t init_key[], int key_length);
-        PcgRNG(const CrawlVector &v);
-        CrawlVector to_vector();
-        uint32_t get_uint32();
-        uint64_t get_uint64();
-        uint32_t operator()() { return get_uint32(); }
+    class PcgRNG
+    {
+        public:
+            PcgRNG();
+            PcgRNG(uint64_t init_key[], int key_length);
+            PcgRNG(const CrawlVector &v);
+            CrawlVector to_vector();
+            uint32_t get_uint32();
+            uint64_t get_uint64();
+            uint32_t operator()() { return get_uint32(); }
 
-        typedef uint32_t result_type;
-        static constexpr uint32_t min() { return 0; }
-        static constexpr uint32_t max() { return 0xffffffffU; }
+            typedef uint32_t result_type;
+            static constexpr uint32_t min() { return 0; }
+            static constexpr uint32_t max() { return 0xffffffffU; }
 
-        uint64_t get_state() { return state_; };
-        uint64_t get_inc() { return inc_; };
-        uint64_t get_count() { return count_; };
+            uint64_t get_state() { return state_; };
+            uint64_t get_inc() { return inc_; };
+            uint64_t get_count() { return count_; };
 
-    private:
-        uint64_t state_;
-        uint64_t inc_;
-        uint64_t count_;
-};
+        private:
+            uint64_t state_;
+            uint64_t inc_;
+            uint64_t count_;
+    };
+}

--- a/crawl-ref/source/pcg.h
+++ b/crawl-ref/source/pcg.h
@@ -12,6 +12,7 @@ namespace rng
         PcgRNG(const CrawlVector &v);
         CrawlVector to_vector();
         uint32_t get_uint32();
+        uint32_t get_bounded_uint32(uint32_t bound);
         uint64_t get_uint64();
         uint32_t operator()() { return get_uint32(); }
 

--- a/crawl-ref/source/pcg.h
+++ b/crawl-ref/source/pcg.h
@@ -5,26 +5,27 @@ namespace rng
 {
     class PcgRNG
     {
-        public:
-            PcgRNG();
-            PcgRNG(uint64_t init_key[], int key_length);
-            PcgRNG(const CrawlVector &v);
-            CrawlVector to_vector();
-            uint32_t get_uint32();
-            uint64_t get_uint64();
-            uint32_t operator()() { return get_uint32(); }
+    public:
+        PcgRNG();
+        PcgRNG(uint64_t init_state, uint64_t sequence);
+        PcgRNG(uint64_t init_state);
+        PcgRNG(const CrawlVector &v);
+        CrawlVector to_vector();
+        uint32_t get_uint32();
+        uint64_t get_uint64();
+        uint32_t operator()() { return get_uint32(); }
 
-            typedef uint32_t result_type;
-            static constexpr uint32_t min() { return 0; }
-            static constexpr uint32_t max() { return 0xffffffffU; }
+        typedef uint32_t result_type;
+        static constexpr uint32_t min() { return 0; }
+        static constexpr uint32_t max() { return 0xffffffffU; }
 
-            uint64_t get_state() { return state_; };
-            uint64_t get_inc() { return inc_; };
-            uint64_t get_count() { return count_; };
+        uint64_t get_state() { return state_; };
+        uint64_t get_inc() { return inc_; };
+        uint64_t get_count() { return count_; };
 
-        private:
-            uint64_t state_;
-            uint64_t inc_;
-            uint64_t count_;
+    private:
+        uint64_t state_;
+        uint64_t inc_;
+        uint64_t count_;
     };
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5089,6 +5089,8 @@ player::player()
 
     uniq_map_tags.clear();
     uniq_map_names.clear();
+    uniq_map_tags_abyss.clear();
+    uniq_map_names_abyss.clear();
     vault_list.clear();
 
     global_info = PlaceInfo();

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -309,6 +309,8 @@ public:
     // Maps without allow_dup that have been already used.
     set<string> uniq_map_tags;
     set<string> uniq_map_names;
+    set<string> uniq_map_tags_abyss;
+    set<string> uniq_map_names_abyss;
     // All maps, by level.
     map<level_id, vector<string> > vault_list;
 

--- a/crawl-ref/source/random.cc
+++ b/crawl-ref/source/random.cc
@@ -77,6 +77,11 @@ namespace rng
         _generator = previous;
     }
 
+    PcgRNG &current_generator()
+    {
+        return _global_state[_generator];
+    }
+
     uint32_t get_uint32(rng_type generator)
     {
         return _global_state[generator].get_uint32();
@@ -166,33 +171,21 @@ int random_range(int low, int high, int nrolls)
     return low + roll;
 }
 
-static int _random2(int max, rng::rng_type rng)
+// [0, max)
+int random2(int max)
 {
     if (max <= 1)
         return 0;
 
-    uint32_t partn = rng::PcgRNG::max() / max;
-
-    while (true)
-    {
-        uint32_t bits = rng::get_uint32(rng);
-        uint32_t val  = bits / partn;
-
-        if (val < (uint32_t)max)
-            return (int)val;
-    }
-}
-
-// [0, max)
-int random2(int max)
-{
-    return _random2(max, rng::_generator);
+    return rng::current_generator().get_bounded_uint32(max);
 }
 
 // [0, max), separate RNG state
 int ui_random(int max)
 {
-    return _random2(max, rng::UI);
+    rng::generator ui(rng::UI);
+
+    return random2(max);
 }
 
 // [0, 1]

--- a/crawl-ref/source/random.cc
+++ b/crawl-ref/source/random.cc
@@ -107,6 +107,7 @@ namespace rng
 
     PcgRNG *get_generator(rng_type r)
     {
+        ASSERT(_generator != ASSERT_NO_RNG);
         if (_generator == SUB_GENERATOR)
             return _sub_generator;
         else

--- a/crawl-ref/source/random.cc
+++ b/crawl-ref/source/random.cc
@@ -61,17 +61,18 @@ namespace rng
 
     generator::generator(rng_type g) : previous(_generator)
     {
+        ASSERT(g != rng::SUB_GENERATOR);
         _generator = g;
     }
 
-    static rng_type _get_branch_generator(const branch_type b)
+    rng_type get_branch_generator(const branch_type b)
     {
         return static_cast<rng_type>(rng::LEVELGEN + static_cast<int>(b));
     }
 
     generator::generator(branch_type b) : previous(_generator)
     {
-        _generator = _get_branch_generator(b);
+        _generator = get_branch_generator(b);
     }
 
     generator::~generator()

--- a/crawl-ref/source/random.cc
+++ b/crawl-ref/source/random.cc
@@ -98,8 +98,10 @@ namespace rng
         : subgenerator(seed, get_uint64())
     { }
 
+    // call the 1-arg constructor so as to ensure a sequence point between the
+    // two get_uint64 calls.
     subgenerator::subgenerator()
-        : subgenerator(get_uint64(), get_uint64())
+        : subgenerator(get_uint64())
     { }
 
     PcgRNG *get_generator(rng_type r)

--- a/crawl-ref/source/random.cc
+++ b/crawl-ref/source/random.cc
@@ -135,6 +135,12 @@ namespace rng
         return current_generator().get_uint64();
     }
 
+    uint64_t peek_uint64()
+    {
+        PcgRNG tmp = current_generator(); // make a copy
+        return tmp.get_uint64();
+    }
+
     static void _do_seeding(PcgRNG &master)
     {
         // TODO: don't initialize gameplay/ui rng?

--- a/crawl-ref/source/random.h
+++ b/crawl-ref/source/random.h
@@ -8,31 +8,36 @@
 #include "hash.h"
 #include "rng-type.h"
 
-class rng_generator
-{
-public:
-    rng_generator(rng_type g);
-    rng_generator(branch_type b);
-    ~rng_generator();
-private:
-    rng_type previous;
-};
-
 class CrawlVector;
-CrawlVector generators_to_vector();
-void load_generators(const CrawlVector &v);
-vector<uint64_t> get_rng_states();
 
-void seed_rng();
-void seed_rng(uint64_t seed);
-void seed_rng(uint64_t[], int);
-void reset_rng();
+namespace rng
+{
+    class generator
+    {
+    public:
+        generator(rng_type g);
+        generator(branch_type b);
+        ~generator();
+    private:
+        rng_type previous;
+    };
 
-uint32_t get_uint32(rng_type generator);
-uint64_t get_uint64(rng_type generator);
-uint32_t get_uint32();
-uint64_t get_uint64();
-uint32_t peek_uint32();
+    CrawlVector generators_to_vector();
+    void load_generators(const CrawlVector &v);
+    vector<uint64_t> get_states();
+
+    void seed();
+    void seed(uint64_t seed);
+    void seed(uint64_t[], int);
+    void reset();
+
+    uint32_t get_uint32(rng_type generator);
+    uint64_t get_uint64(rng_type generator);
+    uint32_t get_uint32();
+    uint64_t get_uint64();
+    uint32_t peek_uint32();
+}
+
 bool coinflip();
 int div_rand_round(int num, int den);
 int rand_round(double x);

--- a/crawl-ref/source/random.h
+++ b/crawl-ref/source/random.h
@@ -7,6 +7,7 @@
 
 #include "hash.h"
 #include "rng-type.h"
+#include "pcg.h"
 
 class CrawlVector;
 
@@ -22,9 +23,24 @@ namespace rng
         rng_type previous;
     };
 
+    class subgenerator
+    {
+    public:
+        subgenerator();
+        subgenerator(uint64_t seed);
+        subgenerator(uint64_t seed, uint64_t sequence);
+        ~subgenerator();
+    private:
+        PcgRNG current;
+        PcgRNG *previous;
+        rng_type previous_main;
+    };
+
     CrawlVector generators_to_vector();
     void load_generators(const CrawlVector &v);
     vector<uint64_t> get_states();
+    PcgRNG *get_generator(rng_type r);
+    PcgRNG &current_generator();
 
     void seed();
     void seed(uint64_t seed);

--- a/crawl-ref/source/random.h
+++ b/crawl-ref/source/random.h
@@ -36,6 +36,7 @@ namespace rng
         rng_type previous_main;
     };
 
+    rng_type get_branch_generator(const branch_type b);
     CrawlVector generators_to_vector();
     void load_generators(const CrawlVector &v);
     vector<uint64_t> get_states();

--- a/crawl-ref/source/random.h
+++ b/crawl-ref/source/random.h
@@ -52,6 +52,20 @@ namespace rng
     uint32_t get_uint32();
     uint64_t get_uint64();
     uint32_t peek_uint32();
+    uint64_t peek_uint64();
+
+    class ASSERT_stable
+    {
+    public:
+        ASSERT_stable() : initial_peek(peek_uint64()) { }
+        ~ASSERT_stable()
+        {
+            ASSERT(peek_uint64() == initial_peek);
+        }
+
+    private:
+        uint64_t initial_peek;
+    };
 }
 
 bool coinflip();

--- a/crawl-ref/source/rng-type.h
+++ b/crawl-ref/source/rng-type.h
@@ -1,12 +1,15 @@
 #pragma once
 #include "branch-type.h"
 
-enum rng_type {
-    RNG_GAMEPLAY,        // gameplay effects in general
-    RNG_UI,              // UI randomization
-    RNG_SYSTEM_SPECIFIC, // anything that may vary from system to system, e.g. ghosts
-    RNG_SPARE2,
-    RNG_SPARE3,
-    RNG_LEVELGEN,        // branch 0, i.e. the dungeon
-    NUM_RNGS = RNG_LEVELGEN + NUM_BRANCHES, // and then one for each other branch
-};
+namespace rng
+{
+    enum rng_type {
+        GAMEPLAY,        // gameplay effects in general
+        UI,              // UI randomization
+        SYSTEM_SPECIFIC, // anything that may vary from system to system, e.g. ghosts
+        SPARE2,
+        SPARE3,
+        LEVELGEN,        // branch 0, i.e. the dungeon
+        NUM_RNGS = LEVELGEN + NUM_BRANCHES, // and then one for each other branch
+    };
+}

--- a/crawl-ref/source/rng-type.h
+++ b/crawl-ref/source/rng-type.h
@@ -11,5 +11,6 @@ namespace rng
         SPARE3,
         LEVELGEN,        // branch 0, i.e. the dungeon
         NUM_RNGS = LEVELGEN + NUM_BRANCHES, // and then one for each other branch
+        SUB_GENERATOR,   // unsaved -- past NUM_RNGS
     };
 }

--- a/crawl-ref/source/rng-type.h
+++ b/crawl-ref/source/rng-type.h
@@ -12,5 +12,6 @@ namespace rng
         LEVELGEN,        // branch 0, i.e. the dungeon
         NUM_RNGS = LEVELGEN + NUM_BRANCHES, // and then one for each other branch
         SUB_GENERATOR,   // unsaved -- past NUM_RNGS
+        ASSERT_NO_RNG,   // debugging tool
     };
 }

--- a/crawl-ref/source/scripts/seed_explorer.lua
+++ b/crawl-ref/source/scripts/seed_explorer.lua
@@ -38,7 +38,8 @@ Usage: seed_explorer.lua -seed <seed> ([<seed> ...]|[-count <n>]) ([-depth <dept
               the range of possible values to some degree.
     <depth>:  A level or branch name in short form, e.g. `Zot:5`, `Hell`, or
               `D`, a number, or 'all'. If this is a number, then this value is
-              depth relative to the level generation order. Defaults to `all`.
+              depth relative to the level generation order. Defaults to Tomb:3,
+              i.e. excluding the hells.
     <lvl>:    same format as <depth>, but will only show levels in the list.
               Note that this doesn't affect which levels are generated, so
               `-show Zot:5` will take as long to run as `-depth Zot:5`.
@@ -150,14 +151,25 @@ if args["-show"] ~= nil then
     if #levels_to_show == 0 then
         usage_error("\nNo valid levels or depths provided with -show!")
     end
-    util.sort(levels_to_show)
-    if max_depth == nil then max_depth = levels_to_show[#levels_to_show] end
+    if max_depth == nil then
+        -- this doesn't handle portal-only lists correctly
+        max_depth = 0
+        for i, depth in ipairs(levels_to_show) do
+            if depth > max_depth then max_depth = depth end
+        end
+        if max_depth == 0 then
+            -- portals only.
+            -- TODO: this is a heuristic; but no portals currently generate
+            -- later than this. (In fact, elf:2 is really the latest.)
+            max_depth = explorer.level_to_gendepth("Zot:4")
+        end
+    end
     local levels_set = util.set(levels_to_show)
     show_level_fun = function (l) return levels_set[l] end
 end
 
 if max_depth == nil then
-    max_depth = #explorer.generation_order
+    max_depth = explorer.level_to_gendepth("Tomb:3")
 end
 
 -- TODO: these are kind of ad hoc, maybe some kind of more general interface?

--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -441,7 +441,7 @@ static void _update_monster(monster* mons)
     if (you.attribute[ATTR_SEEN_INVIS_TURN] != you.num_turns)
     {
         you.attribute[ATTR_SEEN_INVIS_TURN] = you.num_turns;
-        you.attribute[ATTR_SEEN_INVIS_SEED] = get_uint32();
+        you.attribute[ATTR_SEEN_INVIS_SEED] = rng::get_uint32();
     }
     // After the player finishes this turn, the monster's unseen pos (and
     // its invis indicator due to going unseen) will be erased.

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -232,6 +232,14 @@ void leaving_level_now(dungeon_feature_type stair_used)
                        you.depth));
     }
 
+    if (stair_used == DNGN_EXIT_ABYSS)
+    {
+#ifdef DEBUG
+        auto &vault_list =  you.vault_list[level_id::current()];
+        vault_list.push_back("[exit]");
+#endif
+    }
+
     dungeon_events.fire_position_event(DET_PLAYER_CLIMBS, you.pos());
     dungeon_events.fire_event(DET_LEAVING_LEVEL);
 

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -85,7 +85,7 @@ static void _initialize()
     you.symbol = MONS_PLAYER;
     msg::initialise_mpr_streams();
 
-    seed_rng(); // don't use any chosen seed yet
+    rng::seed(); // don't use any chosen seed yet
 
     init_char_table(Options.char_set);
     init_show_table();

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -233,6 +233,7 @@ enum tag_minor_version
     TAG_MINOR_THROW_CONSOLIDATION, // Throwing brands consolidated
     TAG_MINOR_VAMPIRE_NO_EAT,      // Decouple Vampires from the food system
     TAG_MINOR_SINGULAR_THEY,       // Add singular they pronouns
+    TAG_MINOR_ABYSS_UNIQUE_VAULTS, // Separate abyss vault tracking from main dungeon
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1671,7 +1671,7 @@ static void tag_construct_you(writer &th)
     marshallUByte(th, 1); // number of seeds, for historical reasons: always 1
     marshallUnsigned(th, you.game_seed);
     marshallBoolean(th, you.game_is_seeded);
-    CrawlVector rng_states = generators_to_vector();
+    CrawlVector rng_states = rng::generators_to_vector();
     rng_states.write(th);
 
     CANARY;
@@ -3609,7 +3609,7 @@ static void tag_read_you(reader &th)
         if (th.getMinorVersion() >= TAG_MINOR_REMOVE_ABYSS_SEED
             && th.getMinorVersion() < TAG_MINOR_ADD_ABYSS_SEED)
         {
-            abyssal_state.seed = get_uint32();
+            abyssal_state.seed = rng::get_uint32();
         }
         else
 #endif
@@ -3623,7 +3623,7 @@ static void tag_read_you(reader &th)
         unmarshallFloat(th); // converted abyssal_state.depth to int.
         abyssal_state.depth = 0;
         abyssal_state.destroy_all_terrain = true;
-        abyssal_state.seed = get_uint32();
+        abyssal_state.seed = rng::get_uint32();
     }
 #endif
     abyssal_state.phase = unmarshallFloat(th);
@@ -3688,7 +3688,7 @@ static void tag_read_you(reader &th)
     ASSERT(th.getMinorVersion() < TAG_MINOR_GAMESEEDS || count == 1);
     if (th.getMinorVersion() < TAG_MINOR_GAMESEEDS)
     {
-        you.game_seed = count > 0 ? unmarshallInt(th) : get_uint64();
+        you.game_seed = count > 0 ? unmarshallInt(th) : rng::get_uint64();
         dprf("Upgrading from unseeded game.");
         crawl_state.seed = you.game_seed;
         you.game_is_seeded = false;
@@ -3707,7 +3707,7 @@ static void tag_read_you(reader &th)
         you.game_is_seeded = unmarshallBoolean(th);
         CrawlVector rng_states;
         rng_states.read(th);
-        load_generators(rng_states);
+        rng::load_generators(rng_states);
 #if TAG_MAJOR_VERSION == 34
     }
 #endif

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1838,6 +1838,10 @@ static void tag_construct_you_dungeon(writer &th)
                       marshallString);
     marshall_iterator(th, you.uniq_map_names.begin(), you.uniq_map_names.end(),
                       marshallString);
+    marshall_iterator(th, you.uniq_map_tags_abyss.begin(),
+                        you.uniq_map_tags_abyss.end(), marshallString);
+    marshall_iterator(th, you.uniq_map_names_abyss.begin(),
+                        you.uniq_map_names_abyss.end(), marshallString);
     marshallMap(th, you.vault_list, marshall_level_id, marshallStringVector);
 
     write_level_connectivity(th);
@@ -4297,6 +4301,19 @@ static void tag_read_you_dungeon(reader &th)
                          &string_set::insert,
                          unmarshallString);
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_ABYSS_UNIQUE_VAULTS)
+    {
+#endif
+    unmarshall_container(th, you.uniq_map_tags_abyss,
+                         (ssipair (string_set::*)(const string &))
+                         &string_set::insert,
+                         unmarshallString);
+    unmarshall_container(th, you.uniq_map_names_abyss,
+                         (ssipair (string_set::*)(const string &))
+                         &string_set::insert,
+                         unmarshallString);
+#if TAG_MAJOR_VERSION == 34
+    }
     if (th.getMinorVersion() >= TAG_MINOR_VAULT_LIST) // 33:17 has it
 #endif
     unmarshallMap(th, you.vault_list, unmarshall_level_id,

--- a/crawl-ref/source/test/rng_test.lua
+++ b/crawl-ref/source/test/rng_test.lua
@@ -3,6 +3,15 @@
 
 local eol = string.char(13)
 
+function big_rng_test()
+    crawl.stderr("Running big rng test, this may take a while...")
+    for i = 1, 0xffffffff do
+        crawl.random2(i)
+    end
+    debug.reset_rng(1)
+
+end
+
 local results = {51, 11, 78, 21, 19, 95, 21, 43, 33, 75}
 
 debug.reset_rng(1)
@@ -15,3 +24,5 @@ end
 crawl.stderr(eol)
 
 debug.reset_rng(1)
+
+--big_rng_test()

--- a/crawl-ref/source/test/rng_test.lua
+++ b/crawl-ref/source/test/rng_test.lua
@@ -3,7 +3,7 @@
 
 local eol = string.char(13)
 
-local results = {49, 97, 51, 75, 3, 38, 66, 84, 28, 76}
+local results = {51, 11, 78, 21, 19, 95, 21, 43, 33, 75}
 
 debug.reset_rng(1)
 crawl.stderr("Here are 10 random numbers from seed 1:" .. eol)

--- a/crawl-ref/source/test/stress/fireworks.rc
+++ b/crawl-ref/source/test/stress/fireworks.rc
@@ -7,6 +7,7 @@ species = mu
 background = ar
 restart_after_game = false
 show_more = false
+incremental_pregen = false
 #message_colour = mute:.*
 
 : bot_start = true

--- a/crawl-ref/source/test/stress/fireworks.rc
+++ b/crawl-ref/source/test/stress/fireworks.rc
@@ -7,7 +7,7 @@ species = mu
 background = ar
 restart_after_game = false
 show_more = false
-incremental_pregen = false
+pregen_dungeon = false
 #message_colour = mute:.*
 
 : bot_start = true

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -313,10 +313,11 @@ void tile_clear_flavour()
 void tile_init_flavour()
 {
     vector<unsigned int> output;
+
     {
         uint64_t seed[] = { static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
             static_cast<uint64_t>(you.depth) };
-        PcgRNG rng(seed, ARRAYSZ(seed));
+        rng::PcgRNG rng(seed, ARRAYSZ(seed));
         if (you.where_are_you == BRANCH_CRYPT)
         {
             output.reserve(X_WIDTH * Y_WIDTH);

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -315,8 +315,7 @@ void tile_init_flavour()
     vector<unsigned int> output;
 
     {
-<<<<<<< HEAD
-        rng::PcgRNG rng(
+        rng::subgenerator sub_rng(
             static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
             static_cast<uint64_t>(you.depth));
 
@@ -324,13 +323,15 @@ void tile_init_flavour()
         {
             output.reserve(X_WIDTH * Y_WIDTH);
             domino::DominoSet<domino::EdgeDomino> dominoes(domino::cohen_set, 8);
-            dominoes.Generate(X_WIDTH, Y_WIDTH, output, rng);
+            // TODO: don't pass a PcgRNG object
+            dominoes.Generate(X_WIDTH, Y_WIDTH, output,
+                                                    rng::current_generator());
         }
         else
         {
             output.resize(X_WIDTH * Y_WIDTH);
             for (auto &o : output)
-                o = rng();
+                o = rng::get_uint32();
         }
     }
     for (rectangle_iterator ri(0); ri; ++ri)

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -308,37 +308,36 @@ void tile_clear_flavour()
         tile_clear_flavour(*ri);
 }
 
+static bool _level_uses_dominoes()
+{
+    return you.where_are_you == BRANCH_CRYPT;
+}
+
 // For floors and walls that have not already been set to a particular tile,
 // set them to a random instance of the default floor and wall tileset.
 void tile_init_flavour()
 {
-    vector<unsigned int> output;
-
+    if (_level_uses_dominoes())
     {
-        rng::subgenerator sub_rng(
-            static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
-            static_cast<uint64_t>(you.depth));
+        vector<unsigned int> output;
 
-        if (you.where_are_you == BRANCH_CRYPT)
         {
+            rng::subgenerator sub_rng(
+                static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
+                static_cast<uint64_t>(you.depth));
             output.reserve(X_WIDTH * Y_WIDTH);
             domino::DominoSet<domino::EdgeDomino> dominoes(domino::cohen_set, 8);
             // TODO: don't pass a PcgRNG object
             dominoes.Generate(X_WIDTH, Y_WIDTH, output,
                                                     rng::current_generator());
         }
-        else
-        {
-            output.resize(X_WIDTH * Y_WIDTH);
-            for (auto &o : output)
-                o = rng::get_uint32();
-        }
+
+        for (rectangle_iterator ri(0); ri; ++ri)
+            tile_init_flavour(*ri, output[ri->x + ri->y * GXM]);
     }
-    for (rectangle_iterator ri(0); ri; ++ri)
-    {
-        unsigned int idx = ri->x + ri->y * GXM;
-        tile_init_flavour(*ri, output[idx]);
-    }
+    else
+        for (rectangle_iterator ri(0); ri; ++ri)
+            tile_init_flavour(*ri, 0);
 }
 
 // 11111333333   55555555

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -315,9 +315,11 @@ void tile_init_flavour()
     vector<unsigned int> output;
 
     {
-        uint64_t seed[] = { static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
-            static_cast<uint64_t>(you.depth) };
-        rng::PcgRNG rng(seed, ARRAYSZ(seed));
+<<<<<<< HEAD
+        rng::PcgRNG rng(
+            static_cast<uint64_t>(you.where_are_you ^ you.game_seed),
+            static_cast<uint64_t>(you.depth));
+
         if (you.where_are_you == BRANCH_CRYPT)
         {
             output.reserve(X_WIDTH * Y_WIDTH);

--- a/crawl-ref/source/util/monster/monster-main.cc
+++ b/crawl-ref/source/util/monster/monster-main.cc
@@ -703,7 +703,7 @@ int main(int argc, char* argv[])
     }
     else if (!strcmp(argv[1], "-name") || !strcmp(argv[1], "--name"))
     {
-        seed_rng();
+        rng::seed();
         printf("%s\n", make_name().c_str());
         return 0;
     }

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -588,6 +588,8 @@ static void debug_load_map_by_name(string name, bool primary)
     {
         unwind_var<string_set> um(you.uniq_map_names, string_set());
         unwind_var<string_set> umt(you.uniq_map_tags, string_set());
+        unwind_var<string_set> um_a(you.uniq_map_names_abyss, string_set());
+        unwind_var<string_set> umt_a(you.uniq_map_tags_abyss, string_set());
         unwind_var<string_set> lum(env.level_uniq_maps, string_set());
         unwind_var<string_set> lumt(env.level_uniq_map_tags, string_set());
         if (dgn_place_map(toplace, false, false, where))
@@ -790,6 +792,8 @@ void wizard_clear_used_vaults()
 {
     you.uniq_map_tags.clear();
     you.uniq_map_names.clear();
+    you.uniq_map_tags_abyss.clear();
+    you.uniq_map_names_abyss.clear();
     env.level_uniq_maps.clear();
     env.level_uniq_map_tags.clear();
     mpr("All vaults are now eligible for [re]use.");

--- a/crawl-ref/source/wiz-item.h
+++ b/crawl-ref/source/wiz-item.h
@@ -11,7 +11,7 @@ void wizard_tweak_object();
 void wizard_make_object_randart();
 void wizard_value_item();
 void wizard_uncurse_item();
-void wizard_create_all_artefacts();
+void wizard_create_all_artefacts(bool override_unique = true);
 void wizard_identify_pack();
 void wizard_unidentify_pack();
 void wizard_draw_card();

--- a/crawl-ref/source/wizard.cc
+++ b/crawl-ref/source/wizard.cc
@@ -210,7 +210,8 @@ static void _do_wizard_command(int wiz_command)
         break;
 
     case '\\': debug_make_shop(); break;
-    case '|': wizard_create_all_artefacts(); break;
+    case '|': wizard_create_all_artefacts(true); break;
+    case CONTROL('\\'): wizard_create_all_artefacts(false); break;
 
     case ';': wizard_list_levels(); break;
     case ':': wizard_list_branches(); break;
@@ -486,6 +487,7 @@ int list_wizard_commands(bool do_redraw_screen)
                        "<w>Ctrl-V</w> show gold value of an item\n"
                        "<w>-</w>      get a god gift\n"
                        "<w>|</w>      create all unrand artefacts\n"
+                       "<w>Ctrl-\\</w> create all unrands / fallbacks\n"
                        "<w>+</w>      make randart from item\n"
                        "<w>'</w>      list items\n"
                        "<w>J</w>      Jiyva off-level sacrifice\n"


### PR DESCRIPTION
I'm still doing a bunch of testing but this is getting close to a merge, so I'll PR it in case anyone else has time to look.

This PR uses a single standard levelgen mechanism that is intended to be stable across devices etc given a seed: incremental pregeneration. The core problem is that levelgen choices are not independent between levels, so the order in which levels are generated heavily impacts later parts of the dungeon, something that can't be mitigated by fancier rng seeding (for example, many vaults can only place once). What this new levelgen technique does is generate all levels in a stable order, but only as many as needed to catch up when entering a new level. So, for example, if you fall through a shaft and skip a level, it will generate the skipped level first. Some cases are a bit heavier; e.g. if you enter depths before lair, the game will generate lair and both lair branches entirely before depths 1. This technique supposed to get (almost) exactly the same results as full pregeneration, but without the up front CPU cost.

The main case where incremental pregen can differ from full pregeneration involves unrandarts. This is because there are various ways for the player to get unrands at any point in the game, and so there's no practical way to avoid things like acquirement being able to scoop an artifact that on a full pregeneration run would try to place later in the game. What these changes do instead are systemize the code (which already sort of existed) for placing similar randarts where an unrand should've placed but couldn't, as well as isolate the rng calculations from this from the main levelgen rng. The impact of acquiring an unrand in this kind of case should then amount to a change in just one item later.

This PR also includes various improvements to the RNG API, bugfixes, etc.