### PR TITLE
Show that bloodless vampires' bite can heal

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -645,6 +645,7 @@ string describe_mutations(bool drop_title)
         {
             result += "<green>You do not regenerate when monsters are visible.</green>\n";
             result += "<green>You are frail without blood (-20% HP).</green>\n";
+            result += "<green>You can heal yourself when you bite living creatures.</green>\n";
         }
         else
             result += "<green>Your natural rate of healing is unusually fast.</green>\n";
@@ -775,16 +776,18 @@ static string _display_vampire_attributes()
 
     string result;
 
-    const int lines = 11;
+    const int lines = 12;
     string column[lines][3] =
     {
         {"                     ", "<green>Alive</green>      ", "<lightred>Bloodless</lightred>"},
                                  //Full       Bloodless
         {"Regeneration         ", "fast       ", "none with monsters in sight"},
 
-        {"HP Modifier          ", "none       ", "-20%"},
+        {"HP modifier          ", "none       ", "-20%"},
 
         {"Stealth boost        ", "none       ", "major "},
+
+        {"Heal on bite         ", "no         ", "yes "},
 
         {"\n<w>Resistances</w>\n"
          "Poison resistance    ", "           ", "immune"},


### PR DESCRIPTION
It's not obvious that vampires can heal themselves when they bite
something, and that this works only when they're bloodless. Add some
messages to the abilities screens.

Also make a word lowercase for consistency. 

I don't feel strongly about the wording used on the new messages. Perhaps they could be improved.