### PR TITLE
fix mutations/vamp-attrs toggle

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -891,14 +891,16 @@ void display_mutations()
         lastch = ev.key.keysym.sym;
         if (you.species == SP_VAMPIRE && (lastch == '!' || lastch == CK_MOUSE_CMD || lastch == '^'))
         {
-            int c = 1 - switcher->current();
-            switcher->current() = c;
+            int& c = switcher->current();
+
+            bottom->set_text(_vampire_Ascreen_footer(c));
+
+            c = 1 - c;
 #ifdef USE_TILE_WEB
             tiles.json_open_object();
             tiles.json_write_int("pane", c);
             tiles.ui_state_change("mutations", 0);
 #endif
-            bottom->set_text(_vampire_Ascreen_footer(c));
         } else
             done = !vbox->on_event(ev);
         return true;

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -186,8 +186,8 @@
             </div>
         </div>
         <div class="footer paneset">
-            <div class="pane">[!/^]: Mutations | Blood properties</div>
-            <div class=pane>[!/^]: Mutations | Blood properties</div>
+            <div class="pane">[!/^]: <b class=fg15>Mutations</b> | Blood properties</div>
+            <div class="pane">[!/^]: Mutations | <b class=fg15>Blood properties</b></div>
         </div>
     </div>
     <div id="describe-god-basic" class="describe-god fg7">


### PR DESCRIPTION
When player is Vampire:
- Toggling works wrong. (console)
  - Hit 'A' -> '!', 'Mutations' is still highlighted, then, Hit '!', 'Blood properties' is highlighted.
- Didn't highlight mutations/vamp-attrs tab (webtile)