### PR TITLE
Unify two loot lines

### DIFF
--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -587,8 +587,7 @@ local function ziggurat_create_loot_at(c)
                                   dgn.good_scrolls)
   local super_loot = dgn.item_spec("| no_pickup w:7000 /" ..
                                    "potion of experience no_pickup w:190 q:1 /" ..
-                                   "potion of mutation no_pickup w:190 /" ..
-                                   "potion of mutation no_pickup w:40 q:1 /" ..
+                                   "potion of mutation no_pickup w:220 /" ..
                                    "ration no_pickup w:80 /" ..
                                    "potion of heal wounds q:5 no_pickup / " ..
                                    "potion of haste q:5 no_pickup / " ..


### PR DESCRIPTION
Based on absolutely nothing, I think the average stack size of mutation potions is a touch over 1, adjust the new weight accordingly.