### PR TITLE
Encode nested colours in formatted_string

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -310,6 +310,7 @@ catch2-tests/test_coordit.o \
 catch2-tests/test_describe.o \
 catch2-tests/test_english.o \
 catch2-tests/test_files.o \
+catch2-tests/test_format.o \
 catch2-tests/test_items.o \
 catch2-tests/test_mon-util.o \
 catch2-tests/test_ng-init-branches.o \

--- a/crawl-ref/source/catch2-tests/test_format.cc
+++ b/crawl-ref/source/catch2-tests/test_format.cc
@@ -61,3 +61,23 @@ TEST_CASE( "formatted_string::parse_string_to_multiple() preserves nesting over 
         REQUIRE( out[1].to_colour_string() == "<red>1</red>" );
     }
 }
+
+TEST_CASE("formatted_string::add_glyph() reuses current colour",
+          "[single-file]")
+{
+    formatted_string str;
+    str.textcolour(RED);
+
+    str.add_glyph({' ', RED});
+
+    REQUIRE(str.to_colour_string() == "<red> ");
+}
+
+TEST_CASE("formatted_string::add_glyph() will push/pop colour"
+          "[single-file]")
+{
+    formatted_string str;
+    str.add_glyph({' ', RED});
+
+    REQUIRE(str.to_colour_string() == "<red> </red>");
+}

--- a/crawl-ref/source/catch2-tests/test_format.cc
+++ b/crawl-ref/source/catch2-tests/test_format.cc
@@ -1,0 +1,63 @@
+#include "catch.hpp"
+
+#include "AppHdr.h"
+#include "format.h"
+
+string roundtrip(string str)
+{
+    return formatted_string::parse_string(str, COLOUR_INHERIT).to_colour_string();
+};
+
+void check_roundtrip(string str)
+{
+    REQUIRE( str == roundtrip(str) );
+};
+
+TEST_CASE( "formatted_string::to_colour_string always close tags", "[single-file]" ) {
+    REQUIRE( roundtrip("<red>") == "<red></red>" );
+}
+
+TEST_CASE( "formatted_string round-trip preserves close tags", "[single-file]" ) {
+    check_roundtrip("");
+    check_roundtrip("test");
+    check_roundtrip("<<");
+    check_roundtrip(" \r\n test  \n\r ");
+    check_roundtrip("<red><green></green></red>");
+    check_roundtrip("<green> </green>");
+    check_roundtrip("<red> <green> </green> </red>");
+}
+
+TEST_CASE( "formatted_string::parse_string() warns on malformed input", "[single-file]" ) {
+    REQUIRE( roundtrip("<inherit>") == "<lightred><<inherit></lightred>" );
+    REQUIRE( roundtrip("<not-a-colour>") == "<lightred><<not-a-colour></lightred>" );
+    REQUIRE( roundtrip("</not-a-colour>") == "<lightred><</not-a-colour></lightred>" );
+    REQUIRE( roundtrip("<red> </blue> </red>") == "<red> <lightred><</blue></lightred> </red>" );
+    REQUIRE( roundtrip("<red> </blue> ") == "<red> <lightred><</blue></lightred> </red>" );
+    REQUIRE( roundtrip("<red >") == "<lightred><<red ></lightred>" );
+}
+
+TEST_CASE( "formatted_string::parse_string() parses unclosed/empty tags as text", "[single-file]" ) {
+    REQUIRE( roundtrip("<red ") == "<<red " );
+    REQUIRE( roundtrip("<red") == "<<red" );
+    REQUIRE( roundtrip("</red ") == "<</red " );
+    REQUIRE( roundtrip("</red") == "<</red" );
+    REQUIRE( roundtrip("</>") == "<</>" );
+    REQUIRE( roundtrip("</") == "<</" );
+    REQUIRE( roundtrip("<") == "<<" );
+    REQUIRE( roundtrip(">") == ">" );
+}
+
+TEST_CASE( "formatted_string::parse_string_to_multiple() preserves nesting over newlines", "[single-file]" ) {
+    {
+        vector<formatted_string> out;
+        formatted_string::parse_string_to_multiple("<red>01", out, 1);
+        REQUIRE( out[0].to_colour_string() == "<red>0</red>" );
+        REQUIRE( out[1].to_colour_string() == "<red>1</red>" );
+    }
+    {
+        vector<formatted_string> out;
+        formatted_string::parse_string_to_multiple("<red><green>0</green>1", out, 1);
+        REQUIRE( out[0].to_colour_string() == "<red><green>0</green></red>" );
+        REQUIRE( out[1].to_colour_string() == "<red>1</red>" );
+    }
+}

