### PR TITLE
Add missing SUBST to gammafunk_ghost_icy

### DIFF
--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -1165,7 +1165,7 @@ NSUBST: - = 4=1 / 6=1' / 2=45 / 3=45'' / 67 / D''' / '
 :     end
 : elseif you.in_branch("Lair") then
 KITEM:  O = ring of fire ident:type / ring of fire randart ident:type
-SUBST:  f = *%, h = %$--, ij = -
+SUBST:  f = *%, g = %$--, hij = -
 NSUBST: - = 4=1 / 5=1' / 2=4 / 2=4' / 7''' / '
 # Depths
 : else


### PR DESCRIPTION
Fixes an ugly green tile when placed in Lair:
![ghost_vault_bad_tile_cropped](https://user-images.githubusercontent.com/49602874/69919329-4e75e380-1441-11ea-8407-536a710ea1b2.png)
