### PR TITLE
Rework the Pain card's level 2

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1143,27 +1143,7 @@ static void _damaging_card(card_type card, int power,
     case CARD_PAIN:
         if (power_level == 2)
         {
-            mpr(prompt);
-
-            if (monster *ghost = _friendly(MONS_FLAYED_GHOST, 3))
-            {
-                apply_visible_monsters([&, ghost](monster& mons)
-                {
-                    if (mons.wont_attack()
-                        || !(mons.holiness() & MH_NATURAL))
-                    {
-                        return false;
-                    }
-
-
-                    flay(*ghost, mons, mons.hit_points * 2 / 5);
-                    return true;
-                }, ghost->pos());
-
-                ghost->foe = MHITYOU; // follow you around (XXX: rethink)
-                return;
-            }
-            // else, fallback to level 1
+            torment(&you, TORMENT_CARD_PAIN, you.pos());
         }
 
         ztype = painzaps[min(power_level, (int)ARRAYSZ(painzaps)-1)];

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1190,6 +1190,7 @@ void torment_player(actor *attacker, torment_source_type taux)
     {
     case TORMENT_CARDS:
     case TORMENT_SPELL:
+    case TORMENT_CARD_PAIN:
         aux = "Symbol of Torment";
         break;
 
@@ -1232,8 +1233,9 @@ void torment_player(actor *attacker, torment_source_type taux)
 void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
 {
     if (where == you.pos()
-        // The Sceptre of Torment doesn't affect the  wielder.
-        && !(attacker && attacker->is_player() && taux == TORMENT_SCEPTRE))
+        // The Sceptre of Torment and pain card do not affect the user.
+        && !(attacker && attacker->is_player()
+            && (taux == TORMENT_SCEPTRE || taux == TORMENT_CARD_PAIN)))
     {
         torment_player(attacker, taux);
     }

--- a/crawl-ref/source/torment-source-type.h
+++ b/crawl-ref/source/torment-source-type.h
@@ -11,4 +11,5 @@ enum torment_source_type
     TORMENT_KIKUBAAQUDGHA = -7,   // Kikubaaqudgha effect
     TORMENT_MISCAST       = -8,
     TORMENT_AGONY         = -9,   // SPELL_AGONY
+    TORMENT_CARD_PAIN    = -10, // for pain card
 };


### PR DESCRIPTION
Level 2 pain card's old effect (summon flayed ghost) was an unsuitable effect on the deck of destruction. Also, flay effect is just another torment.
New effects: cast torment. Torment does not damage the caster.