### PR TITLE
Mantis Ticket 1583 - Cyclops have one eye

### DIFF
--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -639,8 +639,6 @@ VISUAL:@The_monster@ ponders the situation.
 @The_monster@ says, "Why is everything spinning?"
 
 @The_monster@ screams, "I'll kill you anyway!"
-
-VISUAL:@The_monster@ covers @possessive@ eyes.
 %%%%
 _confused_humanoid_rare_
 


### PR DESCRIPTION
This is in reference to Mantis 1583:

https://crawl.develz.org/mantis/view.php?id=1583

The problem with the visual is that it generates sentences like:

* "The cyclops covers its eyes."
* "The slime covers its eyes." 

Neither of which make sense.  We could change this visual to something like "The cyclops covers its face."  That's another solution. But... do slimes have faces? Do worms? Dart slugs?

I think a better solution would be to remove the offending visual gag entirely.