### PR TITLE
Change player tile to use multiple levels of poison

### DIFF
--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -457,7 +457,7 @@ tileidx_t tilep_equ_boots(const item_def &item)
 
 tileidx_t tileidx_player()
 {
-    int ch = TILEP_PLAYER;
+    tileidx_t ch = TILEP_PLAYER;
 
     // Handle shapechange first
     switch (you.form)
@@ -524,7 +524,16 @@ tileidx_t tileidx_player()
     }
 
     if (you.duration[DUR_POISONING])
-        ch |= TILE_FLAG_POISON;
+    {
+        int pois_perc = (you.hp <= 0) ? 100
+                                  : ((you.hp - max(0, poison_survival())) * 100 / you.hp);
+        if (pois_perc >= 100)
+            ch |= TILE_FLAG_MAX_POISON;
+        else if (pois_perc >= 35)
+            ch |= TILE_FLAG_MORE_POISON;
+        else
+            ch |= TILE_FLAG_POISON;
+    }
 
     return ch;
 }


### PR DESCRIPTION
Follows the same breakpoints as the color of the 'Pois' status indicator.