### PR TITLE
Let scroll of immolation affect summons

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3196,12 +3196,8 @@ void read_scroll(item_def& scroll)
         bool had_effect = false;
         for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
         {
-            // Don't leak information about Mara and rakshasa clones.
-            if (mons_immune_magic(**mi)
-                || mi->is_summoned() && !mi->is_illusion())
-            {
+            if (mons_immune_magic(**mi))
                 continue;
-            }
 
             if (mi->add_ench(mon_enchant(ENCH_INNER_FLAME, 0, &you)))
                 had_effect = true;


### PR DESCRIPTION
Since this scroll was added in 388d670c250b25dcf88b5f54042bb083f48a9a51,
the effect has been limited to non-summoned creatures. It's hard to be
exactly sure why.

This limitation is a little non-intuitive, and for a limited resource
like scrolls, probably unnecessary. The scrolls are situational enough
as-is.

---

If you decide not to accept this PR, please update the description to mention the scroll has no effect on summoned creatures.