### PR TITLE
Fixed terrain change duration not decrementing while off-floor

### DIFF
--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -892,6 +892,7 @@ void update_level(int elapsedTime)
     rot_floor_items(elapsedTime);
     shoals_apply_tides(turns, true);
     timeout_tombs(turns);
+    timeout_terrain_changes(elapsedTime);
 
     if (env.sanctuary_time)
     {


### PR DESCRIPTION
This was most noticeable for Summon Forest, whose trees wouldn't tick down while off level.