### PR TITLE
Prevent swapping to regen when resting

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -128,6 +128,7 @@ static void _unequip_jewellery_effect(item_def &item, bool mesg, bool meld,
                                       equipment_type slot);
 static void _equip_use_warning(const item_def& item);
 static void _equip_regeneration_item(const item_def& item);
+static void _deactivate_regeneration_item(const item_def& item, bool meld);
 
 static void _assert_valid_slot(equipment_type eq, equipment_type slot)
 {
@@ -1103,6 +1104,9 @@ static void _unequip_armour_effect(item_def& item, bool meld,
         break;
     }
 
+    if (armour_type_prop(item.sub_type, ARMF_REGENERATION))
+        _deactivate_regeneration_item(item, meld);
+
     if (is_artefact(item))
         _unequip_artefact_effect(item, nullptr, meld, slot, false);
 }
@@ -1375,6 +1379,16 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
         auto_assign_item_slot(item);
 }
 
+static void _deactivate_regeneration_item(const item_def &item, bool meld)
+{
+    if (!meld)
+    {
+        string prop_key = item.base_type == OBJ_JEWELLERY ? REGEN_AMULET_ACTIVE
+            : REGEN_ARMOUR_ACTIVE;
+        you.props[prop_key] = 0;
+    }
+}
+
 static void _unequip_jewellery_effect(item_def &item, bool mesg, bool meld,
                                       equipment_type slot)
 {
@@ -1393,7 +1407,10 @@ static void _unequip_jewellery_effect(item_def &item, bool mesg, bool meld,
     case RING_STEALTH:
     case RING_TELEPORTATION:
     case RING_WIZARDRY:
+        break;
+
     case AMU_REGENERATION:
+        _deactivate_regeneration_item(item, meld);
         break;
 
     case RING_SEE_INVISIBLE:

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -902,7 +902,7 @@ static void _update_equipment_attunement_by_health()
     }
 
     string eq_str;
-    switch(eq_list.size())
+    switch (eq_list.size())
     {
     case 0:
         return;

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -915,6 +915,10 @@ static void _regenerate_hp_and_mp(int delay)
         "more quickly.", you.hp == you.hp_max, REGEN_AMULET_ACTIVE,
                              !you.get_mutation_level(MUT_NO_REGENERATION));
 
+    _update_equipment_attunement(EQ_BODY_ARMOUR, ARM_TROLL_LEATHER_ARMOUR,
+        "Your armour attunes itself to your body and you begin to regenerate "
+        "more quickly.", you.hp == you.hp_max, REGEN_ARMOUR_ACTIVE);
+
     _update_equipment_attunement(EQ_AMULET, AMU_ACROBAT,
         "Your amulet attunes itself to your body. You feel like doing "
         "cartwheels.", you.hp == you.hp_max, ACROBAT_AMULET_ACTIVE);

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -860,20 +860,16 @@ static void _handle_emergency_flight()
 
 // Some equipment only begins to function when some condition is met, e.g., full
 // health is reached.
-static void _update_equipment_attunement(equipment_type slot, int eq, string msg,
-                                         bool activate_condition, string prop_key,
-                                         bool active_requirement = true)
+static void _update_equipment_attunement(equipment_type slot, int eq,
+                                         string msg, bool activate_condition,
+                                         string prop_key)
 {
-    if (you.wearing(slot, eq) && active_requirement)
-    {
-        if (activate_condition && !you.props[prop_key].get_int())
+    if (you.wearing(slot, eq) && activate_condition
+        && !you.props[prop_key].get_int())
         {
             you.props[prop_key] = 1;
             mpr(msg);
         }
-    }
-    else
-        you.props[prop_key] = 0;
 }
 
 // cjo: Handles player hp and mp regeneration. If the counter
@@ -910,14 +906,16 @@ static void _regenerate_hp_and_mp(int delay)
 
     ASSERT_RANGE(you.hit_points_regeneration, 0, 100);
 
+    if (!you.get_mutation_level(MUT_NO_REGENERATION))
+    {
     _update_equipment_attunement(EQ_AMULET, AMU_REGENERATION,
         "Your amulet attunes itself to your body and you begin to regenerate "
-        "more quickly.", you.hp == you.hp_max, REGEN_AMULET_ACTIVE,
-                             !you.get_mutation_level(MUT_NO_REGENERATION));
+        "more quickly.", you.hp == you.hp_max, REGEN_AMULET_ACTIVE);
 
     _update_equipment_attunement(EQ_BODY_ARMOUR, ARM_TROLL_LEATHER_ARMOUR,
         "Your armour attunes itself to your body and you begin to regenerate "
         "more quickly.", you.hp == you.hp_max, REGEN_ARMOUR_ACTIVE);
+    }
 
     _update_equipment_attunement(EQ_AMULET, AMU_ACROBAT,
         "Your amulet attunes itself to your body. You feel like doing "

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -858,6 +858,24 @@ static void _handle_emergency_flight()
     }
 }
 
