### PR TITLE
More quotes

### DIFF
--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -1540,7 +1540,7 @@ hell hound
  If aught disturbed their noise, into her womb,
  And kennel there; yet there still barked and howled
  Within unseen.”
-    -John Milton, _Paradise Lost_, Book II, l. 653-659. 1667.
+    -John Milton, _Paradise Lost_, Book II, 1667.
 %%%%
 hell knight
 
@@ -1630,7 +1630,7 @@ insubstantial wisp
  Misleads th' amaz'd Night-wanderer from his way
  To Boggs and Mires, and oft through Pond or Poole,
  There swallow'd up and lost, from succour farr.”
-    -John Milton, _Paradise Lost_
+    -John Milton, _Paradise Lost_, Book IX, 1667.
 %%%%
 Iskenderun's Battlesphere spell
 
@@ -2054,7 +2054,7 @@ pandemonium lord
  A solemn Councel forthwith to be held
  At Pandaemonium, the high Capital
  Of Satan and his Peers...”
-    -John Milton, _Paradise Lost_,  Book I, l. 752-7. 1667.
+    -John Milton, _Paradise Lost_, Book I, 1667.
 %%%%
 Passwall spell
 
@@ -2495,9 +2495,9 @@ scroll of silence
 %%%%
 scroll of summoning
 
-“When thou attended gloriously from heaven , Shalt in the sky appear, and from
+“When thou attended gloriously from heaven, Shalt in the sky appear, and from
  thee send Thy summoning archangels to proclaim Thy dread tribunal.”
-    -John Milton
+    -John Milton, _Paradise Lost_, Book III, 1667.
 %%%%
 scroll of teleportation
 

--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -238,7 +238,8 @@ A staircase to the Shoals
 %%%%
 A staircase to the Tomb
 
-<Tomb>
+“A tomb now suffices him for whom the world was not enough.”
+    -Alexander the Great's tombstone epitaph
 %%%%
 A stormy altar of Qazlal
 
@@ -2347,7 +2348,8 @@ ring of slaying
 %%%%
 ring of strength
 
-<ring>
+“That which does not kill us makes us stronger.”
+    -Friedrich Nietzsche
 %%%%
 ring of stealth
 
@@ -2421,7 +2423,8 @@ scroll of acquirement
 %%%%
 scroll of amnesia
 
-<scroll>
+“But revenge is hollow. I'd prefer amnesia.”
+    -Tera Lynn Childs
 %%%%
 scroll of blinking
 
@@ -2441,7 +2444,9 @@ scroll of enchant weapon
 %%%%
 scroll of fear
 
-<scroll>
+“We can easily forgive a child who is afraid of the dark;
+the real tragedy of life is when men are afraid of the light.”
+    -Plato
 %%%%
 scroll of fog
 
@@ -2588,7 +2593,8 @@ shapeshifter
 %%%%
 shield
 
-<buckler>
+“...for the shield may be as important for victory, as the sword or spear.”
+    -Charles Darwin, “The Origin of Species”. 1859.
 %%%%
 shortbow
 

--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -2454,7 +2454,9 @@ scroll of fog
 %%%%
 scroll of holy word
 
-<scroll>
+“However many holy words you read, however many you speak,
+what good will they do you if you do not act on upon them?”
+    -Gautama Buddha
 %%%%
 scroll of identify
 

--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -239,7 +239,7 @@ A staircase to the Shoals
 A staircase to the Tomb
 
 “A tomb now suffices him for whom the world was not enough.”
-    -Alexander the Great's tombstone epitaph
+    -Alexander the Great's epitaph
 %%%%
 A stormy altar of Qazlal
 

--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -1512,7 +1512,9 @@ hand axe
 %%%%
 hand crossbow
 
-<arbalest>
+“Energy may be likened to the bending of a crossbow;
+ decision, to the releasing of a trigger.”
+    -Sun Tzu
 %%%%
 harpy
 
@@ -1806,7 +1808,8 @@ hee most desireth.”
 %%%%
 manual
 
-<book>
+“Manuals have their uses... but they are not to be confused with living.”
+    -Robert Fulghum
 %%%%
 merfolk
 
@@ -2338,7 +2341,9 @@ see rightly; what is essential is invisible to the eye.”
 %%%%
 ring of slaying
 
-<ring>
+“Life is too short to occupy oneself with the slaying of the slain more than
+ once.”
+    -Thomas Huxley
 %%%%
 ring of strength
 
@@ -2346,7 +2351,9 @@ ring of strength
 %%%%
 ring of stealth
 
-<ring>
+“No one ever approaches perfection except by stealth, and unknown to
+ themselves.”
+    -William Hazlitt
 %%%%
 ring of teleportation
 
@@ -2483,7 +2490,9 @@ scroll of silence
 %%%%
 scroll of summoning
 
-<scroll>
+“When thou attended gloriously from heaven , Shalt in the sky appear, and from
+ thee send Thy summoning archangels to proclaim Thy dread tribunal.”
+    -John Milton
 %%%%
 scroll of teleportation
 

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1833,8 +1833,8 @@ static const mutation_def mut_data[] =
   "MP-powered wands",
 
   {"You expend magic power (3 MP) to strengthen your wands.", "", ""},
-  {"You feel your magical essence would now empower your wands.", "", ""},
-  {"Your magical essence will no longer be empower your wands.", "", ""},
+  {"You feel your magical essence link to your wands.", "", ""},
+  {"Your magical essence is no longer linked to your wands.", "", ""},
 },
 
 { MUT_UNSKILLED, 0, 3, mutflag::bad, false,

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1833,8 +1833,8 @@ static const mutation_def mut_data[] =
   "MP-powered wands",
 
   {"You expend magic power (3 MP) to strengthen your wands.", "", ""},
-  {"You feel your magical essence link to your wands.", "", ""},
-  {"Your magical essence is no longer linked to your wands.", "", ""},
+  {"You feel your magical essence would now be drained by using wands.", "", ""},
+  {"Your magical essence will no longer be drained by using wands.", "", ""},
 },
 
 { MUT_UNSKILLED, 0, 3, mutflag::bad, false,

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1833,8 +1833,8 @@ static const mutation_def mut_data[] =
   "MP-powered wands",
 
   {"You expend magic power (3 MP) to strengthen your wands.", "", ""},
-  {"You feel your magical essence would now be drained by using wands.", "", ""},
-  {"Your magical essence will no longer be drained by using wands.", "", ""},
+  {"You feel your magical essence would now empower your wands.", "", ""},
+  {"Your magical essence will no longer be empower your wands.", "", ""},
 },
 
 { MUT_UNSKILLED, 0, 3, mutflag::bad, false,


### PR DESCRIPTION
There are lots of big holes in the list of default flavour descriptions, so over the last couple weeks I have dug up some new quotes.

Some thoughts:

* I favoured adding shorter descriptions over longer ones.
* **Paradise Lost** - I found some differences among the Paradise Lost references, some included line numbers and some did not. I added one Paradise Lost reference myself, and in the process found the line numbers listed did not match my book at all.  As such, I removed the faulty line numbers entirely.

I have a thought for future work:

* The book and section headers like this are hideous: `_Paradise Lost_`, `_The Fellowship of the Ring_`.  Why don't we just use single quotes, or more double quotes? Either is more standard and easier to read.
