### PR TITLE
Make the Warlock's Mirror's reflection chance scale as intended

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6635,7 +6635,7 @@ bool shoot_through_monster(const bolt& beam, const monster* victim)
  */
 int omnireflect_chance_denom(int SH)
 {
-    return SH + 40;
+    return SH + 20;
 }
 
 /// Set up a beam aiming from the given monster to their target.


### PR DESCRIPTION
Commentary about the omnireflection property granted by the Warlock's Mirror (see line 3099 of beam.cc) indicates that it is intended to reflect 50% of ench-type effects at 20 displayed SH; however, the the actual chance is 33% due to a mathematical error. This commit changes the chance to the intended 50% at 20 SH.