### PR TITLE
Change show_more default to false

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1425,7 +1425,7 @@ clear_messages = false
         between player actions (default is false which will delay the
         clearing of messages until the message space is full).
 
-show_more = true
+show_more = false
         Setting this option to false will cause the game not to prompt
         if more than a window-full of messages are output at once. This
         option has no effect if clear_messages is set. Additionally, it

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -196,11 +196,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(note_chat_messages), false),
         new BoolGameOption(SIMPLE_NAME(note_dgl_messages), true),
         new BoolGameOption(SIMPLE_NAME(clear_messages), false),
-#ifdef DEBUG
         new BoolGameOption(SIMPLE_NAME(show_more), false),
-#else
-        new BoolGameOption(SIMPLE_NAME(show_more), !USING_TOUCH),
-#endif
         new BoolGameOption(SIMPLE_NAME(small_more), false),
         new BoolGameOption(SIMPLE_NAME(pickup_thrown), true),
         new BoolGameOption(SIMPLE_NAME(show_travel_trail), USING_DGL),


### PR DESCRIPTION
For new players, it's confusing and inconsistent to sometimes be
prompted to press space while waiting to play your next turn.
Additionally, the prompt to press space is small and easily overlooked
(and it's not clear what the --MORE-- prompt means unless you are
familiar with Unix command line environments).