### PR TITLE
Allow player know the full name of dead orc during Resurrect

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1689,7 +1689,7 @@ bool beogh_resurrect()
         {
             found_any = true;
             if (yesno(("Resurrect "
-                       + si->props[ORC_CORPSE_KEY].get_monster().name(DESC_THE)
+                       + si->props[ORC_CORPSE_KEY].get_monster().full_name(DESC_THE)
                        + "?").c_str(), true, 'n'))
             {
                 corpse = &*si;


### PR DESCRIPTION
Now, the players don't know the role of the dead orc if the one is  blessed, when they use Resurrection ability onto the corpse of dead orc.
For example, if you tried to resurrect Borug the orc warlord, then you will see only Borug.
The point of this commit is, if there is another orc corpse that you don't know the role(possibly, just orc) and has its own name, then player can make mistakes.

This fix may help Beogh players to use their ability in intened way.