### PR TITLE
Prevent overtraining skill targets

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -529,6 +529,25 @@ int manual_slot_for_skill(skill_type skill)
     return slot;
 }
 
+int get_all_manual_charges_for_skill(skill_type skill)
+{
+    int charges = 0;
+
+    FixedVector<item_def,ENDOFPACK>::const_pointer iter = you.inv.begin();
+    for (;iter!=you.inv.end(); ++iter)
+    {
+        if (iter->base_type != OBJ_BOOKS || iter->sub_type != BOOK_MANUAL)
+            continue;
+
+        if (iter->skill != skill || iter->skill_points == 0)
+            continue;
+
+        charges += iter->skill_points;
+    }
+
+    return charges;
+}
+
 bool skill_has_manual(skill_type skill)
 {
     return manual_slot_for_skill(skill) != -1;

--- a/crawl-ref/source/evoke.h
+++ b/crawl-ref/source/evoke.h
@@ -6,6 +6,7 @@
 #pragma once
 
 int manual_slot_for_skill(skill_type skill);
+int get_all_manual_charges_for_skill(skill_type skill);
 bool skill_has_manual(skill_type skill);
 void finish_manual(int slot);
 void get_all_manual_charges(vector<int> &charges);

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1022,7 +1022,7 @@ static void _train_skills(int exp, const int cost, const bool simu)
         skill_type sk = SK_NONE;
         if (!skip_first_phase)
             sk = static_cast<skill_type>(random_choose_weighted(sk_exp));
-        if (is_invalid_skill(sk))
+        if (is_invalid_skill(sk) || !you.train[sk])
             sk = static_cast<skill_type>(random_choose_weighted(you.training));
         if (!is_invalid_skill(sk))
         {
@@ -1334,7 +1334,8 @@ static int _train(skill_type exsk, int &max_exp, bool simu)
     {
         // TODO should check_training_targets be called here, to halt training
         // and clean up cross-training immediately?
-        check_training_target(exsk);
+        if (check_training_target(exsk))
+            reset_training();
         redraw_skill(exsk, old_best_skill, (you.skill(exsk, 10, true) > old_level));
         check_selected_skills();
     }


### PR DESCRIPTION
Currently, skill targets are not always respected when a single experience gain is large enough to push the the skill level to and beyond a skill target. This is fairly easy to reproduce when starting a new game and training only one skill with a skill target of 0.1 -- after the first experience gain, the skill will likely jump beyond 0.1 (perhaps 0.2, 0.3, etc. depending on the gain) before turning off.

This change will better ensure that skill targets are respected and not overtrained. It's a minor change with an arguably negligible impact on gameplay, but some players, like myself, prefer to train to "round" numbers ending in .0 or .5 and are put off when the skills are trained beyond the set targets.

Regarding the approach, I initially tried to take a more clever strategy of calculating the skill points required to reach the target, and using that as a ceiling for [`skill_inc`](https://github.com/nirrattner/crawl/blob/4073cf80fb89cbf380539eab6ea495c3f1859f43/crawl-ref/source/skills.cc#L1268), and that worked well except for incorporating the Ashenzari skill boost. So instead of putting together that more complex approach, I opted for the brute-force iteration of adding experience one-at-a-time while checking each time to see if the target were hit. I felt like this would be an easier way to handle the Ashenzari skill boost and that it might also be easier to maintain if any other edge cases were introduced to skill calculations. Of course the tradeoff here is some performance.

Still, I'm open to suggestions for other approaches if this one isn't desirable. Also looking for as much scrutiny as possible for the code in case there are other edge cases I didn't consider or if the code style could be improved.

Thank you for your time!