### PR TITLE
Reflect Bounces Back

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -272,6 +272,11 @@ bool actor::no_cast(bool calc_unid, bool items) const
     return items && scan_artefacts(ARTP_PREVENT_SPELLCASTING, calc_unid);
 }
 
+bool actor::reflection(bool calc_unid, bool items) const
+{
+    return items && wearing(EQ_AMULET, AMU_REFLECTION, calc_unid);
+}
+
 bool actor::extra_harm(bool calc_unid, bool items) const
 {
     return items &&

--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -335,6 +335,7 @@ public:
     virtual int archmagi(bool calc_unid = true, bool items = true) const;
     virtual int spec_evoke(bool calc_unid = true, bool items = true) const;
     virtual bool no_cast(bool calc_unid = true, bool items = true) const;
+    virtual bool reflection(bool calc_unid = true, bool items = true) const;
     virtual bool extra_harm(bool calc_unid = true, bool items = true) const;
 
     virtual bool rmut_from_item(bool calc_unid = true) const;

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1016,10 +1016,10 @@ INT:     3
 MAGIC:   2
 
 NAME:     brooch of Shielding
-OBJ:      OBJ_JEWELLERY/AMU_REFLECTION
+OBJ:      OBJ_JEWELLERY/AMU_GUARDIAN_SPIRIT
 COLOUR:   ETC_MAGIC
 TILE:     urand_brooch_of_shielding
-PLUS:     +8
+SH:       +8
 
 ENUM:     RCLOUDS
 NAME:     robe of Clouds

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1015,13 +1015,11 @@ TILE:    urand_mage
 INT:     3
 MAGIC:   2
 
-# start TAG_MAJOR_VERSION == 34
 NAME:     brooch of Shielding
-OBJ:      OBJ_JEWELLERY/AMU_GUARDIAN_SPIRIT
+OBJ:      OBJ_JEWELLERY/AMU_REFLECTION
 COLOUR:   ETC_MAGIC
 TILE:     urand_brooch_of_shielding
-BOOL:     nogen
-# end TAG_MAJOR_VERSION
+PLUS:     +8
 
 ENUM:     RCLOUDS
 NAME:     robe of Clouds

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -347,6 +347,7 @@ struct jewellery_fake_artp
 
 static map<jewellery_type, vector<jewellery_fake_artp>> jewellery_artps = {
     { AMU_REGENERATION, { { ARTP_REGENERATION, 1 } } },
+    { AMU_REFLECTION, { { ARTP_SHIELDING, 0 } } },
 
     { RING_MAGICAL_POWER, { { ARTP_MAGICAL_POWER, 9 } } },
     { RING_FLIGHT, { { ARTP_FLY, 1 } } },
@@ -1485,6 +1486,10 @@ static bool _randart_is_redundant(const item_def &item,
 
     case AMU_REGENERATION:
         provides = ARTP_REGENERATION;
+        break;
+
+    case AMU_REFLECTION:
+        provides = ARTP_SHIELDING;
         break;
     }
 

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -347,7 +347,7 @@ struct jewellery_fake_artp
 
 static map<jewellery_type, vector<jewellery_fake_artp>> jewellery_artps = {
     { AMU_REGENERATION, { { ARTP_REGENERATION, 1 } } },
-    { AMU_REFLECTION, { { ARTP_SHIELDING, 0 } } },
+    { AMU_REFLECTION, { { ARTP_SHIELDING, AMU_REFLECT_SH / 2} } },
 
     { RING_MAGICAL_POWER, { { ARTP_MAGICAL_POWER, 9 } } },
     { RING_FLIGHT, { { ARTP_FLY, 1 } } },

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -123,8 +123,13 @@ bool attack::handle_phase_damaged()
 bool attack::handle_phase_killed()
 {
     monster* mon = defender->as_monster();
-    if (!invalid_monster(mon))
-        monster_die(*mon, attacker);
+    if (!invalid_monster(mon)) {
+        // Was this a reflected missile from the player?
+        if (responsible->mid == MID_YOU_FAULTLESS)
+            monster_die(*mon, KILL_YOU_MISSILE, YOU_FAULTLESS);
+        else
+            monster_die(*mon, attacker);
+    }
 
     return true;
 }

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2869,7 +2869,7 @@ bool bolt::is_reflectable(const actor &whom) const
         return false;
 
     const item_def *it = whom.shield();
-    return it && is_shield(*it) && shield_reflects(*it);
+    return (it && is_shield(*it) && shield_reflects(*it)) || whom.reflection();
 }
 
 bool bolt::is_big_cloud() const

--- a/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
+++ b/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
@@ -82,6 +82,7 @@ ae += [^n]identified.*spellbook
 :  or itsubtype == "amulet of inaccuracy"
 :  or itsubtype == "amulet of magic regeneration"
 :  or itsubtype == "amulet of nothing"
+:  or itsubtype == "amulet of reflection"
 :  or itsubtype == "amulet of regeneration"
 :  or itsubtype == "amulet of the acrobat"
 :  or itsubtype == "ring of flight"

--- a/crawl-ref/source/dat/des/branches/depths_encompass.des
+++ b/crawl-ref/source/dat/des/branches/depths_encompass.des
@@ -223,7 +223,7 @@ KMONS:   ~ = ice dragon
 KMONS:   z = killer bee
 KMONS:   Z = queen bee
 ITEM:    scroll of teleportation
-ITEM:    amulet of the acrobat
+ITEM:    amulet of reflection
 KITEM:   gzZ = ration w:5 tile:food_honeycomb / nothing w:40
 KFEAT:   L = l
 KFEAT:   ~ = w

--- a/crawl-ref/source/dat/des/builder/alphashops.des
+++ b/crawl-ref/source/dat/des/builder/alphashops.des
@@ -142,7 +142,7 @@
       elseif s == "Q" then i = { "quarterstaff", "quicksilver dragon scales",
        "quick blade" }
 
-      elseif s == "R" then i = {
+      elseif s == "R" then i = { "amulet of reflection",
        "amulet of regeneration", "rapier", "ring of resist corrosion",
        "ration", "potion of resistance", "robe", "ring mail",
        "scroll of random uselessness", "scroll of remove curse",

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -730,6 +730,7 @@ KFEAT:  S = jewellery shop ; \
             ring of strength | \
             ring of dexterity | \
             ring of intelligence | \
+            amulet of reflection | \
             ring of evasion | \
             ring of protection | \
             ring of slaying w:3

--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -63,7 +63,8 @@ function trove.get_trove_item(e, value, base_item)
     end
     local jwith_pluses = {"ring of protection", "ring of evasion",
                           "ring of strength", "ring of intelligence",
-                          "ring of dexterity", "ring of slaying"}
+                          "ring of dexterity", "ring of slaying",
+                          "amulet of reflection"}
     local bt = shop_item.base_type
     if bt == "armour" or bt == "weapon" or bt == "jewellery" then
       if shop_item.identified() then

--- a/crawl-ref/source/dat/des/sprint/arena_sprint.des
+++ b/crawl-ref/source/dat/des/sprint/arena_sprint.des
@@ -1098,6 +1098,7 @@ KFEAT:  J = general shop type:Miscellaneous suffix:Merchandise count:14 greed:15
             ration q:20 | ring of poison resistance |\
             ring of protection from fire | ring of protection from cold |\
             ring of protection from magic | amulet of regeneration |\
+            amulet of reflection |\
             ring of see invisible
 SUBST:  b : cb
 TILE:   c = wall_marble

--- a/crawl-ref/source/dat/des/sprint/linesprint.des
+++ b/crawl-ref/source/dat/des/sprint/linesprint.des
@@ -787,6 +787,7 @@ ORIENT:   encompass
 KITEM:    a = amulet of faith randart not_cursed ident:all /\
     amulet of guardian spirit randart not_cursed ident:all /\
     amulet of magic regeneration randart not_cursed ident:all /\
+    amulet of reflection randart not_cursed ident:all /\
     amulet of regeneration randart ident:all not_cursed /\
     ring of slaying plus:3 randart ident:all not_cursed /\
     any jewellery randart level:27 not_cursed ident:all w:40 /\

--- a/crawl-ref/source/dat/des/sprint/pitsprint.des
+++ b/crawl-ref/source/dat/des/sprint/pitsprint.des
@@ -482,6 +482,7 @@ function coven_setup(e)
   e.kitem("b = amulet of faith randart not_cursed ident:all /\
           amulet of guardian spirit randart not_cursed ident:all /\
           amulet of magic regeneration randart not_cursed ident:all /\
+          amulet of reflection randart not_cursed ident:all /\
           amulet of regeneration randart ident:all not_cursed /\
           ring of slaying plus:5 randart ident:all not_cursed /\
           any jewellery randart level:27 not_cursed ident:all w:40")

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -33,6 +33,11 @@ amulet of nothing
 
 An amulet with no special properties.
 %%%%
+amulet of reflection
+
+An amulet which exerts a force that blocks some incoming attacks, and can even
+reflect any blocked ranged attacks back towards the attacker.
+%%%%
 amulet of regeneration
 
 An amulet that increases the wearer's natural regeneration rate. In order to

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -36,7 +36,8 @@ An amulet with no special properties.
 amulet of reflection
 
 An amulet which exerts a force that blocks some incoming attacks, and can even
-reflect any blocked ranged attacks back towards the attacker.
+reflect any blocked ranged attacks back towards the attacker. In order to
+function, it must first attune itself to the wearer's body at full health.
 %%%%
 amulet of regeneration
 

--- a/crawl-ref/source/dat/dlua/lm_trove.lua
+++ b/crawl-ref/source/dat/dlua/lm_trove.lua
@@ -328,7 +328,8 @@ function TroveMarker:item_name(do_grammar)
 
   local jwith_pluses = {"ring of protection", "ring of evasion",
                         "ring of strength", "ring of intelligence",
-                        "ring of dexterity", "ring of slaying"}
+                        "ring of dexterity", "ring of slaying",
+                        "amulet of reflection"}
   if item.base_type == "jewellery" and
      util.contains(jwith_pluses, item.sub_type) then
     s = s .. " +" .. item.plus1
@@ -422,7 +423,8 @@ function TroveMarker:search_for_item(marker, pname, iter_table, dry_run)
 
     local jwith_pluses = {"ring of protection", "ring of evasion",
                           "ring of strength", "ring of intelligence",
-                          "ring of dexterity", "ring of slaying"}
+                          "ring of dexterity", "ring of slaying",
+                          "amulet of reflection"}
     if it.base_type == "jewellery" then
       if not util.contains(jwith_pluses, it.sub_type) then
          iplus1 = false

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -246,10 +246,10 @@ const char* jewellery_base_ability_string(int subtype)
 #if TAG_MAJOR_VERSION == 34
     case AMU_CONSERVATION:        return "Cons";
     case AMU_CONTROLLED_FLIGHT:   return "cFly";
-    case AMU_REFLECTION:          return "Reflect";
 #endif
     case AMU_GUARDIAN_SPIRIT:     return "Spirit";
     case AMU_FAITH:               return "Faith";
+    case AMU_REFLECTION:          return "Reflect";
     case AMU_INACCURACY:          return "Inacc";
     }
     return "";
