### PR TITLE
Rework the Sword of Power

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -80,6 +80,7 @@
 # * fragile:  Is destroyed when unequipped.
 # * fog:      Lets wearer use the evoke fog ability.
 # * evil:     Is treated as an evil item (hated by good gods).
+# * harm:     Provides harm effect.
 # * holy:     Is treated as a holy item.
 # * inv:      Lets wearer evoke invisibility ability.
 # * fly:      Lets wearer evoke flight ability.
@@ -220,7 +221,7 @@ COLOUR:  RED
 TILE:    spwpn_sword_of_power
 TILE_EQ: sword_of_power
 VALUE:   800
-BOOL:    special, no_upgrade
+BOOL:    special, no_upgrade, mutate
 
 NAME:    staff of Olgreb
 INSCRIP: rPois∞

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -314,10 +314,11 @@ static void _OLGREB_melee_effects(item_def* /*weapon*/, actor* attacker,
 }
 
 ////////////////////////////////////////////////////
+// UNRAND_POWER aka Sword of Power
 
 static void _power_pluses(item_def *item)
 {
-    item->plus = min(you.hp / 10, 27);
+    item->plus = you.hp / 7;
 }
 
 static void _POWER_equip(item_def *item, bool *show_msgs, bool /*unmeld*/)

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -37,7 +37,7 @@ purple skin and a few wrinkles.
 sword of Power
 
 A mighty sword which rewards the powerful with power and the meek with
-weakness.
+weakness. Its enchantment equals your hit points, divided by seven.
 %%%%
 staff of Olgreb
 


### PR DESCRIPTION
Increase the enchantment to hp / 5, remove the cap of 27, and add the
properties Harm, *Contam, *Curse.

Sword of Power is fun and evocative, but a little underwhelming in terms
of power level. Doubling the bonus will make the weapon much more
competitive.

Without any swap penalty, players are incentivised to carry their next
best long blade as a swap when the damage falls too much. The Sword of
Power requires commitment from the player, and so gains the
quasi-strategic costs of *Contam and *Curse.

Finally, adding Harm is an obvious choice. It's newly available for
artifacts (so no other unrand uses it), and fits perfectly with this
sword's theme.