### PR TITLE
Fix a crash when cloning an almost dead monster (geekosaur)

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -3196,8 +3196,8 @@ monster* cast_phantom_mirror(monster* mons, monster* targ, int hp_perc, int summ
     mirror->mark_summoned(5, true, summ_type);
     mirror->add_ench(ENCH_PHANTOM_MIRROR);
     mirror->summoner = mons->mid;
-    mirror->hit_points = mirror->hit_points * hp_perc / 100;
-    mirror->max_hit_points = mirror->max_hit_points * hp_perc / 100;
+    mirror->hit_points = max(mirror->hit_points * hp_perc / 100, 1);
+    mirror->max_hit_points = max(mirror->max_hit_points * hp_perc / 100, 1);
 
     // Sometimes swap the two monsters, so as to disguise the original and the
     // copy.


### PR DESCRIPTION
A copy created via rakshasa's Phantom Mirror has only 35% of
the target's hp and max hp. If the original monster is almost dead
(1-2 HP), its copy will have 0 hp, which crashes the game.

Fix this by giving cloned monsters at least 1 hp. Also, it allows
rakshasas to clone lurking horrors, who always spawn with only 1 hp.

Thanks to geekosaur for finding what was causing two recent crashes on CUE.