### PR TITLE
Indicate damage done by Ignite Poison

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1457,7 +1457,13 @@ static int _ignite_poison_monsters(coord_def where, int pow, actor *agent)
             return mons_aligned(mon, agent) ? -1 : 1;
         return mons_aligned(mon, agent) ? -1 * damage : damage;
     }
-    simple_monster_message(*mon, " seems to burn from within!");
+
+    if (you.see_cell(mon->pos()))
+    {
+        mprf("%s seems to burn from within%s",
+             mon->name(DESC_THE).c_str(),
+             attack_strength_punctuation(damage).c_str());
+    }
 
     dprf("Dice: %dd%d; Damage: %d", dam_dice.num, dam_dice.size, damage);
 


### PR DESCRIPTION
This commit brings Ignite Poison in line with other damaging spells
that use exclamation marks to show the amount of damage done.

It is a followup for PR #952 and commits 4a3ee908 and 1f260a4b.