### PR TITLE
Add the possibility of one more Xom demon

### DIFF
--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2513,7 +2513,7 @@ static void _xom_summon_hostiles(int sever)
         // Limit number of demons by experience level.
         if (!you.penance[GOD_XOM])
         {
-            const int maxdemons = (you.experience_level / 2);
+            const int maxdemons = ((you.experience_level / 2) + 1);
             if (numdemons > maxdemons)
                 numdemons = maxdemons;
         }


### PR DESCRIPTION
At low XL, it's difficult for Xom to effectively kill a waitscumming mummy or vampire. This change is largely washed out at larger XLs, but should effectively create more nasty monsters to drop on low-level waitscummers.