### PR TITLE
Fix showing regen amulets as useless for Vampires

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3585,10 +3585,9 @@ bool is_useless_item(const item_def &item, bool temp)
         case AMU_REGENERATION:
             return you.get_mutation_level(MUT_NO_REGENERATION) > 0
                    || (temp
-                       && you.get_mutation_level(MUT_INHIBITED_REGENERATION) > 0
-                       && regeneration_is_inhibited())
-                   || (temp && you.species == SP_VAMPIRE
-                       && !you.vampire_alive);
+                       && (you.get_mutation_level(MUT_INHIBITED_REGENERATION) > 0
+                           || you.species == SP_VAMPIRE)
+                       && regeneration_is_inhibited());
 
 #if TAG_MAJOR_VERSION == 34
         case AMU_MANA_REGENERATION:


### PR DESCRIPTION
Vampires now heal when bloodless as long as no monsters are in LOS.