### PR TITLE
Add code coverage tracking

### DIFF
--- a/crawl-ref/docs/develop/arena.txt
+++ b/crawl-ref/docs/develop/arena.txt
@@ -1,30 +1,4 @@
-A.   Unit tests
-===============
-
-Crawl has a set of unit tests in the source/test/ directory, with each lua
-file being a separate unit test. To use unit tests, you must compile Crawl
-either with the macro DEBUG_DIAGNOSTICS defined (the debug make target) or
-with both the macros DEBUG and DEBUG_TESTS defined (the wizard make target,
-plus -DDEBUG_TESTS). You can then do
-
-    crawl -test
-
-to run the unit tests. To run paricular unit tests, you can do
-
-    crawl -test foo
-
-and that will run all unit tests which have "foo" in their file name.
-
-If you want to write your own unit tests, take a look at the files in
-source/test for examples. test/los_maps.lua and test/bounce.lua have
-examples which use vaults (maps) which are located in test/des. You
-might need to create new Lua functions in the source/l_*.cc files if none of
-the crawl.foo()/dgn.foo()/etc functions do what you need.
-
-=============================================================================
-=============================================================================
-
-B.    Testing with the arena
+A.    Testing with the arena
 ============================
 
 Crawl's arena mode can be used to pit one set of monsters against another and
@@ -48,7 +22,7 @@ prefixed with the channel name, to make grepping for results easier:
 
 See docs/arena.txt for more details.
 
-B.1  Testing specific problems with the arena
+A.1  Testing specific problems with the arena
 =============================================
 
 Using the arena to test problems with specific monsters is rather easy:
@@ -82,7 +56,7 @@ an appropriate amount is given automatically.
 For more on monster and item specifications, look up ITEM and MONS in
 docs/develop/level/syntax.txt
 
-B.2  Testing general problems with the arena
+A.2  Testing general problems with the arena
 ============================================
 
 You can also use the arena to just see if anything unusual is happening, or if
@@ -113,7 +87,7 @@ can forbid monsters with certain glyphs from being randomly generated:
 
     crawl -arena "ban_glyphs:J 10 random v 10 random"
 
-B.3  Getting the arena to run for a long time
+A.3  Getting the arena to run for a long time
 ==============================================
 
 By default the arena exits when all the monsters on one team die, ending the
@@ -154,7 +128,7 @@ through the monsters that can possibly appear in the place chosen by
 "arena_place:", rather than being chosen with the weights appropriate for that
 place. This will cause rare monsters to be generated a lot more often.
 
-B.4  Speeding up the arena
+A.4  Speeding up the arena
 ==========================
 
 You can speed up the arena by reducing the delay in miliseconds between turns.
@@ -166,7 +140,7 @@ This will cause there to be no delay between turns, or when animating beams or
 explosions. You can also set the option "arena_delay" in your init file to
 have it apply to all arena runs.
 
-B.5  Changing the arena terrain
+A.5  Changing the arena terrain
 ===============================
 
 You can change the terrain used in the arena with the "arena:" tag. For

