### PR TITLE
Remove the per-weapon-type vorpal brand adjectives

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1360,15 +1360,15 @@ static string _describe_weapon(const item_def &item, bool verbose)
 
     if (you.duration[DUR_EXCRUCIATING_WOUNDS] && &item == you.weapon())
     {
-        description += "\nIt is temporarily rebranded; it is actually a";
+        description += "\nIt is temporarily rebranded; it is actually ";
         if ((int) you.props[ORIGINAL_BRAND_KEY] == SPWPN_NORMAL)
-            description += "n unbranded weapon.";
+            description += "an unbranded weapon.";
         else
         {
-            description += " weapon of "
-                        + ego_type_string(item, false,
-                           (brand_type) you.props[ORIGINAL_BRAND_KEY].get_int())
-                        + ".";
+            brand_type original = static_cast<brand_type>(
+                you.props[ORIGINAL_BRAND_KEY].get_int());
+            description += article_a(
+                weapon_brand_desc("weapon", item, false, original) + ".", true);
         }
     }
 

--- a/crawl-ref/source/item-name.h
+++ b/crawl-ref/source/item-name.h
@@ -157,8 +157,11 @@ const char *base_type_string(const item_def &item);
 
 string sub_type_string(const item_def &item, bool known = true);
 
-string ego_type_string(const item_def &item, bool terse = false, brand_type override_brand = SPWPN_NORMAL);
+string ego_type_string(const item_def &item, bool terse = false);
 string ghost_brand_name(brand_type brand, monster_type mtype);
+string weapon_brand_desc(const char *body, const item_def &weap,
+                         bool terse = false,
+                         brand_type override_brand = SPWPN_NORMAL);
 
 const char* potion_type_name(int potiontype);  //used in xom.cc
 const char* jewellery_effect_name(int jeweltype, bool terse = false) PURE; //used in l-item.cc


### PR DESCRIPTION
These mostly served to confuse players and hide the relation between
the vorpal brands.