### PR TITLE
Fix edge cases for destroying Summon Forest's trees

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -447,8 +447,11 @@ static void _spread_fire(const cloud_struct &cloud)
 
         // forest fire doesn't spread in all directions at once,
         // every neighbouring square gets a separate roll
-        if (!feat_is_tree(grd(*ai)) || x_chance_in_y(19, 20))
+        if (!feat_is_tree(grd(*ai)) || is_temp_terrain(*ai)
+            || x_chance_in_y(19, 20))
+        {
             continue;
+        }
 
         if (env.markers.property_at(*ai, MAT_ANY, "veto_fire") == "veto")
             continue;

--- a/crawl-ref/source/spl-tornado.cc
+++ b/crawl-ref/source/spl-tornado.cc
@@ -319,7 +319,8 @@ void tornado_damage(actor *caster, int dur, bool is_vortex)
         vector<coord_def> clouds;
         for (; dam_i && dam_i.radius() == r; ++dam_i)
         {
-            if (feat_is_tree(grd(*dam_i)) && dur > 0
+            if ((feat_is_tree(grd(*dam_i)) && !is_temp_terrain(*dam_i))
+                && dur > 0
                 && bernoulli(rdur * 0.01, 0.05)) // 5% chance per 10 aut
             {
                 grd(*dam_i) = DNGN_FLOOR;


### PR DESCRIPTION
Tornado and forest fires were not checking whether a tree was created
by Summon Forest.