### PR TITLE
Increase Quicksilver Dragon Armour ER to 8 (was 7)

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -157,7 +157,7 @@ static const armour_def Armour_prop[] =
         ARMF_RES_STEAM),
     DRAGON_ARMOUR(ACID,        "acid",                    6,  -50,  400,
         ARMF_RES_CORR),
-    DRAGON_ARMOUR(QUICKSILVER, "quicksilver",             9,  -70,  600,
+    DRAGON_ARMOUR(QUICKSILVER, "quicksilver",             9,  -80,  600,
         ARMF_RES_MAGIC),
     DRAGON_ARMOUR(SWAMP,       "swamp",                   7,  -70,  500,
         ARMF_RES_POISON),


### PR DESCRIPTION
QDA is extremely rare and can't be enchanted, so it can afford to be
quite powerful. But its stats are extremely attractive when comparing
against similar AC (IDA: 11 vs 7 ER) or similar ER (Swmp DA: 7 AC vs 9).

Increase its ER by one. Another option could be to tweak its AC, but
no other armour has 8 ER so this is probably a more interesting choice.