### PR TITLE
Rework pain card's level 2 and cloud card

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -89,7 +89,6 @@ deck_archetype deck_of_escape =
     { CARD_TOMB,       5 },
     { CARD_EXILE,      1 },
     { CARD_ELIXIR,     5 },
-    { CARD_CLOUD,      5 },
     { CARD_VELOCITY,   5 },
     { CARD_SHAFT,      5 },
 };
@@ -102,6 +101,7 @@ deck_archetype deck_of_destruction =
     { CARD_DEGEN,      3 },
     { CARD_WILD_MAGIC, 5 },
     { CARD_STORM,      5 },
+    { CARD_CLOUD,      5 },
 };
 
 deck_archetype deck_of_summoning =
@@ -1495,13 +1495,13 @@ static void _cloud_card(int power)
         for (adjacent_iterator ai(mons->pos()); ai; ++ai)
         {
             // don't place clouds on the player or monsters
-            if (*ai == you.pos() || monster_at(*ai))
+            if (*ai == you.pos())
                 continue;
 
-            if (grd(*ai) == DNGN_FLOOR && !cloud_at(*ai))
+            if (grd(*di) == DNGN_FLOOR && !cloud_at(*di))
             {
                 const int cloud_power = 5 + random2((power_level + 1) * 3);
-                place_cloud(cloudy, *ai, cloud_power, &you);
+                place_cloud(cloudy, *di, cloud_power, &you);
 
                 if (you.see_cell(*ai))
                     something_happened = true;

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1122,7 +1122,8 @@ static void _damaging_card(card_type card, int power,
 
     dist target;
     zap_type ztype = ZAP_DEBUGGING_RAY;
-    const zap_type painzaps[2] = { ZAP_AGONY, ZAP_BOLT_OF_DRAINING };
+    const zap_type painzaps[3] = { ZAP_AGONY, ZAP_BOLT_OF_DRAINING,
+                                   ZAP_BOLT_OF_DRAINING };
     const zap_type acidzaps[3] = { ZAP_BREATHE_ACID, ZAP_CORROSIVE_BOLT,
                                    ZAP_CORROSIVE_BOLT };
     const zap_type orbzaps[3]  = { ZAP_ISKENDERUNS_MYSTIC_BLAST, ZAP_IOOD,
@@ -1154,30 +1155,9 @@ static void _damaging_card(card_type card, int power,
     case CARD_PAIN:
         if (power_level == 2)
         {
-            mpr(prompt);
-
-            if (monster *ghost = _friendly(MONS_FLAYED_GHOST, 3))
-            {
-                apply_visible_monsters([&, ghost](monster& mons)
-                {
-                    if (mons.wont_attack()
-                        || !(mons.holiness() & MH_NATURAL))
-                    {
-                        return false;
-                    }
-
-
-                    flay(*ghost, mons, mons.hit_points * 2 / 5);
-                    return true;
-                }, ghost->pos());
-
-                ghost->foe = MHITYOU; // follow you around (XXX: rethink)
-                return;
-            }
-            // else, fallback to level 1
+            torment(&you, TORMENT_CARDS_PAIN, you.pos());
         }
-
-        ztype = painzaps[min(power_level, (int)ARRAYSZ(painzaps)-1)];
+        ztype = painzaps[power_level];
         break;
 
     default:

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1190,6 +1190,7 @@ void torment_player(actor *attacker, torment_source_type taux)
     {
     case TORMENT_CARDS:
     case TORMENT_SPELL:
+    case TORMENT_CARDS_PAIN:
         aux = "Symbol of Torment";
         break;
 
@@ -1232,8 +1233,8 @@ void torment_player(actor *attacker, torment_source_type taux)
 void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
 {
     if (where == you.pos()
-        // The Sceptre of Torment doesn't affect the  wielder.
-        && !(attacker && attacker->is_player() && taux == TORMENT_SCEPTRE))
+        // The Sceptre of Torment doesn't affect the  wielder, also pain card.
+        && !(attacker && attacker->is_player() && (taux == TORMENT_SCEPTRE || taux == TORMENT_CARDS_PAIN)))
     {
         torment_player(attacker, taux);
     }

--- a/crawl-ref/source/torment-source-type.h
+++ b/crawl-ref/source/torment-source-type.h
@@ -11,4 +11,5 @@ enum torment_source_type
     TORMENT_KIKUBAAQUDGHA = -7,   // Kikubaaqudgha effect
     TORMENT_MISCAST       = -8,
     TORMENT_AGONY         = -9,   // SPELL_AGONY
+    TORMENT_CARDS_PAIN    = -10, // for pain card
 };


### PR DESCRIPTION
Level 2 pain card's old effect (summon flayed ghost) was an unsuitable effect on the deck of destruction. Also, flay effect is just another torment.
New effects: cast torment and bolt of draining. Torment does not damage the caster.

The old cloud card produces clouds that damage the enemy. This effect is more suitable for deck of destruction, so the card is moved to deck of destruction. It was also changed accordingly to create clouds under the enemy's feet, so that it could be used more aggressively. Instead, the size of clouds decreased from 3x3 to 1x1.