--- a/crawl-ref/source/format.cc
+++ b/crawl-ref/source/format.cc
@@ -513,9 +513,14 @@ void formatted_string::del_char()
 void formatted_string::add_glyph(cglyph_t g)
 {
     const int last_col = find_last_colour();
-    textcolour(g.col);
+    if (last_col != g.col)
+        textcolour(g.col);
     cprintf("%s", stringize_glyph(g.ch).c_str());
-    textcolour(last_col);
+    if (last_col != g.col)
+    {
+        textcolour(last_col);
+        ops.back().closing_colour = g.col;
+    }
 }
 
 void formatted_string::textcolour(int colour)

--- a/crawl-ref/source/format.h
+++ b/crawl-ref/source/format.h
@@ -48,6 +48,9 @@ public:
     int width() const;
     string html_dump() const;
 
+    int string_width() const;
+    int string_height() const;
+
     bool operator < (const formatted_string &other) const;
     bool operator == (const formatted_string &other) const;
     const formatted_string &operator += (const formatted_string &other);
@@ -128,3 +131,5 @@ inline formatted_string&& operator+(formatted_string&& lhs, const char* rhs)
 int count_linebreaks(const formatted_string& fs);
 
 void display_tagged_block(const string& s);
+
+formatted_string linebreak_formatted_string(const formatted_string &str, int max_str_width, int max_str_height);

--- a/crawl-ref/source/format.h
+++ b/crawl-ref/source/format.h
@@ -31,6 +31,10 @@ public:
     void cprintf(const string &s);
     void add_glyph(cglyph_t g);
     void textcolour(int colour);
+
+    void push_colour(int colour, vector<int> &colour_stack);
+    void pop_colour(vector<int> &colour_stack);
+
     formatted_string chop(int length) const;
     formatted_string chop_bytes(int length) const;
     formatted_string substr_bytes(int pos, int length) const;
@@ -78,7 +82,8 @@ public:
     struct fs_op
     {
         fs_op_type type;
-        int colour;
+        colour_t colour;
+        colour_t closing_colour = -1;
         string text;
 
         fs_op(int _colour) : type(FSOP_COLOUR), colour(_colour), text()

--- a/crawl-ref/source/ui.h
+++ b/crawl-ref/source/ui.h
@@ -772,14 +772,13 @@ protected:
     bool ellipsize = false;
 
     formatted_string m_text;
-#ifdef USE_TILE_LOCAL
     struct brkpt { unsigned int op, line; };
     vector<brkpt> m_brkpts;
     formatted_string m_text_wrapped;
+#ifdef USE_TILE_LOCAL
     ShapeBuffer m_hl_buf;
     FontWrapper *m_font;
 #else
-    vector<formatted_string> m_wrapped_lines;
     COLOURS m_bg_colour = BLACK;
 #endif
     Size m_wrapped_size = Size{-1};

--- a/crawl-ref/source/webserver/game_data/static/util.js
+++ b/crawl-ref/source/webserver/game_data/static/util.js
@@ -31,7 +31,8 @@ function () {
 
     function formatted_string_to_html(str)
     {
-        var other_open = false;
+        var colour_stack = [];
+
         var filtered = str.replace(/<?<(\/?[a-z]*)>?|>|&/ig, function (str, p1) {
             if (p1 === undefined)
                 p1 = "";
@@ -45,15 +46,20 @@ function () {
             {
                 if (closing)
                 {
-                    other_open = false;
-                    return "</span>";
+                    if (colour_stack.length == 0)
+                        return "";
+                    colour_stack.pop();
+                    var text = "</span>";
+                    if (colour_stack.length > 0)
+                        text += "<span class='fg" + colour_stack[colour_stack.length - 1] + "'>";
+                    return text;
                 }
                 else
                 {
                     var text = "<span class='fg" + cols[p1] + "'>";
-                    if (other_open)
+                    if (colour_stack.length > 0)
                         text = "</span>" + text;
-                    other_open = true;
+                    colour_stack.push(cols[p1]);
                     return text;
                 }
             }
@@ -67,8 +73,13 @@ function () {
                 }
             }
         });
-        if (other_open)
+
+        while (colour_stack.length > 0)
+        {
             filtered += "</span>";
+            colour_stack.pop();
+        }
+
         return filtered;
     }
 


### PR DESCRIPTION
This attempts to make formatted_string a closer fit to the textual
colour string format; nested colours are now encoded, and parsing a
colour string and then converting to a string again should in many cases
now be a no-op.

parse_string_to_multiple() is also changed so that the colour nesting is
preserved across newlines, i.e. the colour stack is unwound and then
rewound at each newline.

Not sure if anyone else has a preferred unit test style, e.g. BDD? Catch2 does support that, but I stuck with the existing style from `test_english.cc`.

Fixes https://crawl.develz.org/mantis/view.php?id=12143
Fixes #1224