### PR TITLE
Fix resource leak if allocating PNG structs fails.

### DIFF
--- a/crawl-ref/source/rltiles/tool/tile_colour.cc
+++ b/crawl-ref/source/rltiles/tool/tile_colour.cc
@@ -251,12 +251,16 @@ bool write_png(const char *filename, tile_colour *pixels,
     png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
                                                   nullptr, nullptr, nullptr);
     if (!png_ptr)
+    {
+        fclose(fp);
         return false;
+    }
 
     png_infop info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr)
     {
         png_destroy_write_struct(&png_ptr, (png_infopp)nullptr);
+        fclose(fp);
         return false;
     }
 


### PR DESCRIPTION
Cppcheck complains "Resource leak: fp" at lines 254 and 260 where the
function write_png returns on error without closing the file opened
at the beginning of the function. After write_png returns, the file
would still be open, but the pointer to it has been lost.

Cppcheck errors:
```
[crawl-ref/source/rltiles/tool/tile_colour.cc:254] (error) Resource leak: fp [resourceLeak]
[crawl-ref/source/rltiles/tool/tile_colour.cc:260] (error) Resource leak: fp [resourceLeak]
```