### PR TITLE
Increase Depth of cheibrodos_wizards_tower

### DIFF
--- a/crawl-ref/source/dat/des/variable/float.des
+++ b/crawl-ref/source/dat/des/variable/float.des
@@ -3924,7 +3924,7 @@ ENDMAP
 
 NAME: cheibrodos_wizards_tower
 TAGS: no_item_gen no_monster_gen no_pool_fixup
-DEPTH: D:7-12, Elf
+DEPTH: D:12-15, Elf
 ORIENT: float
 : if you.branch() == "Elf" then
 MONS: deep elf sorcerer / deep elf annihilator


### PR DESCRIPTION
cheibrodos_wizards_tower potentially places wizards and orc sorcerers on D:7-12. While vaults containing out-of-depth monsters are fine in principle, this vault is particularly egregious for the following reasons: (1) The vault is open and thus easy to explore into and (2) The spells of these monsters (most notably paralysis and crystal spear) can lead to single-turn deaths. If generated on D:7, this vault at best leads to a floor skip and at worst leads to an exploration death. This commit moves this vault to D:12-15, placing these monsters after the entrance to Lair and closer to where wizards normally appear.