### PR TITLE
Don't fail CI if Codecov upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,4 +230,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.info
           flags: catch2
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Pull requests from forked repositories don't have access to secrets in
the master branch (because attackers could trivially retrieve them).
This means we can't upload Codecov reports from cross-repo pull
requests.

Luckily, the Codecov action has an option for this.

(In future, it would be better if this value was `true` for in-repo
builds and false for cross-repo builds, but the implementation of that
is awkward and probably not worth it. (For the record: write a previous
step which uses a shell script to determine the parent repo and set
`true` or `false` as an output, which you can reference to set the value
of fail_ci_if_error.)