### PR TITLE
make merfolk treat water the same way as ground for pathfinding purpo…

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -610,9 +610,9 @@ bool player_in_connected_branch()
 
 bool player_likes_water(bool permanently)
 {
-    return !permanently && you.can_water_walk()
-           || (species_likes_water(you.species) || !permanently)
-               && form_likes_water();
+    return species_likes_water(you.species)
+           || !permanently && you.can_water_walk()
+           || !permanently && form_likes_water();
 }
 
 /**

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -214,11 +214,8 @@ static inline bool _is_safe_cloud(const coord_def& c)
 static inline int _feature_traverse_cost(dungeon_feature_type feature)
 {
     if (feat_is_closed_door(feature)
-        // Higher cost for shallow water if species doesn't like water or if
-        // they are merfolk, since those will prefer to avoid melding their
-        // boots during travel.
-        || feature == DNGN_SHALLOW_WATER
-           && (!player_likes_water(true) || you.species == SP_MERFOLK))
+        // Higher cost for shallow water if species doesn't like water
+        || feature == DNGN_SHALLOW_WATER && (!player_likes_water(true)))
     {
         return 2;
     }


### PR DESCRIPTION
Formerly, merfolk would avoid travelling through water because 'their boots would meld'. In water merfolk gain bonus EV and speed (equivalent to 4 boots of running), so this was a bit silly.

a poll showed support to even make merfolk prefer travelling through water, but I don't think I can do so without introducing bugs.
The forum discussion (and poll) is here: https://crawl.develz.org/tavern/viewtopic.php?f=8&t=26848&p=343894#p343894

This pull request might conflict with my other pull request (https://github.com/crawl/crawl/pull/1342) because I've fixed the same bug in both. (Hopefully in the same manner)