### PR TITLE
The Elemental Staff give spell power boost on wearer

### DIFF
--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -210,7 +210,8 @@ A beautiful mithril axe, probably lost by some dwarven hero.
 Elemental Staff
 
 A powerful staff which used to belong to the leader of the Guild of Five
-Elements. In addition to the protection it provides, those skilled in
+Elements. A staff that increases the power of elemental spells cast by its
+wielder. In addition to the protection it provides, those skilled in
 Evocations may discharge powerful blasts of elemental energy when striking with
 it.
 %%%%

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1695,6 +1695,9 @@ int player_spec_fire()
     if (you.duration[DUR_FIRE_SHIELD])
         sf++;
 
+    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF))
+        sf++;
+
     return sf;
 }
 
@@ -1708,6 +1711,9 @@ int player_spec_cold()
     // rings of ice:
     sc += you.wearing(EQ_RINGS, RING_ICE);
 
+    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF))
+        sc++;
+
     return sc;
 }
 
@@ -1718,6 +1724,9 @@ int player_spec_earth()
     // Staves
     se += you.wearing(EQ_STAFF, STAFF_EARTH);
 
+    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF))
+        se++;
+
     return se;
 }
 
@@ -1727,6 +1736,9 @@ int player_spec_air()
 
     // Staves
     sa += you.wearing(EQ_STAFF, STAFF_AIR);
+
+    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF))
+        sa++;
 
     return sa;
 }


### PR DESCRIPTION
It has improved its performance to become a more useful item for users of elemental schools.

I thought about adding a function to reduce costs by one, limited to elemental schools. But I didn't implement this idea because I thought it wouldn't be acceptable to the dev-team.