### PR TITLE
force autopickup with ;;

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -2350,6 +2350,8 @@ Ctrl-direction or * direction
 ;
   Examine occupied tile and auto-pickup eligible items. Can also be used to pick
   up only part of a stack with no other item on the same square.
+  When a monster is present the first press of ; will only examine the tile
+  and a second press of ; will pick up all auto-pickup eligible items.
 
 x
   Examine surroundings, see below. Has '?' help.

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -129,8 +129,6 @@ static bool _merge_items_into_inv(item_def &it, int quant_got,
 static bool will_autopickup   = false;
 static bool will_autoinscribe = false;
 
-static int last_auto_pickup_try = 1;
-
 static inline string _autopickup_item_name(const item_def &item)
 {
     return userdef_annotate_item(STASH_LUA_SEARCH_ANNOTATE, &item)
@@ -3313,20 +3311,12 @@ static void _do_autopickup()
 
 void autopickup(bool forced)
 {
-    // register when ; is pressed twice in a row, and force autopickup.
-    if (forced)
-    {
-        if (last_auto_pickup_try == you.num_turns)
-            _do_autopickup();
-        last_auto_pickup_try = you.num_turns;
-        return;
-    }
-
     _autoinscribe_floor_items();
-    if (!can_autopickup())
-        item_check();
-    else
+    // pick up things when forced (by input ;;), or when you feel save
+    if (forced || can_autopickup())
         _do_autopickup();
+    else
+        item_check();
 }
 
 int inv_count()

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -129,6 +129,8 @@ static bool _merge_items_into_inv(item_def &it, int quant_got,
 static bool will_autopickup   = false;
 static bool will_autoinscribe = false;
 
+static int last_auto_pickup_try = 1;
+
 static inline string _autopickup_item_name(const item_def &item)
 {
     return userdef_annotate_item(STASH_LUA_SEARCH_ANNOTATE, &item)
@@ -3239,12 +3241,6 @@ static void _do_autopickup()
 
     will_autopickup = false;
 
-    if (!can_autopickup())
-    {
-        item_check();
-        return;
-    }
-
     // Store last_pickup in case we need to restore it.
     // Then clear it to fill with items picked up.
     map<int,int> tmp_l_p = you.last_pickup;
@@ -3315,10 +3311,22 @@ static void _do_autopickup()
     explore_pickup_event(n_did_pickup, n_tried_pickup);
 }
 
-void autopickup()
+void autopickup(bool forced)
 {
+    // register when ; is pressed twice in a row, and force autopickup.
+    if (forced)
+    {
+        if (last_auto_pickup_try == you.num_turns)
+            _do_autopickup();
+        last_auto_pickup_try = you.num_turns;
+        return;
+    }
+
     _autoinscribe_floor_items();
-    _do_autopickup();
+    if (!can_autopickup())
+        item_check();
+    else
+        _do_autopickup();
 }
 
 int inv_count()

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -141,7 +141,7 @@ bool item_needs_autopickup(const item_def &, bool ignore_force = false);
 bool can_autopickup();
 
 bool need_to_autopickup();
-void autopickup();
+void autopickup(bool forced = false);
 
 void set_item_autopickup(const item_def &item, autopickup_level_type ap);
 int item_autopickup_level(const item_def &item);

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1117,12 +1117,6 @@ static void _input()
         if (!crawl_state.is_replaying_keys())
             you.elapsed_time_at_last_input = you.elapsed_time;
 
-        if (cmd != CMD_PREV_CMD_AGAIN && cmd != CMD_NO_CMD
-            && !crawl_state.is_replaying_keys())
-        {
-            crawl_state.prev_cmd = cmd;
-        }
-
         if (cmd != CMD_MOUSE_MOVE)
             c_input_reset(false);
 
@@ -1131,6 +1125,12 @@ static void _input()
         // macro.
         if (!you.turn_is_over && cmd != CMD_NEXT_CMD)
             process_command(cmd);
+
+        if (cmd != CMD_PREV_CMD_AGAIN && cmd != CMD_NO_CMD
+            && !crawl_state.is_replaying_keys())
+        {
+            crawl_state.prev_cmd = cmd;
+        }
 
         repeat_again_rec.paused = true;
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1800,7 +1800,8 @@ void process_command(command_type cmd)
         if (player_on_single_stack() && !you.running)
             pickup(true);
         else
-            autopickup(true);
+            // Forced autopickup if CMD_INSPECT_FLOOR is used twice in a row
+            autopickup(crawl_state.prev_cmd == CMD_INSPECT_FLOOR);
         break;
     case CMD_SHOW_TERRAIN: toggle_show_terrain(); break;
     case CMD_ADJUST_INVENTORY: adjust(); break;

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1797,9 +1797,10 @@ void process_command(command_type cmd)
         break;
 
     case CMD_INSPECT_FLOOR:
-        request_autopickup();
         if (player_on_single_stack() && !you.running)
             pickup(true);
+        else
+            autopickup(true);
         break;
     case CMD_SHOW_TERRAIN: toggle_show_terrain(); break;
     case CMD_ADJUST_INVENTORY: adjust(); break;


### PR DESCRIPTION
; usually displays the items in the stack the player is standing
of if the player is 'unsafe', and forces autopickup otherwise.
As of this commit autopickup can be forced even if the player
feels unsafe by pressing ; twice.