### PR TITLE
Fix segfault for Summon Mushrooms spell

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5889,11 +5889,17 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
             // Attempt to place adjacent to target first, and only at a wider
             // radius if no adjacent spots can be found
             coord_def empty;
-            find_habitable_spot_near(mons->get_foe()->pos(),
+
+            // Wizard mode creates a dummy friendly monster, with no foe
+            // Prevent a segfault by checking for that
+            if (!foe)
+                return;
+
+            find_habitable_spot_near(foe->pos(),
                                      MONS_WANDERING_MUSHROOM, 1, false, empty);
             if (empty.origin())
             {
-                find_habitable_spot_near(mons->get_foe()->pos(),
+                find_habitable_spot_near(foe->pos(),
                                          MONS_WANDERING_MUSHROOM, 2, false, empty);
             }
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5630,6 +5630,8 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
         return;
 
     case SPELL_SUMMON_SPECTRAL_ORCS:
+        if (!foe)
+            return;
         if (foe->is_player())
             mpr("Orcish apparitions take form around you.");
         else

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5630,6 +5630,8 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
         return;
 
     case SPELL_SUMMON_SPECTRAL_ORCS:
+        // Wizard mode creates a dummy friendly monster, with no foe
+        // Prevent a segfault by checking for that and silently failing
         if (!foe)
             return;
         if (foe->is_player())
@@ -5893,7 +5895,7 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
             coord_def empty;
 
             // Wizard mode creates a dummy friendly monster, with no foe
-            // Prevent a segfault by checking for that
+            // Prevent a segfault by checking for that and silently failing
             if (!foe)
                 return;
 


### PR DESCRIPTION
https://crawl.develz.org/mantis/view.php?id=11889

In wizmode, attempting to cast summon mushrooms (A monster-only spell) causes a segfault.
This is because it's targeted on a foe, which is a nullptr for wizmode monster casts.