### PR TITLE
Remove haste potion from FoWn start (12115)

### DIFF
--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -405,7 +405,8 @@ static void _good_potion_or_scroll()
             (you.species == SP_MUMMY
              || you.species == SP_VINE_STALKER) ? 0 : 1 },
         { { OBJ_POTIONS, POT_HASTE },
-            you.species == SP_MUMMY ? 0 : 1 },
+            (you.species == SP_MUMMY
+             || you.species == SP_FORMICID) ? 0 : 1 },
         { { OBJ_POTIONS, POT_BERSERK_RAGE },
             (you.species == SP_FORMICID
              || you.is_lifeless_undead(false)) ? 0 : 1},


### PR DESCRIPTION
This PR relates to Mantis ticket 12115:

https://crawl.develz.org/mantis/view.php?id=12115

Essentially, Formicid Wanderers can start with haste potions, but that is a useless item for them.  We already have already have several exclusions so that various types of wanderers don't start with items that would be useless for them (`crawl-ref/source/ng-wanderer.cc`).

It appears this items was an oversight on the useless item exclusions.  Luckily, it was super easy to fix.
