### PR TITLE
Make fire spells better at burning trees

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2490,7 +2490,10 @@ bool bolt::can_burn_trees() const
            || origin_spell == SPELL_BOLT_OF_FIRE
            || origin_spell == SPELL_BOLT_OF_MAGMA
            || origin_spell == SPELL_FIREBALL
-           || origin_spell == SPELL_INNER_FLAME;
+           || origin_spell == SPELL_FIRE_STORM
+           || origin_spell == SPELL_IGNITION
+           || origin_spell == SPELL_INNER_FLAME
+           || origin_spell == SPELL_STARBURST;
 }
 
 bool bolt::can_affect_wall(const coord_def& p, bool map_knowledge) const
@@ -6028,6 +6031,7 @@ void bolt::determine_affected_cells(explosion_map& m, const coord_def& delta,
     // those and simplify feat_is_wall() to return true for trees. -gammafunk
     if (feat_is_wall(dngn_feat)
         || feat_is_tree(dngn_feat)
+           && !can_burn_trees()
         || feat_is_closed_door(dngn_feat))
     {
         // Special case: explosion originates from rock/statue

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1763,6 +1763,7 @@ spret cast_ignition(const actor *agent, int pow, bool fail)
         beam_actual.ex_size       = 0;
         beam_actual.is_explosion  = true;
         beam_actual.loudness      = 0;
+        beam_actual.origin_spell  = SPELL_IGNITION;
         beam_actual.apply_beam_conducts();
 
 #ifdef DEBUG_DIAGNOSTICS
@@ -1775,8 +1776,12 @@ spret cast_ignition(const actor *agent, int pow, bool fail)
         {
             for (adjacent_iterator ai(pos); ai; ++ai)
             {
-                if (cell_is_solid(*ai))
+                if (cell_is_solid(*ai)
+                    && (!beam_actual.can_affect_wall(*ai))
+                        || you_worship(GOD_FEDHAS))
+                {
                     continue;
+                }
 
                 actor *act = actor_at(*ai);
 


### PR DESCRIPTION
Fireball could previously burn trees with all squares of its explosion,
not just the centre, but this was inadvertently changed in be81960.
This commit restores that behaviour.

It also allows the spells Fire Storm and Ignition to burn trees,
because it seemed strange to me that the most powerful fire spells
did nothing on trees. This allows a player to easily clear out large
amounts of trees at once, but by the time a player can cast these
spells, this is not usually all that relevant.