### PR TITLE
Catch2 Coverage

### DIFF
--- a/crawl-ref/INSTALL.txt
+++ b/crawl-ref/INSTALL.txt
@@ -127,6 +127,10 @@ recommended that you also install and configure ccache and binutils-gold:
     apt-get install ccache binutils-gold
     less /usr/share/doc/ccache/README.Debian
 
+To build HTML code coverage reports (using `make catch2-coverage`), you need
+gcovr:
+    pip3 install gcovr
+
 
 Prerequisites (Fedora):
 

--- a/crawl-ref/source/.gitignore
+++ b/crawl-ref/source/.gitignore
@@ -1,0 +1,3 @@
+coverage-html-report/
+*.gcda
+*.gcno

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -65,6 +65,7 @@
 #
 #    ANDROID       -- perform an Android build (see docs/develop/android.txt)
 #    TOUCH_UI      -- enable UI behaviour more compatible with touch-screens
+#    COVERAGE	   -- compile with coverage information (for gcov)
 #
 #
 # Requirements:
@@ -553,6 +554,10 @@ ifdef AUTO_OPT
 ifndef NO_AUTO_OPT
 CFOPTIMIZE += -march=native
 endif
+endif
+
+ifdef COVERAGE
+	CFOPTIMIZE_L = -fprofile-arcs -ftest-coverage
 endif
 
 ifdef LTO
@@ -1597,8 +1602,12 @@ plug-and-play-tests: $(CATCH2_PNP_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
 catch2-tests: just-compile-catch2-tests
 	./catch2-tests-executable
 
+catch2-coverage: catch2-tests
+	mkdir -p coverage-html-report
+	gcovr --html coverage-html-report/index.html --html-details coverage-html-report/ -e 'levcomp' -e 'conftest' .
+
 clean-catch2:
-	$(RM) catch2-tests-executable catch2-tests-executable.exe
+	$(RM) catch2-tests-executable catch2-tests-executable.exe coverage-html-report
 
 clean-plug-and-play-tests:
 	$(RM) plug-and-play-tests plug-and-play-tests.exe

--- a/crawl-ref/source/platform.h
+++ b/crawl-ref/source/platform.h
@@ -212,13 +212,6 @@
 #endif
 
 #if !defined (OS_DETECTED)
-#if defined (TARGET_CPU_ARM)
-#define OS_DETECTED
-#define TARGET_OS_NDSFIRMWARE
-#endif
-#endif
-
-#if !defined (OS_DETECTED)
 #if defined (MSDOS) || defined (__DOS__) || defined (__DJGPP__)
 #define OS_DETECTED
 #define TARGET_OS_DOS
@@ -264,6 +257,13 @@
 #if defined (__hurd__)
 #define OS_DETECTED
 #define TARGET_OS_HURD
+#endif
+#endif
+
+#if !defined (OS_DETECTED)
+#if defined (TARGET_CPU_ARM)
+#define OS_DETECTED
+#define TARGET_OS_NDSFIRMWARE
 #endif
 #endif
 


### PR DESCRIPTION
This uses gcov and gcovr to generate pretty HTML reports of code
coverage for catch2 tests.

Usage: make catch2-coverage COVERAGE=1
Then open coverage-html-report/index.html

In future, it would be nice to improve the UX so:

1. There's no need to remember to specify COVERAGE=1
2. You can generate coverage from execution of crawl normally, not just
   catch2.

