### PR TITLE
Always save macros

### DIFF
--- a/crawl-ref/source/end.cc
+++ b/crawl-ref/source/end.cc
@@ -456,8 +456,7 @@ NORETURN void end_game(scorefile_entry &se)
 
     clua.save_persist();
 
-    // Prompt for saving macros.
-    if (crawl_state.unsaved_macros && yesno("Save macros?", true, 'n'))
+    if (crawl_state.unsaved_macros)
         macro_save();
 
     auto title_hbox = make_shared<Box>(Widget::HORZ);

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2063,12 +2063,8 @@ static void _save_game_exit()
     clua.save_persist();
 
     // Prompt for saving macros.
-    if (crawl_state.unsaved_macros
-        && !crawl_state.seen_hups
-        && yesno("Save macros?", true, 'n'))
-    {
+    if (crawl_state.unsaved_macros)
         macro_save();
-    }
 
     // Must be exiting -- save level & goodbye!
     if (!you.entering_level)


### PR DESCRIPTION
We don't need to ask the player this. It's a simpler mental model for
macro changes to be always saved, rather than sometimes asking the
player (during normal session end, but not eg webtiles tab close /
dgamelaunch hangup).