### PR TITLE
Plug an information leak in summoner highlighting

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1767,10 +1767,15 @@ coord_def direction_chooser::find_summoner()
 {
     const monster* mon = monster_at(target());
 
-    // Don't leak information about rakshasa mirrored illusions.
-    if (mon && mon->is_summoned() && !mon->has_ench(ENCH_PHANTOM_MIRROR))
+    if (mon && mon->is_summoned()
+        // Don't leak information about rakshasa mirrored illusions.
+        && !mon->has_ench(ENCH_PHANTOM_MIRROR)
+        // Don't leak information about invisible or out-of-los summons.
+        && you.can_see(*mon))
+    {
         if (const monster *summ = monster_by_mid(mon->summoner))
             return summ->pos();
+    }
     return INVALID_COORD;
 }
 


### PR DESCRIPTION
During the do_look_around loop, placing the cursor over an invisible or out of
los monster highlighted the summoner. This commit makes the highlighting code
call can_see to make sure the character should know about the summon.

(A leak with respect to invisible monsters in los remains if you scan with the
cursor while scrying without sinv. This is leaked anyway in that case by the
monster description in the message log area, and there are other leaks with
respect to invisibility while scrying. I've left this alone here on the grounds
that it is part of a bigger, separate problem with scrying and invisibility, and
deserves a more general fix.)