### PR TITLE
Add crawl.get_target

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -827,7 +827,7 @@ void full_describe_view()
 
 void do_look_around(const coord_def &whence)
 {
-    dist lmove = _look_around_target(whence);
+    dist lmove = _look_around_target(you.pos() + whence);
     if (lmove.isValid && lmove.isTarget && !lmove.isCancel
         && !crawl_state.arena_suspended)
     {
@@ -837,7 +837,7 @@ void do_look_around(const coord_def &whence)
 
 bool get_look_position(coord_def *c)
 {
-    dist lmove = _look_around_target(coord_def(0, 0));
+    dist lmove = _look_around_target(you.pos());
     if (lmove.isCancel)
         return false;
     *c = lmove.target;
@@ -852,7 +852,7 @@ static dist _look_around_target(const coord_def &whence)
     args.just_looking = true;
     args.needs_path = false;
     args.target_prefix = "Here";
-    args.default_place = whence;
+    args.default_place = whence - you.pos();
     direction(lmove, args);
     return lmove;
 }

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -841,6 +841,21 @@ void do_look_around(const coord_def &whence)
     }
 }
 
+bool get_look_position(coord_def *c)
+{
+    dist lmove;   // Will be initialised by direction().
+    direction_chooser_args args;
+    args.restricts = DIR_TARGET;
+    args.just_looking = true;
+    args.needs_path = false;
+    args.target_prefix = "Here";
+    args.default_place = coord_def(0, 0);
+    direction(lmove, args);
+    if (lmove.isCancel)
+        return false;
+    *c = lmove.target;
+    return true;
+}
 
 range_view_annotator::range_view_annotator(targeter *range)
 {

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -88,6 +88,7 @@ enum LOSSelect
 #ifdef WIZARD
 static void _wizard_make_friendly(monster* m);
 #endif
+static dist _look_around_target(const coord_def &whence);
 static void _describe_oos_feature(const coord_def& where);
 static void _describe_cell(const coord_def& where, bool in_range = true);
 static bool _print_cloud_desc(const coord_def where);
@@ -826,14 +827,7 @@ void full_describe_view()
 
 void do_look_around(const coord_def &whence)
 {
-    dist lmove;   // Will be initialised by direction().
-    direction_chooser_args args;
-    args.restricts = DIR_TARGET;
-    args.just_looking = true;
-    args.needs_path = false;
-    args.target_prefix = "Here";
-    args.default_place = whence;
-    direction(lmove, args);
+    dist lmove = _look_around_target(whence);
     if (lmove.isValid && lmove.isTarget && !lmove.isCancel
         && !crawl_state.arena_suspended)
     {
@@ -843,18 +837,24 @@ void do_look_around(const coord_def &whence)
 
 bool get_look_position(coord_def *c)
 {
+    dist lmove = _look_around_target(coord_def(0, 0));
+    if (lmove.isCancel)
+        return false;
+    *c = lmove.target;
+    return true;
+}
+
+static dist _look_around_target(const coord_def &whence)
+{
     dist lmove;   // Will be initialised by direction().
     direction_chooser_args args;
     args.restricts = DIR_TARGET;
     args.just_looking = true;
     args.needs_path = false;
     args.target_prefix = "Here";
-    args.default_place = coord_def(0, 0);
+    args.default_place = whence;
     direction(lmove, args);
-    if (lmove.isCancel)
-        return false;
-    *c = lmove.target;
-    return true;
+    return lmove;
 }
 
 range_view_annotator::range_view_annotator(targeter *range)

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -321,5 +321,6 @@ vector<dungeon_feature_type> features_by_desc(const base_pattern &pattern);
 
 void full_describe_view();
 void do_look_around(const coord_def &whence = coord_def(0, 0));
+bool get_look_position(coord_def *c);
 
 extern const struct coord_def Compass[9];

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -10,6 +10,7 @@
 #include "cluautil.h"
 #include "command.h"
 #include "delay.h"
+#include "directn.h"
 #include "dlua.h"
 #include "end.h"
 #include "english.h"
@@ -207,13 +208,29 @@ static int crawl_c_input_line(lua_State *ls)
     return 1;
 }
 
+/*** Prompt the user to choose a location via the targeting screen.
+ * @treturn int, int the relative position of the chosen location to the user
+ * @function get_target
+ */
+LUAFN(crawl_get_target) {
+    coord_def out;
+
+    if (!get_look_position(&out))
+        return 0;
+
+    lua_pushinteger(ls, out.x - you.position.x);
+    lua_pushinteger(ls, out.y - you.position.y);
+
+    return 2;
+}
+
 /*** Get input key (combo).
  * @treturn int the key (combo) input
  * @function getch */
 LUARET1(crawl_getch, number, getchm())
 /*** Check for pending input.
  * @return int 1 if there is, 0 otherwise
- * function kbhit
+ * @function kbhit
  */
 LUARET1(crawl_kbhit, number, kbhit())
 /*** Flush the input buffer (typeahead).
@@ -1382,6 +1399,7 @@ static const struct luaL_reg crawl_clib[] =
 
     { "redraw_screen",      crawl_redraw_screen },
     { "c_input_line",       crawl_c_input_line},
+    { "get_target",         crawl_get_target },
     { "getch",              crawl_getch },
     { "yesno",              crawl_yesno },
     { "yesnoquit",          crawl_yesnoquit },

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -209,6 +209,11 @@ static int crawl_c_input_line(lua_State *ls)
 }
 
 /*** Prompt the user to choose a location via the targeting screen.
+ * This is useful for scripts that require a user-selected target. For example,
+ * one could imagine a "mark dangerous monster" script that would place a large
+ * exclusion around a user-chosen monster that would then be deleted if the
+ * monster moved or died. This function could be used for the user to select
+ * a target monster.
  * @treturn int, int the relative position of the chosen location to the user
  * @function get_target
  */


### PR DESCRIPTION
This clua function opens the targeting dialog in the same way it is opened when you press x to examine. The user is allowed to move the cursor around (same as examine). If the user makes a selection and presses enter, this function returns the player-relative coordinates of the selection. Note that the target is valid even if it is past the bounds of the map, so there is no leak of world borders. If the user cancels the selection, this function returns nil.