### PR TITLE
Fix macOS OS detection with catch2

### DIFF
--- a/crawl-ref/source/platform.h
+++ b/crawl-ref/source/platform.h
@@ -212,13 +212,6 @@
 #endif
 
 #if !defined (OS_DETECTED)
-#if defined (TARGET_CPU_ARM)
-#define OS_DETECTED
-#define TARGET_OS_NDSFIRMWARE
-#endif
-#endif
-
-#if !defined (OS_DETECTED)
 #if defined (MSDOS) || defined (__DOS__) || defined (__DJGPP__)
 #define OS_DETECTED
 #define TARGET_OS_DOS
@@ -264,6 +257,13 @@
 #if defined (__hurd__)
 #define OS_DETECTED
 #define TARGET_OS_HURD
+#endif
+#endif
+
+#if !defined (OS_DETECTED)
+#if defined (TARGET_CPU_ARM)
+#define OS_DETECTED
+#define TARGET_OS_NDSFIRMWARE
 #endif
 #endif
 


### PR DESCRIPTION
Catch2 erroneously defines TARGET_CPU_ARM on macOS, which causes
platform.h to mis-detect the target OS as Nintendo DS.

Fix this by changing the order of OS detection.

There are a couple of alternate approaches for this fix:
* Fix Catch2 so that TARGET_CPU_ARM (and possibly other TARGET_CPU_*
  defines) is not erroneously defined on macOS
* Remove Nintendo DS support from the project