### PR TITLE
WIndows installer package build cleanup

### DIFF
--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -186,7 +186,7 @@ makefile.dep
 /source/debian/files
 
 # Windows packaging
-/source/crawl-win
+/source/stone_soup
 
 # Windows thumbnail files
 Thumbs.db

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1838,6 +1838,7 @@ endif
 	if $(GXX) -dumpmachine|grep -q x86_64; \
 	  then WINARCH=win64; else WINARCH=win32; fi; \
 	makensis -NOCD -DVERSION=$(SRC_VERSION) -DWINARCH="$$WINARCH" util/crawl.nsi
+	rm -rf build-win
 
 build-windows:
 ifneq ($(GAME),crawl.exe)


### PR DESCRIPTION
1. The installer package build (unlike the zip build) currently
doesn't delete the build-win folder after it finishes
and the folder needs to be deleted manually.
There may be reason that I'm missing, but I can't think of any,
as the zip build deletes the folder, only the installer build doesn't.

2. The final win packages are actually named 'stone_soup...',
so update gitignore accordingly.