### PR TITLE
Let Trog and Okawaru gift regular boomerangs and javelins

### DIFF
--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -495,8 +495,6 @@ static void _generate_weapon_item(item_def& item, bool allow_uniques,
     }
 }
 
-// Current list is based on dpeg's original post to the Wiki, found at the
-// page: <http://crawl.develz.org/wiki/doku.php?id=DCSS%3Aissue%3A41>.
 // Remember to update the code in is_missile_brand_ok if adding or altering
 // brands that are applied to missiles. {due}
 static special_missile_type _determine_missile_brand(const item_def& item,
@@ -506,11 +504,17 @@ static special_missile_type _determine_missile_brand(const item_def& item,
     if (item.brand != 0)
         return static_cast<special_missile_type>(item.brand);
 
-    const bool force_good = item_level >= ISPEC_GIFT;
     special_missile_type rc = SPMSL_NORMAL;
 
-    // "Normal weight" of SPMSL_NORMAL.
-    int nw = force_good ? 0 : random2(2000 - 55 * item_level);
+    // Weight of SPMSL_NORMAL
+    // Gifts from Trog/Oka can be unbranded boomerangs/javelins
+    // but not poisoned darts
+    int nw = item_level >= ISPEC_GOOD_ITEM ?   0 :
+             item_level == ISPEC_GIFT      ? 120
+                                           : random2(2000 - 55 * item_level);
+
+    // Weight of SPMSL_POISONED
+    int pw = item_level >= ISPEC_GIFT ? 0 : random2(2000 - 55 * item_level);
 
     switch (item.sub_type)
     {
@@ -532,7 +536,7 @@ static special_missile_type _determine_missile_brand(const item_def& item,
 
         rc = random_choose_weighted(60, SPMSL_BLINDING,
                                     20, SPMSL_FRENZY,
-                                    nw, SPMSL_POISONED);
+                                    pw, SPMSL_POISONED);
         break;
     case MI_JAVELIN:
         rc = random_choose_weighted(90, SPMSL_SILVER,

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -514,7 +514,7 @@ static special_missile_type _determine_missile_brand(const item_def& item,
                                            : random2(2000 - 55 * item_level);
 
     // Weight of SPMSL_POISONED
-    int pw = item_level >= ISPEC_GIFT ? 0 : random2(2000 - 55 * item_level);
+    int pw = item_level >= ISPEC_GIFT ? 0 : nw;
 
     switch (item.sub_type)
     {


### PR DESCRIPTION
Previously, when tomahawks and javelins had no innate special
properties and each had about 5 different brands, it made sense that
Trog and Okawaru should always gift branded tomahawks and javelins.

However, there are now only two different types of javelin: plain and
silver; and three different types of boomerang: plain, silver and
dispersal. This behaviour led to all such ammo gifts being silver
javelins, or silver or dispersal boomerangs, which seems a little
unbalanced. Additionally, new javelins are equivalent to branded
penetration javelins previously, and likewise with boomerangs and
tomahawks of returning, so this behaviour no longer makes sense.

As such, Trog and Okawaru now gift regular boomerangs and javelins, with
these having weight 120. This means the chance of a javelin gift giving
silver javelins is reduced from 100% to 43%, and the chance of a
boomerang gift being branded is reduced from 100% to 33%.

This commit preserves Trog and Okawaru only gifting
curare/datura/atropa-tipped darts and not poisoned darts, and also
preserves the behaviour of ISPEC_GOOD_ITEM always producing branded
missiles, so as to not affect dungeon generation in any way.

-------------------------
Note: The 120 weight figure that I've used is a rough estimate based on my recent playing experience; I am very much open to suggestions to refine this figure, and anything else in this PR for that matter.