### PR TITLE
Fix dancing weapon headsup messages (hittemvvvhard)

### DIFF
--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -337,11 +337,14 @@ static string _monster_headsup(const vector<monster*> &monsters,
         else
             warning_msg += "is";
 
+        mons_equip_desc_level_type level = mon->type != MONS_DANCING_WEAPON
+            ? DESC_IDENTIFIED : DESC_WEAPON_WARNING;
+
         if (!divine)
         {
-            warning_msg += " ";
-            warning_msg += get_monster_equipment_desc(mi, DESC_IDENTIFIED,
-                                                      DESC_NONE);
+            if (mon->type != MONS_DANCING_WEAPON)
+                warning_msg += " ";
+            warning_msg += get_monster_equipment_desc(mi, level, DESC_NONE);
             warning_msg += ".";
             continue;
         }
@@ -358,8 +361,7 @@ static string _monster_headsup(const vector<monster*> &monsters,
             // TODO: deduplicate
             if (mon->type != MONS_DANCING_WEAPON)
                 warning_msg += " ";
-            warning_msg += get_monster_equipment_desc(mi, DESC_IDENTIFIED,
-                                                      DESC_NONE);
+            warning_msg += get_monster_equipment_desc(mi, level, DESC_NONE);
         }
         warning_msg += ".";
     }


### PR DESCRIPTION
Commit 7046ed1b expanded the conditions under which headsup messages
happen and how much information they give, but broke the special case of
dancing weapons. The result was that when multiple enemies came into view
the game tried to warn the player about an interesting dancing weapon
with the unhelpful message 'There is .' This commit fixes that.