### PR TITLE
Fix CI ccache caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v1
         with:
-          path: $HOME/.ccache
+          path: ~/.ccache
           key: ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}
           restore-keys: |
             ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}
@@ -172,7 +172,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v1
         with:
-          path: $HOME/.ccache
+          path: ~/.ccache
           key: ccache-macos-clang-${{ matrix.build_type }}
           restore-keys: |
             ccache-macos-clang-${{ matrix.build_type }}
@@ -244,7 +244,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v1
         with:
-          path: $HOME/.ccache
+          path: ~/.ccache
           key: ccache-mingw64-${{ matrix.build_type }}
           restore-keys: |
             ccache-mingw64-${{ matrix.build_type }}
@@ -319,7 +319,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v1
         with:
-          path: /home/runner/.ccache
+          path: ~/.ccache
           key: ccache-catch2
           restore-keys: |
             ccache-catch2


### PR DESCRIPTION
Current runs are giving the following error during the "post cache
compilation" step:

Post job cleanup.
/bin/tar -cz -f /home/runner/work/_temp/17c1f8fd-a821-43cb-a606-fc036b1b78dc/cache.tgz -C /home/runner/work/crawl/crawl/$HOME/.ccache .
/bin/tar: /home/runner/work/crawl/crawl/$HOME/.ccache: Cannot open: No such file or directory
/bin/tar: Error is not recoverable: exiting now
[warning]Tar failed with error: The process '/bin/tar' failed with exit code 2

It seems like environment variables are not supported. However, examples
in the actions/cache repo show use of `~`, so we can use that instead:
https://github.com/actions/cache/blob/master/examples.md#python---pip