### PR TITLE
Fix gitignore for windows packages

### DIFF
--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -186,7 +186,8 @@ makefile.dep
 /source/debian/files
 
 # Windows packaging
-/source/stone_soup
+/source/stone_soup*.exe
+/source/stone_soup*.zip
 
 # Windows thumbnail files
 Thumbs.db


### PR DESCRIPTION
Change to wildcard matching, also add the exe, which is already excluded
elsewhere with *.exe, but should be also here for consistency.