### PR TITLE
Mantis 12049 - Lava is deadly

### DIFF
--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -36,8 +36,8 @@ teleportation.
 Fly status
 
 You fly above the ground, and are able to cross water and lava or fight above
-shallow water without penalties. Most types of flight will time out – be sure
-you're not above deadly liquids when that happens!
+shallow water without penalties. Most types of flight will time out – be
+careful what you are above when that happens!
 %%%%
 Agi status
 


### PR DESCRIPTION
This is in reference to Mantis 12049: https://crawl.develz.org/mantis/view.php?id=12049

People thought "deadly liquids" when referring to lava was redundant.  I agree. 

My new phrasing is more flavourful and fun, without trying to specifically call out lava as a "deadly liquid".
