### PR TITLE
Show scarves on player in tiles (11977)

### DIFF
--- a/crawl-ref/source/tiledoll.cc
+++ b/crawl-ref/source/tiledoll.cc
@@ -546,6 +546,17 @@ void pack_doll_buf(SubmergedTileBuffer& buf, const dolls_data &doll,
         p_order[6] = TILEP_PART_LEG;
     }
 
+    // Draw scarves above other clothing.
+    if (doll.parts[TILEP_PART_CLOAK] >= TILEP_CLOAK_SCARF_FIRST_NORM)
+    {
+        p_order[4] = p_order[5];
+        p_order[5] = p_order[6];
+        p_order[6] = p_order[7];
+        p_order[7] = p_order[8];
+        p_order[8] = p_order[9];
+        p_order[9] = TILEP_PART_CLOAK;
+    }
+
     // Special case bardings from being cut off.
     const bool is_naga = is_player_tile(doll.parts[TILEP_PART_BASE],
                                         TILEP_BASE_NAGA);

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -346,7 +346,7 @@ tileidx_t tilep_equ_armour(const item_def &item)
 
 tileidx_t tilep_equ_cloak(const item_def &item)
 {
-    if (item.base_type != OBJ_ARMOUR || item.sub_type != ARM_CLOAK)
+    if (item.base_type != OBJ_ARMOUR)
         return 0;
 
     if (item.props.exists("worn_tile"))
@@ -359,7 +359,18 @@ tileidx_t tilep_equ_cloak(const item_def &item)
             return tile;
     }
 
-    return _modrng(item.rnd, TILEP_CLOAK_FIRST_NORM, TILEP_CLOAK_LAST_NORM);
+    switch (item.sub_type)
+    {
+        case ARM_CLOAK:
+            return _modrng(item.rnd, TILEP_CLOAK_FIRST_NORM,
+                           TILEP_CLOAK_LAST_NORM);
+
+        case ARM_SCARF:
+            return _modrng(item.rnd, TILEP_CLOAK_SCARF_FIRST_NORM,
+                           TILEP_CLOAK_SCARF_LAST_NORM);
+    }
+
+    return 0;
 }
 
 tileidx_t tilep_equ_helm(const item_def &item)

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1132,6 +1132,17 @@ static void _send_doll(const dolls_data &doll, bool submerged, bool ghost)
         p_order[6] = TILEP_PART_LEG;
     }
 
+    // Draw scarves above other clothing.
+    if (doll.parts[TILEP_PART_CLOAK] >= TILEP_CLOAK_SCARF_FIRST_NORM)
+    {
+        p_order[4] = p_order[5];
+        p_order[5] = p_order[6];
+        p_order[6] = p_order[7];
+        p_order[7] = p_order[8];
+        p_order[8] = p_order[9];
+        p_order[9] = TILEP_PART_CLOAK;
+    }
+
     // Special case bardings from being cut off.
     const bool is_naga = is_player_tile(doll.parts[TILEP_PART_BASE],
                                         TILEP_BASE_NAGA);


### PR DESCRIPTION
Scarves weren't being shown at all unless the player chose one through
the doll editor. And even then they were practically invisible, since
they were drawn behind the body (like cloaks) instead of in front
where I think they were meant to be.

The green scarf tile looks quite strange to me, but that's a separate
problem.