### PR TITLE
Add setting a waypoint to clua

### DIFF
--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -26,7 +26,7 @@ LUAFN(l_set_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
     // XXX: dedup w/_get_full_exclusion_radius()?
     int r = LOS_RADIUS;
     if (lua_gettop(ls) > 2)
@@ -48,7 +48,7 @@ LUAFN(l_del_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
     del_exclude(p);
     return 0;
 }
@@ -129,7 +129,7 @@ LUAFN(l_set_waypoint)
     s.y = luaL_safe_checkint(ls, 3);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
     travel_cache.set_waypoint(waynum, p.x, p.y);
     return 0;
 }

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -13,7 +13,7 @@
 #include "travel.h"
 
 /*** Set an exclusion.
- * Uses player centered coordinates
+ * Uses player-centered coordinates
  * @tparam int x
  * @tparam int y
  * @tparam[opt=LOS_RADIUS] int r
@@ -36,7 +36,7 @@ LUAFN(l_set_exclude)
 }
 
 /*** Remove an exclusion.
- * Uses player centered coordinates
+ * Uses player-centered coordinates
  * @tparam int x
  * @tparam int y
  * @function del_eclude
@@ -113,7 +113,7 @@ LUAFN(l_waypoint_delta)
 }
 
 /*** Set a numbered waypoint.
- * Uses player-centered coordinates.
+ * Uses player-centered coordinates
  * @tparam int waynum
  * @tparam int x
  * @tparam int y

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -26,7 +26,7 @@ LUAFN(l_set_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return 0;
+        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     // XXX: dedup w/_get_full_exclusion_radius()?
     int r = LOS_RADIUS;
     if (lua_gettop(ls) > 2)
@@ -48,7 +48,7 @@ LUAFN(l_del_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return 0;
+        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     del_exclude(p);
     return 0;
 }
@@ -129,7 +129,7 @@ LUAFN(l_set_waypoint)
     s.y = luaL_safe_checkint(ls, 3);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        return 0;
+        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     travel_cache.set_waypoint(waynum, p.x, p.y);
     return 0;
 }

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -114,7 +114,7 @@ LUAFN(l_waypoint_delta)
 
 /*** Set a numbered waypoint.
  * Uses player-centered coordinates.
- * @tparam int n Waypoint number
+ * @tparam int waynum
  * @tparam int x
  * @tparam int y
  * @function set_waypoint

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -26,7 +26,7 @@ LUAFN(l_set_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     // XXX: dedup w/_get_full_exclusion_radius()?
     int r = LOS_RADIUS;
     if (lua_gettop(ls) > 2)
@@ -48,7 +48,7 @@ LUAFN(l_del_exclude)
     s.y = luaL_safe_checkint(ls, 2);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     del_exclude(p);
     return 0;
 }
@@ -102,7 +102,7 @@ LUAFN(l_waypoint_delta)
 {
     int waynum = luaL_safe_checkint(ls, 1);
     if (waynum < 0 || waynum >= TRAVEL_WAYPOINT_COUNT)
-        luaL_error(ls, "Bad waypoint number: %d", waynum);
+        return luaL_error(ls, "Bad waypoint number: %d", waynum);
     const level_pos waypoint = travel_cache.get_waypoint(waynum);
     if (waypoint.id != level_id::current())
         return 0;
@@ -123,13 +123,13 @@ LUAFN(l_set_waypoint)
 {
     int waynum = luaL_safe_checkint(ls, 1);
     if (waynum < 0 || waynum >= TRAVEL_WAYPOINT_COUNT)
-        luaL_error(ls, "Bad waypoint number: %d", waynum);
+        return luaL_error(ls, "Bad waypoint number: %d", waynum);
     coord_def s;
     s.x = luaL_safe_checkint(ls, 2);
     s.y = luaL_safe_checkint(ls, 3);
     const coord_def p = player2grid(s);
     if (!in_bounds(p))
-        luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", p.x, p.y);
     travel_cache.set_waypoint(waynum, p.x, p.y);
     return 0;
 }

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -101,8 +101,8 @@ LUAFN(l_find_deepest_explored)
 LUAFN(l_waypoint_delta)
 {
     int waynum = luaL_safe_checkint(ls, 1);
-    if (waynum < 0 || waynum > 9)
-        return 0;
+    if (waynum < 0 || waynum >= TRAVEL_WAYPOINT_COUNT)
+        luaL_error(ls, "Bad waypoint number: %d", waynum);
     const level_pos waypoint = travel_cache.get_waypoint(waynum);
     if (waypoint.id != level_id::current())
         return 0;
@@ -122,8 +122,8 @@ LUAFN(l_waypoint_delta)
 LUAFN(l_set_waypoint)
 {
     int waynum = luaL_safe_checkint(ls, 1);
-    if (waynum < 0 || waynum > 9)
-        return 0;
+    if (waynum < 0 || waynum >= TRAVEL_WAYPOINT_COUNT)
+        luaL_error(ls, "Bad waypoint number: %d", waynum);
     coord_def s;
     s.x = luaL_safe_checkint(ls, 2);
     s.y = luaL_safe_checkint(ls, 3);

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -112,6 +112,28 @@ LUAFN(l_waypoint_delta)
     return 2;
 }
 
+/*** Set a numbered waypoint.
+ * Uses player-centered coordinates.
+ * @tparam int n Waypoint number
+ * @tparam int x
+ * @tparam int y
+ * @function set_waypoint
+ */
+LUAFN(l_set_waypoint)
+{
+    int waynum = luaL_safe_checkint(ls, 1);
+    if (waynum < 0 || waynum > 9)
+        return 0;
+    coord_def s;
+    s.x = luaL_safe_checkint(ls, 2);
+    s.y = luaL_safe_checkint(ls, 3);
+    const coord_def p = player2grid(s);
+    if (!in_bounds(p))
+        return 0;
+    travel_cache.set_waypoint(waynum, p.x, p.y);
+    return 0;
+}
+
 static const struct luaL_reg travel_lib[] =
 {
     { "set_exclude", l_set_exclude },
@@ -120,6 +142,7 @@ static const struct luaL_reg travel_lib[] =
     { "feature_solid", l_feature_is_solid },
     { "find_deepest_explored", l_find_deepest_explored },
     { "waypoint_delta", l_waypoint_delta },
+    { "set_waypoint", l_set_waypoint },
 
     { nullptr, nullptr }
 };

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -3968,7 +3968,7 @@ void TravelCache::add_waypoint(int x, int y)
 
 void TravelCache::set_waypoint(int waynum, int x, int y)
 {
-    // Assumes that the waynum input is a valid number between 0 and 9 inclusive.
+    ASSERT_RANGE(waynum, 0, TRAVEL_WAYPOINT_COUNT);
     coord_def pos(x,y);
     if (x == -1 || y == -1)
         pos = you.pos();

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -3989,7 +3989,7 @@ void TravelCache::set_waypoint(int waynum, int x, int y)
     if (overwrite)
     {
         if (lid == old_lid) // same level
-            mprf("Waypoint %d re-assigned to your current position.", waynum);
+            mprf("Waypoint %d re-assigned to %s.", waynum, new_dest.c_str());
         else
         {
             mprf("Waypoint %d re-assigned from %s to %s.",

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -3962,8 +3962,13 @@ void TravelCache::add_waypoint(int x, int y)
         return;
     }
 
-    int waynum = keyin - '0';
+    set_waypoint(keyin - '0', x, y);
 
+}
+
+void TravelCache::set_waypoint(int waynum, int x, int y)
+{
+    // Assumes that the waynum input is a valid number between 0 and 9 inclusive.
     coord_def pos(x,y);
     if (x == -1 || y == -1)
         pos = you.pos();

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -449,6 +449,7 @@ public:
     void set_level_excludes();
 
     void add_waypoint(int x = -1, int y = -1);
+    void set_waypoint(int waynum, int x, int y);
     void delete_waypoint();
     uint8_t is_waypoint(const level_pos &lp) const;
     void list_waypoints() const;


### PR DESCRIPTION
As `travel.set_exclude` and `travel.waypoint_delta` exist as clua functions, I believe `travel.set_waypoint(int waynum, int x, int y)` is a pretty harmless and useful addition to the `travel` clua module. This function sets the position of waypoint #`waynum` to `(x, y)` in player-centered coordinates. In addition, this PR slightly refactors the current `TravelCache.add_waypoint` function to separate out the logic of actually setting the coordinates of a specific waypoint (which is now `TravelCache.set_waypoint`) from the logic of getting and parsing the player's input for which waypoint should be set. The `set_waypoint` clua function simply calls `travel_cache.set_waypoint`. 