### PR TITLE
Fix initial god ability slot assignment in local tiles

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3646,9 +3646,9 @@ void join_religion(god_type which_god)
     whereis_record();
 #endif
 
-    _set_initial_god_piety();
-
     set_god_ability_slots();    // remove old god's slots, reserve new god's
+
+    _set_initial_god_piety();
 
     // When you start worshipping a good god, you make all non-hostile
     // unholy and evil beings hostile.


### PR DESCRIPTION
Ability slots need to be claimed before setting initial piety. This is because if a player's starting piety is at least 1*, the local tiles version will trigger a redraw of the ability tab, a side effect of which is to fix any available but unassigned abilities using the default logic (starting at f) rather than the god ability rules (a-e + X).