### PR TITLE
Fix being able to pick out barbs while incapacitated (12065)

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -829,8 +829,15 @@ static void _decrement_durations()
         doom_howl(min(delay, you.duration[DUR_DOOM_HOWL]));
 
     dec_elixir_player(delay);
-    extract_manticore_spikes("You carefully extract the barbed spikes from "
-                             "your body.");
+
+    if (!you.cannot_move()
+        && !you.confused()
+        && !you.asleep()
+        && !you.berserk())
+    {
+        extract_manticore_spikes("You carefully extract the barbed spikes from "
+                                 "your body.");
+    }
 
     if (!env.sunlight.empty())
         process_sunlights();


### PR DESCRIPTION
Carefully pulling out barbs now requires that you can move (not paralyzed or petrified), aren't confused, aren't asleep, and not berserk.