### PR TITLE
Draw shields on deep elf knights

### DIFF
--- a/crawl-ref/source/tilemcache.cc
+++ b/crawl-ref/source/tilemcache.cc
@@ -824,6 +824,7 @@ bool mcache_monster::get_shield_offset(tileidx_t mon_tile,
     case TILEP_MONS_ORC_WARRIOR:
     case TILEP_MONS_ORC_KNIGHT:
     case TILEP_MONS_ORC_WARLORD:
+    case TILEP_MONS_DEEP_ELF_KNIGHT:
     case TILEP_MONS_KIRKE:
     case TILEP_MONS_DIMME:
         *ofs_x = 1;


### PR DESCRIPTION
They used to have shields drawn on them in tiles; I don't know why this changed but I suspect it was a mistake. Here's how they looks after this patch:

![Screenshot_2019-10-19_13-22-09-elfshield](https://user-images.githubusercontent.com/47063032/67148989-ecd42e00-f273-11e9-8816-b1fa16dd66c0.png)
