### PR TITLE
Change spell chances in Kiku's second book

### DIFF
--- a/crawl-ref/source/randbook.cc
+++ b/crawl-ref/source/randbook.cc
@@ -992,36 +992,12 @@ void make_book_kiku_gift(item_def &book, bool first)
     }
     else
     {
-        chosen_spells[0] = coinflip() ? SPELL_ANIMATE_DEAD : SPELL_SIMULACRUM;
+        chosen_spells[0] = SPELL_ANIMATE_DEAD;
         chosen_spells[1] = (you.species == SP_FELID || coinflip())
-            ? SPELL_BORGNJORS_VILE_CLUTCH : SPELL_EXCRUCIATING_WOUNDS;
-        chosen_spells[2] = random_choose(SPELL_BOLT_OF_DRAINING,
-                                         SPELL_AGONY,
-                                         SPELL_DEATH_CHANNEL);
-
-        spell_type extra_spell;
-        do
-        {
-            extra_spell = random_choose(SPELL_ANIMATE_DEAD,
-                                        SPELL_AGONY,
-                                        SPELL_BORGNJORS_VILE_CLUTCH,
-                                        SPELL_EXCRUCIATING_WOUNDS,
-                                        SPELL_BOLT_OF_DRAINING,
-                                        SPELL_SIMULACRUM,
-                                        SPELL_DEATH_CHANNEL);
-            if (you.species == SP_FELID
-                && extra_spell == SPELL_EXCRUCIATING_WOUNDS)
-            {
-                extra_spell = SPELL_NO_SPELL;
-            }
-
-            for (int i = 0; i < 3; i++)
-                if (extra_spell == chosen_spells[i])
-                    extra_spell = SPELL_NO_SPELL;
-        }
-        while (extra_spell == SPELL_NO_SPELL);
-
-        chosen_spells[3] = extra_spell;
+            ? SPELL_AGONY : SPELL_EXCRUCIATING_WOUNDS;
+        chosen_spells[2] = coinflip()
+            ? SPELL_BOLT_OF_DRAINING : SPELL_BORGNJORS_VILE_CLUTCH;
+        chosen_spells[3] = coinflip() ? SPELL_SIMULACRUM : SPELL_DEATH_CHANNEL;
         chosen_spells[4] = SPELL_DISPEL_UNDEAD;
     }
 


### PR DESCRIPTION
Kiku's Recieve Corpses spell really works best with Animate Dead, which
makes is frustrating when you don't get it -- especially since you
might not get Animate Skeleton either.

This commit changes the spells in Kiku's second book to always give you
Animate Dead as well as Dispel Undead. The other spell options are also
changed, to make them a little more predictable:

* Agony or Exrcuciating Wounds (pure pain damage)
* Bolt of Draining or BVC (can be used behind undead allies)
* Simulacrum or Death Channel (high level necro allies)