@@ -494,14 +494,14 @@ static const char* _jewellery_base_ability_description(int subtype)
 #if TAG_MAJOR_VERSION == 34
     case AMU_CONSERVATION:
         return "It protects your inventory from destruction.";
-    case AMU_REFLECTION:
-        return "It shields you and reflects attacks.";
 #endif
     case AMU_GUARDIAN_SPIRIT:
         return "It causes incoming damage to be split between your health and "
                "magic.";
     case AMU_FAITH:
         return "It allows you to gain divine favour quickly.";
+    case AMU_REFLECTION:
+        return "It shields you and reflects attacks.";
     case AMU_INACCURACY:
         return "It reduces the accuracy of all your attacks.";
     }
@@ -1920,6 +1920,11 @@ static string _describe_jewellery(const item_def &item, bool verbose)
                 description += make_stringf("\nIt affects your accuracy and"
                       " damage with ranged weapons and melee attacks (%+d).",
                       item.plus);
+                break;
+
+            case AMU_REFLECTION:
+                description += make_stringf("\nIt affects your shielding (%+d).",
+                                            item.plus);
                 break;
 
             default:

--- a/crawl-ref/source/equipment-type.h
+++ b/crawl-ref/source/equipment-type.h
@@ -37,9 +37,5 @@ enum equipment_type
     EQ_STAFF            = 100,         // weapon with base_type OBJ_STAVES
     EQ_RINGS,                          // check both rings
     EQ_RINGS_PLUS,                     // check both rings and sum plus
