### PR TITLE
Fix an information leak about Mara and rakshasa clones

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5038,7 +5038,8 @@ bool ench_flavour_affects_monster(beam_type flavour, const monster* mon,
         break;
 
     case BEAM_INNER_FLAME:
-        rc = !(mon->is_summoned() || mon->has_ench(ENCH_INNER_FLAME));
+        rc = !(mon->is_summoned() && !mon->is_illusion()
+               || mon->has_ench(ENCH_INNER_FLAME));
         break;
 
     case BEAM_PETRIFY:
@@ -5458,7 +5459,7 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
 
     case BEAM_INNER_FLAME:
         if (!mon->has_ench(ENCH_INNER_FLAME)
-            && !mon->is_summoned()
+            && (!mon->is_summoned() || mon->is_illusion())
             && mon->add_ench(mon_enchant(ENCH_INNER_FLAME, 0, agent())))
         {
             if (simple_monster_message(*mon,

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3200,8 +3200,12 @@ void read_scroll(item_def& scroll)
         bool had_effect = false;
         for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
         {
-            if (mons_immune_magic(**mi) || mi->is_summoned())
+            // Don't leak information about Mara and rakshasa clones.
+            if (mons_immune_magic(**mi)
+                || mi->is_summoned() && !mi->is_illusion())
+            {
                 continue;
+            }
 
             if (mi->add_ench(mon_enchant(ENCH_INNER_FLAME, 0, &you)))
                 had_effect = true;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -260,6 +260,13 @@ bool targeter_beam::affects_monster(const monster_info& mon)
     if (beam.flavour == BEAM_BECKONING)
         return grid_distance(mon.pos, you.pos()) > 1;
 
+    // Inner flame doesn't affect regular summons
+    if (beam.flavour == BEAM_INNER_FLAME && m->is_summoned()
+        && !m->is_illusion())
+    {
+        return false;
+    }
+
     return !beam.is_harmless(m) || beam.nice_to(mon)
     // Inner flame affects allies without harming or helping them.
            || beam.flavour == BEAM_INNER_FLAME && !m->is_summoned();


### PR DESCRIPTION
This PR fixes an information leak about Mara/rakshasa clones by making all illusions inner-flameable.