### PR TITLE
Add support for minor tags > 255

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -306,6 +306,7 @@ fontwrapper-ft.o
 TEST_OBJECTS = \
 catch2-tests/test_branch.o \
 catch2-tests/test_english.o \
+catch2-tests/test_files.o \
 catch2-tests/test_items.o \
 catch2-tests/test_ng-init-branches.o \
 catch2-tests/test_player.o \

--- a/crawl-ref/source/catch2-tests/test_files.cc
+++ b/crawl-ref/source/catch2-tests/test_files.cc
@@ -1,0 +1,102 @@
+#include "catch.hpp"
+
+#include "AppHdr.h"
+
+#include "files.h"
+#include "random.h"
+#include "tags.h"
+
+TEST_CASE( "Test save version reading/writing works", "[single-file]" ) {
+
+    SECTION ("Major version is stored as a single unsigned byte") {
+
+        SECTION ("reading") {
+            vector<unsigned char> input = { 0xff, 0x00, };
+            auto r = reader(input);
+
+            const auto version = get_save_version(r);
+
+            REQUIRE(version.major == 255);
+            REQUIRE(r.valid() == false);
+        }
+
+        SECTION ("writing") {
+            vector<unsigned char> output;
+            vector<unsigned char> expected_output = { 0xff, 0x00, };
+            const auto version = save_version(255, 0);
+            auto w = writer(&output);
+
+            write_save_version(w, version);
+
+            REQUIRE(output == expected_output);
+        }
+    }
+
+    SECTION ("Minor version < 255 is stored as a single unsigned byte") {
+
+        SECTION ("reading") {
+            vector<unsigned char> input = { 0x00, 0xfe, };
+            auto r = reader(input);
+
+            const auto version = get_save_version(r);
+
+            REQUIRE(version.minor == 254);
+            REQUIRE(r.valid() == false);
+        }
+
+        SECTION ("writing") {
+            vector<unsigned char> output;
+            vector<unsigned char> expected_output = { 0x00, 0xfe, };
+            const auto version = save_version(0, 254);
+            auto w = writer(&output);
+
+            write_save_version(w, version);
+
+            REQUIRE(output == expected_output);
+        }
+    }
+
+    SECTION ("Minor version >= 255 is stored as a big-endian 4-byte integer") {
+
+        SECTION ("reading") {
+            vector<unsigned char> input = { 0x00, 0xff, 0x01, 0x02, 0x03, 0x04 };
+            auto r = reader(input);
+            const auto expected_minor = (1 << 24) + (2 << 16) + (3 << 8) + 4;
+
+            const auto version = get_save_version(r);
+
+            REQUIRE(version.minor == expected_minor);
+            REQUIRE(r.valid() == false);
+        }
+
+        SECTION ("writing") {
+            vector<unsigned char> output;
+            vector<unsigned char> expected_output = { 0x00, 0xff, 0x01, 0x02, 0x03, 0x04 };
+            const auto version = save_version(0, (1 << 24) + (2 << 16) + (3 << 8) + 4);
+            auto w = writer(&output);
+
+            write_save_version(w, version);
+
+            REQUIRE(output == expected_output);
+        }
+    }
+
+    SECTION ("Saving and loading is a reversible operation") {
+        rng::subgenerator subgen(0, 0);
+
+        for (auto i = 0; i < 1000; i++)
+        {
+            const auto version = save_version(random2(255), random2(1000));
+
+            vector<unsigned char> buf;
+            auto w = writer(&buf);
+            write_save_version(w, version);
+
+            auto r = reader(buf);
+            const auto roundtrip_version = get_save_version(r);
+
+            REQUIRE(version == roundtrip_version);
+            REQUIRE(r.valid() == false);
+        }
+    }
+}

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -828,9 +828,7 @@ string get_prefs_filename()
 void write_ghost_version(writer &outf)
 {
     // this may be distinct from the current save version
-    auto bones_version = save_version::current_bones();
-    marshallUByte(outf, bones_version.major);
-    marshallUByte(outf, bones_version.minor);
+    write_save_version(outf, save_version::current_bones());
 
     // extended_version just pads the version out to four 32-bit words.
     // This makes the bones file compatible with Hearse with no extra
@@ -853,10 +851,7 @@ static void _write_tagged_chunk(const string &chunkname, tag_type tag)
 {
     writer outf(you.save, chunkname);
 
-    // write version
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
-
+    write_save_version(outf, save_version::current());
     tag_write(tag, outf);
 }
 
@@ -2880,18 +2875,32 @@ level_excursion::~level_excursion()
 
 save_version get_save_version(reader &file)
 {
-    // Read first two bytes.
-    uint8_t buf[2];
+    int major, minor;
     try
     {
-        file.read(buf, 2);
+        major = unmarshallUByte(file);
+        minor = unmarshallUByte(file);
+        if (minor == UINT8_MAX)
+            minor = unmarshallInt(file);
     }
     catch (short_read_exception& E)
     {
         // Empty file?
         return save_version(-1, -1);
     }
-    return save_version(buf[0], buf[1]);
+    return save_version(major, minor);
+}
+
+void write_save_version(writer &outf, save_version version)
+{
+    marshallUByte(outf, version.major);
+    if (version.minor < UINT8_MAX)
+        marshallUByte(outf, version.minor);
+    else
+    {
+        marshallUByte(outf, UINT8_MAX);
+        marshallInt(outf, version.minor);
+    }
 }
 
 static bool _convert_obsolete_species()
@@ -2950,9 +2959,9 @@ static bool _read_char_chunk(package *save)
 
     try
     {
-        uint8_t format, major, minor;
-        inf.read(&major, 1);
-        inf.read(&minor, 1);
+        const auto version = get_save_version(inf);
+        const auto major = version.major, minor = version.minor;
+        uint8_t format;
 
         unsigned int len = unmarshallInt(inf);
         if (len > 1024) // something is fishy

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -94,6 +94,7 @@ void save_game(bool leave_game, const char *bye = nullptr);
 // Save game without exiting (used when changing levels).
 void save_game_state();
 
+void write_save_version(writer &file, save_version version);
 save_version get_save_version(reader &file);
 
 bool save_exists(const string& filename);

--- a/crawl-ref/source/kills.cc
+++ b/crawl-ref/source/kills.cc
@@ -61,9 +61,8 @@ bool KillMaster::empty() const
 
 void KillMaster::save(writer& outf) const
 {
-    // Write the version of the kills file
-    marshallByte(outf, KILLS_MAJOR_VERSION);
-    marshallByte(outf, KILLS_MINOR_VERSION);
+    const auto version = save_version(KILLS_MAJOR_VERSION, KILLS_MINOR_VERSION);
+    write_save_version(outf, version);
 
     for (int i = 0; i < KC_NCATEGORIES; ++i)
         categorized_kills[i].save(outf);
@@ -71,8 +70,9 @@ void KillMaster::save(writer& outf) const
 
 void KillMaster::load(reader& inf)
 {
-    int major = unmarshallByte(inf),
-        minor = unmarshallByte(inf);
+    const auto version = get_save_version(inf);
+    const auto major = version.major, minor = version.minor;
+
     if (major != KILLS_MAJOR_VERSION
         || (minor != KILLS_MINOR_VERSION && minor > 0))
     {

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -2355,8 +2355,7 @@ string map_def::desc_or_name() const
 void map_def::write_full(writer& outf) const
 {
     cache_offset = outf.tell();
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
+    write_save_version(outf, save_version::current());
     marshallString4(outf, name);
     prelude.write(outf);
     mapchunk.write(outf);
@@ -2376,8 +2375,8 @@ void map_def::read_full(reader& inf)
     // reloading the index), but it's easier to save the game at this
     // point and let the player reload.
 
-    const uint8_t major = unmarshallUByte(inf);
-    const uint8_t minor = unmarshallUByte(inf);
+    const auto version = get_save_version(inf);
+    const auto major = version.major, minor = version.minor;
 
     if (major != TAG_MAJOR_VERSION || minor > TAG_MINOR_VERSION)
     {

--- a/crawl-ref/source/maps.cc
+++ b/crawl-ref/source/maps.cc
@@ -1235,8 +1235,8 @@ static bool verify_file_version(const string &file, time_t mtime)
     try
     {
         reader inf(fp);
-        const uint8_t major = unmarshallUByte(inf);
-        const uint8_t minor = unmarshallUByte(inf);
+        const auto version = get_save_version(inf);
+        const auto major = version.major, minor = version.minor;
         const int8_t word = unmarshallByte(inf);
         const int64_t t = unmarshallSigned(inf);
         fclose(fp);
@@ -1269,8 +1269,8 @@ static bool _load_map_index(const string& cache, const string &base,
     if (FILE *fp = fopen_u((base + ".lux").c_str(), "rb"))
     {
         reader inf(fp, TAG_MINOR_VERSION);
-        uint8_t major = unmarshallUByte(inf);
-        uint8_t minor = unmarshallUByte(inf);
+        const auto version = get_save_version(inf);
+        const auto major = version.major, minor = version.minor;
         int8_t word = unmarshallByte(inf);
         int64_t t = unmarshallSigned(inf);
         if (major != TAG_MAJOR_VERSION || minor > TAG_MINOR_VERSION
@@ -1291,8 +1291,8 @@ static bool _load_map_index(const string& cache, const string &base,
 
     reader inf(fp, TAG_MINOR_VERSION);
     // Re-check version, might have been modified in the meantime.
-    uint8_t major = unmarshallUByte(inf);
-    uint8_t minor = unmarshallUByte(inf);
+    const auto version = get_save_version(inf);
+    const auto major = version.major, minor = version.minor;
     int8_t word = unmarshallByte(inf);
     int64_t t = unmarshallSigned(inf);
     if (major != TAG_MAJOR_VERSION || minor > TAG_MINOR_VERSION
@@ -1358,8 +1358,7 @@ static void _write_map_prelude(const string &filebase, time_t mtime)
 
     FILE *fp = fopen_u(luafile.c_str(), "wb");
     writer outf(luafile, fp);
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
+    write_save_version(outf, save_version::current());
     marshallByte(outf, WORD_LEN);
     marshallSigned(outf, mtime);
     lc_global_prelude.write(outf);
@@ -1375,8 +1374,7 @@ static void _write_map_full(const string &filebase, size_t vs, size_t ve,
         end(1, true, "Unable to open %s for writing", cfile.c_str());
 
     writer outf(cfile, fp);
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
+    write_save_version(outf, save_version::current());
     marshallByte(outf, WORD_LEN);
     marshallSigned(outf, mtime);
     for (size_t i = vs; i < ve; ++i)
@@ -1393,8 +1391,7 @@ static void _write_map_index(const string &filebase, size_t vs, size_t ve,
         end(1, true, "Unable to open %s for writing", cfile.c_str());
 
     writer outf(cfile, fp);
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
+    write_save_version(outf, save_version::current());
     marshallByte(outf, WORD_LEN);
     marshallSigned(outf, mtime);
     marshallShort(outf, ve > vs? ve - vs : 0);

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -246,9 +246,6 @@ enum tag_minor_version
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1
 };
 
-// Marshalled as a byte in several places.
-COMPILE_CHECK(TAG_MINOR_VERSION <= 0xff);
-
 // tags that affect loading bones files. If you do save compat that affects
 // ghosts, these must be updated in addition to the enum above.
 const set<int> bones_minor_tags =

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4156,9 +4156,7 @@ bool TravelCache::is_known_branch(uint8_t branch) const
 
 void TravelCache::save(writer& outf) const
 {
-    // Travel cache version information
-    marshallUByte(outf, TAG_MAJOR_VERSION);
-    marshallUByte(outf, TAG_MINOR_VERSION);
+    write_save_version(outf, save_version::current());
 
     // Write level count.
     marshallShort(outf, levels.size());
@@ -4178,8 +4176,8 @@ void TravelCache::load(reader& inf, int minorVersion)
     levels.clear();
 
     // Check version. If not compatible, we just ignore the file altogether.
-    int major = unmarshallUByte(inf),
-        minor = unmarshallUByte(inf);
+    const auto version = get_save_version(inf);
+    const auto major = version.major, minor = version.minor;
     if (major != TAG_MAJOR_VERSION || minor > TAG_MINOR_VERSION)
         return;
 


### PR DESCRIPTION
Previous versions of crawl serialize the minor version as a single byte,
which prevents storing minor versions greater than 255. This commit adds
support for eventually moving to such minor versions: values greater
than 255 are stored as a byte equal to 255, and then the real minor
version as a four-byte big-endian integer.

This commit also consolidates some of the chunk tag reading and writing.
Most of the code for reading/writing various chunks directly accessed
bytes; this commit adds two helper functions for reading and writing
respectively.

This change is being added now because directly adding a four-byte
value, while possible, breaks the save browser, causing new games to not
be displayed at all in older crawl binaries. This change adds immediate
support for the save browser to read files with four-byte integer
minors, even though saves will continue to use a single byte. By the
time we reach minor 256 (perhaps around ~3 years at the current pace),
most binaries in the wild should be newer than this binary.