### PR TITLE
Add !cancellation to Zig loot table (EugeneJudo)

### DIFF
--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -587,9 +587,10 @@ local function ziggurat_create_loot_at(c)
                                   dgn.good_scrolls)
   local super_loot = dgn.item_spec("| no_pickup w:7000 /" ..
                                    "potion of experience no_pickup w:190 q:1 /" ..
-                                   "potion of mutation no_pickup w:190 /" ..
+                                   "potion of mutation no_pickup w:185 /" ..
                                    "potion of mutation no_pickup w:40 q:1 /" ..
                                    "ration no_pickup w:80 /" ..
+                                   "potion of cancellation q:5 no_pickup / " ..
                                    "potion of heal wounds q:5 no_pickup / " ..
                                    "potion of haste q:5 no_pickup / " ..
                                    dgn.good_scrolls)


### PR DESCRIPTION
"Do cancellation potions not spawn in zigs? They're very useful for surviving -wiz on pan floors when things get out of hand (brilliance doesn't help, or at least it still leaves things unreliable to cast.) My supply is running low, while it's pretty rare that I ever use them."