### PR TITLE
Allows followers of Qazlal to walk on lava

### DIFF
--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -375,8 +375,8 @@ blocks attacks, and (for the particularly devout) deflects incoming
 projectiles. Qazlal allows followers to incite nature against their foes,
 causing a localised natural disturbance or, for particularly devout followers,
 a more widespread disaster. Followers of Qazlal eventually gain temporary
-resistances after taking damage, and can give life to clouds, turning them into
-allied elementals.
+resistances after taking damage, learn to walk on lava, and can give life to
+clouds, turning them into allied elementals.
 %%%%
 Ru powers
 

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -368,6 +368,7 @@ static const vector<god_passive> god_passives[] =
         {  0, passive_t::cloud_immunity, "and your divine allies are ADV immune to clouds" },
         {  1, passive_t::storm_shield,
               "generate elemental clouds to protect yourself" },
+        {  3, passive_t::lava_walk, "walk on lava" },
         {  4, passive_t::upgraded_storm_shield,
               "Your chances to be struck by projectiles are NOW reduced" },
         {  5, passive_t::elemental_adaptation,

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -219,6 +219,9 @@ enum class passive_t
     /// You generate elemental clouds to protect you
     storm_shield,
 
+    /// You can walk on lava.
+    lava_walk,
+
     /// Chances to be struck by projectiles are reduced
     upgraded_storm_shield,
 

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -715,6 +715,14 @@ string describe_mutations(bool drop_title)
                   "</lightgreen>";
     }
 
+    if (have_passive(passive_t::lava_walk))
+        result += "<green>You can walk on water.</green>\n";
+    else if (you.can_lava_walk())
+    {
+        result += "<lightgreen>You can walk on water until reaching land."
+                  "</lightgreen>";
+    }
+
     if (have_passive(passive_t::frail)
         || player_under_penance(GOD_HEPLIAKLQANA))
     {

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -501,6 +501,8 @@ void moveto_location_effects(dungeon_feature_type old_feat,
         }
         else if (you.props.exists(TEMP_WATERWALK_KEY))
             you.props.erase(TEMP_WATERWALK_KEY);
+        else if (you.props.exists(TEMP_LAVAWALK_KEY))
+            you.props.erase(TEMP_LAVAWALK_KEY);
     }
 
     id_floor_items();
@@ -573,7 +575,7 @@ bool is_feat_dangerous(dungeon_feature_type grid, bool permanently,
         return false;
     }
     else if (grid == DNGN_DEEP_WATER && !player_likes_water(permanently)
-             || grid == DNGN_LAVA)
+             || grid == DNGN_LAVA && !player_likes_lava(permanently))
     {
         return true;
     }
@@ -608,11 +610,20 @@ bool player_in_connected_branch()
     return is_connected_branch(you.where_are_you);
 }
 
