### PR TITLE
Check holiness before casting dispel undead

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -7630,7 +7630,7 @@ static bool _ms_waste_of_time(monster* mon, mon_spell_slot slot)
     case SPELL_MIASMA_BREATH:
         return !foe || foe->res_rotting() || no_clouds;
 
-    case SPELL_DISPEL_UNDEAD:
+    case SPELL_DISPEL_UNDEAD_RANGE:
         // [ds] How is dispel undead intended to interact with vampires?
         // Currently if the vampire's undead state returns MH_UNDEAD it
         // affects the player.


### PR DESCRIPTION
Commit 3b7ae84e64 removed SPELL_DISPEL_UNDEAD from monsters and replaced
it with SPELL_DISPEL_UNDEAD_RANGE, but forgot to update the case in
_ms_waste_of_time accordingly. This resulted in monsters attempting to
cast dispel undead on non-undead creatures; before they never thought
that was worth trying. This commit restores the check.