-#if TAG_MAJOR_VERSION == 34
-    EQ_RINGS_PLUS2,                    // check both rings and sum plus2
-#endif
     EQ_ALL_ARMOUR,                     // check all armour types
-    EQ_AMULET_PLUS,                    // check amulet for pluses.
 };

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -767,12 +767,12 @@ const char* jewellery_effect_name(int jeweltype, bool terse)
         case AMU_HARM:              return "harm";
         case AMU_CONSERVATION:      return "conservation";
         case AMU_CONTROLLED_FLIGHT: return "controlled flight";
-        case AMU_REFLECTION:        return "reflection";
 #endif
         case AMU_INACCURACY:        return "inaccuracy";
         case AMU_NOTHING:           return "nothing";
         case AMU_GUARDIAN_SPIRIT:   return "guardian spirit";
         case AMU_FAITH:             return "faith";
+        case AMU_REFLECTION:        return "reflection";
         case AMU_REGENERATION:      return "regeneration";
         default: return "buggy jewellery";
         }
@@ -804,10 +804,7 @@ const char* jewellery_effect_name(int jeweltype, bool terse)
         case RING_LIFE_PROTECTION:       return "rN+";
         case RING_PROTECTION_FROM_MAGIC: return "MR+";
         case AMU_REGENERATION:           return "Regen";