--- a/crawl-ref/docs/develop/testing.md
+++ b/crawl-ref/docs/develop/testing.md
@@ -1,0 +1,162 @@
+# Testing
+
+## Contents
+
+* [Unit Tests](#unit-tests)
+  * [Plug & Play / Bisect Testing](#plug-play-bisect-testing)
+* [Functional (Lua) Tests](#functional-lua-tests)
+* [Arena Testing](#arena-testing)
+* [Code Coverage](#code-coverage)
+
+## Unit Tests
+
+Crawl integrates the Catch2 unit testing framework. Tests are in the [crawl-ref/source/catch2-tests](crawl-ref/source/catch2-tests) directory. To compile and run all units tests, use:
+
+```sh
+make catch2-tests
+```
+
+### Plug & Play / Bisect Testing
+
+`test_plug_and_play.cc` is an optional source file for catch2 tests. If
+the source file is available, the `make plug-and-play-tests` command
+will use it to create a catch2 tests binary. If the source file is not
+available, the `make plug-and-play-tests` command will fail. This source
+file is in the .gitignore and should never be added to the git project.
+
+The main use of `test_plug_and_play.cc` is for the file to be used in
+conjunction with the `git bisect` command. If you don't know how the git
+bisect command works, reference `git bisect --help` because otherwise
+none of the following will make sense.
+
+`test_plug_and_play.cc` is a file which:
+
+1. Compilations of versions of crawl older than master can search for
+catch2 tests
+2. Will not be overwritten by git history changes, such as those which
+occur while using git bisect.
+
+This combination of features allows for you to write tests once, then
+use them for any version of crawl which has previously existed, all the
+way back to the original implementation of catch2 support for crawl.
+
+While you are hunting down a bug introduced in newer versions of crawl,
+see if you can create a catch2 test which checks for the bug in
+`test_plug_and_play.cc`. Verify this test works with `make
+plug-and-play-tests`. Then, see if this test works correctly when you
+`git checkout` a version of crawl which does not have the bug. If both
+are true, you can use `test_plug_and_play.cc` to easily find the bug.
+
+Simply use git bisect as normally, but compile and run
+plug-and-play-tests instead of normal crawl. Whenever the bug is
+present, your test will fail and you can mark that commit as bad.
+Whenever the bug is absent, your test will pass and you can mark that
+commit as good.
+
+This test process is so easy git bisect allows you to automate it. Look
+into `git bisect run` for more details.
+
+When you've finished solving the bug, remember to move the new test from
+`test_plug_and_play.cc` to a regular test file included in the git
+project! This will help prevent regressions.
+
+## Functional (Lua) Tests
+
+Crawl has a set of functional tests in the [source/test/](crawl-ref/source/test/) directory, with each lua
+file being a separate unit test. To use unit tests, you must compile Crawl
+either with the macro `DEBUG_DIAGNOSTICS` defined (the debug make target) or
+with both the macros `DEBUG` and `DEBUG_TESTS` defined (the wizard make target,
+plus `-DDEBUG_TESTS`). You can then do
+
+```sh
+crawl -test
+```
+
+to run all unit tests. To run a particular test, you can do
+
+```sh
+crawl -test foo
+```
+
+and that will run all unit tests which have "foo" in their file name.
+
+If you want to write your own unit tests, take a look at the files in
+[source/test/](crawl-ref/source/test/) for examples. [los_maps.lua](crawl-ref/source/test/los_maps.lua) and [bounce.lua](crawl-ref/source/test/bounce.lua) have
+examples which use vaults (maps) which are located in test/des. You
+might need to create new Lua functions in the `source/l_*.cc` files if none of
+the `crawl.foo()`/`dgn.foo()`/etc functions do what you need.
+
+## Arena Testing
+
+You can use Crawl's arena mode to test a lot of things. See [arena.txt](crawl-ref/docs/develop/arena.txt) for more information.
+
+## Code Coverage
+
+Code coverage instrumentation is included in all debug & unit test builds. You can use it as follows:
+
+1. Compile the game in debug or unit test mode:
+
+```sh
+make debug
+# or
+make catch2-tests
+```
+
+2. Run the compiled binary to generate coverage data:
+
+```sh
+./crawl -test
+# or
+# ./catch2-test-executable # no need, Makefile ran this automatically
+```
+
+3. Generate the coverage report:
+
+```sh
+util/coverage # Add --help to see customisation options
+```
+
+### Quirks
+
+1. Coverage data from multiple runs is combined. This can lead to confusing execution counts for source code lines in reports. Use `make clean-coverage` to remove all temporary coverage files (including reports!).
+
+### A Quick Comparison of HTML Report Formats
+
+Sub-expression coverage covers the granularity of testing a line of code like this:
+
+```cpp
+if (test1() && test2())
+```
+
+#### lcov (genhtml)
+
+* Included with GCC on many Linux distributions (if not, easy to install)
+* No sub-expression coverage (line-coverage only)
+
+#### llvm-cov
+
+* Included with LLVM/Clang
+* Partial sub-expression coverage (will detect un-executed sub-expressions)
+
+#### gcovr
+
+* Python 3-based utility, harder to install on mingw and older systems
+* Full sub-expression coverage (will detect if each sub-expression was tested with a positive and negative test case)
+
+### Implementation Details
+
+Code coverage is handled very differently between the GCC and LLVM toolchains. The `Makefile` and `util/coverage` both auto-detect your toolchain, so this is abstracted away for general use. However, coverage percentages and details will be slightly different.
+
+#### GCC
+
+1. Compile with `-fprofile-arcs -ftest-coverage`
+2. When run, your executable creates `.gcda` and `.gcno` files (one per source file)
+3. Parse these with `gcov` into a `.gcov` file
+4. Generate reports with `genhtml`.
+
+#### LLVM
+
+1. Compile with `-fprofile-instr-generate -fcoverage-mapping`
+2. When run, your executable creates `default.profraw`
+3. Parse this with `llvm-profdata` into a `.profdata` file
+4. Generate reports with `llvm-cov`.

--- a/crawl-ref/docs/develop/testing.md
+++ b/crawl-ref/docs/develop/testing.md
@@ -118,7 +118,7 @@ util/coverage # Add --help to see customisation options
 
 ### Quirks
 
-1. Coverage data from multiple runs is combined. This can lead to confusing execution counts for source code lines in reports. Use `make clean-coverage` to remove all temporary coverage files (including reports!).
+1. Coverage data from multiple runs is combined. This can lead to confusing execution counts for source code lines in reports. Use `make clean-coverage` to remove all temporary coverage files (including reports).
 
 ### A Quick Comparison of HTML Report Formats
 
@@ -128,7 +128,7 @@ Sub-expression coverage covers the granularity of testing a line of code like th
 if (test1() && test2())
 ```
 
-#### lcov (genhtml)
+#### lcov / genhtml
 
 * Included with GCC on many Linux distributions (if not, easy to install)
 * No sub-expression coverage (line-coverage only)
@@ -149,10 +149,15 @@ Code coverage is handled very differently between the GCC and LLVM toolchains. T
 
 #### GCC
 
-1. Compile with `-fprofile-arcs -ftest-coverage`
-2. When run, your executable creates `.gcda` and `.gcno` files (one per source file)
-3. Parse these with `gcov` into a `.gcov` file
-4. Generate reports with `genhtml`.
+1. Compile with `-fprofile-arcs -ftest-coverage`, this generates `.gcno` files (one per source file)
+2. When run, your executable creates `.gcda` (one per source file)
+3. Use either `lcov`/`genhtml` or `gcovr`:
+    * `lcov`/`genhtml`
+        1. Parse `gcno`/`gcda` files with `lcov` into a `.info` file
+        2. Generate reports with `genhtml`.
+    * `gcovr`
+        1. Generate reports with `gcovr`.
+            * (`gcovr` uses `gcov` to parse `gcno`/`gcda` files.)
 
 #### LLVM
 

--- a/crawl-ref/source/.gitignore
+++ b/crawl-ref/source/.gitignore
@@ -1,0 +1,7 @@
+coverage-html-report/
+*.gcda
+*.gcno
+*.gcov
+default.profraw
+coverage.profdata
+coverage.info

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -118,7 +118,7 @@ ifdef FORCE_SSE
 CFOTHERS += -mfpmath=sse -msse2
 endif
 
-CFWARN := 
+CFWARN :=
 CFWARN_L := -Wall -Wformat-security -Wundef
 
 # Exceptions:
@@ -255,7 +255,7 @@ ifeq ($(uname_S),Darwin)
 		BUILD_SDL2 = YesPlease
 		BUILD_SDL2IMAGE = YesPlease
 		ifdef SOUND
-			ifndef WIN32 
+			ifndef WIN32
 				BUILD_SDL2MIXER = YesPlease
 			endif
 		endif
@@ -287,7 +287,7 @@ ifdef BUILD_ALL
 
 	BUILD_PCRE = YesPlease
 	ifdef SOUND
-		ifndef WIN32 
+		ifndef WIN32
 			BUILD_SDL2MIXER = YesPlease
 		endif
 	endif
@@ -720,7 +720,7 @@ SDL2_LDFLAGS := $(shell $(PKGCONFIG) sdl2 --libs-only-L) $(shell $(PKGCONFIG) sd
 endif
 
 ifdef SOUND
-ifndef WIN32 
+ifndef WIN32
 LIBS += -lSDL2_mixer
 endif
 endif
@@ -1029,7 +1029,7 @@ endif
 
 ifdef BUILD_PCRE
 DEFINES += -DREGEX_PCRE
-else 
+else
   ifdef USE_PCRE
   DEFINES += -DREGEX_PCRE
   LIBS += -lpcre

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -83,7 +83,8 @@ MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
 .SUFFIXES:       # ... so zap the suffix list to neutralize most predifined rules, too
 
 .PHONY: all test install clean clean-contrib clean-rltiles clean-android \
-        clean-catch2 clean-plug-and-play-tests clean-coverage \
+        clean-catch2 clean-plug-and-play-tests \
+		clean-coverage clean-coverage-full \
         distclean debug debug-lite profile package-source source \
         build-windows package-windows docs greet api api-dev android FORCE \
         monster catch2-tests plug-and-play-tests
@@ -1543,7 +1544,7 @@ ifeq ($(USE_DGAMELAUNCH),)
 endif
 
 clean: clean-rltiles clean-webserver clean-android clean-monster clean-catch2 \
-       clean-plug-and-play-tests clean-coverage
+       clean-plug-and-play-tests clean-coverage-full
 	+$(MAKE) -C $(UTIL) clean
 	$(RM) $(GAME) $(GAME).exe $(GENERATED_FILES) $(EXTRA_OBJECTS) libw32c.o\
 	    libunix.o $(ALL_OBJECTS) $(ALL_OBJECTS:.o=.d) *.ixx  \
@@ -1607,9 +1608,12 @@ plug-and-play-tests: $(CATCH2_PNP_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
 catch2-tests: catch2-tests-executable
 	./catch2-tests-executable
 
+clean-coverage-full: clean-coverage
+	find . -type f -name '*.gcno' -delete
+
 clean-coverage:
 	$(RM) default.profraw default.profdata coverage.info coverage.profdata
-	find . -type f \( -name '*.gcda' -or -name '*.gcno' \) -delete
+	find . -type f \( -name '*.gcda' -or -name '*.gcov' \) -delete
 	$(RM) -r coverage-html-report
 
 clean-catch2:

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -86,7 +86,7 @@ MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
         clean-catch2 clean-plug-and-play-tests clean-coverage \
         distclean debug debug-lite profile package-source source \
         build-windows package-windows docs greet api api-dev android FORCE \
-        monster just-compile-catch2-tests catch2-tests plug-and-play-tests
+        monster catch2-tests plug-and-play-tests
 
 include Makefile.obj
 
@@ -1097,14 +1097,6 @@ ifndef V
         QUIET_HOSTCC      = @echo '   ' HOSTCC $@;
         QUIET_PNGCRUSH    = @echo '   ' $(PNGCRUSH_LABEL) $@;
         QUIET_ADVPNG      = @echo '   ' ADVPNG $@;
-
-        # The following is just QUIET_LINK with a hard coded string
-        # replacing $@. The point of this is to fix a text bug where
-        # compiling catch2-tests would say
-        # "LINK just-compile-catch2-tests" when
-        # "LINK catch2-tests-executable" is more informative.
-
-        QUIET_CATCH2_LINK = @echo '   ' LINK catch2-tests-executable;
         export V
 endif
 endif
@@ -1603,8 +1595,8 @@ install-monster: monster
 	  echo 'Monster database of master branch on crawl.develz.org updated to: $(VERSION)' >>~/source/announcements.log;\
 	fi
 
-just-compile-catch2-tests: $(CATCH2_TEST_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
-	+$(QUIET_CATCH2_LINK)$(CXX) $(LDFLAGS) $(CATCH2_TEST_OBJECTS) -o catch2-tests-executable $(LIBS)
+catch2-tests-executable: $(CATCH2_TEST_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
+	+$(QUIET_LINK)$(CXX) $(LDFLAGS) $(CATCH2_TEST_OBJECTS) -o catch2-tests-executable $(LIBS)
 
 CATCH2_PNP_OBJECTS = $(OBJECTS) catch2-tests/test_plug_and_play.o \
                      catch2-tests/test_main.o $(EXTRA_OBJECTS)
@@ -1612,7 +1604,7 @@ CATCH2_PNP_OBJECTS = $(OBJECTS) catch2-tests/test_plug_and_play.o \
 plug-and-play-tests: $(CATCH2_PNP_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
 	+$(QUIET_LINK)$(CXX) $(LDFLAGS) $(CATCH2_PNP_OBJECTS) -o $@ $(LIBS)
 
-catch2-tests: just-compile-catch2-tests
+catch2-tests: catch2-tests-executable
 	./catch2-tests-executable
 
 clean-coverage:

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -83,7 +83,7 @@ MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
 .SUFFIXES:       # ... so zap the suffix list to neutralize most predifined rules, too
 
 .PHONY: all test install clean clean-contrib clean-rltiles clean-android \
-        clean-catch2 clean-plug-and-play-tests \
+        clean-catch2 clean-plug-and-play-tests clean-coverage \
         distclean debug debug-lite profile package-source source \
         build-windows package-windows docs greet api api-dev android FORCE \
         monster just-compile-catch2-tests catch2-tests plug-and-play-tests
@@ -783,6 +783,7 @@ ifneq (,$(filter debug,$(MAKECMDGOALS)))
 	FULLDEBUG=YesPlease
 	DEBUG=YesPlease
 	NO_OPTIMIZE=YesPlease
+	COVERAGE=YesPlease
 endif
 
 # Debug-Lite
@@ -790,6 +791,7 @@ endif
 ifneq (,$(filter debug-lite,$(MAKECMDGOALS)))
 	DEBUG=YesPlease
 	NO_OPTIMIZE=YesPlease
+	COVERAGE=YesPlease
 endif
 
 # Profile
@@ -797,10 +799,26 @@ endif
 ifneq (,$(filter profile,$(MAKECMDGOALS)))
 	FULLDEBUG=YesPlease
 	DEBUG=YesPlease
+	COVERAGE=YesPlease
+endif
+
+# Unit tests
+ifneq (,$(filter catch2-tests,$(MAKECMDGOALS)))
+	COVERAGE=YesPlease
 endif
 
 ifdef HURRY
 	NO_OPTIMIZE=YesPlease
+endif
+
+ifdef COVERAGE
+    # GCC
+    ifeq ($(shell $(GXX) -v 2>&1|grep clang),)
+		CFOPTIMIZE_L = -fprofile-arcs -ftest-coverage
+    else
+    # Clang
+		CFOPTIMIZE_L = -fprofile-instr-generate -fcoverage-mapping
+    endif
 endif
 
 ifdef FULLDEBUG
@@ -1533,7 +1551,7 @@ ifeq ($(USE_DGAMELAUNCH),)
 endif
 
 clean: clean-rltiles clean-webserver clean-android clean-monster clean-catch2 \
-       clean-plug-and-play-tests
+       clean-plug-and-play-tests clean-coverage
 	+$(MAKE) -C $(UTIL) clean
 	$(RM) $(GAME) $(GAME).exe $(GENERATED_FILES) $(EXTRA_OBJECTS) libw32c.o\
 	    libunix.o $(ALL_OBJECTS) $(ALL_OBJECTS:.o=.d) *.ixx  \
@@ -1596,6 +1614,11 @@ plug-and-play-tests: $(CATCH2_PNP_OBJECTS) $(CONTRIB_LIBS) dat/dlua/tags.lua
 
 catch2-tests: just-compile-catch2-tests
 	./catch2-tests-executable
+
+clean-coverage:
+	$(RM) default.profraw default.profdata coverage.info coverage.profdata
+	find . -type f \( -name '*.gcda' -or -name '*.gcno' \) -delete
+	$(RM) -r coverage-html-report
 
 clean-catch2:
 	$(RM) catch2-tests-executable catch2-tests-executable.exe

--- a/crawl-ref/source/util/coverage
+++ b/crawl-ref/source/util/coverage
@@ -84,6 +84,18 @@ def clean(name: str):
         die("Not sure how to do that actually...")
 
 
+def gcovr_common_args():
+    return (
+        "gcovr",
+        "--exclude=catch2-tests/catch.hpp",
+        "--exclude=conftest",
+        "--exclude=levcomp",
+        "--exclude=catch2-tests/catch.hpp",
+        "--exclude=conftest",
+        "--exclude=levcomp",
+    )
+
+
 def generate_report(generator, report_format, binary):
     if report_format == "html":
         clean("coverage-html-report")
@@ -112,25 +124,13 @@ def generate_report(generator, report_format, binary):
             ]
         )
     elif generator == "gcovr" and report_format == "summary":
-        run(
-            [
-                "gcovr",
-                "--keep",
-                # "--use-gcov-files",
-                "--print-summary",
-                "--exclude=catch2-tests/catch.hpp",
-                "--exclude=conftest",
-            ]
-        )
+        run([*gcovr_common_args(), "--print-summary"])
     elif generator == "gcovr" and report_format == "html":
         run(
             [
-                "gcovr",
-                "--keep",
-                # "--use-gcov-files",
+                *gcovr_common_args(),
                 "--html=coverage-html-report/index.html",
                 "--html-details",
-                "--exclude=conftest",
             ]
         )
     else:

--- a/crawl-ref/source/util/coverage
+++ b/crawl-ref/source/util/coverage
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+import os
+import shutil
+from typing import List
+
+ACCEPTABLE_COMBINATIONS = (
+    ("gcov", "genhtml", "html"),
+    ("clang", "llvm-cov", "html"),
+    ("gcov", "gcovr", "summary"),
+    ("gcov", "gcovr", "html"),
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Create a coverage report for Dungeon Crawl Stone Soup.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog="Acceptable combinations for coverage/generator/format:\n{combos}.".format(
+            combos=acceptable_combinations_description()
+        ),
+    )
+    parser.add_argument(
+        "-c",
+        "--coverage",
+        choices=("gcov", "clang"),
+        default=default_coverage(),
+        help="Coverage type. Use the same value you passed to the Makefile as COVERAGE. (auto-detected default)",
+    )
+    parser.add_argument(
+        "-g",
+        "--generator",
+        choices=("genhtml", "llvm-cov", "gcovr"),
+        default=default_generator(),
+        help="Report generator (auto-detected default)",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        choices=("html", "summary"),
+        default="html",
+        help="Report format",
+    )
+    parser.add_argument(
+        "-b",
+        "--binary",
+        choices=("crawl", "catch2-tests-executable"),
+        help="Binary to report on (auto-detected default)",
+        default=default_binary(),
+    )
+
+    return parser.parse_args()
+
+
+def acceptable_combinations_description():
+    return ", ".join("/".join(combo) for combo in sorted(ACCEPTABLE_COMBINATIONS))
+
+
+def sanity_check_args(args):
+    combo = (args.coverage, args.generator, args.format)
+    if combo not in ACCEPTABLE_COMBINATIONS:
+        die("Unsupported combination of coverage, generator & format.")
+
+    if not shutil.which(args.generator):
+        die(
+            "Report generator %s doesn't exist. Do you need to install it?"
+            % args.generator
+        )
+
+
+def clean(name: str):
+    if os.path.exists(name):
+        print("Deleting existing %s" % name)
+    else:
+        return
+    if os.path.isfile(name):
+        os.unlink(name)
+    elif os.path.isdir(name):
+        subprocess.run(["rm", "-r", name])
+    else:
+        die("Not sure how to do that actually...")
+
+
+def generate_report(generator, report_format, binary):
+    if report_format == "html":
+        clean("coverage-html-report")
+        os.makedirs("coverage-html-report")
+
+    if generator == "llvm-cov" and report_format == "html":
+        run(
+            [
+                "llvm-cov",
+                "show",
+                binary,
+                "-instr-profile=coverage.profdata",
+                "-format=html",
+                "-output-dir=coverage-html-report",
+            ]
+        )
+    elif generator == "genhtml":
+        run(
+            [
+                "genhtml",
+                "coverage.info",
+                "--output-directory",
+                "coverage-html-report",
+                "--ignore-errors",
+                "source",
+            ]
+        )
+    elif generator == "gcovr" and report_format == "summary":
+        run(
+            [
+                "gcovr",
+                "--keep",
+                # "--use-gcov-files",
+                "--print-summary",
+                "--exclude=catch2-tests/catch.hpp",
+                "--exclude=conftest",
+            ]
+        )
+    elif generator == "gcovr" and report_format == "html":
+        run(
+            [
+                "gcovr",
+                "--keep",
+                # "--use-gcov-files",
+                "--html=coverage-html-report/index.html",
+                "--html-details",
+                "--exclude=conftest",
+            ]
+        )
+    else:
+        die("Unhandled generator/format combo")
+
+    if report_format == "html" and shutil.which("open"):
+        run(["open", "coverage-html-report/index.html"])
+
+
+def prepare_intermediate_profiling_data(coverage: str, generator: str):
+    if coverage == "gcov" and generator != "gcovr":
+        clean("coverage.info")
+        run(
+            [
+                "lcov",
+                "--capture",
+                "--directory",
+                ".",
+                "--output-file",
+                "coverage.info",
+                "--ignore-errors",
+                "source",
+            ]
+        )
+    elif coverage == "gcov" and generator == "gcovr":
+        pass
+    elif coverage == "clang":
+        clean("coverage.profdata")
+        run(
+            [
+                "llvm-profdata",
+                "merge",
+                "-sparse",
+                "default.profraw",
+                "-o",
+                "coverage.profdata",
+            ]
+        )
+    else:
+        die("Can't prepare profiling data of unknown type (%s)." % coverage)
+
+
+def profiling_data_exists(coverage: str) -> bool:
+    if coverage == "gcov":
+        return os.path.isfile("english.gcda")  # file picked arbitrarily
+    elif coverage == "clang":
+        return os.path.isfile("default.profraw")
+    else:
+        die("Can't check for unknown type of profiling data (%s)." % coverage)
+
+
+def run(cmd: List[str]) -> int:
+    print("Running: %s" % " ".join(cmd))
+    ret = subprocess.call(cmd)
+    if ret != 0:
+        die("Command failed, exiting %s" % sys.argv[0])
+    return ret
+
+
+def die(msg: str):
+    print(msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def default_coverage() -> str:
+    # capture_output=True requires Python 3.7+ :(
+    p = subprocess.run(["cc", "-v"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if b"clang" in p.stderr.split(b"\n")[0]:
+        return "clang"
+    return "gcov"
+
+
+def default_generator() -> str:
+    if default_coverage() == "gcov":
+        return "genhtml"
+    else:
+        return "llvm-cov"
+
+
+def default_binary() -> str:
+    if os.path.isfile("catch2-tests-executable"):
+        return "catch2-tests-executable"
+    else:
+        return "crawl"
+
+
+def main():
+    if sys.version_info < (3, 5):
+        # hint for subprocess.run
+        raise ImportError("This script requires Python 3.5+")
+
+    args = parse_args()
+
+    print(
+        "Generating {format} report with {generator} for '{binary}' (with {coverage} coverage data)".format(
+            format=args.format,
+            generator=args.generator,
+            coverage=args.coverage,
+            binary=args.binary,
+        )
+    )
+
+    sanity_check_args(args)
+
+    if not profiling_data_exists(args.coverage):
+        die(
+            "There is no profiling data (hint: did you make {bin} with COVERAGE={cov} set and then run the binary?)".format(
+                bin=args.binary, cov=args.coverage
+            )
+        )
+
+    prepare_intermediate_profiling_data(args.coverage, args.generator)
+
+    generate_report(args.generator, args.format, args.binary)
+
+
+if __name__ == "__main__":
+    main()

--- a/crawl-ref/source/util/coverage
+++ b/crawl-ref/source/util/coverage
@@ -205,9 +205,10 @@ def default_coverage() -> str:
 
 def default_generator() -> str:
     if default_coverage() == "gcov":
+        if shutil.which("gcovr"):
+            return "gcovr"
         return "genhtml"
-    else:
-        return "llvm-cov"
+    return "llvm-cov"
 
 
 def default_binary() -> str:


### PR DESCRIPTION
Add code coverage tracking

Supports both GCC and LLVM toolchains.

Bluffer's guide:
1. make catch2-tests
2. util/coverage

More explanation has been added to testing.md (which reworks
testing.txt) and `util/coverage --help`.