### PR TITLE
Fix stash search menu not showing tiles for some dungeon features

### DIFF
--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1687,13 +1687,10 @@ dungeon_feature_type feat_by_desc(string desc)
 {
     lowercase(desc);
 
-    if (desc[desc.size() - 1] != '.')
-        desc += ".";
-
 #if TAG_MAJOR_VERSION == 34
     // hard-coded because all the dry fountain variants match this description,
     // and they have a lower enum value, so the first is incorrectly returned
-    if (desc == "a dry fountain.")
+    if (desc == "a dry fountain")
         return DNGN_DRY_FOUNTAIN;
 #endif
 


### PR DESCRIPTION
This PR fixes the stash search menu no longer displaying tiles for some dungeon features:
![searching_for_hat](https://user-images.githubusercontent.com/3328424/78262504-2e8a2580-74f0-11ea-9041-fcca5baa8b02.png)
Also, it fixes the ?/F lookup-help.
