### PR TITLE
New morgue section `screenshots`

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2266,7 +2266,7 @@ dump_message_count = 20
 
 dump_order  = header,hiscore,stats,misc,inventory,
 dump_order += skills,spells,overview,mutations,messages,screenshot,
-dump_order += monlist,kills,notes,skill_gains,action_counts
+dump_order += monlist,kills,notes,screenshots,skill_gains,action_counts
         (Ordered list option)
         Controls the order of sections in the dump.
 

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -71,6 +71,7 @@ static void _sdump_gold(dump_params &);
 static void _sdump_misc(dump_params &);
 static void _sdump_turns_by_place(dump_params &);
 static void _sdump_notes(dump_params &);
+static void _sdump_screenshots(dump_params &);
 static void _sdump_inventory(dump_params &);
 static void _sdump_skills(dump_params &);
 static void _sdump_spells(dump_params &);
@@ -129,6 +130,7 @@ static dump_section_handler dump_handlers[] =
     { "misc",           _sdump_misc          },
     { "turns_by_place", _sdump_turns_by_place},
     { "notes",          _sdump_notes         },
+    { "screenshots",    _sdump_screenshots   },
     { "inventory",      _sdump_inventory     },
     { "skills",         _sdump_skills        },
     { "spells",         _sdump_spells        },
@@ -631,6 +633,28 @@ static void _sdump_screenshot(dump_params &par)
 {
     par.text += screenshot();
     par.text += "\n\n";
+}
+
+static void _sdump_screenshots(dump_params &par)
+{
+    string &text(par.text);
+    if (note_list.empty())
+        return;
+
+    text += "Illustrated notes\n\n";
+
+    for (const Note &note : note_list)
+    {
+        if (note.hidden() || note.type != NOTE_USER_NOTE)
+            continue;
+
+        text += note.screen;
+        text += "\n";
+        text += make_stringf("Turn %d on ", note.turn);
+        text += note.place.describe() + ": ";
+        text += note.name;
+        text += "\n\n";
+    }
 }
 
 static void _sdump_notes(dump_params &par)

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -645,7 +645,7 @@ static void _sdump_screenshots(dump_params &par)
 
     for (const Note &note : note_list)
     {
-        if (note.hidden() || note.type != NOTE_USER_NOTE)
+        if (note.hidden() || note.type != NOTE_USER_NOTE || note.screen.length() == 0)
             continue;
 
         text += note.screen;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1157,7 +1157,7 @@ void game_options::reset_options()
     dump_order.clear();
     new_dump_fields("header,hiscore,stats,misc,inventory,"
                     "skills,spells,overview,mutations,messages,"
-                    "screenshot,monlist,kills,notes,vaults,"
+                    "screenshot,monlist,kills,notes,screenshots,vaults,"
                     "skill_gains,action_counts");
     // Currently enabled by default for testing in trunk.
     if (Version::ReleaseType == VER_ALPHA)

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -462,7 +462,8 @@ void Note::load(reader& inf)
     second = unmarshallInt(inf);
     unmarshallString4(inf, name);
     unmarshallString4(inf, desc);
-    screen = unmarshallString(inf);
+    if (inf.getMinorVersion() >= TAG_MINOR_MORGUE_SCREENSHOTS)
+        screen = unmarshallString(inf);
 }
 
 static bool notes_active = false;

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -28,6 +28,7 @@
 #define NOTES_VERSION_NUMBER 1002
 
 vector<Note> note_list;
+int last_screen_turn = -1;
 
 static bool _is_highest_skill(int skill)
 {
@@ -517,6 +518,10 @@ void make_user_note()
         return;
     Note unote(NOTE_USER_NOTE);
     unote.name = buf;
-    unote.screen = screenshot();
+    // Only one screenshot a turn allowed
+    if (last_screen_turn != unote.turn) {
+        last_screen_turn = unote.turn;
+        unote.screen = screenshot();
+    }
     take_note(unote);
 }

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -23,6 +23,7 @@
 #include "state.h"
 #include "stringutil.h"
 #include "unicode.h"
+#include "view.h"
 
 #define NOTES_VERSION_NUMBER 1002
 
@@ -444,6 +445,7 @@ void Note::save(writer& outf) const
     marshallInt(outf, second);
     marshallString4(outf, name);
     marshallString4(outf, desc);
+    marshallString(outf, screen);
 }
 
 void Note::load(reader& inf)
@@ -460,6 +462,7 @@ void Note::load(reader& inf)
     second = unmarshallInt(inf);
     unmarshallString4(inf, name);
     unmarshallString4(inf, desc);
+    screen = unmarshallString(inf);
 }
 
 static bool notes_active = false;
@@ -513,5 +516,6 @@ void make_user_note()
         return;
     Note unote(NOTE_USER_NOTE);
     unote.name = buf;
+    unote.screen = screenshot();
     take_note(unote);
 }

--- a/crawl-ref/source/notes.h
+++ b/crawl-ref/source/notes.h
@@ -67,8 +67,9 @@ struct Note
 {
     Note() {}
     Note(NOTE_TYPES t, int f = 0, int s = 0, const string& n = "",
-                                             const string& d = "") :
-        type(t), first(f), second(s), name(n), desc(d) {}
+                                             const string& d = "",
+                                             const string& sc = "") :
+        type(t), first(f), second(s), name(n), desc(d), screen(sc) {}
     void save(writer& outf) const;
     void load(reader& inf);
     string describe(bool when = true, bool where = true, bool what = true) const;
@@ -82,6 +83,7 @@ struct Note
 
     string name;
     string desc;
+    string screen;
 };
 
 extern vector<Note> note_list;

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -241,6 +241,7 @@ enum tag_minor_version
     TAG_MINOR_MORE_GHOST_MAGIC,    // Update already placed ghosts for positional magic
     TAG_MINOR_DUMMY_AGILITY,       // Convert garbage "agility" potions into stab
     TAG_MINOR_TRACK_REGEN_ITEMS,   // Regen items take effect only after maxhp is reached
+    TAG_MINOR_MORGUE_SCREENSHOTS,  // Screenshots morgue section
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1


### PR DESCRIPTION
Notes can have an associated screenshot. For now only user notes take
screenshots. They are printed out in the `screenshots` section of the
morgue.