+//TODO note I've fixed a bug here in a commit that's primarily doing something
+//else, the fix makes sure this function returns True for merfolk always,
+//as I think it was supposed to. This could cause problems, which is why I'm leaving
+//a comment. Change made in April 2019. -- petercordia
 bool player_likes_water(bool permanently)
 {
-    return !permanently && you.can_water_walk()
-           || (species_likes_water(you.species) || !permanently)
-               && form_likes_water();
+    return species_likes_water(you.species)
+           || !permanently && you.can_water_walk()
+           || !permanently && form_likes_water();
+}
+
+bool player_likes_lava(bool permanently)
+{
+    return !permanently && you.can_lava_walk();
 }
 
 /**
@@ -5371,6 +5382,12 @@ bool player::can_water_walk() const
 {
     return have_passive(passive_t::water_walk)
            || you.props.exists(TEMP_WATERWALK_KEY);
+}
+
+bool player::can_lava_walk() const
+{
+    return have_passive(passive_t::lava_walk)
+           || you.props.exists(TEMP_LAVAWALK_KEY);
 }
 
 int player::visible_igrd(const coord_def &where) const

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -49,6 +49,7 @@
 #define ACROBAT_AMULET_ACTIVE "acrobat_amulet_active"
 #define SAP_MAGIC_KEY "sap_magic_amount"
 #define TEMP_WATERWALK_KEY "temp_waterwalk"
+#define TEMP_LAVAWALK_KEY "temp_lavawalk"
 #define EMERGENCY_FLIGHT_KEY "emergency_flight"
 #define PARALYSED_BY_KEY "paralysed_by"
 #define PETRIFIED_BY_KEY "petrified_by"
@@ -504,6 +505,7 @@ public:
     bool in_liquid() const;
     bool can_swim(bool permanently = false) const;
     bool can_water_walk() const;
+    bool can_lava_walk() const;
     int visible_igrd(const coord_def&) const;
     bool is_banished() const override;
     bool is_sufficiently_rested() const; // Up to rest_wait_percent HP and MP.
@@ -1009,6 +1011,7 @@ bool player_kiku_res_torment();
 
 bool player_likes_chunks(bool permanently = false);
 bool player_likes_water(bool permanently = false);
+bool player_likes_lava(bool permanently = false);
 
 int player_res_electricity(bool calc_unid = true, bool temp = true,
                            bool items = true);

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -321,6 +321,7 @@ const vector<god_power> god_powers[NUM_GODS] =
            "You are surrounded by a storm." },
       { 2, ABIL_QAZLAL_UPHEAVAL, "call upon nature to destroy your foes" },
       { 3, ABIL_QAZLAL_ELEMENTAL_FORCE, "give life to nearby clouds" },
+      { 3, "walk on lava" },
       { 4, "The storm surrounding you is now powerful enough to repel missiles.",
            "The storm surrounding you is now too weak to repel missiles.",
            "The storm surrounding you is powerful enough to repel missiles." },
@@ -709,6 +710,19 @@ static void _grant_temporary_waterwalk()
     you.props[TEMP_WATERWALK_KEY] = true;
 }
 
+// TODO: I copied this from _need_water_walking, and that one also has a TODO
+static bool _need_lava_walking()
+{
+    return you.ground_level()
+           && grd(you.pos()) == DNGN_LAVA;
+}
+
+static void _grant_temporary_lavawalk()
+{
+    mprf("Your lava-walking will last only until you reach solid ground.");
+    you.props[TEMP_LAVAWALK_KEY] = true;
+}
+
 bool jiyva_is_dead()
 {
     return you.royal_jelly_dead
@@ -760,6 +774,12 @@ static void _inc_penance(god_type god, int val)
             && _need_water_walking() && !have_passive(passive_t::water_walk))
         {
             _grant_temporary_waterwalk();
+        }
+
+        if (will_have_passive(passive_t::lava_walk)
+            && _need_lava_walking() && !have_passive(passive_t::lava_walk))
+        {
+            _grant_temporary_lavawalk();
         }
 
         if (will_have_passive(passive_t::stat_boost))
@@ -2581,6 +2601,11 @@ void lose_piety(int pgn)
     {
         _grant_temporary_waterwalk();
     }
+    if (will_have_passive(passive_t::lava_walk) && _need_lava_walking()
+        && !have_passive(passive_t::lava_walk))
+    {
+        _grant_temporary_lavawalk();
+    }
     if (will_have_passive(passive_t::stat_boost)
         && chei_stat_boost(old_piety) > chei_stat_boost())
     {
@@ -2704,6 +2729,7 @@ void excommunication(bool voluntary, god_type new_god)
     const bool had_halo       = have_passive(passive_t::halo);
     const bool had_umbra      = have_passive(passive_t::umbra);
     const bool had_water_walk = have_passive(passive_t::water_walk);
+    const bool had_lava_walk  = have_passive(passive_t::lava_walk);
     const bool had_stat_boost = have_passive(passive_t::stat_boost);
     const int  old_piety      = you.piety;
 
@@ -2777,6 +2803,8 @@ void excommunication(bool voluntary, god_type new_god)
     // You might have lost water walking at a bad time...
     if (had_water_walk && _need_water_walking())
         _grant_temporary_waterwalk();
+    if (had_lava_walk && _need_lava_walking())
+        _grant_temporary_lavawalk();
     if (had_stat_boost)
     {
         redraw_screen();

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1639,6 +1639,9 @@ void fall_into_a_pool(dungeon_feature_type terrain)
         }
     }
 
+    if (terrain == DNGN_LAVA && you.can_lava_walk())
+        return;
+
     mprf("You fall into the %s!",
          (terrain == DNGN_LAVA)       ? "lava" :
          (terrain == DNGN_DEEP_WATER) ? "water"

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -273,10 +273,10 @@ bool feat_is_traversable_now(dungeon_feature_type grid, bool try_fallback)
 
         // lava-walkers get lava
         if (grid == DNGN_LAVA && have_passive(passive_t::lava_walk))
+            return true;
 
         // The player can safely walk over shafts.
         if (grid == DNGN_TRAP_SHAFT)
-
             return true;
 
         // Permanently flying players can cross most hostile terrain.

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -271,8 +271,12 @@ bool feat_is_traversable_now(dungeon_feature_type grid, bool try_fallback)
             return true;
         }
 
+        // lava-walkers get lava
+        if (grid == DNGN_LAVA && have_passive(passive_t::lava_walk))
+
         // The player can safely walk over shafts.
         if (grid == DNGN_TRAP_SHAFT)
+
             return true;
 
         // Permanently flying players can cross most hostile terrain.


### PR DESCRIPTION
Walking on lava has an epic feel to it, and fits thematically with
Qazlal. Followers of Qazlal get the ability at *** piety, and it
functions identically to Beogh's water walking. Nothing has been
removed from Qazlal as I don't anticipate the ability being
particularly useful.

This commit also fixes a logic bugg in player_likes_water in player.cc, which formerly only recognised merfolk as permanently liking water when they were in iceform.
I know that that should ideally be done in a separate commit, but I couldn't figure out how to make 2 different commits and I didn't want to leave the bug in the code.