### PR TITLE
Fix randart weapon names (12228)

### DIFF
--- a/crawl-ref/source/dat/database/rand_wpn.txt
+++ b/crawl-ref/source/dat/database/rand_wpn.txt
@@ -578,7 +578,10 @@ Slime-mould
 
 Toadstool
 %%%%
-_evil_stuff_Abomination
+_evil_stuff_
+
+Abomination
+
 Abuse
 
 Ancient Evil


### PR DESCRIPTION
Missing end of line, probably caused by the recent commits
that reorganized the lookup files.