### PR TITLE
Fix the x-mode description of walls covered in ice and blood

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -2888,11 +2888,8 @@ string feature_description_at(const coord_def& where, bool covering,
 
     if (covering && you.see_cell(where) && is_bloodcovered(where))
     {
-        string prefix = ", ";
-        if (!covering_description.empty())
-            prefix = ", and ";
-
-        covering_description = prefix + "spattered with blood";
+        string prefix = covering_description.empty() ? ", " : " and ";
+        covering_description += prefix + "spattered with blood";
     }
 
     // FIXME: remove desc markers completely; only Zin walls are left.


### PR DESCRIPTION
Currently, if icy walls made by Frozen Ramparts are covered in blood,
then they have only the second part of a covering description:
for example, "A rock wall, and spattered with blood."