### PR TITLE
Change chance of triggering paralysis/pain bond to be turn-length inv…

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -431,7 +431,7 @@ static void _handle_uskayaw_time(int time_taken)
     // timer down to a minimum of 0, at which point it becomes eligible to
     // trigger again.
     if (audience_timer == -1 || (you.piety >= piety_breakpoint(2)
-            && x_chance_in_y(time_taken, time_taken * 10 + audience_timer)))
+            && x_chance_in_y(time_taken, 100 + audience_timer)))
     {
         uskayaw_prepares_audience();
     }
@@ -439,7 +439,7 @@ static void _handle_uskayaw_time(int time_taken)
         you.props[USKAYAW_AUDIENCE_TIMER] = max(0, audience_timer - time_taken);
 
     if (bond_timer == -1 || (you.piety >= piety_breakpoint(3)
-            && x_chance_in_y(time_taken, time_taken * 10 + bond_timer)))
+            && x_chance_in_y(time_taken, 100 + bond_timer)))
     {
         uskayaw_bonds_audience();
     }


### PR DESCRIPTION
…ariant

Previously, this formula gave you a significant higher chance of triggering a paralysis or painbond event per aut if you were taking shorter actions:

0 auts remaining on TIMER:
10 aut turn => 0.01 events/aut
5 aut turn => 0.02 events/aut

200 auts remaining on TIMER:
10 aut turn => 0.0033 events/aut
5 aut turn => 0.004 events/aut

This incentivizes doing fast actions whenever you have to wait at higher piety instead of simply resting. It's even optimal when enemies are out of sight, since a paralysis/pain bond event triggering when no enemies are in sight resets the relevant TIMER to 0.

The new formula makes the expected value of events proportional to the duration of the turn, and so eliminates all turn-length dependence except for rounding errors. Event rates are all set to the same as with 10 aut actions previously, regardless of action length. This is probably a slight nerf in general, but a significant nerf to quickblade Uskers.