### PR TITLE
Adjust Trog weapon gifting (ebering)

### DIFF
--- a/crawl-ref/source/acquire.h
+++ b/crawl-ref/source/acquire.h
@@ -5,6 +5,11 @@
 
 #pragma once
 
+#include "item-prop-enum.h"
+
+const brand_type TROG_BRANDS[] = {SPWPN_NORMAL, SPWPN_VORPAL, SPWPN_FLAMING,
+    SPWPN_ANTIMAGIC};
+
 bool acquirement(object_class_type force_class, int agent,
                  bool quiet = false, int *item_index = nullptr,
                  bool known_scroll = false);

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -196,9 +196,6 @@ const vector<god_power> god_powers[NUM_GODS] =
       { 1, ABIL_TROG_BERSERK, "go berserk at will" },
       { 2, ABIL_TROG_REGEN_MR,
            "call upon Trog for regeneration and magic resistance" },
-      { 3, "Trog will now gift you ammunition as you gain piety.",
-           "Trog will no longer gift you ammunition.",
-           "Trog will gift you ammunition as you gain piety." },
       { 4, ABIL_TROG_BROTHERS_IN_ARMS, "call in reinforcements" },
       { 5, "Trog will now gift you weapons as you gain piety.",
            "Trog will no longer gift you weapons.",
@@ -1368,21 +1365,22 @@ static bool _give_trog_oka_gift(bool forced)
     if (you.species == SP_FELID)
         return false;
 
-    const bool need_missiles = _need_missile_gift(forced);
+    const bool need_missiles = you_worship(GOD_OKAWARU)
+                               && _need_missile_gift(forced);
     object_class_type gift_type;
 
-    if (forced && coinflip()
-        || (!forced && you.piety >= piety_breakpoint(4)
-            && random2(you.piety) > 120
-            && one_chance_in(4)))
-    {
-        if (you_worship(GOD_TROG)
-            || (you_worship(GOD_OKAWARU) && coinflip()))
-        {
+    if (you_worship(GOD_TROG))
             gift_type = OBJ_WEAPONS;
-        }
-        else
-            gift_type = OBJ_ARMOUR;
+    else if (forced)
+        gift_type = random_choose_weighted(
+            1, OBJ_WEAPONS,
+            1, OBJ_ARMOUR,
+            need_missiles ? 1 : 0, OBJ_MISSILES);
+    else if (you.piety >= piety_breakpoint(4)
+             && random2(you.piety) > 120
+             && one_chance_in(4))
+    {
+        gift_type = coinflip() ? OBJ_WEAPONS : OBJ_ARMOUR;
     }
     else if (need_missiles)
         gift_type = OBJ_MISSILES;


### PR DESCRIPTION
Only gift melee weapons with a restricted set of brands (plain, vorpal,
flaming, antimagic).

This also slightly modifies the minimum enchantment of gifts from Trog
and Okawaru. Previously the minimum was 0 or 1 (random per-item), now it
is always 0.