### PR TITLE
One tin of tremorstones should be enough for anybody

### DIFF
--- a/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
+++ b/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
@@ -28,6 +28,7 @@ ae += [^n]identified.*spellbook
 :add_autopickup_func(function (it, name)
 :  local itname = it.name(true) -- Not the name parameter, which includes prefixes.
 :  if string.find(itname, "phial of floods")
+:  or string.find(itname, "tin of tremorstones")
 :  or string.find(itname, "lightning rod") then
 :    for inv in iter.invent_iterator:new(items.inventory()) do
 :      if itname == inv.name() then


### PR DESCRIPTION
...even for players who enable autopickup of them
via `autopickup_exceptions ^= <tin of tremorstones`.
