### PR TITLE
Tweak phial of floods description (Flugkiller)

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -628,8 +628,8 @@ phial of floods
 
 An enchanted vessel brimming over with elemental water. Removing the stopper
 unleashes a torrent of water from the phial, dealing damage to the target and
-flooding the nearby area. Any creatures within the flooded area are also
-engulfed in water, silencing them temporarily. The strength of the torrent and
+flooding the nearby area. Any creatures hit by the wave are also engulfed
+in water, silencing them temporarily. The strength of the torrent and
 the duration of the flooding are increased with Evocations skill.
 %%%%
 plate armour


### PR DESCRIPTION
Change description to better indicate that only monsters hit
by the initial wave will be affected by silence, not monsters that
walk into the water later.