### PR TITLE
Apply AC to Ramparts damage before monster speed effect (Flugkiller)

### DIFF
--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -2383,10 +2383,11 @@ void ice_wall_damage(monster &mons, int delay)
          you.can_see(mons) ? mons.name(DESC_THE).c_str() : "something");
 
     const int pow = calc_spell_power(SPELL_FROZEN_RAMPARTS, true);
-    int dam = div_rand_round(delay * roll_dice(1, 2 + div_rand_round(pow, 4)),
-                BASELINE_DELAY);
+    int dam = roll_dice(1, 2 + div_rand_round(pow, 4));
 
     dam = mons.apply_ac(dam);
+
+    dam = div_rand_round(delay * dam, BASELINE_DELAY);
 
     bolt beam;
     beam.flavour = BEAM_ICE;


### PR DESCRIPTION
Frozen ramparts does damage after every monster action. Previously, it would compensate for the length of the action and then apply AC. That effectively increased the AC of fast monsters and reduced the AC of slow monsters. (Juggernauts, for instance, take almost no damage when moving due to their considerable AC, but would take a big chunk after an attack action (which is 30 auts and still only had AC applied once.)

This changes the formula so that the AC is applied before the monster speed normalization.