### PR TITLE
Cigotuvi's Embrace, unrand body armour

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1388,7 +1388,6 @@ COLOUR:   ETC_UNHOLY
 # XXX TODO: tiles
 LIFE:     1
 INSCRIP:  rRot
-BOOL:     evil
 
 # This entry must always be last.
 ENUM:   DUMMY2

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1388,6 +1388,7 @@ COLOUR:   ETC_UNHOLY
 # XXX TODO: tiles
 LIFE:     1
 INSCRIP:  rRot
+BOOL:     evil
 
 # This entry must always be last.
 ENUM:   DUMMY2

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1380,6 +1380,16 @@ TILE:     urand_staff_of_battle
 TILE_EQ:  battle_staff
 VALUE:    800
 
+ENUM:     EMBRACE
+NAME:     Cigotuvi's embrace
+OBJ:      OBJ_ARMOUR/ARM_LEATHER_ARMOUR
+PLUS:     +4 # varies with corpse count
+COLOUR:   ETC_UNHOLY
+# XXX TODO: tiles
+LIFE:     1
+INSCRIP:  rRot
+BOOL:     evil
+
 # This entry must always be last.
 ENUM:   DUMMY2
 NAME:   DUMMY UNRANDART 2

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -38,6 +38,7 @@
 #include "nearby-danger.h" // For Zhor
 #include "player.h"
 #include "player-stats.h"
+#include "showsymb.h"      // For Cigotuvi's Embrace
 #include "spl-cast.h"      // For evokes
 #include "spl-damage.h"    // For the Singing Sword.
 #include "spl-goditem.h"   // For Sceptre of Torment tormenting
@@ -1472,4 +1473,103 @@ static void _BATTLE_world_reacts(item_def */*item*/)
         your_spells(SPELL_BATTLESPHERE, 0, false);
         did_god_conduct(DID_SPELL_CASTING, 1);
     }
+}
+
+////////////////////////////////////////////////////
+
+static const int base_embrace_plus = 4;
+
+static void _EMBRACE_unequip(item_def *item, bool *show_msgs)
+{
+    int &armour = item->props[EMBRACE_ARMOUR_KEY].get_int();
+    if (armour > 0) {
+        _equip_mpr(show_msgs, "Your corpse armour falls away.");
+        armour = 0;
+        item->plus = base_embrace_plus;
+    }
+}
+
+/**
+ * Iterate over all corpses in LOS and harvest them.
+ *
+ * @return            The total number of corpses destroyed.
+ */
+static int _harvest_corpses()
+{
+    int harvested = 0;
+
+    for (radius_iterator ri(you.pos(), LOS_NO_TRANS); ri; ++ri)
+    {
+        for (stack_iterator si(*ri, true); si; ++si)
+        {
+            item_def &item = *si;
+            if (item.base_type != OBJ_CORPSES)
+                continue;
+
+            // forbid harvesting orcs under Beogh
+            if (you.religion == GOD_BEOGH)
+            {
+                const monster_type monnum
+                    = static_cast<monster_type>(item.orig_monnum);
+                if (mons_genus(monnum) == MONS_ORC)
+                    continue;
+            }
+
+            ++harvested;
+
+            // don't spam animations
+            if (harvested <= 5)
+            {
+                bolt beam;
+                beam.source = *ri;
+                beam.target = you.pos();
+                beam.glyph = get_item_glyph(item).ch;
+                beam.colour = item.get_colour();
+                beam.range = LOS_RADIUS;
+                beam.aimed_at_spot = true;
+                beam.item = &item;
+                beam.flavour = BEAM_VISUAL;
+                beam.draw_delay = 3;
+                beam.fire();
+                viewwindow();
+            }
+
+            destroy_item(item.index());
+        }
+    }
+
+    return harvested;
+}
+
+static void _EMBRACE_world_reacts(item_def *item)
+{
+    // roughly, the number of 10-aut turns the armour has left
+    int &armour = item->props[EMBRACE_ARMOUR_KEY].get_int();
+    const int harvested = _harvest_corpses();
+    // diminishing returns for more corpses
+    for (int i = 0; i < harvested; i++) {
+        armour += div_rand_round(100 * 100, (armour + 100));
+    }
+
+    // decay over time
+    armour -= div_rand_round(you.time_taken, 10);
+
+    const int last_plus = item->plus;
+    if (armour <= 0) {
+        armour = 0;
+        item->plus = base_embrace_plus;
+        if (last_plus > base_embrace_plus) {
+            mpr("Your corpse armour falls away.");
+        }
+    } else {
+        item->plus = base_embrace_plus + 1 + (armour-1) * 4 / 100;
+        if (item->plus < last_plus) {
+            mpr("A chunk of your corpse armour falls away.");
+        } else if (last_plus == base_embrace_plus) {
+            mpr("The bodies of the dead rush to embrace you!");
+        } else if (item->plus > last_plus)
+            mpr("Your shell of carrion and bone grows thicker.");
+    }
+
+    you.redraw_armour_class = true;
 }

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -16,6 +16,7 @@
 #define ARTEFACT_APPEAR_KEY "artefact_appearance"
 
 #define DAMNATION_BOLT_KEY "damnation_bolt"
