### PR TITLE
Revert "bound missing colemak attack keys"

### DIFF
--- a/crawl-ref/settings/colemak_command_keys.txt
+++ b/crawl-ref/settings/colemak_command_keys.txt
@@ -54,15 +54,6 @@ bindkey = [L] CMD_MAP_JUMP_UP_RIGHT
 bindkey = [B] CMD_MAP_JUMP_DOWN_LEFT
 bindkey = [K] CMD_MAP_JUMP_DOWN_RIGHT
 
-bindkey = [^H] CMD_ATTACK_LEFT
-bindkey = [^N] CMD_ATTACK_DOWN
-bindkey = [^E] CMD_ATTACK_UP
-bindkey = [^I] CMD_ATTACK_RIGHT
-bindkey = [^J] CMD_ATTACK_UP_LEFT
-bindkey = [^L] CMD_ATTACK_UP_RIGHT
-bindkey = [^B] CMD_ATTACK_DOWN_LEFT
-bindkey = [^K] CMD_ATTACK_DOWN_RIGHT
-
 # replace (e) with (u)
 bindkey = [u] CMD_EAT
 bindkey = [u] CMD_TARGET_EXCLUDE


### PR DESCRIPTION
Reverts crawl/crawl#1138

Rebinding ctrl-i is not great, because that's also TAB.