### PR TITLE
Check for known map bounds in the clua travel library

### DIFF
--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -8,46 +8,16 @@
 #include "branch.h"
 #include "cluautil.h"
 #include "coord.h"
-#include "env.h"
 #include "player.h"
 #include "terrain.h"
 #include "travel.h"
-
-static bool _in_map_bounds(int x, int y)
-{
-    // code to get bounds stolen from viewmap.cc
-    int min_x = GXM, max_x = 0, min_y = 0, max_y = 0;
-    bool found_y = false;
-
-    for (int j = 0; j < GYM; j++)
-        for (int i = 0; i < GXM; i++)
-        {
-            if (env.map_knowledge[i][j].known())
-            {
-                if (!found_y)
-                {
-                    found_y = true;
-                    min_y = j;
-                    if (y < min_y)
-                        return false;
-                }
-
-                max_y = j;
-
-                if (i < min_x)
-                    min_x = i;
-
-                if (i > max_x)
-                    max_x = i;
-            }
-        }
-
-    return y <= max_y && x >= min_x && x <= max_x;
-}
+#include "map-knowledge.h"
 
 static bool _in_map_bounds(const coord_def& p)
 {
-    return _in_map_bounds(p.x, p.y);
+    std::pair<coord_def, coord_def> b = known_map_bounds();
+    return p.x >= b.first.x && p.y >= b.first.y
+        && p.x <= b.second.x && p.y <= b.second.y;
 }
 
 /*** Set an exclusion.

--- a/crawl-ref/source/map-knowledge.cc
+++ b/crawl-ref/source/map-knowledge.cc
@@ -326,3 +326,31 @@ bool map_cell::update_cloud_state()
     // TODO: track decay & vanish appropriately (based on some worst case?)
     return false;
 }
+
+std::pair<coord_def, coord_def> known_map_bounds() {
+    int min_x = GXM, max_x = 0, min_y = 0, max_y = 0;
+    bool found_y = false;
+
+    for (int j = 0; j < GYM; j++)
+        for (int i = 0; i < GXM; i++)
+        {
+            if (env.map_knowledge[i][j].known())
+            {
+                if (!found_y)
+                {
+                    found_y = true;
+                    min_y = j;
+                }
+
+                max_y = j;
+
+                if (i < min_x)
+                    min_x = i;
+
+                if (i > max_x)
+                    max_x = i;
+            }
+        }
+
+    return std::make_pair(coord_def(min_x, min_y), coord_def(max_x, max_y));
+}

--- a/crawl-ref/source/map-knowledge.h
+++ b/crawl-ref/source/map-knowledge.h
@@ -46,6 +46,6 @@ void reautomap_level();
 /**
  * @brief Get the bounding box of the known map.
  *
- * @return vector of [topleft coord, bottomright coord] of bbox.
+ * @return pair of {topleft coord, bottomright coord} of bbox.
  */
 std::pair<coord_def, coord_def> known_map_bounds();

--- a/crawl-ref/source/map-knowledge.h
+++ b/crawl-ref/source/map-knowledge.h
@@ -3,6 +3,7 @@
 #include "coord.h"
 #include "enum.h"
 #include "feature.h"
+#include "externs.h"
 
 void set_terrain_mapped(const coord_def c);
 void set_terrain_seen(const coord_def c);
@@ -41,3 +42,10 @@ map_feature get_cell_map_feature(const map_cell& cell);
 bool is_explore_horizon(const coord_def& c);
 
 void reautomap_level();
+
+/**
+ * @brief Get the bounding box of the known map.
+ *
+ * @return vector of [topleft coord, bottomright coord] of bbox.
+ */
+std::pair<coord_def, coord_def> known_map_bounds();

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -641,7 +641,6 @@ bool show_map(level_pos &lpos,
             lpos.id = level_id::current();
 
         cursor_control ccon(!Options.use_fake_cursor);
-        int i, j;
 
         int move_x = 0, move_y = 0, scroll_y = 0;
 
@@ -702,29 +701,11 @@ bool show_map(level_pos &lpos,
 
                 feats.init();
 
-                min_x = GXM, max_x = 0, min_y = 0, max_y = 0;
-                bool found_y = false;
-
-                for (j = 0; j < GYM; j++)
-                    for (i = 0; i < GXM; i++)
-                    {
-                        if (env.map_knowledge[i][j].known())
-                        {
-                            if (!found_y)
-                            {
-                                found_y = true;
-                                min_y = j;
-                            }
-
-                            max_y = j;
-
-                            if (i < min_x)
-                                min_x = i;
-
-                            if (i > max_x)
-                                max_x = i;
-                        }
-                    }
+                std::pair<coord_def, coord_def> bounds = known_map_bounds();
+                min_x = bounds.first.x;
+                min_y = bounds.first.y;
+                max_x = bounds.second.x;
+                max_y = bounds.second.y;
 
                 map_lines = max_y - min_y + 1;
 


### PR DESCRIPTION
The set_exclude, del_exclude, and set_waypoint functions all previously ignored the bounds normally set on your cursor in map mode, i.e. you can only move your cursors to points within the bounding box of the known map. These bounds being ignored by the above functions meant both that clua could do something that couldn't be done manually, and that your absolute coordinates could be leaked by careful use of the above functions. This fix will prevent both from happening.