### PR TITLE
Simplify Phial of Floods

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2067,42 +2067,28 @@ void fire_tracer(const monster* mons, bolt &pbolt, bool explode_only,
     pbolt.is_tracer = false;
 }
 
-static coord_def _random_point_hittable_from(const coord_def &c,
-                                            int radius,
-                                            int margin = 1,
-                                            int tries = 5)
-{
-    while (tries-- > 0)
-    {
-        const coord_def point = dgn_random_point_from(c, radius, margin);
-        if (point.origin())
-            continue;
-        if (!cell_see_cell(c, point, LOS_SOLID))
-            continue;
-        return point;
-    }
-    return coord_def();
-}
-
-void create_feat_splash(coord_def center,
+vector<coord_def> create_feat_splash(coord_def center,
                                 int radius,
-                                int nattempts)
+                                int number,
+                                int duration)
 {
-    // Always affect center, if compatible
-    if ((grd(center) == DNGN_FLOOR || grd(center) == DNGN_SHALLOW_WATER))
+    vector<coord_def> splash_coords;
+
+    for (distance_iterator di(center, true, false, radius); di && number > 0; ++di)
     {
-        temp_change_terrain(center, DNGN_SHALLOW_WATER, 100 + random2(100),
-                            TERRAIN_CHANGE_FLOOD);
+        const dungeon_feature_type feat = grd(*di);
+        if ((feat == DNGN_FLOOR || feat == DNGN_SHALLOW_WATER)
+            && cell_see_cell(center, *di, LOS_NO_TRANS))
+        {
+            number--;
+            int time = random_range(duration, duration * 3 / 2) - (di.radius() * 20);
+            temp_change_terrain(*di, DNGN_SHALLOW_WATER, time,
+                                TERRAIN_CHANGE_FLOOD);
+            splash_coords.push_back(*di);
+        }
     }
 
-    for (int i = 0; i < nattempts; ++i)
-    {
-        const coord_def newp(_random_point_hittable_from(center, radius));
-        if (newp.origin() || (grd(newp) != DNGN_FLOOR && grd(newp) != DNGN_SHALLOW_WATER))
-            continue;
-        temp_change_terrain(newp, DNGN_SHALLOW_WATER, 100 + random2(100),
-                            TERRAIN_CHANGE_FLOOD);
-    }
+    return splash_coords;
 }
 
 void bolt_parent_init(const bolt &parent, bolt &child)
@@ -2359,6 +2345,7 @@ void bolt::affect_endpoint()
     switch (origin_spell)
     {
     case SPELL_PRIMAL_WAVE:
+    {
         if (you.see_cell(pos()))
         {
             mpr("The wave splashes down.");
@@ -2369,9 +2356,26 @@ void bolt::affect_endpoint()
             noisy(spell_effect_noise(SPELL_PRIMAL_WAVE),
                   pos(), "You hear a splash.");
         }
-        create_feat_splash(pos(), 2, random_range(3, 12, 2));
+        const int num = agent() && agent()->is_player() ? div_rand_round(ench_power * 3, 20) + 3 + random2(7)
+                                                        : random_range(3, 12, 2);
+        const int dur = div_rand_round(ench_power * 4, 3) + 66;
+        vector<coord_def> splash_coords = create_feat_splash(pos(), agent()->is_player() ? 2 : 1, num, dur);
+        dprf(DIAG_BEAM, "Creating pool at %d,%d with %d tiles of water for %d auts.", pos().x, pos().y, num, dur);
+        if (agent() && agent()->is_player())
+        {
+            for (const coord_def coord: splash_coords)
+            {
+                monster* mons = monster_at(coord);
+                if (mons && !mons->res_water_drowning())
+                {
+                    simple_monster_message(*mons, " is engulfed in water.");
+                    mons->add_ench(mon_enchant(ENCH_WATERLOGGED, 0, &you,
+                                                   random_range(dur, dur * 3 / 2) - 20 * coord.distance_from(pos())));
+                }
+            }
+        }
         break;
-
+    }
     case SPELL_BLINKBOLT:
     {
         actor *act = agent(true); // use orig actor even when reflected

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -326,7 +326,7 @@ spret zapping(zap_type ztype, int power, bolt &pbolt,
                    bool fail = false);
 bool player_tracer(zap_type ztype, int power, bolt &pbolt, int range = 0);
 
-void create_feat_splash(coord_def center, int radius, int nattempts);
+vector<coord_def> create_feat_splash(coord_def center, int radius, int num, int dur);
 
 void init_zap_index();
 void clear_zap_info_on_exit();

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -939,38 +939,7 @@ static bool _phial_of_floods()
         const int power = player_adjust_evoc_power(base_pow, surge);
         // use real power to recalc hit/dam
         zappy(ZAP_PRIMAL_WAVE, power, false, beam);
-
         beam.fire();
-
-        // Flood the endpoint
-        coord_def center = beam.path_taken.back();
-        const int rnd_factor = random2(7);
-        int num = player_adjust_evoc_power(
-                      5 + you.skill_rdiv(SK_EVOCATIONS, 3, 5) + rnd_factor,
-                      surge);
-        int dur = player_adjust_evoc_power(
-                      40 + you.skill_rdiv(SK_EVOCATIONS, 8, 3),
-                      surge);
-        for (distance_iterator di(center, true, false, 2); di && num > 0; ++di)
-        {
-            const dungeon_feature_type feat = grd(*di);
-            if ((feat == DNGN_FLOOR || feat == DNGN_SHALLOW_WATER)
-                && cell_see_cell(center, *di, LOS_NO_TRANS))
-            {
-                num--;
-                int time = random_range(dur * 2, dur * 3) - (di.radius() * 20);
-                temp_change_terrain(*di, DNGN_SHALLOW_WATER, time,
-                                    TERRAIN_CHANGE_FLOOD);
-
-                monster* mons = monster_at(*di);
-                if (mons && !mons->res_water_drowning())
-                {
-                    simple_monster_message(*mons, " is engulfed in water.");
-                    mons->add_ench(mon_enchant(ENCH_WATERLOGGED, 0, &you,
-                                               time));
-                }
-            }
-        }
 
         return true;
     }


### PR DESCRIPTION
Previously, phial of floods did three things:
 a) It fired a Primal Wave at the target
 b) It created a pool around the target
 c) It waterlogged monsters in the pool

Primal Wave deals damage, potentially knocks back a tile, and creates its own pool. This led to phial of floods creating two different overlapping temporary pools, one waterlogged and the other not.

This commit consolidates everything into Primal Wave. Phial no longer manually creates its own pool; instead player-created Primal Waves now scale with power like the Phial pool did, and apply waterlogged appropriately.

This commit also reworks Primal Wave's pool generation. Previously, it created the center tile manually, and then randomly added tiles on a 2-radius circeLOS ring to it. I switched it to use the Phial pool generation method which uses a fair distance_iterator to fill the pool from the center. The results are fairly similar without the weird spoilery effects of circle-LoS math.

This commit also incidentally solves the issue where the actual target of the phial could be pushed out of the pool by the primal wave and miss getting waterlogged. Now that we silence based on the Primal Wave pool (which was always centered on the pushed-back monster) you're guaranteed to at least waterlog your target (if it's vulnerable.)