-#if TAG_MAJOR_VERSION == 34
         case AMU_RAGE:                   return "+Rage";
-        case AMU_REFLECTION:             return "Reflect";
-#endif
         case AMU_ACROBAT:                return "Acrobat";
         case AMU_NOTHING:                return "";
         default: return "buggy";

--- a/crawl-ref/source/item-prop-enum.h
+++ b/crawl-ref/source/item-prop-enum.h
@@ -245,9 +245,7 @@ enum jewellery_type
     AMU_NOTHING,
     AMU_GUARDIAN_SPIRIT,
     AMU_FAITH,
-#if TAG_MAJOR_VERSION == 34
     AMU_REFLECTION,
-#endif
     AMU_REGENERATION,
 
     NUM_JEWELLERY

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -741,7 +741,6 @@ const set<pair<object_class_type, int> > removed_items =
     { OBJ_JEWELLERY, AMU_THE_GOURMAND },
     { OBJ_JEWELLERY, AMU_HARM },
     { OBJ_JEWELLERY, AMU_RAGE },
-    { OBJ_JEWELLERY, AMU_REFLECTION },
     { OBJ_JEWELLERY, RING_REGENERATION },
     { OBJ_JEWELLERY, RING_SUSTAIN_ATTRIBUTES },
     { OBJ_JEWELLERY, RING_TELEPORT_CONTROL },
@@ -2195,6 +2194,7 @@ bool jewellery_has_pluses(const item_def &item)
     case RING_STRENGTH:
     case RING_INTELLIGENCE:
     case RING_DEXTERITY:
+    case AMU_REFLECTION:
         return true;
 
     default:

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -2186,7 +2186,12 @@ bool jewellery_has_pluses(const item_def &item)
     if (!item_type_known(item))
         return false;
 
-    switch (item.sub_type)
+    return jewellery_type_has_plusses(item.sub_type);
+}
+
+bool jewellery_type_has_plusses(int jewel_type)
+{
+    switch (jewel_type)
     {
     case RING_SLAYING:
     case RING_PROTECTION:
@@ -2194,7 +2199,6 @@ bool jewellery_has_pluses(const item_def &item)
     case RING_STRENGTH:
     case RING_INTELLIGENCE:
     case RING_DEXTERITY:
-    case AMU_REFLECTION:
         return true;
 
     default:

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -44,6 +44,8 @@ enum armour_flag
     ARMF_VUL_COLD           = ard(ARMF_RES_COLD, -1),
 };
 
+#define AMU_REFLECT_SH 5*2
+
 /// Removed items that have item knowledge.
 extern const set<pair<object_class_type, int> > removed_items;
 /// Check for membership in removed_items.
@@ -189,6 +191,7 @@ int evoker_charges(int evoker_type);
 int evoker_max_charges(int evoker_type);
 
 // ring functions:
+bool jewellery_type_has_plusses(int jewel_type) PURE;
 bool jewellery_has_pluses(const item_def &item) PURE;
 bool ring_has_stackable_effect(const item_def &item) PURE;
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4457,7 +4457,7 @@ bool get_item_by_name(item_def *item, const char* specs,
         break;
 
     case OBJ_JEWELLERY:
-        if (jewellery_is_amulet(*item))
+        if (jewellery_is_amulet(*item) && item->sub_type != AMU_REFLECTION)
             break;
 
         switch (item->sub_type)
@@ -4468,6 +4468,7 @@ bool get_item_by_name(item_def *item, const char* specs,
         case RING_STRENGTH:
         case RING_DEXTERITY:
         case RING_INTELLIGENCE:
+        case AMU_REFLECTION:
             item->plus = 5;
         default:
             break;

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4457,7 +4457,7 @@ bool get_item_by_name(item_def *item, const char* specs,
         break;
 
     case OBJ_JEWELLERY:
-        if (jewellery_is_amulet(*item) && item->sub_type != AMU_REFLECTION)
+        if (jewellery_is_amulet(*item))
             break;
 
         switch (item->sub_type)
@@ -4468,7 +4468,6 @@ bool get_item_by_name(item_def *item, const char* specs,
         case RING_STRENGTH:
         case RING_DEXTERITY:
         case RING_INTELLIGENCE:
-        case AMU_REFLECTION:
             item->plus = 5;
         default:
             break;

--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -815,7 +815,8 @@ IDEF(plus)
                    || item->sub_type == RING_SLAYING
                    || item->sub_type == RING_EVASION
                    || item->sub_type == RING_DEXTERITY
-                   || item->sub_type == RING_INTELLIGENCE)))
+                   || item->sub_type == RING_INTELLIGENCE
+                   || item->sub_type == AMU_REFLECTION)))
     {
         lua_pushnumber(ls, item->plus);
     }

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1638,6 +1638,7 @@ static int _good_jewellery_plus(int subtype)
         case RING_STRENGTH:
         case RING_DEXTERITY:
         case RING_INTELLIGENCE:
