### PR TITLE
Add the new octopode loading image to webtiles

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1250,7 +1250,7 @@ TITLEIMGS = denzi_dragon denzi_kitchen_duty denzi_summoner \
             peileppe_bloax_eye baconkid_duvessa_dowan ploomutoo_ijyb \
 	    froggy_thunder_fist_nikola froggy_rune_and_run_failed_on_dis \
 	    froggy_natasha_and_boris froggy_jiyva_felid \
-	    froggy_goodgod_tengu_gold Cws_Minotauros
+	    froggy_goodgod_tengu_gold Cws_Minotauros nibiki_octopode
 
 STATICFILES = $(TILEIMAGEFILES:%=webserver/game_data/static/%.png) \
               webserver/static/stone_soup_icon-32x32.png \

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -237,6 +237,7 @@
         <img style="display:none;" alt="" src="{{ static_url("title_froggy_natasha_and_boris.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_froggy_rune_and_run_failed_on_dis.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_froggy_thunder_fist_nikola.png") }}">
+        <img style="display:none;" alt="" src="{{ static_url("title_nibiki_octopode.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_omndra_zot_demon.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_peileppe_bloax_eye.png") }}">
         <img style="display:none;" alt="" src="{{ static_url("title_ploomutoo_ijyb.png") }}">


### PR DESCRIPTION
Commit ee0576305db0a1a64f1e85ae863a749289b8fd71
added the new image to local tiles, but not to webtiles.
I used commit da47cbf8c3a56b00bc71d06f4eb5fa7dc4a1203e
as a template for this.