### PR TITLE
Preferred food and menu_colour rules cleanup

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1664,8 +1664,8 @@ menu_colour ^= <match>:<colour>:<regex>, <colour>:<regex>, ...
         The following apply only to items of certain base types, whether
         identified or not:
            inedible        (You cannot eat this, or get no nutrition from it.)
-           preferred       (The food type your character prefers, for example
-                            for herbivores/carnivores.)
+           preferred       (The food type your character prefers. For example,
+                            Ghouls prefer chunks to rations.)
            poisonous       (Chunks/corpses that are poisonous.)
            mutagenic       (Chunks/corpses that are mutagenic.)
            contaminated    (Chunks/corpses that give reduced nutrition.)

--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -123,10 +123,6 @@ function ch_stash_search_annotate_item(it)
     end
   end
 
-  if it.class(true) == "potion" and it.is_preferred_food then
-    annot = annot .. "{food} "
-  end
-
   if it.class(true) == "armour" then
       annot = annot .. "{" .. it.subtype() .. " "
   elseif it.class(true) == "weapon" then

--- a/crawl-ref/source/dat/defaults/food_colouring.txt
+++ b/crawl-ref/source/dat/defaults/food_colouring.txt
@@ -12,6 +12,7 @@ inv += $inedible:.*useless_item.*carrion.*
 # will be overridden by "useless" and "inedible".
 inv += $forbidden:.*forbidden.*(chunk|corpse)
 
+# Ghouls prefer chunks to rations.
 inv += $preferred:.*preferred.*
 
 inv += $inedible:.*inedible.*

--- a/crawl-ref/source/dat/defaults/menu_colours.txt
+++ b/crawl-ref/source/dat/defaults/menu_colours.txt
@@ -49,16 +49,12 @@ menu += yellow:.*emergency_item.*
 
 # Good items
 menu += cyan:.*good_item.*
-menu += cyan:.*misc.*[lL]antern
 
 # Dangerous (but still useful) items
 menu += $dangerous:.*dangerous_item.*
 
 # Defaults for normal items
 menu += lightblue:unidentified.*(potion|scroll|wand|jewellery|magical staff)
-# : if you.god() == "Nemelex Xobeh" then
-#     menu += lightblue:deck of cards
-# : end
 menu += green:uncursed
 
 

--- a/crawl-ref/source/food.cc
+++ b/crawl-ref/source/food.cc
@@ -690,10 +690,6 @@ bool is_inedible(const item_def &item, bool temp)
 // still be edible or even delicious.
 bool is_preferred_food(const item_def &food)
 {
-    // Mummies, vampirees, and liches don't eat.
-    if (you_foodless())
-        return false;
-
     if (you.species == SP_GHOUL)
         return food.is_type(OBJ_FOOD, FOOD_CHUNK);
 

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3281,14 +3281,6 @@ string item_prefix(const item_def &item, bool temp)
             prefixes.push_back("inedible");
         break;
 
-    case OBJ_POTIONS:
-        if (is_preferred_food(item))
-        {
-            prefixes.push_back("preferred");
-            prefixes.push_back("food");
-        }
-        break;
-
     case OBJ_STAVES:
     case OBJ_WEAPONS:
         if (is_range_weapon(item))


### PR DESCRIPTION
This PR removes a few *leftovers* from when potions of blood and more types of
food for carnivores/herbivores existed.

Also, it removes `menu_colour` rules for decks of cards and the lantern of shadows.