### PR TITLE
Ensure stash update on being shafted (minqmay)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7209,6 +7209,10 @@ bool player::do_shaft()
         return false;
     }
 
+    // Ensure altars, items, and shops discovered at the moment
+    // the player gets shafted are correctly registered.
+    maybe_update_stashes();
+
     duration[DUR_SHAFT_IMMUNITY] = 1;
     down_stairs(DNGN_TRAP_SHAFT);
 


### PR DESCRIPTION
Currently, if a player discovers an altar and get shafted by a trap at the same time, the altar will appear in dungeon overview but not in stash tracker.

This change ensures items, shops, and altars discovered at the moment the player gets shafted are correctly registered.