### PR TITLE
Add missing feature tiles to the stash search menu

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -479,6 +479,7 @@ vector<stash_search_result> Stash::matches_search(
             res.match = fdesc;
             res.primary_sort = fdesc;
             res.feat = feat;
+            res.trap = trap;
             results.push_back(res);
         }
     }
@@ -1759,6 +1760,17 @@ bool StashTracker::display_search_results(
         }
         else if (res.shop)
             me->add_tile(tile_def(tileidx_shop(&res.shop->shop), TEX_FEAT));
+        else if (feat_is_trap(res.feat))
+        {
+            const tileidx_t idx = tileidx_trap(res.trap);
+            me->add_tile(tile_def(idx, get_dngn_tex(idx)));
+        }
+        else if (feat_is_runed(res.feat))
+        {
+            // Handle large doors and huge gates
+            const tileidx_t idx = tileidx_feature_base(res.feat);
+            me->add_tile(tile_def(idx, get_dngn_tex(idx)));
+        }
         else
         {
             const dungeon_feature_type feat = feat_by_desc(res.match);

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -147,6 +147,9 @@ struct stash_search_result
     // Type of feature, if this result is for a feature.
     dungeon_feature_type feat;
 
+    // Type of trap, if this result is for a trap.
+    trap_type trap;
+
     // Whether the found items are in the player's inventory.
     bool in_inventory;
 
@@ -156,8 +159,8 @@ struct stash_search_result
 
     stash_search_result() : pos(), player_distance(0), match_type(), match(),
                             primary_sort(), item(), shop(nullptr), feat(),
-                            in_inventory(false), duplicates(0),
-                            duplicate_piles(0)
+                            trap(TRAP_UNASSIGNED), in_inventory(false),
+                            duplicates(0), duplicate_piles(0)
     {
     }
 

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -75,7 +75,7 @@ TextureID get_dngn_tex(tileidx_t idx)
         return TEX_FEAT;
 }
 
-static tileidx_t _tileidx_trap(trap_type type)
+tileidx_t tileidx_trap(trap_type type)
 {
     switch (type)
     {
@@ -558,7 +558,7 @@ tileidx_t tileidx_feature(const coord_def &gc)
 
     case DNGN_TRAP_MECHANICAL:
     case DNGN_TRAP_TELEPORT:
-        return _tileidx_trap(env.map_knowledge(gc).trap());
+        return tileidx_trap(env.map_knowledge(gc).trap());
 
     case DNGN_TRAP_WEB:
     {

--- a/crawl-ref/source/tilepick.h
+++ b/crawl-ref/source/tilepick.h
@@ -8,6 +8,7 @@
 #include "ability-type.h"
 #include "command-type.h"
 #include "game-type.h"
+#include "trap-type.h"
 #include "tiledef_defines.h"
 
 #define TILE_NUM_KEY "tile_num"
@@ -24,6 +25,7 @@ bool is_door_tile(tileidx_t tile);
 
 // Tile index lookup from Crawl data.
 tileidx_t tileidx_feature(const coord_def &gc);
+tileidx_t tileidx_trap(trap_type type);
 tileidx_t tileidx_shop(const shop_struct *shop);
 tileidx_t tileidx_feature_base(dungeon_feature_type feat);
 tileidx_t tileidx_out_of_bounds(int branch);


### PR DESCRIPTION
Currently, the stash search menu doesn't show tiles for several features, including net traps, large runed doors, and permanent teleport traps:

![missing_tiles](https://user-images.githubusercontent.com/3328424/63774782-819e5900-c8cd-11e9-80a0-cc6a9cd5db81.png)

This PR fixes that by handling tile picking for these features separately.
