### PR TITLE
Show flay damage in status light

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -193,6 +193,10 @@ bool fill_status_info(int status, status_info& inf)
                           (-4 * you.props["corrosion_amount"].get_int()));
         break;
 
+    case DUR_FLAYED:
+        inf.light_text = make_stringf("Flay (%d)",
+                          (-1 * you.props["flay_damage"].get_int()));
+
     case DUR_NO_POTIONS:
         if (you_foodless())
             inf.light_colour = DARKGREY;


### PR DESCRIPTION
It is tactically useful to know how much damage is due to flay. For
example, it matters in deciding whether to quaff cancellation or who to
attack.

This information is already revealed to the player, but not in a
convenient way. At the moment the careful player must pay attention to
what the sources of damage are as the fight proceeds in order to know
this; and, if this is neglected, it is difficult to recover the
information from the message log later in the fight.

This commit reveals that information more straightforwardly by adding it
to the flay status light. I show a number instead of a more
coarse-grained indicator. Note that otherwise the conscientious player
will still want to keep track manually of damage since they can get
better information that way.

The damage is displayed as a negative number for consistency with the
similar corrosion status light.