### PR TITLE
Make faded Xom altars less disappointing

### DIFF
--- a/crawl-ref/source/god-prayer.cc
+++ b/crawl-ref/source/god-prayer.cc
@@ -26,6 +26,7 @@
 #include "stringutil.h"
 #include "terrain.h"
 #include "unwind.h"
+#include "xom.h"
 
 string god_prayer_reaction()
 {
@@ -89,6 +90,12 @@ static bool _pray_ecumenical_altar()
 
         if (you_worship(GOD_RU))
             you.props[RU_SACRIFICE_PROGRESS_KEY] = 9999;
+        else if (you_worship(GOD_XOM))
+        {
+            xom_take_action(XOM_GOOD_ACQUIREMENT, 1);
+            xom_take_action(XOM_GOOD_RANDOM_ITEM, 1);
+            xom_acts(1, MB_TRUE, 0);
+        }
         else
             gain_piety(20, 1, false);
 


### PR DESCRIPTION
The player's still stuck with Xom, but at least they get two gifties 
and a random Xom action.

This is particularly intended to assist unlucky tournament players 
who, in aiming for the Inheritor (Hepliaklqana) banner, wind up 
worshipping Xom instead of say, Makh or the like.

In a not-very-exhaustive wizmode test, it seemed like the items
tended to be not very great, but I wasn't able to make heads or
tails of the variables "sever" and "tension".  Those could be set
to any ol' value if someone better understands what they do!