### PR TITLE
Put runes back on default autopickup (Lici the Crawler)

### DIFF
--- a/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
+++ b/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
@@ -6,7 +6,7 @@ ae := autopickup_exceptions
 ae = <rune of Zot
 
 # Make it harder to miss out on zigfigs.
-ae = <figurine of a ziggurat
+ae += <figurine of a ziggurat
 
 ### exclusions ###
 


### PR DESCRIPTION
Fixes a syntax error in 458a23e4a.