+        case AMU_REFLECTION:
             return 2 + (one_chance_in(3) ? random2(2) : random2avg(5, 2));
         default:
             return 1 + (one_chance_in(3) ? random2(3) : random2avg(6, 2));
@@ -1662,6 +1663,9 @@ static int _determine_ring_plus(int subtype)
     case RING_INTELLIGENCE:
         if (one_chance_in(5)) // 20% of such rings are cursed {dlb}
             return _bad_ring_plus();
+        return _good_jewellery_plus(subtype);
+
+    case AMU_REFLECTION:
         return _good_jewellery_plus(subtype);
 
     default:

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1638,7 +1638,6 @@ static int _good_jewellery_plus(int subtype)
         case RING_STRENGTH:
         case RING_DEXTERITY:
         case RING_INTELLIGENCE:
-        case AMU_REFLECTION:
             return 2 + (one_chance_in(3) ? random2(2) : random2avg(5, 2));
         default:
             return 1 + (one_chance_in(3) ? random2(3) : random2avg(6, 2));
@@ -1653,24 +1652,12 @@ static int _good_jewellery_plus(int subtype)
  */
 static int _determine_ring_plus(int subtype)
 {
-    switch (subtype)
-    {
-    case RING_PROTECTION:
-    case RING_STRENGTH:
-    case RING_SLAYING:
-    case RING_EVASION:
-    case RING_DEXTERITY:
-    case RING_INTELLIGENCE:
-        if (one_chance_in(5)) // 20% of such rings are cursed {dlb}
-            return _bad_ring_plus();
-        return _good_jewellery_plus(subtype);
-
-    case AMU_REFLECTION:
-        return _good_jewellery_plus(subtype);
-
-    default:
+    if (!jewellery_type_has_plusses(subtype))
         return 0;
-    }
+
+    if (one_chance_in(5)) // 20% of such rings are cursed {dlb}
+        return _bad_ring_plus();
+    return _good_jewellery_plus(subtype);
 }
 
 static void _generate_jewellery_item(item_def& item, bool allow_uniques,

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1574,6 +1574,7 @@ static void _fire_kill_conducts(monster &mons, killer_type killer,
     // player gets credit for reflection kills, but not blame
     const bool blameworthy = god_hates_killing(you.religion, mons)
                              && killer_index != YOU_FAULTLESS;
+
     // if you can't get piety for it & your god won't give penance/-piety for
     // it, no one cares
     // XXX: this will break holy death curses if they're added back...

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1560,7 +1560,8 @@ static void _fire_kill_conducts(monster &mons, killer_type killer,
 {
     const bool your_kill = killer == KILL_YOU ||
                            killer == KILL_YOU_CONF ||
-                           killer == KILL_YOU_MISSILE;
+                           killer == KILL_YOU_MISSILE ||
+                           killer_index == YOU_FAULTLESS;
     const bool pet_kill = _is_pet_kill(killer, killer_index);
 
     // Pretend the monster is already dead, so that make_god_gifts_disappear

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -512,7 +512,7 @@ move_again:
         if (victim && _iood_shielded(mon, *victim))
         {
             item_def *shield = victim->shield();
-            if (!shield || !shield_reflects(*shield))
+            if ((!shield || !shield_reflects(*shield)) && !victim->reflection())
             {
                 if (victim->is_player())
                     mprf("You block %s.", mon.name(DESC_THE, true).c_str());

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -477,14 +477,13 @@ int monster::wearing(equipment_type slot, int sub_type, bool calc_unid) const
         break;
 
     case EQ_AMULET:
-    case EQ_AMULET_PLUS:
     case EQ_RINGS:
     case EQ_RINGS_PLUS:
         item = mslot_item(MSLOT_JEWELLERY);
         if (item && item->is_type(OBJ_JEWELLERY, sub_type)
             && (calc_unid || item_type_known(*item)))
         {
-            if (slot == EQ_RINGS_PLUS || slot == EQ_AMULET_PLUS)
+            if (slot == EQ_RINGS_PLUS)
                 ret += item->plus;
             else
                 ret++;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -1789,7 +1789,8 @@ static int _get_monster_jewellery_value(const monster *mon,
 
     if (item.sub_type == RING_PROTECTION
         || item.sub_type == RING_EVASION
-        || item.sub_type == RING_SLAYING)
+        || item.sub_type == RING_SLAYING
+        || item.sub_type == AMU_REFLECTION)
     {
         value += item.plus;
     }
@@ -3122,7 +3123,8 @@ bool monster::pacified() const
  */
 bool monster::shielded() const
 {
-    return shield();
+    return shield()
+           || wearing(EQ_AMULET_PLUS, AMU_REFLECTION) > 0;
 }
 
 int monster::shield_bonus() const
@@ -3139,6 +3141,14 @@ int monster::shield_bonus() const
         shld_c = shld_c * 2 + (body_size(PSIZE_TORSO) - SIZE_MEDIUM)
                             * (shld->sub_type - ARM_TOWER_SHIELD);
         sh = random2avg(shld_c + get_hit_dice() * 4 / 3, 2) / 2;
+    }
+    // shielding from jewellery
+    const item_def *amulet = mslot_item(MSLOT_JEWELLERY);
+    if (amulet && amulet->sub_type == AMU_REFLECTION)
+    {
+        const int jewellery_plus = amulet->plus;
+        ASSERT(abs(jewellery_plus) < 30); // sanity check
+        sh += jewellery_plus * 2;
     }
 
     return sh;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -2888,7 +2888,7 @@ void monster::banish(actor *agent, const string &, const int, bool force)
         // Note: we do not set MF_PACIFIED, the monster is usually not
         // distinguishable from others of the same kind in the Abyss.
 
-        if (agent->is_player())
+        if (agent->is_player() || agent->mid == MID_YOU_FAULTLESS)
         {
             did_god_conduct(DID_BANISH, get_experience_level(),
                             true /*possibly wrong*/, this);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -1789,8 +1789,7 @@ static int _get_monster_jewellery_value(const monster *mon,
 
     if (item.sub_type == RING_PROTECTION
         || item.sub_type == RING_EVASION
-        || item.sub_type == RING_SLAYING
-        || item.sub_type == AMU_REFLECTION)
+        || item.sub_type == RING_SLAYING)
     {
         value += item.plus;
     }
@@ -3123,8 +3122,7 @@ bool monster::pacified() const
  */
 bool monster::shielded() const
 {
-    return shield()
-           || wearing(EQ_AMULET_PLUS, AMU_REFLECTION) > 0;
+    return shield() || wearing(EQ_AMULET, AMU_REFLECTION);
 }
 
 int monster::shield_bonus() const
@@ -3145,11 +3143,7 @@ int monster::shield_bonus() const
     // shielding from jewellery
     const item_def *amulet = mslot_item(MSLOT_JEWELLERY);
     if (amulet && amulet->sub_type == AMU_REFLECTION)
-    {
-        const int jewellery_plus = amulet->plus;
-        ASSERT(abs(jewellery_plus) < 30); // sanity check
-        sh += jewellery_plus * 2;
-    }
+        sh += AMU_REFLECT_SH;
 
     return sh;
 }

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2453,7 +2453,8 @@ static vector<formatted_string> _get_overview_resistances(
     out += _resist_composer("Spirit", cwidth, rspir) + "\n";
 
     const item_def *sh = you.shield();
-    const int reflect = sh && shield_reflects(*sh);
+    const int reflect = you.reflection(calc_unid)
+                        || sh && shield_reflects(*sh);
     out += _resist_composer("Reflect", cwidth, reflect) + "\n";
 
     const int harm = you.extra_harm(calc_unid);

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1172,6 +1172,21 @@ static void _equip_amulet_of_mana_regeneration()
     }
 }
 
+static void _equip_amulet_of_reflection()
+{
+    if (you.hp == you.hp_max)
+    {
+        you.activated.set(EQ_AMULET);
+        you.redraw_armour_class = true;
+        mpr("You feel a shielding aura gather around you.");
+    }
+    else
+    {
+        you.activated.set(EQ_AMULET, false);
+        mpr("Your injuries prevent the amulet from attuning itself.");
+    }
+}
+
 static void _equip_jewellery_effect(item_def &item, bool unmeld,
                                     equipment_type slot)
 {
@@ -1196,7 +1211,6 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
         break;
 
     case RING_PROTECTION:
-    case AMU_REFLECTION:
         you.redraw_armour_class = true;
         break;
 
@@ -1261,6 +1275,11 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
     case AMU_MANA_REGENERATION:
         if (!unmeld)
             _equip_amulet_of_mana_regeneration();
+        break;
+
+    case AMU_REFLECTION:
+        if (!unmeld)
+            _equip_amulet_of_reflection();
         break;
 
     case AMU_GUARDIAN_SPIRIT:
@@ -1350,7 +1369,12 @@ static void _unequip_jewellery_effect(item_def &item, bool mesg, bool meld,
         break;
 
     case RING_PROTECTION:
+        you.redraw_armour_class = true;
+        break;
+
     case AMU_REFLECTION:
+        if (!meld)
+            you.activated.set(EQ_AMULET, false);
         you.redraw_armour_class = true;
         break;
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1196,6 +1196,7 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
         break;
 
     case RING_PROTECTION:
+    case AMU_REFLECTION:
         you.redraw_armour_class = true;
         break;
 
@@ -1349,6 +1350,7 @@ static void _unequip_jewellery_effect(item_def &item, bool mesg, bool meld,
         break;
 
     case RING_PROTECTION:
+    case AMU_REFLECTION:
         you.redraw_armour_class = true;
         break;
 

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -858,6 +858,14 @@ static void _update_equipment_attunement_by_health()
         you.activated.set(EQ_AMULET);
     }
 
+    if (!you.activated[EQ_AMULET] && you.wearing(EQ_AMULET, AMU_REFLECTION))
+    {
+        mprf("Your amulet attunes itself to your body. You feel a shielding "
+             "aura gather around you.");
+        you.activated.set(EQ_AMULET);
+        you.redraw_armour_class = true;
+    }
+
     if (you.get_mutation_level(MUT_NO_REGENERATION))
         return;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2219,7 +2219,8 @@ int player_shield_class()
 
     shield += qazlal_sh_boost() * 100;
     shield += tso_sh_boost() * 100;
-    shield += you.wearing(EQ_AMULET, AMU_REFLECTION) * AMU_REFLECT_SH * 100;
+    shield += you.activated[EQ_AMULET] * you.wearing(EQ_AMULET, AMU_REFLECTION)
+              * AMU_REFLECT_SH * 100;
     shield += you.scan_artefacts(ARTP_SHIELDING) * 200;
 
     return (shield + 50) / 100;
@@ -5515,7 +5516,7 @@ bool player::shielded() const
            || duration[DUR_DIVINE_SHIELD]
            || get_mutation_level(MUT_LARGE_BONE_PLATES) > 0
            || qazlal_sh_boost() > 0
-           || you.wearing(EQ_AMULET, AMU_REFLECTION)
+           || you.wearing(EQ_AMULET, AMU_REFLECTION) && you.activated[EQ_AMULET]
            || you.scan_artefacts(ARTP_SHIELDING);
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -882,13 +882,12 @@ int player::wearing(equipment_type slot, int sub_type, bool calc_unid) const
         break;
 
     case EQ_AMULET:
-    case EQ_AMULET_PLUS:
         if ((item = slot_item(static_cast<equipment_type>(EQ_AMULET)))
             && item->sub_type == sub_type
             && (calc_unid
                 || item_type_known(*item)))
         {
-            ret += (slot == EQ_AMULET_PLUS ? item->plus : 1);
+            ret++;
         }
         break;
 
@@ -2220,7 +2219,7 @@ int player_shield_class()
 
     shield += qazlal_sh_boost() * 100;
     shield += tso_sh_boost() * 100;
-    shield += you.wearing(EQ_AMULET_PLUS, AMU_REFLECTION) * 200;
+    shield += you.wearing(EQ_AMULET, AMU_REFLECTION) * AMU_REFLECT_SH * 100;
     shield += you.scan_artefacts(ARTP_SHIELDING) * 200;
 
     return (shield + 50) / 100;
@@ -5516,7 +5515,7 @@ bool player::shielded() const
            || duration[DUR_DIVINE_SHIELD]
            || get_mutation_level(MUT_LARGE_BONE_PLATES) > 0
            || qazlal_sh_boost() > 0
-           || you.wearing(EQ_AMULET_PLUS, AMU_REFLECTION) > 0
+           || you.wearing(EQ_AMULET, AMU_REFLECTION)
            || you.scan_artefacts(ARTP_SHIELDING);
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2220,6 +2220,7 @@ int player_shield_class()
 
     shield += qazlal_sh_boost() * 100;
     shield += tso_sh_boost() * 100;
+    shield += you.wearing(EQ_AMULET_PLUS, AMU_REFLECTION) * 200;
     shield += you.scan_artefacts(ARTP_SHIELDING) * 200;
 
     return (shield + 50) / 100;
@@ -5515,6 +5516,7 @@ bool player::shielded() const
            || duration[DUR_DIVINE_SHIELD]
            || get_mutation_level(MUT_LARGE_BONE_PLATES) > 0
            || qazlal_sh_boost() > 0
+           || you.wearing(EQ_AMULET_PLUS, AMU_REFLECTION) > 0
            || you.scan_artefacts(ARTP_SHIELDING);
 }
 

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -168,7 +168,7 @@ bool ranged_attack::handle_phase_blocked()
     const bool reflected_by_shield = defender_shield
                                      && is_shield(*defender_shield)
                                      && shield_reflects(*defender_shield);
-    if (reflected_by_shield)
+    if (reflected_by_shield || defender->reflection())
     {
         reflected = true;
         verb = "reflect";

--- a/crawl-ref/source/rltiles/dc-item.txt
+++ b/crawl-ref/source/rltiles/dc-item.txt
@@ -834,9 +834,7 @@ i-inaccuracy AMU_INACCURACY
 i-rage AMU_NOTHING
 i-spirit AMU_GUARDIAN_SPIRIT
 i-faith AMU_FAITH
-# start TAG_MAJOR_VERSION == 34
 i-reflection AMU_REFLECTION
-# end TAG_MAJOR_VERSION
 i-regeneration AMU_REGENERATION AMU_ID_LAST
 
 ####################OBJ_POTIONS

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -584,7 +584,8 @@ unsigned int item_value(item_def item, bool ident)
                     || item.sub_type == RING_EVASION
                     || item.sub_type == RING_DEXTERITY
                     || item.sub_type == RING_INTELLIGENCE
-                    || item.sub_type == RING_SLAYING))
+                    || item.sub_type == RING_SLAYING
+                    || item.sub_type == AMU_REFLECTION))
             {
                 // Formula: price = kn(n+1) / 2, where k depends on the subtype,
                 // n is the power. (The base variable is equal to 2n.)
@@ -605,6 +606,7 @@ unsigned int item_value(item_def item, bool ident)
                 case RING_STRENGTH:
                 case RING_DEXTERITY:
                 case RING_INTELLIGENCE:
+                case AMU_REFLECTION:
                     coefficient = 30;
                     break;
                 default:

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -579,13 +579,7 @@ unsigned int item_value(item_def item, bool ident)
         {
             // Variable-strength rings.
             if (item_ident(item, ISFLAG_KNOW_PLUSES)
-                && (item.sub_type == RING_PROTECTION
-                    || item.sub_type == RING_STRENGTH
-                    || item.sub_type == RING_EVASION
-                    || item.sub_type == RING_DEXTERITY
-                    || item.sub_type == RING_INTELLIGENCE
-                    || item.sub_type == RING_SLAYING
-                    || item.sub_type == AMU_REFLECTION))
+                && jewellery_type_has_plusses(item.sub_type))
             {
                 // Formula: price = kn(n+1) / 2, where k depends on the subtype,
                 // n is the power. (The base variable is equal to 2n.)
@@ -606,7 +600,6 @@ unsigned int item_value(item_def item, bool ident)
                 case RING_STRENGTH:
                 case RING_DEXTERITY:
                 case RING_INTELLIGENCE:
-                case AMU_REFLECTION:
                     coefficient = 30;
                     break;
                 default:
@@ -631,6 +624,7 @@ unsigned int item_value(item_def item, bool ident)
                 case AMU_GUARDIAN_SPIRIT:
                 case AMU_MANA_REGENERATION:
                 case AMU_ACROBAT:
+                case AMU_REFLECTION:
                     valued += 300;
                     break;
 

--- a/crawl-ref/source/wiz-dump.cc
+++ b/crawl-ref/source/wiz-dump.cc
@@ -74,6 +74,8 @@ static uint8_t _jewellery_type_from_artefact_prop(const string &s
         return AMU_GUARDIAN_SPIRIT;
     if (s == "Faith")
         return AMU_FAITH;
+    if (s == "Reflect")
+        return AMU_REFLECTION;
     if (s == "Acrobat")
         return AMU_ACROBAT;
 


### PR DESCRIPTION
- Bring back amulets of reflection, but always +5 (no variable plusses), to simplify our much-maligned ID game.
- Give piety for reflected missiles, poison, and omnireflected Banishments.
- Add a delay before reflect amulets turn on, to avoid the dreaded Swap Micromanagement. It's always exactly 100 turns right now - doesn't seem like there's much point randomizing it, since there's no real hidden information or tactical gameplay around managing it?

I'll squash up some of these commits before merging if they're approved.