### PR TITLE
#984 making text more clear for wands mutation

### DIFF
--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1833,8 +1833,8 @@ static const mutation_def mut_data[] =
   "MP-powered wands",
 
   {"You expend magic power (3 MP) to strengthen your wands.", "", ""},
-  {"You feel your magical essence link to your wands.", "", ""},
-  {"Your magical essence is no longer linked to your wands.", "", ""},
+  {"You feel your magical essence would now be drained by using wands.", "", ""},
+  {"Your magical essence will no longer be drained by using wands.", "", ""},
 },
 
 { MUT_UNSKILLED, 0, 3, mutflag::bad, false,

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1833,8 +1833,8 @@ static const mutation_def mut_data[] =
   "MP-powered wands",
 
   {"You expend magic power (3 MP) to strengthen your wands.", "", ""},
-  {"You feel your magical essence would now be drained by using wands.", "", ""},
-  {"Your magical essence will no longer be drained by using wands.", "", ""},
+  {"You feel your magical essence would now empower your wands.", "", ""},
+  {"Your magical essence will no longer be empower your wands.", "", ""},
 },
 
 { MUT_UNSKILLED, 0, 3, mutflag::bad, false,


### PR DESCRIPTION
Trying to making the warning more clear for the wands mutation (issue #984 ).

I note that ticket has been open a while, so I assume people would like more clarity in the warning. The only other option I see is that we WANT the warning to be a bit mysterious, in which case I would suggest denying this Pull Request and closing #984 as "Won't Fix".