### PR TITLE
Don't stop travel for changes from (un)melding

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -80,17 +80,6 @@
 #include "view.h"
 #include "xom.h"
 
-class interrupt_block
-{
-public:
-    interrupt_block() { ++interrupts_blocked; }
-    ~interrupt_block() { --interrupts_blocked; }
-
-    static bool blocked() { return interrupts_blocked > 0; }
-private:
-    static int interrupts_blocked;
-};
-
 int interrupt_block::interrupts_blocked = 0;
 
 static void _xom_check_corpse_waste();

--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -13,6 +13,25 @@
 #include "operation-types.h"
 #include "seen-context-type.h"
 
+class interrupt_block
+{
+public:
+    interrupt_block(bool block = true) {
+        m_block = block;
+        if (block)
+            ++interrupts_blocked;
+    }
+    ~interrupt_block() {
+        if (m_block)
+            --interrupts_blocked;
+    }
+
+    static bool blocked() { return interrupts_blocked > 0; }
+private:
+    bool m_block;
+    static int interrupts_blocked;
+};
+
 class monster;
 struct ait_hp_loss;
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -162,6 +162,8 @@ void equip_effect(equipment_type slot, int item_slot, bool unmeld, bool msg)
     if (msg)
         _equip_use_warning(item);
 
+    const interrupt_block block_unmeld_interrupts(unmeld);
+
     if (slot == EQ_WEAPON)
         _equip_weapon_effect(item, msg, unmeld);
     else if (slot >= EQ_CLOAK && slot <= EQ_BODY_ARMOUR)
@@ -179,6 +181,8 @@ void unequip_effect(equipment_type slot, int item_slot, bool meld, bool msg)
         return;
 
     _assert_valid_slot(eq, slot);
+
+    const interrupt_block block_meld_interrupts(meld);
 
     if (slot == EQ_WEAPON)
         _unequip_weapon_effect(item, msg, meld);


### PR DESCRIPTION
If you are auto-travelling, and you lose stats from armour
melding or unmelding, don't stop auto-travel for that reason
alone. This is really only relevant for merfolk with artefact
boots, but the fix should apply to the general case.

