### PR TITLE
Upgrade Wyrmbane's tile according to its enchantment

### DIFF
--- a/crawl-ref/source/rltiles/dc-item.txt
+++ b/crawl-ref/source/rltiles/dc-item.txt
@@ -14,6 +14,11 @@
 ##### Artefacts (fixed and unrandart)
 %include dc-unrand.txt
 
+urand_wyrmbane1 UNRAND_WYRMBANE1
+urand_wyrmbane2 UNRAND_WYRMBANE2
+urand_wyrmbane3 UNRAND_WYRMBANE3
+urand_wyrmbane4 UNRAND_WYRMBANE4
+
 #####NORMAL
 %sdir item/weapon
 %rim 0

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2073,6 +2073,20 @@ static tileidx_t _tileidx_unrand_artefact(int idx)
     return tile ? tile : TILE_TODO;
 }
 
+static tileidx_t _tileidx_wyrmbane(int plus)
+{
+    if (plus < 10)
+        return TILE_UNRAND_WYRMBANE;
+    else if (plus < 12)
+        return TILE_UNRAND_WYRMBANE1;
+    else if (plus < 15)
+        return TILE_UNRAND_WYRMBANE2;
+    else if (plus < 18)
+        return TILE_UNRAND_WYRMBANE3;
+    else
+        return TILE_UNRAND_WYRMBANE4;
+}
+
 static tileidx_t _tileidx_weapon_base(const item_def &item)
 {
     switch (item.sub_type)
@@ -2574,7 +2588,9 @@ tileidx_t tileidx_item(const item_def &item)
     switch (clas)
     {
     case OBJ_WEAPONS:
-        if (is_unrandom_artefact(item) && !is_randapp_artefact(item))
+        if (is_unrandom_artefact(item, UNRAND_WYRMBANE))
+            return _tileidx_wyrmbane(item.plus);
+        else if (is_unrandom_artefact(item) && !is_randapp_artefact(item))
             return _tileidx_unrand_artefact(find_unrandart_index(item));
         else
             return _tileidx_weapon(item);


### PR DESCRIPTION
As a followup to 1cd5daa3, this commit adds code to upgrade Wyrmbane's
tile as the lance grows more powerful.

It'll look like this:
![wyrmbane_tiles](https://user-images.githubusercontent.com/3328424/63094963-722c2100-bf59-11e9-93b4-ecdfbf6f1953.png)
