### PR TITLE
Prevent torment from killing spriggan riders

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -6062,7 +6062,8 @@ void monster::react_to_damage(const actor *oppressor, int damage,
     {
         if (hit_points + damage > max_hit_points / 2)
             damage = max_hit_points / 2 - hit_points;
-        if (damage > 0 && x_chance_in_y(damage, damage + hit_points))
+        if (damage > 0 && x_chance_in_y(damage, damage + hit_points)
+            && flavour != BEAM_TORMENT_DAMAGE)
         {
             bool fly_died = coinflip();
             int old_hp                = hit_points;


### PR DESCRIPTION
Torment shouldn't be able to kill spriggan riders or their mounts.