+// Some equipment only begins to function when some condition is met, e.g., full
+// health is reached.
+static void _update_equipment_attunement(equipment_type slot, int eq, string msg,
+                                         bool activate_condition, string prop_key,
+                                         bool active_requirement = true)
+{
+    if (you.wearing(slot, eq) && active_requirement)
+    {
+        if (activate_condition && !you.props[prop_key].get_int())
+        {
+            you.props[prop_key] = 1;
+            mpr(msg);
+        }
+    }
+    else
+        you.props[prop_key] = 0;
+}
+
 // cjo: Handles player hp and mp regeneration. If the counter
 // you.hit_points_regeneration is over 100, a loop restores 1 hp and decreases
 // the counter by 100 (so you can regen more than 1 hp per turn). If the counter
@@ -892,7 +910,14 @@ static void _regenerate_hp_and_mp(int delay)
 
     ASSERT_RANGE(you.hit_points_regeneration, 0, 100);
 
-    update_amulet_attunement_by_health();
+    _update_equipment_attunement(EQ_AMULET, AMU_REGENERATION,
+        "Your amulet attunes itself to your body and you begin to regenerate "
+        "more quickly.", you.hp == you.hp_max, REGEN_AMULET_ACTIVE,
+                             !you.get_mutation_level(MUT_NO_REGENERATION));
+
+    _update_equipment_attunement(EQ_AMULET, AMU_ACROBAT,
+        "Your amulet attunes itself to your body. You feel like doing "
+        "cartwheels.", you.hp == you.hp_max, ACROBAT_AMULET_ACTIVE);
 
     // MP Regeneration
     if (!player_regenerates_mp())
@@ -913,7 +938,10 @@ static void _regenerate_hp_and_mp(int delay)
 
     ASSERT_RANGE(you.magic_points_regeneration, 0, 100);
 
-    update_mana_regen_amulet_attunement();
+    _update_equipment_attunement(EQ_AMULET, AMU_MANA_REGENERATION,
+        "Your amulet attunes itself to your body and you begin to regenerate "
+        "magic more quickly.", you.magic_points == you.max_magic_points,
+        MANA_REGEN_AMULET_ACTIVE);
 }
 
 void player_reacts()

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1182,61 +1182,6 @@ int player_mp_regen()
     return regen_amount;
 }
 
