### PR TITLE
Fix stray commas in chardump notes for dungeon features

### DIFF
--- a/crawl-ref/source/map-knowledge.cc
+++ b/crawl-ref/source/map-knowledge.cc
@@ -133,7 +133,7 @@ void set_terrain_seen(const coord_def pos)
 
         if (!is_boring_terrain(feat))
         {
-            string desc = feature_description_at(pos, false, DESC_A) + ",";
+            string desc = feature_description_at(pos, false, DESC_A) + ".";
             take_note(Note(NOTE_SEEN_FEAT, 0, 0, desc));
         }
     }


### PR DESCRIPTION
After c225cfcd, notes for dungeon features end in a colon instead
of a full stop.

For example, "60174 | Depths:2 | Found a sacrificial altar of Ru,"