### PR TITLE
Ely's Divine Protection always protects at 120 piety.

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4006,7 +4006,7 @@ lifesaving_chance elyvilon_lifesaving()
     if (you.piety < piety_breakpoint(0))
         return lifesaving_chance::never;
 
-    return you.piety > 119 ? lifesaving_chance::always
+    return you.piety >= piety_breakpoint(4) ? lifesaving_chance::always
                            : lifesaving_chance::sometimes;
 }
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4006,7 +4006,7 @@ lifesaving_chance elyvilon_lifesaving()
     if (you.piety < piety_breakpoint(0))
         return lifesaving_chance::never;
 
-    return you.piety > 130 ? lifesaving_chance::always
+    return you.piety > 119 ? lifesaving_chance::always
                            : lifesaving_chance::sometimes;
 }
 


### PR DESCRIPTION
At present, the always protection of this power begins at 131 piety. This figure is slightly different from when the player's faith becomes *****(120). This subtle difference is confusing for a player who doesn't read a spoiler because inside the game doesn't tell the moment when the odds of protection are 100%. This confusion can be resolved by aligning the point at which the protection probability is 100% to the moment at which the number of stars changes.
As a result, this power will work somewhat in favor of the player, but players will be able to clearly see when this sentence means without a spoiler: Especially pious individuals may be certain of this help.