### PR TITLE
Display Zz and ? status icons for allies

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3513,7 +3513,7 @@ bool mons_is_removed(monster_type mc)
 bool mons_looks_stabbable(const monster& m)
 {
     const stab_type st = find_stab_type(&you, m, false);
-    return !m.friendly() && stab_bonus_denom(st) == 1; // top-tier stab
+    return stab_bonus_denom(st) == 1; // top-tier stab
 }
 
 bool mons_looks_distracted(const monster& m)

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1996,8 +1996,11 @@ tileidx_t tileidx_monster(const monster_info& mons)
         ch |= TILE_FLAG_STAB;
     }
     // Should petrify show the '?' symbol?
-    else if (mons.is(MB_DISTRACTED) && !mons.is(MB_PETRIFYING))
+    else if (mons.is(MB_DISTRACTED) && !mons.is(MB_PETRIFYING)
+            || mons.attitude == ATT_FRIENDLY && mons.is(MB_CONFUSED))
+    {
         ch |= TILE_FLAG_MAY_STAB;
+    }
 
     mon_dam_level_type damage_level = mons.dam;
 


### PR DESCRIPTION
Having this information on the main view is useful because confused
allies can attack the player, and paralysed allies block movement.
Also, since the player gets the top-tier stabbing bonus when
attacking sleeping/paralysed/petrified allies, that should be
indicated by the Zz's, TILE_FLAG_STAB, too.