### PR TITLE
Fireproof trees

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2622,7 +2622,7 @@ bool bolt::can_affect_wall(const coord_def& p, bool map_knowledge) const
         return true;
     }
 
-    // Temporary trees (from Summon Forest) can't be burned/distintegrated.
+    // Temporary trees (from Summon Forest) can't be burned.
     if (feat_is_tree(wall) && is_temp_terrain(p))
         return false;
 

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -250,6 +250,14 @@ A large tree that has been enchanted to grant it some limited motility,
 allowing it to lash out out at any adjacent enemies of the creature who awoke
 it.
 %%%%
+An awoken autumnal tree
+
+<An awoken tree>
+%%%%
+An awoken dead tree
+
+<An awoken tree>
+%%%%
 An abandoned shop
 
 A shop that has been abandoned.

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -242,15 +242,13 @@ A tree
 
 A large tree. While in most places the dim light of the dungeon is not bright
 enough to sustain large plants, there are spots where, with the grace of
-Fedhas, trees as big as those on the surface can grow underground. It is
-susceptible to bolts of lightning and to sufficiently intense sources of fire.
+Fedhas, trees as big as those on the surface can grow underground.
 %%%%
 An awoken tree
 
 A large tree that has been enchanted to grant it some limited motility,
 allowing it to lash out out at any adjacent enemies of the creature who awoke
-it. It is susceptible to bolts of lightning and to sufficiently intense sources
-of fire.
+it.
 %%%%
 An abandoned shop
 

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2198,6 +2198,7 @@ void get_feature_desc(const coord_def &pos, describe_info &inf, bool include_ext
 
     string desc      = feature_description_at(pos, false, DESC_A, false);
     string db_name   = feat == DNGN_ENTER_SHOP ? "a shop" : desc;
+    strip_suffix(db_name, " (summoned)");
     string long_desc = getLongDescription(db_name);
 
     inf.title = uppercase_first(desc);
@@ -2234,6 +2235,15 @@ void get_feature_desc(const coord_def &pos, describe_info &inf, bool include_ext
         long_desc +=
             make_stringf("\n(Pray here with '%s' to learn more.)\n",
                          command_to_string(CMD_GO_DOWNSTAIRS).c_str());
+    }
+
+    // mention that permanent trees are usually flammable
+    // (expect for autumnal trees in Wucad Mu's Monastery)
+    if (feat_is_tree(feat) && !is_temp_terrain(pos)
+        && env.markers.property_at(pos, MAT_ANY, "veto_fire") != "veto")
+    {
+        long_desc += "\nIt is susceptible to bolts of lightning";
+        long_desc += " and to sufficiently intense sources of fire.";
     }
 
     inf.body << long_desc;

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -2991,6 +2991,8 @@ string feature_description_at(const coord_def& where, bool covering,
             desc += "awoken ";
         desc += grid == grd(where) ? raw_feature_description(where)
                                    : _base_feature_desc(grid, trap);
+        if (is_temp_terrain(where))
+            desc += " (summoned)";
         desc += covering_description;
         return thing_do_grammar(dtype, add_stop, false, desc);
     }


### PR DESCRIPTION
This PR updates descriptions of trees to make it possible to distinguish flammable and non-flammable trees as well as permanent and summoned ones.