### PR TITLE
Make species-gen.py explicitly depend on python3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,7 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install ccache
-          sudo easy_install pip
-          sudo pip install PyYAML
+          sudo pip3 install PyYAML
       - name: Add ccache to PATH
         run: echo "::add-path::/usr/local/opt/ccache/libexec"
       - name: Cache compilation

--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -72,7 +72,7 @@ These instructions may work for other DPKG-based distros.
 
 ```sh
 sudo apt install build-essential libncursesw5-dev bison flex liblua5.1-0-dev \
-libsqlite3-dev libz-dev pkg-config python-yaml binutils-gold
+libsqlite3-dev libz-dev pkg-config python3-yaml binutils-gold
 
 # Dependencies for tiles builds
 sudo apt install libsdl2-image-dev libsdl2-mixer-dev libsdl2-dev \
@@ -87,7 +87,7 @@ These instructions may work for other RPM-based distros.
 
 ```sh
 sudo dnf install gcc gcc-c++ make bison flex ncurses-devel compat-lua-devel \
-sqlite-devel zlib-devel pkgconfig python-yaml
+sqlite-devel zlib-devel pkgconfig python3-yaml
 
 # Dependencies for tiles builds:
 sudo dnf install SDL2-devel SDL2_image-devel libpng-devel freetype-devel \
@@ -104,7 +104,7 @@ You need the following dependencies:
 * gcc / clang
 * perl
 * pkg-config
-* Python and PyYAML
+* Python 3 and PyYAML
 * libncurses
 * flex / bison (optional)
 

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -163,6 +163,11 @@ DOXYGEN = doxygen
 DOXYGEN_SIMPLE_CONF = crawl_simple.doxy
 DOXYGEN_ALL_CONF = crawl_all.doxy
 DOXYGEN_HTML_GEN = html/
+# Prefer python3, if available
+PYTHON = python
+ifneq (, $(shell which python3 2>&1))
+	PYTHON = python3
+endif
 
 export AR
 export RANLIB
@@ -1099,6 +1104,7 @@ ifndef V
         QUIET_HOSTCC      = @echo '   ' HOSTCC $@;
         QUIET_PNGCRUSH    = @echo '   ' $(PNGCRUSH_LABEL) $@;
         QUIET_ADVPNG      = @echo '   ' ADVPNG $@;
+        QUIET_PYTHON      = @echo '   ' PYTHON $@;
         export V
 endif
 endif
@@ -1725,18 +1731,16 @@ mi-enum.h: mon-info.h util/gen-mi-enum
 	$(QUIET_GEN)util/gen-mi-enum
 
 # species-gen.py creates multiple files at once. Ensure Make doesn't run it once
-# per target file. https://stackoverflow.com/q/2973445
+# per target file by adding all the files into a single dependency chain.
+# Ref: https://stackoverflow.com/q/2973445
 species-data.h: dat/species/*.yaml util/species-gen.py util/species-gen/*.txt
-	$(QUIET_GEN)util/species-gen.py dat/species/ util/species-gen/ species-data.h aptitudes.h species-groups.h species-type.h
-
+	$(QUIET_PYTHON)$(PYTHON) util/species-gen.py dat/species/ util/species-gen/ species-data.h aptitudes.h species-groups.h species-type.h
 # no-op
 aptitudes.h: species-data.h
 	$(QUIET_GEN)
-
 # no-op
 species-groups.h: aptitudes.h
 	$(QUIET_GEN)
-
 # no-op
 species-type.h: species-groups.h
 	$(QUIET_GEN)

--- a/crawl-ref/source/util/species-gen.py
+++ b/crawl-ref/source/util/species-gen.py
@@ -1,4 +1,11 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+"""
+Generate species-data.h, aptitudes.h, species-groups.h, and species-type.h
+
+Works with both Python 2 & 3. If that changes, update how the Makefile calls
+this.
+"""
 
 from __future__ import print_function
 
@@ -6,8 +13,12 @@ import argparse
 import os
 import sys
 import traceback
-import collections
 import re
+import collections
+if sys.version_info.major == 2:
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
 
 import yaml  # pip install pyyaml
 
@@ -17,7 +28,7 @@ def quote_or_nullptr(key, d):
     else:
         return 'nullptr'
 
-class Species(collections.MutableMapping):
+class Species(MutableMapping):
     """Parser for YAML definition files.
 
     If any YAML content is invalid, the relevant parser function below should


### PR DESCRIPTION
Rather than "python".

Currently this script works with both major versions, so `python` was
specified to use whatever version is installed. But we are starting to
see OSes that install Python 3 only with a python3 name and no python
shortcut. For example, macOS Catalina (10.15), and possibly msys mingw
on Windows.

This new behaviour follows recommendations from the Python project (PEP
394), so is likely to become more prevalent over time.

---

Older webtiles servers (CAO, CDO) may not have Python 3 already
installed, so will need some manual intervention.

If getting Python 3 on these servers proves too difficult, the build process could be changed to initialise a Python virtualenv and run the command within that (to guarantee the existence of a `python` binary). But this would add complexity to everyone else's build.