### PR TITLE
Revert "Allow running clua from map viewing mode; add clua functions to get information about map cursor"

### DIFF
--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -912,47 +912,6 @@ static int crawl_article_a(lua_State *ls)
     return 1;
 }
 
-/*** If we are in map mode and the cursor is on the same
- * level as the player, get player-relative position of cursor.
- * @treturn int, int
- * @function cursor_pos
- */
-LUAFN(crawl_cursor_pos)
-{
-    map_mode_state &info = crawl_state.map_mode_info;
-    if (!crawl_state.in_map_mode
-        || info.cursor_lpos.id != info.original_lid)
-    {
-        return 0;
-    }
-
-    lua_pushinteger(ls, info.cursor_lpos.pos.x - you.position.x);
-    lua_pushinteger(ls, info.cursor_lpos.pos.y - you.position.y);
-
-    return 2;
-}
-
-/*** If we are in map mode, get description of cursor level
- * in the form <branch-abbreviation>:<depth>.
- * @treturn string
- * @function cursor_level
- */
-LUAFN(crawl_cursor_level)
-{
-    if (!crawl_state.in_map_mode)
-        return 0;
-
-    lua_pushstring(ls, crawl_state.map_mode_info.cursor_lpos.id.describe().c_str());
-
-    return 1;
-}
-
-/*** Are we in map mode?
- * @treturn boolean
- * @function in_map_mode
- */
-LUARET1(crawl_in_map_mode, boolean, crawl_state.in_map_mode)
-
 /*** Has the game started?
  * @treturn boolean
  * @function game_started
@@ -1465,10 +1424,7 @@ static const struct luaL_reg crawl_clib[] =
     { "call_dlua",          crawl_call_dlua },
 #endif
     { "version",            crawl_version },
-    { "weapon_check",       crawl_weapon_check },
-    { "in_map_mode",        crawl_in_map_mode },
-    { "cursor_pos",         crawl_cursor_pos },
-    { "cursor_level",       crawl_cursor_level },
+    { "weapon_check",       crawl_weapon_check},
     { nullptr, nullptr },
 };
 

--- a/crawl-ref/source/state.cc
+++ b/crawl-ref/source/state.cc
@@ -61,7 +61,6 @@ game_state::game_state()
       darken_range(nullptr), unsaved_macros(false), disables(),
       minor_version(-1), save_rcs_version(),
       nonempty_buffer_flush_errors(false),
-      in_map_mode(false), map_mode_info({}),
       mon_act(nullptr)
 {
     reset_cmd_repeat();

--- a/crawl-ref/source/state.h
+++ b/crawl-ref/source/state.h
@@ -30,15 +30,6 @@ public:
     int      depth;
 };
 
-struct map_mode_state
-{
-    // Absolute position + level_id of the cursor
-    level_pos cursor_lpos;
-
-    // Stored level_id of the player character
-    level_id original_lid;
-};
-
 // Track various aspects of Crawl game state.
 struct game_state
 {
@@ -147,12 +138,6 @@ struct game_state
 
     // Should flushing a nonempty key buffer error or crash? Used for tests.
     bool nonempty_buffer_flush_errors;
-
-    // Whether we are in "map mode", i.e. currently in eXamine
-    bool in_map_mode;
-
-    // Info pertaining to map mode, if we are in map mode. If we aren't, value is undefined.
-    map_mode_state map_mode_info;
 
 protected:
     void reset_cmd_repeat();

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -38,7 +38,6 @@
 #include "view.h"
 #include "viewchar.h"
 #include "viewgeom.h"
-#include "delay.h"
 
 #ifdef USE_TILE
 #endif
@@ -619,7 +618,6 @@ static void _forget_map(bool wizard_forget = false)
 bool show_map(level_pos &lpos,
               bool travel_mode, bool allow_esc, bool allow_offlevel)
 {
-    unwind_bool _in_map_mode(crawl_state.in_map_mode, true);
     bool chose      = false;
 #ifdef USE_TILE_LOCAL
     bool first_run  = true;
@@ -638,7 +636,6 @@ bool show_map(level_pos &lpos,
     {
         levelview_excursion le(travel_mode);
         level_id original(level_id::current());
-        unwind_var<level_id> _original_lid(crawl_state.map_mode_info.original_lid, original);
 
         if (!lpos.id.is_valid() || !allow_offlevel)
             lpos.id = level_id::current();
@@ -791,24 +788,17 @@ bool show_map(level_pos &lpos,
 #ifndef USE_TILE_LOCAL
             cursorxy(curs_x, curs_y + top - 1);
 #endif
-            crawl_state.map_mode_info.cursor_lpos = lpos;
             redraw_map = true;
 
             c_input_reset(true);
 #ifdef USE_TILE_LOCAL
             const int key = getchm(KMC_LEVELMAP);
+            command_type cmd = key_to_command(key, KMC_LEVELMAP);
 #else
             const int key = unmangle_direction_keys(getchm(KMC_LEVELMAP),
                                                     KMC_LEVELMAP);
-#endif
-            if (is_userfunction(key))
-            {
-                run_macro(get_userfunction(key).c_str());
-                continue;
-            }
-
             command_type cmd = key_to_command(key, KMC_LEVELMAP);
-
+#endif
             if (cmd < CMD_MIN_OVERMAP || cmd > CMD_MAX_OVERMAP)
                 cmd = CMD_NO_CMD;
 


### PR DESCRIPTION
Reverts crawl/crawl#1103

Adds a bunch of new untested code paths, for example calling `get_monster_at` when the cursor is on the level above the player causes the grid of the level above to be accessed using the player's current coordinates. No easy fix besides fixing all these codepaths, we should revert for now.