### PR TITLE
Shut down cleanly on SIGTERM

### DIFF
--- a/crawl-ref/source/libutil.cc
+++ b/crawl-ref/source/libutil.cc
@@ -645,7 +645,10 @@ void init_signals()
     // shut down only when the actual window is closed.
     signal(SIGHUP, SIG_IGN);
 # else
+    // Graceful shutdown when we get SIGHUP (from dgamelaunch) or SIGTERM
+    // (from webtiles server or task managers).
     signal(SIGHUP, handle_hangup);
+    signal(SIGTERM, handle_hangup);
 # endif
 #endif
 


### PR DESCRIPTION
Treat SIGTERM the same as SIGHUP -- eg gracefully save and quit.

When a SSH client disconnects from a remote session (eg, with
dgamelaunch), the session processes receive SIGHUP. But if a local user
runs eg `killall crawl`, the processes are sent SIGTERM which crashes
the game. Most job control systems (eg systemd, docker) send SIGTERM, so
it makes sense to handle this with the logic that already exists for
SIGHUP.

Don't rename any of the functions or variables relating to this, eg
handle_hangup or seen_hups. That can be done in a future commit, if
desired.