### PR TITLE
Raise Troll Maces & Flails aptitude to +2

### DIFF
--- a/crawl-ref/source/dat/species/troll.yaml
+++ b/crawl-ref/source/dat/species/troll.yaml
@@ -13,7 +13,7 @@ aptitudes:
   short_blades: -2
   long_blades: -2
   axes: -2
-  maces_and_flails: -1
+  maces_and_flails: +2
   polearms: -2
   staves: -2
   slings: -4


### PR DESCRIPTION
This is intended to provide a replacement for Ogres old big club
aptitude and playstyle in Trolls.

This way Ogre stays more of a versatile fat human, while Trolls get an
alternative melee style that is not so clearly inferior to Unarmed
Combat. It also helps differentiate their relationship to big clubs.

Compared to unarmed combat, big clubs give Trolls a road that requires
less XP investment, and that rewards them with the possiblity of brands
and using god gifts - but punishes them by removing the possibility of
using shields like they tipically do with UC.

Right now, big clubs are usually not really worth pursuing for Ogres,
and simply inferior to UC for Trolls. This should help bring the
playstyle back for those that enjoyed it.