+#define EMBRACE_ARMOUR_KEY "embrace_armour"
 
 struct bolt;
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -693,3 +693,10 @@ It was the mage Iskenderun's favorite playtoy. The staff increases the power of
 its wielder's conjurations. When danger looms, it conjures a battlesphere, the
 strength of which depends on the wielder's skill with Charms and Conjurations.
 %%%%
+Cigotuvi's embrace
+
+Armour borne of rotten flesh and bone and gristle, held intact by the will of a
+long-dead sorcerer. The dreadful energies within it call to the bodies of the
+recently dead, sucking them in, protecting the wearer with a cocoon of carrion.
+This protection only lasts a short time, however - the ward against decay holds
+true within, but not without.

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3933,8 +3933,16 @@ static rot_resistance _base_rot_resistance(const monster &mons) {
 rot_resistance monster::res_rotting(bool /*temp*/) const
 {
     const rot_resistance res = _base_rot_resistance(*this);
-    if (res == ROT_RESIST_NONE && get_mons_resist(*this, MR_RES_ROTTING))
+    if (res != ROT_RESIST_NONE)
+        return res;
+
+    if (get_mons_resist(*this, MR_RES_ROTTING))
         return ROT_RESIST_MUNDANE;
+
+    const item_def *armour = mslot_item(MSLOT_ARMOUR);
+    if (armour && is_unrandom_artefact(*armour, UNRAND_EMBRACE))
+        return ROT_RESIST_MUNDANE;
+
     return res;
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6303,11 +6303,15 @@ rot_resistance player::res_rotting(bool temp) const
         return ROT_RESIST_FULL;
     }
 
+    const item_def *armour = slot_item(EQ_BODY_ARMOUR);
+    const bool embraced = armour && is_unrandom_artefact(*armour, UNRAND_EMBRACE);
+    const rot_resistance base_res = embraced ? ROT_RESIST_MUNDANE : ROT_RESIST_NONE;
+
     switch (undead_state(temp))
     {
     default:
     case US_ALIVE:
-        return ROT_RESIST_NONE;
+        return base_res;
 
     case US_HUNGRY_DEAD:
         return ROT_RESIST_MUNDANE; // rottable by Zin, not by necromancy
@@ -6315,7 +6319,7 @@ rot_resistance player::res_rotting(bool temp) const
     case US_SEMI_UNDEAD:
         if (temp && !you.vampire_alive)
             return ROT_RESIST_MUNDANE;
-        return ROT_RESIST_NONE; // no permanent resistance
+        return base_res;
 
     case US_UNDEAD:
         return ROT_RESIST_FULL;


### PR DESCRIPTION
Cigotuvi's Embrace is a unique body armour (currently based on ring
mail) that automatically sucks up corpses within LOS and turns them
into temporary AC. This is primarily intended to provide a fun
press-your-luck mechanic - how long can you keep fighting and keep
your corpse armour on before you have to rest? It also comes as
something of a 'hunger' conduct (since you can't eat those corpses)
and effectively turns off most forms of necromancy, which can be a
plus or a minus, depending on whether you're a necromancer or your
enemies are.

At present, the Embrace starts as +4 rN+ rRot armour (the rRot is for
flavour). It goes to +8 with one corpse harvested, which takes about
100 turns to fully slough off. Four corpses give total ench +12 and
take 200 turns to fully go away, sixteen corpses give total ench +20 and
take 400 turns to fully rot away, etc. All numbers are very much open
to discussion.

The original Embrace was removed because it couldn't compete with
necromancy as a spell; as an unrand it might be more feasible to
balance and make fun.

Some levers to tweak:
- Base type. Ring mail seemed like a reasonable type - most characters can use it if they really want to, and Armour skill is at least a little relevant - but I'm not wedded to it. Going lighter is probably more interesting than going heavier, since the no-corpses conduct is usually a bit more relevant for casters than melee characters.
- Base enchantment. My goal was that the base case should be weak but not terrible, and +4 rN ring mail seems about right.
- The AC from one corpse. My goal was for this to get the armour to be good but not amazing; +8 rN ring seemed pretty decent.
- AC scaling from further corpses. Goal was diminishing returns but still some impact.
- The duration. I wanted players to be able to plausibly carry some AC between fights if they kept moving.
- The decaying-AC-over-time effect. The current approach (directly tying AC to remaining duration) means there's no hidden information for the player to track, but it does make the effect harder to reason about in some respects. 1 corpse is 4 ac for a 25 turns, then 3 ac for the next 25, etc. We could instead have the AC only slowly stack up until the whole thing falls off at once; that seems like its own flavour of mess, though...