### PR TITLE
Fix the comment on max_miscast_damage

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1991,7 +1991,7 @@ const double fail_hp_fraction[] =
  * Compute the maximum miscast damage from the given spell
  *
  * The miscast code uses
- *     dam = div_rand_round(roll_dice(level, level * fail), MISCAST_DIVISOR)
+ *     dam = div_rand_round(roll_dice(level, level + raw_fail), MISCAST_DIVISOR)
  */
 int max_miscast_damage(spell_type spell)
 {


### PR DESCRIPTION
The actual math in this function was updated to calculate the max miscast damage
properly, but the comment was incorrect. dam now uses the sum of level and raw_fail
instead of the product of level and actual fail.