### PR TITLE
Remove the Shaft card and Rework the Exile card

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -87,7 +87,7 @@ typedef map<card_type, int> deck_archetype;
 deck_archetype deck_of_escape =
 {
     { CARD_TOMB,       5 },
-    { CARD_EXILE,      2 },
+    { CARD_EXILE,      3 },
     { CARD_ELIXIR,     5 },
     { CARD_CLOUD,      5 },
     { CARD_VELOCITY,   5 },

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -91,7 +91,6 @@ deck_archetype deck_of_escape =
     { CARD_ELIXIR,     5 },
     { CARD_CLOUD,      5 },
     { CARD_VELOCITY,   5 },
-    { CARD_SHAFT,      5 },
 };
 
 deck_archetype deck_of_destruction =
@@ -179,7 +178,6 @@ const char* card_name(card_type card)
     case CARD_SUMMON_WEAPON:   return "the Dance";
     case CARD_SUMMON_FLYING:   return "Foxfire";
     case CARD_RANGERS:         return "the Rangers";
-    case CARD_SHAFT:           return "the Shaft";
     case CARD_VITRIOL:         return "Vitriol";
     case CARD_CLOUD:           return "the Cloud";
     case CARD_STORM:           return "the Storm";
@@ -1026,34 +1024,6 @@ static void _exile_card(int power)
     }
 }
 
-static void _shaft_card(int power)
-{
-    const int power_level = _get_power_level(power);
-    bool did_something = false;
-
-    if (is_valid_shaft_level())
-    {
-        if (grd(you.pos()) == DNGN_FLOOR)
-        {
-            place_specific_trap(you.pos(), TRAP_SHAFT);
-            trap_at(you.pos())->reveal();
-            mpr("A shaft materialises beneath you!");
-            did_something = true;
-        }
-
-        did_something = apply_visible_monsters([=](monster& mons)
-        {
-            return !mons.wont_attack()
-                   && mons_is_threatening(mons)
-                   && x_chance_in_y(power_level, 3)
-                   && mons.do_shaft();
-        }) || did_something;
-    }
-
-    if (!did_something)
-        canned_msg(MSG_NOTHING_HAPPENS);
-}
-
 static int stair_draw_count = 0;
 
 // This does not describe an actual card. Instead, it only exists to test
@@ -1748,7 +1718,6 @@ void card_effect(card_type which_card,
     case CARD_EXILE:            _exile_card(power); break;
     case CARD_ELIXIR:           _elixir_card(power); break;
     case CARD_STAIRS:           _stairs_card(power); break;
-    case CARD_SHAFT:            _shaft_card(power); break;
     case CARD_TOMB:             entomb(10 + power/20 + random2(power/4)); break;
     case CARD_WRAITH:           drain_player(power / 4, false, true); break;
     case CARD_WRATH:            _godly_wrath(); break;

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -87,7 +87,7 @@ typedef map<card_type, int> deck_archetype;
 deck_archetype deck_of_escape =
 {
     { CARD_TOMB,       5 },
-    { CARD_EXILE,      1 },
+    { CARD_EXILE,      2 },
     { CARD_ELIXIR,     5 },
     { CARD_CLOUD,      5 },
     { CARD_VELOCITY,   5 },
@@ -1007,16 +1007,15 @@ static void _exile_card(int power)
 
     for (int i = 0; i < 1 + extra_targets; ++i)
     {
-        // Pick a random monster nearby to banish (or yourself).
+        // Pick a random monster nearby to banish.
         monster* mon_to_banish = choose_random_nearby_monster(1);
 
         // Bonus banishments only banish monsters.
         if (i != 0 && !mon_to_banish)
             continue;
 
-        if (!mon_to_banish) // Banish yourself!
+        if (!mon_to_banish)
         {
-            banished("drawing a card");
             break;              // Don't banish anything else.
         }
         else

--- a/crawl-ref/source/decks.h
+++ b/crawl-ref/source/decks.h
@@ -26,7 +26,6 @@ enum card_type
     CARD_VELOCITY,            // remove slow, alter others' speeds
     CARD_TOMB,                // a ring of rock walls
     CARD_EXILE,               // banish others, maybe self
-    CARD_SHAFT,               // under the user, maybe others
     CARD_VITRIOL,             // acid damage
     CARD_CLOUD,               // encage enemies in rings of clouds
     CARD_STORM,               // wind and rain


### PR DESCRIPTION
Shaft: This card has a similar effect as an exile card. They both send their enemies to other places. I don't think it's necessary to have two cards with roles like similar.
Also, In the last floor(and Tomb with Ziggurat), which is the most dangerous section for the player, this card has no effect and instead becomes a deadly trap card that wastes one turn. Of course, you can't use exile cards in Abyss, but there are far fewer places that are ineffective and there is a very low probability that you can get this card.

Exile: Remove the function of self banishing. This effect is too powerful and dangerous. The risk of self banishing is gone, so the chance of this card appearing will be a little higher.