### PR TITLE
Remove an inventory hotkey for corpses and skeletons

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -275,9 +275,6 @@ void get_class_hotkeys(const int type, vector<char> &glyphs)
     case OBJ_MISCELLANY:
         glyphs.push_back('}');
         break;
-    case OBJ_CORPSES:
-        glyphs.push_back('&');
-        break;
     default:
         break;
     }


### PR DESCRIPTION
Although the player cannot pickup carrion anymore, the pickup menu
still displays a hotkey for it. The hotkey already does nothing
because corpses and skeletons are stationary objects (62bc8482).