### PR TITLE
Upload release builds to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: Build
 
 on:
-  - push
-  - pull_request
+  push: {}
+  pull_request: {}
+  release:
+    types:
+      - created
 
 jobs:
   linting:
@@ -17,7 +20,7 @@ jobs:
         run: util/checkwhite -n
         working-directory: crawl-ref/source
   build_linux:
-    name: "${{ matrix.compiler }} ${{ matrix.build_opts }} ${{ matrix.debug }}"
+    name: Linux ${{ matrix.compiler }} ${{ matrix.build_opts }} ${{ matrix.debug }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,13 +36,28 @@ jobs:
           - ""
           - FULLDEBUG=1
         exclude:
-          # Only build non-debug with GCC
+          # Limit Clang jobs:
+          # 1. Only build fulldebug
           - compiler: clang
             debug: ""
+          # 2. Skip webtiles builds (all webtiles servers use GCC)
+          - compiler: clang
+            build_opts: WEBTILES=1 USE_DGAMELAUNCH=1
+          - compiler: clang
+            build_opts: WEBTILES=1
     steps:
       - uses: actions/checkout@v2
-      - name: Set fake version
-        run: echo "1.0.0" > util/release_ver
+      - name: Set version
+        run: |
+          ref="${{ github.ref }}"
+          if [[ $ref = refs/tags/*.*.* ]] ; then
+            ver="${ref##refs/tags/}"
+            echo This is a release build, setting version ${ver}.
+          else
+            ver="1.0.0"
+            echo This is not a release build, setting a fake version 1.0.0.
+          fi
+          echo "$ver" > util/release_ver
         working-directory: crawl-ref/source
       - name: Install dependencies
         run: ./deps.py --compiler ${{ matrix.compiler }} --build-opts "${{ matrix.build_opts }}"
@@ -76,8 +94,21 @@ jobs:
         run: ccache -s
 
   build_macos:
-    name: "clang macOS"
+    name: macOS ${{ matrix.build_type }}
     runs-on: macos-latest
+    strategy:
+      matrix:
+        build_type:
+          - tiles
+          - console
+        build_opts:
+          - ""
+          - TILES=y
+        exclude:
+          - build_type: tiles
+            build_opts: ""
+          - build_type: console
+            build_opts: TILES=y
     steps:
       - uses: actions/checkout@v2
       - name: Checkout submodules
@@ -86,8 +117,17 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Set fake version
-        run: echo "1.0.0" > util/release_ver
+      - name: Set version
+        run: |
+          ref="${{ github.ref }}"
+          if [[ $ref = refs/tags/*.*.* ]] ; then
+            ver="${ref##refs/tags/}"
+            echo This is a release build, setting version ${ver}.
+          else
+            ver="1.0.0"
+            echo This is not a release build, setting a fake version 1.0.0.
+          fi
+          echo "$ver" > util/release_ver
         working-directory: crawl-ref/source
       - name: Install Dependencies
         run: |
@@ -100,8 +140,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: $HOME/.ccache
-          key: ccache-macos-clang
+          key: ccache-macos-clang-${{ matrix.build_type }}
           restore-keys: |
+            ccache-macos-clang-${{ matrix.build_type }}
             ccache-macos-clang
       # ccache uses ~110mb to store the output from a single crawl compile
       # (including submodules) (when compressed)
@@ -118,14 +159,30 @@ jobs:
         run: |
           ccache -s
           ls -l /usr/local/opt/ccache/libexec
-      - run: make -j$(sysctl -n hw.ncpu)
+      - run: make -j$(sysctl -n hw.ncpu) mac-app-${{ matrix.build_type }} ${{matrix.build_opts }}
         working-directory: crawl-ref/source
       - name: Print ccache stats
         run: ccache -s
+      - name: Add build to release
+        if: github.event.release.tag_name != null
+        # Go back to the upstream action (svenstaro/upload-release-action) once this PR merges:
+        # https://github.com/svenstaro/upload-release-action/pull/13
+        uses: alexjurkiewicz/upload-release-action@6408db765e9a0413e6c5b8231ecd3eb45352cc99
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file: crawl-ref/source/mac-app-zips/latest.zip
+          asset_name: dcss-$tag-macos-${{ matrix.build_type}}.zip
 
   build_mingw64_crosscompile:
-    name: "gcc mingw64 crosscompile"
+    name: mingw64 ${{ matrix.build_type }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type:
+          - tiles
+          - console
+          - installer
     steps:
       - uses: actions/checkout@v2
       - name: Checkout submodules (for crosscompile)
@@ -134,8 +191,17 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Set fake version
-        run: echo "1.0.0" > util/release_ver
+      - name: Set version
+        run: |
+          ref="${{ github.ref }}"
+          if [[ $ref = refs/tags/*.*.* ]] ; then
+            ver="${ref##refs/tags/}"
+            echo This is a release build, setting version ${ver}.
+          else
+            ver="1.0.0"
+            echo This is not a release build, setting a fake version 1.0.0.
+          fi
+          echo "$ver" > util/release_ver
         working-directory: crawl-ref/source
       - name: Install dependencies
         run: ./deps.py --crosscompile
@@ -146,8 +212,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: $HOME/.ccache
-          key: ccache-mingw64
+          key: ccache-mingw64-${{ matrix.build_type }}
           restore-keys: |
+            ccache-mingw64-${{ matrix.build_type }}
             ccache-mingw64
       # ccache uses ~110mb to store the output from a single crawl compile
       # (including submodules) (when compressed)
@@ -164,17 +231,52 @@ jobs:
         run: |
           ccache -s
           ls -l /usr/lib/ccache
-      - run: make -j$(nproc) CROSSHOST=i686-w64-mingw32 package-windows-zips
+      - run: make -j$(nproc) CROSSHOST=i686-w64-mingw32 package-windows-${{ matrix.build_type }}
         working-directory: crawl-ref/source
       - name: Print ccache stats
         run: ccache -s
+      # The zip & installer targets create different sorts of names, so we need
+      # a little shell script magic here.
+      - name: Determine release file names
+        if: github.event.release.tag_name != null
+        id: release-names
+        run: |
+          if [[ ${{ matrix.build_type }} != installer ]] ; then
+            source='crawl-ref/source/stone_soup-latest-${{ matrix.build_type}}-win32.zip'
+            dest='dcss-$tag-win32-${{ matrix.build_type}}.zip'
+          else
+            source='crawl-ref/source/stone_soup-latest-win32-installer.exe'
+            dest='dcss-$tag-win32-installer.exe'
+          fi
+          echo "::set-output name=source::$source"
+          echo "::set-output name=dest::$dest"
+      - name: Add build to release
+        if: github.event.release.tag_name != null
+        # Go back to the upstream action (svenstaro/upload-release-action) once this PR merges:
+        # https://github.com/svenstaro/upload-release-action/pull/13
+        uses: alexjurkiewicz/upload-release-action@6408db765e9a0413e6c5b8231ecd3eb45352cc99
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          file: ${{ steps.release-names.outputs.source }}
+          asset_name: ${{ steps.release-names.outputs.dest }}
+
   codecov_catch2:
     name: Catch2 (GCC/Linux) + Codecov
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set fake version
-        run: echo "1.0.0" > util/release_ver
+      - name: Set version
+        run: |
+          ref="${{ github.ref }}"
+          if [[ $ref = refs/tags/*.*.* ]] ; then
+            ver="${ref##refs/tags/}"
+            echo This is a release build, setting version ${ver}.
+          else
+            ver="1.0.0"
+            echo This is not a release build, setting a fake version 1.0.0.
+          fi
+          echo "$ver" > util/release_ver
         working-directory: crawl-ref/source
       - name: Install dependencies
         run: ./deps.py --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,18 +47,9 @@ jobs:
             build_opts: WEBTILES=1
     steps:
       - uses: actions/checkout@v2
-      - name: Set version
-        run: |
-          ref="${{ github.ref }}"
-          if [[ $ref = refs/tags/*.*.* ]] ; then
-            ver="${ref##refs/tags/}"
-            echo This is a release build, setting version ${ver}.
-          else
-            ver="1.0.0"
-            echo This is not a release build, setting a fake version 1.0.0.
-          fi
-          echo "$ver" > util/release_ver
-        working-directory: crawl-ref/source
+        with:
+          fetch-depth: 0 # all history
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Install dependencies
         run: ./deps.py --compiler ${{ matrix.compiler }} --build-opts "${{ matrix.build_opts }}"
         working-directory: .github/workflows
@@ -111,24 +102,15 @@ jobs:
             build_opts: TILES=y
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # all history
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Checkout submodules
         shell: bash
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Set version
-        run: |
-          ref="${{ github.ref }}"
-          if [[ $ref = refs/tags/*.*.* ]] ; then
-            ver="${ref##refs/tags/}"
-            echo This is a release build, setting version ${ver}.
-          else
-            ver="1.0.0"
-            echo This is not a release build, setting a fake version 1.0.0.
-          fi
-          echo "$ver" > util/release_ver
-        working-directory: crawl-ref/source
       - name: Install Dependencies
         run: |
           brew install ccache
@@ -185,24 +167,15 @@ jobs:
           - installer
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # all history
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Checkout submodules (for crosscompile)
         shell: bash
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
-      - name: Set version
-        run: |
-          ref="${{ github.ref }}"
-          if [[ $ref = refs/tags/*.*.* ]] ; then
-            ver="${ref##refs/tags/}"
-            echo This is a release build, setting version ${ver}.
-          else
-            ver="1.0.0"
-            echo This is not a release build, setting a fake version 1.0.0.
-          fi
-          echo "$ver" > util/release_ver
-        working-directory: crawl-ref/source
       - name: Install dependencies
         run: ./deps.py --crosscompile
         working-directory: .github/workflows
@@ -266,18 +239,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set version
-        run: |
-          ref="${{ github.ref }}"
-          if [[ $ref = refs/tags/*.*.* ]] ; then
-            ver="${ref##refs/tags/}"
-            echo This is a release build, setting version ${ver}.
-          else
-            ver="1.0.0"
-            echo This is not a release build, setting a fake version 1.0.0.
-          fi
-          echo "$ver" > util/release_ver
-        working-directory: crawl-ref/source
+        with:
+          fetch-depth: 0 # all history
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Install dependencies
         run: ./deps.py --coverage
         working-directory: .github/workflows

--- a/.github/workflows/deps.py
+++ b/.github/workflows/deps.py
@@ -55,6 +55,7 @@ def _packages_to_install(args: argparse.Namespace) -> Set[str]:
         "pkg-config",
         "python-yaml",
         "ccache",
+        "advancecomp",  # used to compress release zips and png sprite sheets
     }
     if "TILES" in args.build_opts or "WEBTILES" in args.build_opts:
         packages.update(
@@ -71,6 +72,7 @@ def _packages_to_install(args: argparse.Namespace) -> Set[str]:
         packages.add("lcov")
     if args.crosscompile:
         packages.add("mingw-w64")
+        packages.add("nsis")  # makensis used to build Windows installer
     if args.compiler == "clang":
         # dependencies for llvm.sh
         packages.update(["lsb-release", "wget", "software-properties-common"])

--- a/.travis/build.pl
+++ b/.travis/build.pl
@@ -33,7 +33,7 @@ if ($ENV{CATCH2_TESTS}) {
 }
 
 if ($ENV{CROSSCOMPILE}) {
-    try("make CROSSHOST=i686-w64-mingw32 package-windows");
+    try("make CROSSHOST=i686-w64-mingw32 package-windows-installer");
     exit 0;
 }
 

--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -186,7 +186,7 @@ makefile.dep
 /source/debian/files
 
 # Windows packaging
-/source/crawl-win
+/source/stone_soup
 
 # Windows thumbnail files
 Thumbs.db

--- a/crawl-ref/docs/develop/release/guide.txt
+++ b/crawl-ref/docs/develop/release/guide.txt
@@ -112,11 +112,15 @@ for those the list begins with step 3.
    cross-compilation difficult. Adding the make option LTO=y will enable
    long-term optimization, but this can fail under cross-compilation.
 
-   The Makefile targets are "package-windows" and "package-windows-zips" for
-   the installer and stand-alone zips respectively. Unless you're on msys, you
-   need to specify CROSSHOST as well:
+   The Makefile targets are:
 
-   make CROSSHOST=i686-w64-mingw32 package-windows
+   * package-windows-installer
+   * package-windows-tiles
+   * package-windows-console
+
+   Unless you're on msys, you need to specify CROSSHOST as well:
+
+   make CROSSHOST=i686-w64-mingw32 package-windows-installer
 
    It's ideal to test the windows packages (both Tiles and console) under wine
    at the very least, assuming you've cross-compiled, and testing under a

--- a/crawl-ref/docs/develop/release/guide.txt
+++ b/crawl-ref/docs/develop/release/guide.txt
@@ -90,64 +90,35 @@ for those the list begins with step 3.
    version.
 
 
-7. Tag the release
+7. Tag and create the release
 
    In the branch you're about to tag:
+
    git tag -a 0.X.y
+   git push --tags
 
-   Don't push the tag yet so you can make final amendments.
+   Then, visit the GitHub releases page:
+
+   https://github.com/crawl/crawl/releases
+
+   You should have the ability to create a release from this tag. Once you
+   create the release, GitHub Actions will automatically upload macOS and
+   Windows builds as release assets.
 
 
-8. Package the source tarball, produce final builds and Debian packages
+8. Package the source tarball, and produce Debian packages
 
-   "make package-source" will create three source tar/zipballs.
-
-   For binary builds, you need to ensure at least the dat/ subdir contains no
-   foreign files (such as editor backup files, uncommitted stuff, random junk,
-   etc). Thus, "git clean -dfx". This is a potentially destructive operation so
-   if you have files lying around, you may want to do this from a separate
-   clone instead.
-
-   You can use enable optimizations in the builds, but these can make
-   cross-compilation difficult. Adding the make option LTO=y will enable
-   long-term optimization, but this can fail under cross-compilation.
-
-   The Makefile targets are:
-
-   * package-windows-installer
-   * package-windows-tiles
-   * package-windows-console
-
-   Unless you're on msys, you need to specify CROSSHOST as well:
-
-   make CROSSHOST=i686-w64-mingw32 package-windows-installer
-
-   It's ideal to test the windows packages (both Tiles and console) under wine
-   at the very least, assuming you've cross-compiled, and testing under a
-   recent version of windows is preferable. Follow the sanity test steps in
-   step 4.
+   "make package-source" will create three source tar/zipballs. You can add
+   these to the GitHub release as additional assets.
 
    For building the Debian packages and installing them into the CDO
    repository, see the debian.txt guide in this directory.
 
 
-9. Push the tag
+9. Update download links on CDO
 
-   Until the moment you push it to the official repository, you can delete it
-   and re-tag:
-
-   git push --tags
-
-   The tags are some sort of frozen state of the source for all releases, so
-   this is the last step you take before the actual release. All further
-   changes make it into the next minor version.
-
-
-10. Upload the files to CDO
-
-    Use the crawl login on CDO to upload the binaries to ~/website/release/
-    over scp or sftp. The links on the download page currently at
-    ~/website/download.htm must then be updated.
+    Use the crawl login on CDO to update the links on the download page
+    currently at ~/website/download.htm.
 
     Presently there's a repository that manages the web files for non-wordpress
     pages on CDO like the splash and download pages. This repo is cloned to
@@ -164,7 +135,7 @@ for those the list begins with step 3.
     guide in this directory.
 
 
-11. Update Sourceforge
+10. Update Sourceforge
 
     We currently use Sourceforge only for the CRD mailing list. Until CRD is
     moved somewhere else, we want to keep the Sourceforge release binaries
@@ -176,12 +147,12 @@ for those the list begins with step 3.
     most, .exe installer for Windows).
 
 
-12. Announce the release
+11. Announce the release
 
     Post a release announcement to the CDO blog and send an email over
     crawl-ref-discuss. If you want you can also write a news item on
     Sourceforge.
 
 
-13. Lean back and enjoy the excitement
+12. Lean back and enjoy the excitement
     ...until the first bug reports roll in. ;)

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -86,7 +86,7 @@ MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
         clean-catch2 clean-plug-and-play-tests \
 		clean-coverage clean-coverage-full \
         distclean debug debug-lite profile package-source source \
-        build-windows package-windows docs greet api api-dev android FORCE \
+        build-windows package-windows-installer docs greet api api-dev android FORCE \
         monster catch2-tests plug-and-play-tests
 
 include Makefile.obj
@@ -1197,8 +1197,10 @@ SRC_PKG_BASE  := stone_soup
 SRC_VERSION   := $(shell git describe --tags $(MERGE_BASE) 2>/dev/null || cat util/release_ver)
 MAJOR_VERSION = $(shell echo "$(SRC_VERSION)"|$(SED) -r 's/-.*//;s/^([^.]+\.[^.]+).*/\1/')
 RECENT_TAG    := $(shell git describe --abbrev=0 --tags $(MERGE_BASE))
+WINARCH := $(shell $(GXX) -dumpmachine | grep -q x64_64 && echo win64 || echo win32)
 
 export SRC_VERSION
+export WINARCH
 
 # Update .ver file if SRC_VERSION has changed
 .ver: FORCE
@@ -1831,13 +1833,12 @@ removeold:
 #
 
 # You need to have NSIS installed.
-package-windows:
+package-windows-installer:
 ifneq (x$(SRC_VERSION),x$(shell cat build-win/version.txt 2>/dev/null))
 	+$(MAKE) build-windows
 endif
-	if $(GXX) -dumpmachine|grep -q x86_64; \
-	  then WINARCH=win64; else WINARCH=win32; fi; \
-	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$$WINARCH" util/crawl.nsi
+	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$(WINARCH)" util/crawl.nsi; \
+	ln -sf "stone_soup-$(SRC_VERSION)-$(WINARCH)-installer.exe" "stone_soup-latest-$(WINARCH)-installer.exe"
 
 build-windows:
 ifneq ($(GAME),crawl.exe)
@@ -1852,20 +1853,25 @@ endif
 	echo $(SRC_VERSION) >build-win/version.txt
 
 ZIP_DOCS=../../LICENSE
-package-windows-zips:
+package-windows-tiles:
 ifneq ($(GAME),crawl.exe)
 	@echo "This is only for Windows; please specify CROSSHOST.";false
 endif
-	+$(MAKE) clean
 	+$(MAKE) TILES=y DESTDIR=build-win/stone_soup-tiles-$(MAJOR_VERSION) FORCE_SSE=y install
 	cp -p $(ZIP_DOCS) build-win/stone_soup-tiles-$(MAJOR_VERSION)/
 	cd build-win && zip -9r ../stone_soup-$(SRC_VERSION)-tiles-win32.zip *
-	rm -rf build-win
-	+$(MAKE) DESTDIR=build-win/stone_soup-$(MAJOR_VERSION) FORCE_SSE=y install
-	cp -p $(ZIP_DOCS) build-win/stone_soup-$(MAJOR_VERSION)/
-	cd build-win && zip -9r ../stone_soup-$(SRC_VERSION)-win32.zip *
-	rm -rf build-win
-	if which advzip >/dev/null;then advzip -z4 stone_soup-$(SRC_VERSION)*-win32.zip;fi
+	if which advzip >/dev/null;then advzip -z3 stone_soup-$(SRC_VERSION)-tiles-win32.zip;fi
+	ln -sf stone_soup-$(SRC_VERSION)-tiles-win32.zip stone_soup-latest-tiles-win32.zip
+
+package-windows-console:
+ifneq ($(GAME),crawl.exe)
+	@echo "This is only for Windows; please specify CROSSHOST.";false
+endif
+	+$(MAKE) DESTDIR=build-win/stone_soup-console-$(MAJOR_VERSION) FORCE_SSE=y install
+	cp -p $(ZIP_DOCS) build-win/stone_soup-console-$(MAJOR_VERSION)/
+	cd build-win && zip -9r ../stone_soup-$(SRC_VERSION)-console-win32.zip *
+	if which advzip >/dev/null;then advzip -z3 stone_soup-$(SRC_VERSION)-console-win32.zip;fi
+	ln -sf stone_soup-$(SRC_VERSION)-console-win32.zip stone_soup-latest-console-win32.zip
 
 #############################################################################
 # Building Mac app bundles

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1837,7 +1837,7 @@ package-windows-installer:
 ifneq (x$(SRC_VERSION),x$(shell cat build-win/version.txt 2>/dev/null))
 	+$(MAKE) build-windows
 endif
-	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$(WINARCH)" util/crawl.nsi; \
+	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$(WINARCH)" util/crawl.nsi
 	ln -sf "stone_soup-$(SRC_VERSION)-$(WINARCH)-installer.exe" "stone_soup-latest-$(WINARCH)-installer.exe"
 
 build-windows:

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1839,6 +1839,7 @@ ifneq (x$(SRC_VERSION),x$(shell cat build-win/version.txt 2>/dev/null))
 endif
 	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$(WINARCH)" util/crawl.nsi
 	ln -sf "stone_soup-$(SRC_VERSION)-$(WINARCH)-installer.exe" "stone_soup-latest-$(WINARCH)-installer.exe"
+	rm -rf build-win
 
 build-windows:
 ifneq ($(GAME),crawl.exe)

--- a/crawl-ref/source/mac/Makefile.app-bundle
+++ b/crawl-ref/source/mac/Makefile.app-bundle
@@ -26,6 +26,8 @@ BUNDLE_NAME := Dungeon\ Crawl\ Stone\ Soup\ -\ Console
 EXECUTABLE_PATH := crawl
 ifdef RELEASE
 ZIP_QUALIFIER := -console
+else
+ZIP_QUALIFIER := _console
 endif
 endif
 
@@ -66,7 +68,10 @@ assemble-app-bundle: create-bundle-directory copy-executable copy-resources \
 zip-app-bundle:
 	rm -f $(ZIPPED_APP_DIR)/$(ZIP_NAME)
 	cd $(STAGING_DIR) && \
-		zip -r $(ZIPPED_APP_DIR)/$(ZIP_NAME) $(BUNDLE_NAME).app
+		zip -9r $(ZIPPED_APP_DIR)/$(ZIP_NAME) $(BUNDLE_NAME).app
+	cd $(STAGING_DIR) && \
+		if which advzip >/dev/null;then advzip -z3 $(ZIPPED_APP_DIR)/$(ZIP_NAME);fi
+	ln -sf $(ZIPPED_APP_DIR)/$(ZIP_NAME) $(ZIPPED_APP_DIR)/latest.zip
 
 create-bundle-directory: $(BUNDLE_DIRNAME)
 


### PR DESCRIPTION
Whenever a GitHub release is created, GitHub Actions will add the
following builds:

* Windows (32-bit) console & tiles zips, plus combined install
* macOS console & tiles apps

Also make the following changes:

* Disable some unnecessary Clang builds
* Rename windows package Makefile targets
* Use advzip on macOS packages