### PR TITLE
Added tactical options to the small arrival vaults

### DIFF
--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -110,29 +110,28 @@ ENDMAP
 
 ###############################################################################
 NAME:   evilmike_arrival_fibonacci_small
-TAGS:   arrival no_monster_gen
+TAGS:   arrival no_monster_gen no_trap_gen
 ORIENT: float
 WEIGHT: 6
 NSUBST: U = 1:+ / *:x, V = 1:+ / *:x, W = 1:+ / *:x, X = 1:+ / *:x
-SUBST:  .= .:2500 1
-MONS:   rat
+NSUBST: Y = 1:+ / *:x, Z = 1:+ / *:x
 MAP
-    xxxxxxxxxxxx
-    xxx........x
-    xxx........x
-xxxxxxx........x
-xxxxxxx........x
-xxxxxxx........x
-x.....W........x
-x.....W........x
+      xxxxxxxYYx
+      x........Y
+      x........Y
+      x........x
+      x........x
+xZZxxxx........x
+Z.....W........x
+Z.....W........x
 x.....W........x
 x.....xxxxxXXXXx
 x.....x{+.x
 xxxxVVxxx+x
-xxxx...U..x
-xxxx...U..x
- xxx...xxxx
- xxxxxxxxxx
+   x...U..x
+   x...U..x
+   x...xxxx
+   xxxxx
 ENDMAP
 
 ###############################################################################
@@ -308,17 +307,17 @@ SUBST:   T = T V G b:3 .:3
 SUBST:   [ = G
 SUBST:   ( = G
 MAP
-xxxxxxx+xxxxxxx
+    x+xxx+x
 xxxxx.....xxxxx
 x...x.....x...x
 x.{.+..T..+.[.x
 x...x.....x...x
 xxxxx.....xxxxx
-xxxxxxx+xxxxxxx
-xxxxxx...xxxxxx
-   xxx.(.xxx
-   xxx...xxx
-   xxxxxxxxx
+    xxx+xxx
+     x...x
+     x.(.x
+     x...x
+     xxxxx
 ENDMAP
 
 ##############################################################
@@ -514,16 +513,17 @@ TAGS:   arrival no_monster_gen
 WEIGHT: 8
 ORIENT: float
 : if crawl.one_chance_in(4) then
-SUBST:  ABCDEFGH = +
-SUBST:  abcdefgh = x
+SUBST:  ABCDEFGHJ = +
+SUBST:  abcdefghj = x
 : else
-SUBST:  a=A, b=B, c=C, d=D, e=E, f=F, g=G, h=H
+SUBST:  a=A, b=B, c=C, d=D, e=E, f=F, g=G, h=H, j=J
 NSUBST: A = 1:+ / *:X , B = 1:+ / *:X , C = 1:+ / *:X , D = 1:+ / *:X
 NSUBST: E = 1:+ / *:X , F = 1:+ / *:X , G = 1:+ / *:X , H = 1:+ / *:X
+NSUBST: J = 1:+ / *:X
 SUBST:  X:Xxxx+, X=xx+
 : end
 MAP
-xxxxxxxxxxx
+xJjjxxxxxxx
 x.........H
 x.........h
 x.........h
@@ -546,14 +546,14 @@ xxxxxxxxxxxxxxxxxx
 ENDMAP
 
 NAME:   minmay_arrival_widening_spiral_narrow
-TAGS:   arrival no_monster_gen
+TAGS:   arrival no_monster_gen no_trap_gen
 WEIGHT: 2
 ORIENT: float
 MAP
-xxxxxxxxxxx
-x.........+
-x.xxxxxxxxx
-x.x.......+
+xxxxxxxxxxxxxxxxxx
+x.........+.......
+x.xxxxxxxxx.xxxxx.
+x.x.......+.......
 x.x.xxxxxxxxxxxxxx
 x.x.x.....+......x
 x.x.x.xxxxxxxxxx.x
@@ -577,21 +577,22 @@ ENDMAP
 NAME:   minmay_arrival_loop
 TAGS:   arrival no_monster_gen
 ORIENT: float
+NSUBST: B = 1:{ / *:.
 MAP
       xxxxxxx
     xxx.....xxx
    xx.........xx
-  xx.....x.....xx
+  xx....Bx.....xx
   x.....xxx.....x
- xx.....xxx.....xx
+ xx....Bxxx.....xx
  x.....xxxxx.....x
  x.....xxxxx.....x
  x.....xxxxx.....x
  x.....xxxxx.....x
  xx.....xxx.....xx
   x.....xxx.....x
-  xx.....x.....xx
-   xx...{x....xx
+  xx...........xx
+   xx...Bx....xx
     xxxxxx@.xxx
 ENDMAP
 
@@ -832,13 +833,12 @@ TAGS:    arrival no_monster_gen no_rotate
 ORIENT:  float
 SHUFFLE: cxxx
 NSUBST:  . = 1:d / *:.
-SUBST:   e = .+
 SUBST:   T = TVVVV
 ITEM:    stone
 MAP
       ...................
       ..ccccccccccccccc..
-    ccecc.............ccecc
+    cc+cc.............cc+cc
   ccc..........T..........ccc
  cc...T.................T...cc
 cc........T.........T........cc
@@ -858,21 +858,22 @@ TAGS:    arrival no_monster_gen no_rotate
 ORIENT:  float
 SHUFFLE: cxxx
 NSUBST:  . = 1:d / *:.
+NSUBST:  e = 2:+ / *:.
 ITEM:    stone
 SUBST:   T = TVVVV
 MAP
      ccccccccccc
   cccc.........cccc
  cc...............cc
- c......T...T......c
+ e......T...T......e
 cc...T.........T...cc
 c.........w.........c
 c...T...........T...c
-c{.....w.....w......@
+c{.....w.....w......e
 c...T...........T...c
 c.........w.........c
 cc...T.........T...cc
- c......T...T......c
+ e......T...T......e
  cc...............cc
   cccc.........cccc
      ccccccccccc
@@ -900,7 +901,7 @@ cc...................cc
 c......T.......T......c
 c..........T..........c
 cc...................cc
-ccccccccccc@ccccccccccc
+cc+ccccccccccccccccc+cc
 ENDMAP
 
 ##############################################################################
@@ -940,6 +941,8 @@ SHUFFLE: cxxx
 NSUBST:  . = 1:d / *:.
 ITEM:    stone
 SUBST:   T = TVVVV
+SUBST:   D = c@
+KMASK:   Z = no_trap_gen
 MAP
    ccccccccccccccccc
   cc.ccccccccccccc.cc
@@ -954,9 +957,9 @@ ccccccc....{....ccccccc
    cccccc..T..cccccc
     cccc.......cccc
      cc..T...T..cc
-     c.....T.....c
+     @Z....T....Z@
      ccc.......ccc
-       cccc@cccc
+       ccccDcccc
 ENDMAP
 
 ##############################################################################
@@ -1570,39 +1573,6 @@ xx...xx.x+x
 ENDMAP
 
 ##############################################################################
-###############################################################################
-# Sounds of Crawl: the *ZOT*
-NAME:    evilmike_arrival_sounds_zot
-TAGS:    arrival no_monster_gen
-ORIENT:  float
-WEIGHT:  1
-KPROP:   >'Z1 = no_tele_into
-KFEAT:   Z = zot trap
-SHUFFLE: vXc
-NSUBST:  { = 1:{ / *:.
-MONS:    generate_awake ooze
-MAP
-     v..@..v
-    vvv...vvv
-   vvvvv{vvvvv
-  vvvvvvvvvvvvv
- vvvvvvvvvvvvvvv
-vvvvvvvvvvvvvvvvv
-.vvvvv>''''vvvvv.
-..vvvv'''''vvvv..
-@.{vvv''Z''vvv{.@
-..vvvv'''''vvvv..
-.vvvvv''1''vvvvv.
-vvvvvvvvvvvvvvvvv
- vvvvvvvvvvvvvvv
-  vvvvvvvvvvvvv
-   vvvvv{vvvvv
-    vvv...vvv
-     v..@..v
-ENDMAP
-
-
-
 ##############################################################################
 NAME:    dpeg_arrival_arbitrary_a
 TAGS:    arrival
@@ -2154,24 +2124,6 @@ x.....{x{x{.....x
 xxxxxxxxxxxxxxxxx
 ENDMAP
 
-##############################################################
-NAME:    onia_arrival_larder
-TAGS:    arrival
-ORIENT:  float
-MONS:    w:100 rat / w:50 giant cockroach / quokka
-SUBST:   ? = .:30 1:20
-MAP
-xxxxxxxxxx@xxxxxxxxxx
-xxxx?x?x?x.x?x?x?xxxx
-xxxx+x+x+x+x+x+x+xxxx
-xxxx.x.x.x.x.x.x.xxxx
-x?+.......{.......+?x
-xxxx.x.x.x.x.x.x.xxxx
-xxxx+x+x+x+x+x+x+xxxx
-xxxx?x?x?x?x?x?x?xxxx
-xxxxxxxxxxxxxxxxxxxxx
-ENDMAP
-
 #############################
 NAME:    onia_arrival_handbag
 TAGS:    arrival
@@ -2547,7 +2499,7 @@ TAGS:   arrival no_monster_gen
 ORIENT: float
 SUBST:  x : x:10 c:2 v:1
 SUBST:  a : ab
-NSUBST: a = 1:< / 1:> / *:.
+NSUBST: a = 2:> / *:.
 NSUBST: b = 1:b / 1:b. / *:.
 KFEAT:  b = known shaft trap
 SUBST:  G : G T t
@@ -2559,7 +2511,7 @@ xxxxxxxxxxxxxxxxxxxxxxxx
 @..xxx.a.xxx.a.xxx.G.xxx
 @..xxx...xxx...xxx...xxx
 @....................xxx
-@..................[.xxx
+@..................{.xxx
 @....................xxx
 @..xxx...xxx...xxx...xxx
 @..xxx.a.xxx.a.xxx.G.xxx
@@ -2765,15 +2717,13 @@ NAME:    sevenhm_arrival_forest_fort_small_2
 TAGS:    arrival no_pool_fixup no_monster_gen
 ORIENT:  float
 WEIGHT:  1
-SHUFFLE: rz
 : if crawl.one_chance_in(4) then
-SUBST:   w : x, u : x, z : @
+SUBST:   w : x, u : x, r : @
 : else
-SUBST:   z : x, u : w
+SUBST:   r : x, u : @
 NSUBST:  w = @ / w
 SUBST:   w : wwwwwwtt.
 : end
-SUBST:   r : x
 NSUBST:  y = { / .....> / .
 KMASK:   W = no_monster_gen
 MONS:    anaconda / death yak / black mamba / elephant / hydra
@@ -2784,7 +2734,7 @@ xtttyytttx
 xt1tyyt1tx
 xcnc..cncx
 x..c++c..x
-r........z
+r........r
 xuwwwwwwux
 ENDMAP
 
@@ -2801,7 +2751,7 @@ NSUBST: {OA = { / . , y = + / c+ / c+ , r = + / c+
 SUBST:  G = GGTTU, R : Ltt1Ww, L : tttw1
 MONS:   plant / bush
 MAP
-xXXxxxxxxxxx
+xXxxxxzxxxXx
 x..........x
 x..cyyycL.Lx
 x.Rc...cLGLx
@@ -2816,7 +2766,7 @@ ENDMAP
 
 ##############################################################################
 NAME:   sevenhm_arrival_forest_fort_small_4
-TAGS:   arrival no_monster_gen
+TAGS:   arrival no_monster_gen no_trap_gen
 ORIENT: float
 NSUBST: { = { / . , @ = @ / t
 SUBST:  X : c@@@ , ' : 'tW
@@ -2836,13 +2786,13 @@ ENDMAP
 
 ##############################################################################
 NAME:    sevenhm_arrival_forest_fort_small_5
-TAGS:    arrival no_pool_fixup
+TAGS:    arrival no_pool_fixup no_trap_gen
 ORIENT:  float
+NSUBST:   X = x...
 : if crawl.one_chance_in(4) then
 SUBST:   o = {
-SUBST:   X : x , Y : @ , p : .
+SUBST:   Y : @ , p : .
 : else
-NSUBST:  X = @ / @@xx.
 SUBST:   Y = x .:1 , o : . , p : [
 : end
 NSUBST:  { = { / . , r = + / +c
@@ -2864,14 +2814,14 @@ xxYWWWWJJJJWWWWWtxxx
 xtttWWWWKKWWWWWccccx
 xtt....WWWW.cccc.{cx
 xt...cNNc...np+..{cx
-x...cc{{cc..ccc..{cx
-x...z...{c..+....{cx
+X...cc{{cc..ccc..{cx
+X...z...{c..+....{cx
 xt..cc...c..cccccccx
 xt..tccc+c.....ttttx
 xxx..ttc.ctt......tx
-  x...tc.cccccc....X
+  +...tc.cccccc....X
   xxx.tc..r...R..ooX
-    xxtc..r...R..o.X
+    xxtc..r...R..o.x
      xxcccccccctttxx
       xxxxxxtttttxx
            xxxxxxx
@@ -2889,6 +2839,8 @@ SUBST:   r : +ccc
 NSUBST:  R = + / ccc+
 SUBST:   = : cc+
 SUBST:   t : tT.
+SUBST:   s : ttc
+SUBST:   u : ttGGT
 SUBST:   T = tt.
 NSUBST:  { = 1:{ / *:.
 MAP
@@ -2897,14 +2849,15 @@ xxxxxxccccccxxxxxx
 xcccccc{{{{ccccccx
 xc>zll=....=llC>cx
 xcccccc....ccccccx
- .ttttc....ctt..
-  ....crRRrct.
-     .........
+.tttttc....cttttt.
+......crRRrc......
+.ssss........ssss.
+.......ussu.......
 ENDMAP
 
 ##############################################################################
 NAME:   saegor_arrival_miasma
-TAGS:   arrival no_monster_gen
+TAGS:   arrival no_monster_gen no_trap_gen
 ORIENT: float
 COLOUR: W# = lightgreen
 NSUBST: W = 6:% / 7:#
@@ -2914,21 +2867,21 @@ MARKER: # = lua:fog_machine { cloud_type = "foul pestilence", pow_max = 10, \
 KFEAT:  %# = W
 KPROP:  W#% = no_tele_into
 MAP
- xxxxxxxxxx
-xxWWWWWWWWxx
-xWWWWWWWWWWx
-xWWvWW#WvWWx
-xWWWWWWWWWWx
-xWWWWWWWWWWx
-xxxmmxxxmmxx
-@+....{....x
-xxxmmxxxmmxx
-xWWWWWWWWWWx
-xWWWWWWWWWWx
-xWWvW#WWvWWx
-xWWWWWWWWWWx
-xxWWWWWWWWxx
- xxxxxxxxxx
+ xxxxxxxxxxx
+xxWWWWWWWWWxx
+xWWWWWWWWWWWx
+xWWvWW#WvWWWx
+xWWWWWWWWWWWx
+xWWWWWWWWWWWx
+xxxmmxxxmmxxx
+@+....{....+@
+xxxmmxxxmmxxx
+xWWWWWWWWWWWx
+xWWWWWWWWWWWx
+xWWvW#WWvWWWx
+xWWWWWWWWWWWx
+xxWWWWWWWWWxx
+ xxxxxxxxxxx
 ENDMAP
 
 ##############################################################################
@@ -3200,7 +3153,7 @@ ENDMAP
 
 ################################################################################
 NAME:       psy_arrival_fountain
-TAGS:       arrival no_monster_gen
+TAGS:       arrival no_monster_gen no_trap_gen
 ORIENT:     float
 FTILE:      t.qpP{T = floor_grass
 COLOUR:     . = green


### PR DESCRIPTION
Recently, a Reddit user posted that one of the small arrival vaults was flawed in their game:

https://old.reddit.com/r/dcss/comments/fb8gi6/promising_start/

As I had *just* improved the small arrival vaults, this was disappointing to me. So I went over the small arrival vaults with a great deal more consideration, and made the smallest changes I could to improve their tactical options.

To these vaults I added an extra exit:

* evilmike_arrival_fibonacci_small
* minmay_arrival_stair_chambers
* minmay_arrival_widening_spiral_wide
* dpeg_arrival_lava_temple_mockup

And to these vaults I added a pillar:

* evilmike_arrival_grusome_pit
* minmay_arrival_widening_spiral_narrow
* minmay_arrival_loop

Removed these vaults:

* evilmike_arrival_sounds_zot
* onia_arrival_larder

I also added `no_trap_gen` to some of these if they were open to the problem the above Reddit poster faced.