-// Some amulets need to be worn while at full health before they begin to
-// function.
-void update_amulet_attunement_by_health()
-{
-    // amulet of regeneration
-    // You must be wearing the amulet and able to regenerate to get benefits.
-    if (you.wearing(EQ_AMULET, AMU_REGENERATION)
-        && you.get_mutation_level(MUT_NO_REGENERATION) == 0)
-    {
-        // If you hit max HP, turn on the amulet.
-        if (you.hp == you.hp_max
-            && you.props[REGEN_AMULET_ACTIVE].get_int() == 0)
-        {
-            you.props[REGEN_AMULET_ACTIVE] = 1;
-            mpr("Your amulet attunes itself to your body and you begin to "
-                "regenerate more quickly.");
-        }
-    }
-    else
-        you.props[REGEN_AMULET_ACTIVE] = 0;
-
-    // amulet of the acrobat
-    if (you.wearing(EQ_AMULET, AMU_ACROBAT))
-    {
-        if (you.hp == you.hp_max
-            && you.props[ACROBAT_AMULET_ACTIVE].get_int() == 0)
-        {
-            you.props[ACROBAT_AMULET_ACTIVE] = 1;
-            mpr("Your amulet attunes itself to your body. You feel like "
-                "doing cartwheels.");
-        }
-    }
-    else
-        you.props[ACROBAT_AMULET_ACTIVE] = 0;
-}
-
-// Amulet of magic regeneration needs to be worn while at full magic before it
-// begins to function.
-void update_mana_regen_amulet_attunement()
-{
-    if (you.wearing(EQ_AMULET, AMU_MANA_REGENERATION)
-        && player_regenerates_mp())
-    {
-        if (you.magic_points == you.max_magic_points
-            && you.props[MANA_REGEN_AMULET_ACTIVE].get_int() == 0)
-        {
-            you.props[MANA_REGEN_AMULET_ACTIVE] = 1;
-            mpr("Your amulet attunes itself to your body and you begin to "
-                "regenerate magic more quickly.");
-        }
-    }
-    else
-        you.props[MANA_REGEN_AMULET_ACTIVE] = 0;
-}
-
 int player_hunger_rate()
 {
     int hunger = 3;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1093,17 +1093,19 @@ static int _player_bonus_regen()
     int rr = 0;
 
     // Jewellery.
-    if (you.props[REGEN_AMULET_ACTIVE].get_int() == 1)
+    if (you.activated[EQ_AMULET])
         rr += REGEN_PIP * you.wearing(EQ_AMULET, AMU_REGENERATION);
 
-    // Artefact & Troll Leather Armour
-    item_def *armour = you.slot_item(EQ_BODY_ARMOUR);
-    if (you.props[REGEN_ARMOUR_ACTIVE].get_int() && armour)
+    // Artefacts (artp_regen is only on armour) and troll leather armour
+    for (int slot = EQ_MIN_ARMOUR; slot <= EQ_MAX_ARMOUR; ++slot)
     {
-        if (is_artefact(*armour) && artefact_property(*armour, ARTP_REGENERATION))
+        if (you.melded[slot] || you.equip[slot] == -1 || !you.activated[slot])
+            continue;
+        const item_def &arm = you.inv[you.equip[slot]];
+        if (armour_type_prop(arm.sub_type, ARMF_REGENERATION))
             rr += REGEN_PIP;
-        if (armour_type_prop(armour->sub_type, ARMF_REGENERATION))
-            rr += REGEN_PIP;
+        if (is_artefact(arm))
+            rr += REGEN_PIP * artefact_property(arm, ARTP_REGENERATION);
     }
 
     // Fast heal mutation.
@@ -1986,7 +1988,7 @@ bool player_is_shapechanged()
 
 void update_acrobat_status()
 {
-    if (you.props[ACROBAT_AMULET_ACTIVE].get_int() != 1)
+    if (!you.wearing(EQ_AMULET, AMU_ACROBAT) || !you.activated[EQ_AMULET])
         return;
 
     // Acrobat duration goes slightly into the next turn, giving the
@@ -4988,6 +4990,7 @@ player::player()
     equip.init(-1);
     melded.reset();
     unrand_reacts.reset();
+    activated.reset();
     last_unequip = -1;
 
     symbol          = MONS_PLAYER;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1096,12 +1096,15 @@ static int _player_bonus_regen()
     if (you.props[REGEN_AMULET_ACTIVE].get_int() == 1)
         rr += REGEN_PIP * you.wearing(EQ_AMULET, AMU_REGENERATION);
 
-    // Artefacts
-    rr += REGEN_PIP * you.scan_artefacts(ARTP_REGENERATION);
-
-    // Troll leather
-    if (you.wearing(EQ_BODY_ARMOUR, ARM_TROLL_LEATHER_ARMOUR))
-        rr += REGEN_PIP;
+    // Artefact & Troll Leather Armour
+    item_def *armour = you.slot_item(EQ_BODY_ARMOUR);
+    if (you.props[REGEN_ARMOUR_ACTIVE].get_int() && armour)
+    {
+        if (is_artefact(*armour) && artefact_property(*armour, ARTP_REGENERATION))
+            rr += REGEN_PIP;
+        if (armour_type_prop(armour->sub_type, ARMF_REGENERATION))
+            rr += REGEN_PIP;
+    }
 
     // Fast heal mutation.
     rr += you.get_mutation_level(MUT_REGENERATION) * REGEN_PIP;

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -44,10 +44,7 @@
 #define POWERED_BY_DEATH_KEY "powered_by_death_strength"
 #define SONG_OF_SLAYING_KEY "song_of_slaying_bonus"
 #define FORCE_MAPPABLE_KEY "force_mappable"
-#define REGEN_AMULET_ACTIVE "regen_amulet_active"
-#define REGEN_ARMOUR_ACTIVE "regen_armour_active"
 #define MANA_REGEN_AMULET_ACTIVE "mana_regen_amulet_active"
-#define ACROBAT_AMULET_ACTIVE "acrobat_amulet_active"
 #define SAP_MAGIC_KEY "sap_magic_amount"
 #define TEMP_WATERWALK_KEY "temp_waterwalk"
 #define EMERGENCY_FLIGHT_KEY "emergency_flight"
@@ -168,6 +165,10 @@ public:
     FixedBitVector<NUM_EQUIP> melded;
     // Whether these are unrands that we should run the _*_world_reacts func for
     FixedBitVector<NUM_EQUIP> unrand_reacts;
+    // True if the slot has an item that activates when worn with max hp (regen
+    // items, acrobat amulet) and max hp has been reached while wearing it;
+    // false otherwise.
+    FixedBitVector<NUM_EQUIP> activated;
 
     FixedArray<int, NUM_OBJECT_CLASSES, MAX_SUBTYPES> force_autopickup;
 

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -999,8 +999,6 @@ int player_prot_life(bool calc_unid = true, bool temp = true,
 bool regeneration_is_inhibited();
 int player_regen();
 int player_mp_regen();
-void update_amulet_attunement_by_health();
-void update_mana_regen_amulet_attunement();
 
 int player_res_cold(bool calc_unid = true, bool temp = true,
                     bool items = true);

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -45,6 +45,7 @@
 #define SONG_OF_SLAYING_KEY "song_of_slaying_bonus"
 #define FORCE_MAPPABLE_KEY "force_mappable"
 #define REGEN_AMULET_ACTIVE "regen_amulet_active"
+#define REGEN_ARMOUR_ACTIVE "regen_armour_active"
 #define MANA_REGEN_AMULET_ACTIVE "mana_regen_amulet_active"
 #define ACROBAT_AMULET_ACTIVE "acrobat_amulet_active"
 #define SAP_MAGIC_KEY "sap_magic_amount"

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -240,6 +240,7 @@ enum tag_minor_version
     TAG_MINOR_GHOST_MAGIC,         // Ghost update for positional magic
     TAG_MINOR_MORE_GHOST_MAGIC,    // Update already placed ghosts for positional magic
     TAG_MINOR_DUMMY_AGILITY,       // Convert garbage "agility" potions into stab
+    TAG_MINOR_TRACK_REGEN_ITEMS,   // Regen items take effect only after maxhp is reached
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1411,6 +1411,8 @@ static void tag_construct_you(writer &th)
         marshallByte(th, you.equip[i]);
     for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
         marshallBoolean(th, you.melded[i]);
+    for (int i = EQ_FIRST_EQUIP; i < NUM_EQUIP; ++i)
+        marshallBoolean(th, you.activated[i]);
 
     ASSERT_RANGE(you.magic_points, 0, you.max_magic_points + 1);
     marshallUByte(th, you.magic_points);
@@ -2484,6 +2486,17 @@ static void tag_read_you(reader &th)
         you.melded.set(i, unmarshallBoolean(th));
     for (int i = count; i < NUM_EQUIP; ++i)
         you.melded.set(i, false);
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_TRACK_REGEN_ITEMS)
+    {
+#endif
+        for (int i = 0; i < count; ++i)
+            you.activated.set(i, unmarshallBoolean(th));
+        for (int i = count; i < NUM_EQUIP; ++i)
+            you.activated.set(i, false);
+#if TAG_MAJOR_VERSION == 34
+    }
+#endif
 
     you.magic_points              = unmarshallUByte(th);
     you.max_magic_points          = unmarshallByte(th);


### PR DESCRIPTION
The main effect of these commits is to make troll leather armour and artefact armour with regen+ behave like "regen in requiring you to have full hp before getting the bonus to your regen rate. This should prevent the pattern of swapping back and forth between TLA and your "real" armour in order to regen faster with TLA while resting. This is fairly boring and repetitive gameplay, and at the cost of tedium allows one to get a part of the armour's benefit without committing to using the armour as armour.