### PR TITLE
Fix red draconian Tiamat tile (12043)

### DIFF
--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1462,7 +1462,7 @@ tileidx_t tileidx_monster_base(int type, bool in_water, int colour, int number,
         case LIGHTMAGENTA:  offset = 4; break;
         case CYAN:          offset = 5; break;
         case MAGENTA:       offset = 6; break;
-        case RED:           offset = 7; break;
+        case LIGHTRED:      offset = 7; break;
         case WHITE:         offset = 8; break;
         }
 


### PR DESCRIPTION
In mon-data.h, the colour of red draconians is LIGHTRED, not RED,
since 54374eb4.

Because tilepick.cc:tileidx_monster_base() had no matching colour for
red draconian Tiamat, it returned a tile with offset 0, the black
draconian Tiamat tile, instead.