### PR TITLE
Change USK Line Pass's cost

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -616,7 +616,7 @@ static const ability_def Ability_List[] =
     { ABIL_USKAYAW_STOMP, "Stomp",
         3, 0, 100, generic_cost::fixed(20), {fail_basis::invo}, abflag::none },
     { ABIL_USKAYAW_LINE_PASS, "Line Pass",
-        4, 0, 200, generic_cost::fixed(20), {fail_basis::invo}, abflag::none},
+        4, 0, 200, generic_cost::fixed(0), {fail_basis::invo}, abflag::exhaustion },
     { ABIL_USKAYAW_GRAND_FINALE, "Grand Finale",
         8, 0, 500, generic_cost::fixed(0),
         {fail_basis::invo, 120 + piety_breakpoint(4), 5, 1}, abflag::none},
@@ -3150,8 +3150,15 @@ static spret _do_ability(const ability_def& abil, bool fail)
         if (_abort_if_stationary())
             return spret::abort;
         fail_check();
+        if (you.duration[DUR_EXHAUSTED])
+        {
+            mpr("You are too exhausted to line pass out.");
+            return spret::abort;
+        }
+        fail_check();
         if (!uskayaw_line_pass())
             return spret::abort;
+        you.increase_duration(DUR_EXHAUSTED, 12 + random2(5));
         break;
 
     case ABIL_USKAYAW_GRAND_FINALE:


### PR DESCRIPTION
Uskayaw's core is to gather piety and use the Grand Finale, Solo Times, and Pain Bonds. Players must suppress the use of piety to use Solo Time and Pain Bond frequently. With such a structure, Stomp and Line Pass meet the requirements despite their low star power and are difficult to use immediately. Due to these difficulties, line pass are only used in very limited situations. Therefore I hope that by altering the piety cost of the line pass, this power can be a tactical option on par with other powers.

Now the Line Pass is zero the piety cost and gets exhaustion time.