### PR TITLE
Misleading text when renouncing religion (8887)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3227,8 +3227,7 @@ static spret _do_ability(const ability_def& abil, bool fail)
         fail_check();
         if (yesno("Really renounce your faith, foregoing its fabulous benefits?",
                   false, 'n')
-            && yesno("Are you sure you won't change your mind later?",
-                     false, 'n'))
+            && yesno("Are you sure?", false, 'n'))
         {
             excommunication(true);
         }


### PR DESCRIPTION
This is in reference to Mantis 8887:

https://crawl.develz.org/mantis/view.php?id=8887

Someone pointed out that the second phrase when renouncing religion is confusing to the point of being wrong.

Well, it's easy enough to fix.