### PR TITLE
Adjust Vehumet gift range

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1122,8 +1122,8 @@ static set<spell_type> _vehumet_eligible_gift_spells(set<spell_type> excluded_sp
     if (gifts >= NUM_VEHUMET_GIFTS)
         return eligible_spells;
 
-    const int min_lev[] = {1,1,2,3,3,4,4,5,5,6,6,6,8};
-    const int max_lev[] = {1,2,3,4,5,7,7,7,7,7,7,7,9};
+    const int min_lev[] = {1,1,2,3,3,4,4,5,5,5,5,6,8};
+    const int max_lev[] = {1,2,3,4,5,7,7,7,7,7,7,8,9};
     COMPILE_CHECK(ARRAYSZ(min_lev) == NUM_VEHUMET_GIFTS);
     COMPILE_CHECK(ARRAYSZ(max_lev) == NUM_VEHUMET_GIFTS);
     int min_level = min_lev[gifts];


### PR DESCRIPTION
Based on discussion in Mantis ticket 12221, this tweaks the range
of Vehumet spell gifts to try to avoid repeated offers at gifts
number 10, 11 and 12.

Extending the range from 6-7 to 5-7 is a small nerf, however
level 5 contains desirable spells (Fireball, LRD). To compensate,
range of gift 12 (the last one before the final) is extended
from 6-7 to 6-8.