### PR TITLE
Tweak some option defaults

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -955,7 +955,7 @@ rest_wait_percent = 100
         it will stop resting when this percent of maximum HP or MP is refilled.
         Resting after this point will still rest up to 100%.
 
-explore_auto_rest = false
+explore_auto_rest = true
         If true, auto-explore waits until your HP and MP are both at
         rest_wait_percent before moving.
 

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1025,7 +1025,7 @@ auto_butcher = true
         full', 'full', 'satiated', 'hungry', 'very hungry', or 'near starving')
         to enable automatic butchery only when at that state or hungrier.
 
-auto_butcher_max_chunks = 0
+auto_butcher_max_chunks = 10
         If this is set to a nonzero value, automatic butchering will not
         be done if you have more than this many chunks in your inventory.
 

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1019,7 +1019,7 @@ allow_self_target = (yes | no | prompt)
         effect on area-effect spells, such as Mephitic Cloud, where you are
         always a valid target.
 
-auto_butcher = very hungry
+auto_butcher = true
         If this is set to true, you will automatically travel to and attempt to
         butcher edible corpses. Can also be set to a hunger threshold ('very
         full', 'full', 'satiated', 'hungry', 'very hungry', or 'near starving')

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -213,7 +213,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(bad_item_prompt), true),
         new BoolGameOption(SIMPLE_NAME(dos_use_background_intensity), true),
         new BoolGameOption(SIMPLE_NAME(explore_greedy), true),
-        new BoolGameOption(SIMPLE_NAME(explore_auto_rest), false),
+        new BoolGameOption(SIMPLE_NAME(explore_auto_rest), true),
         new BoolGameOption(SIMPLE_NAME(travel_key_stop), true),
         new BoolGameOption(SIMPLE_NAME(dump_on_save), true),
         new BoolGameOption(SIMPLE_NAME(rest_wait_both), false),

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1048,7 +1048,7 @@ void game_options::reset_options()
     autopickups.set(OBJ_FOOD);
 
     confirm_butcher        = confirm_butcher_type::normal;
-    auto_butcher           = HS_VERY_HUNGRY;
+    auto_butcher           = HS_ENGORGED;
     easy_confirm           = easy_confirm_type::safe;
     allow_self_target      = confirm_prompt_type::prompt;
     skill_focus            = SKM_FOCUS_ON;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -283,7 +283,7 @@ const vector<GameOption*> game_options::build_options_list()
         new IntGameOption(SIMPLE_NAME(level_map_cursor_step), 7, 1, 50),
         new IntGameOption(SIMPLE_NAME(dump_item_origin_price), -1, -1),
         new IntGameOption(SIMPLE_NAME(dump_message_count), 20),
-        new IntGameOption(SIMPLE_NAME(auto_butcher_max_chunks), 0, 0),
+        new IntGameOption(SIMPLE_NAME(auto_butcher_max_chunks), 10, 0),
         new ListGameOption<text_pattern>(SIMPLE_NAME(confirm_action)),
         new ListGameOption<text_pattern>(SIMPLE_NAME(drop_filter)),
         new ListGameOption<text_pattern>(SIMPLE_NAME(note_monsters)),


### PR DESCRIPTION
I recently watched a few players play their first games, and they all made the same errors:

* Running out of food as MiBe (due to auto butcher leaving chunks behind)
* Auto exploring at low HP

The show_more change is a little more speculative, I saw it cause a problem in one game where a newbie was surrounded and getting attacked multiple times. They didn't even realise the `--MORE--` prompt was showing up, and started getting frustrated that the game was ignoring their commands. They figured out pressing spacebar made the problem go away, but didn't understand the underlying principle.