### PR TITLE
Use felid blade hands tile with mons:natasha

### DIFF
--- a/crawl-ref/source/tiledoll.cc
+++ b/crawl-ref/source/tiledoll.cc
@@ -349,7 +349,8 @@ void fill_doll_equipment(dolls_data &result)
         {
             if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_OCTOPODE))
                 result.parts[TILEP_PART_HAND1] = TILEP_HAND1_BLADEHAND_OP;
-            else if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_FELID))
+            else if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_FELID)
+                     || Options.tile_use_monster == MONS_NATASHA)
                 result.parts[TILEP_PART_HAND1] = TILEP_HAND1_BLADEHAND_FE;
             else result.parts[TILEP_PART_HAND1] = TILEP_HAND1_BLADEHAND;
         }
@@ -366,7 +367,8 @@ void fill_doll_equipment(dolls_data &result)
         {
             if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_OCTOPODE))
                 result.parts[TILEP_PART_HAND2] = TILEP_HAND1_BLADEHAND_OP;
-            else if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_FELID))
+            else if (is_player_tile(result.parts[TILEP_PART_BASE], TILEP_BASE_FELID)
+                     || Options.tile_use_monster == MONS_NATASHA)
                 result.parts[TILEP_PART_HAND2] = TILEP_HAND1_BLADEHAND_FE;
             else result.parts[TILEP_PART_HAND2] = TILEP_HAND1_BLADEHAND;
         }


### PR DESCRIPTION
If the player has tile_player_tile = mons:natasha, show the felid
version of blade hands. It's still not perfect (and doesn't match
with many of the other felid tiles) but looks much better than the
human blade hands tile.