### PR TITLE
Clarified scroll only summons allied creatures

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1000,8 +1000,8 @@ covering only the reader, before it times out.
 %%%%
 scroll of summoning
 
-A scroll that calls forth several creatures woven from shadow into the shapes
-of those beings found within the reader's immediate vicinity.
+A scroll that calls forth several allied creatures woven from shadow into the
+shapes of those beings found within the reader's immediate vicinity.
 %%%%
 scroll of teleportation
 


### PR DESCRIPTION
Recently, a player new to DCSS pointed out she/he didn't know if a "scroll of summoning" would summon friendly or dangerous creatures:

https://old.reddit.com/r/dcss/comments/exa6zm/observations_from_a_dcss_newbie/

Which is a fair point.

I added a single word to clarify that this scroll only ever summons allies.