### PR TITLE
Disallow -tele on artefact weapons and jewellery

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -561,7 +561,9 @@ static bool _artp_can_go_on_item(artefact_prop_type prop, const item_def &item,
             // and obv we shouldn't generate contradictory props
         case ARTP_PREVENT_TELEPORTATION:
             return !extant_props[ARTP_BLINK]
-                   && !extant_props[ARTP_CAUSE_TELEPORTATION];
+                   && !extant_props[ARTP_CAUSE_TELEPORTATION]
+                   && item_class != OBJ_WEAPONS
+                   && item_class != OBJ_JEWELLERY;
             // no contradictory props
         case ARTP_BLINK:
             return !extant_props[ARTP_PREVENT_TELEPORTATION];


### PR DESCRIPTION
-tele is usually not a meaningful bad artefact property on weapons and
jewellery, since swapping away from those items is so quick.
Furthermore, putting -tele on quick-swapping items allows the player to
explore with a -tele item equipped and swap to their "real" equipment
for fights, thereby avoiding teleport traps and teleportitis at marginal
cost. This is frustratingly uninteresting gameplay. And it allows the
player to neutralize the gameplay benefits of teleport traps with little
risk and no real investment or decision-making regarding their
character's loadout.

A simple solution is to prevent -tele from spawning on any weapons or
jewellery. We could also try to make sure that on jewellery and weapons
-tele always pairs with other properties that make swapping less
trivial (*contam, fragile, harm, etc.), but I am skeptical that the
complexity is worth the trouble.

I also considered changing the behaviour of -tele to stop translocations
only from an internal source. Then wearing -tele would not affect
teleporting unless the player could already choose whether or not to
teleport, so there is no reason to swap to -tele to explore. However
this is additional "player-facing" complexity, in that there is another
somewhat fiddly rule for the player to learn; even very careful players
don't need to know about rules governing placement of artefact
properties. Furthermore it does not address the first issue mentioned,
that weapon and jewellery -tele is rarely an interesting drawback.
Finally this approach takes away an arguably interesting strategic
choice that players are making, to wear -tele on armour to prevent
teleport traps in particular places (esp. Zot).