### PR TITLE
Fixes Issue #891 where Arena crashed if the monster name had a typo

### DIFF
--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -1069,7 +1069,10 @@ namespace arena
             catch (const arena_error &error)
             {
                 write_error(error.what());
-                game_ended_with_error(error.what());
+                if(error.fatal)
+                  {
+                    game_ended_with_error(error.what());
+                  }
                 continue;
             }
             do_fight();


### PR DESCRIPTION
Now it just informs the user of the error and asks again.