### PR TITLE
Use yaml.safe_load instead of load

### DIFF
--- a/crawl-ref/source/util/species-gen.py
+++ b/crawl-ref/source/util/species-gen.py
@@ -417,7 +417,7 @@ def main():
             continue
         f_path = os.path.join(args.datadir, f_name)
         try:
-            species_spec = yaml.load(open(f_path))
+            species_spec = yaml.safe_load(open(f_path))
         except yaml.YAMLError as e:
             print("Failed to load %s: %s" % (f_name, e))
             sys.exit(1)


### PR DESCRIPTION
PyYAML's yaml.load is insecure and it is deprecated in 5.1. Some
distributions even disable it, making it difficult to build DCSS on
them. Use the recommended safe_load instead.