### PR TITLE
Make necro a major sac, and charm a moderate sac

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3596,8 +3596,8 @@ static map<const char*, vector<mutation_type>> sacrifice_vector_map =
 /// School-disabling mutations that will be painful for most characters.
 static const vector<mutation_type> _major_arcane_sacrifices =
 {
-    MUT_NO_CHARM_MAGIC,
     MUT_NO_CONJURATION_MAGIC,
+    MUT_NO_NECROMANCY_MAGIC,
     MUT_NO_SUMMONING_MAGIC,
     MUT_NO_TRANSLOCATION_MAGIC,
 };
@@ -3605,8 +3605,8 @@ static const vector<mutation_type> _major_arcane_sacrifices =
 /// School-disabling mutations that are unfortunate for most characters.
 static const vector<mutation_type> _moderate_arcane_sacrifices =
 {
+    MUT_NO_CHARM_MAGIC,
     MUT_NO_TRANSMUTATION_MAGIC,
-    MUT_NO_NECROMANCY_MAGIC,
     MUT_NO_HEXES_MAGIC,
 };
 


### PR DESCRIPTION
In its present state, charm is not a major sacrifice.  Its most powerful spells are dual-school with Hexes or Necromancy, but being barred from those schools has a larger impact because those schools have further powerful spells, some of which are single-school. It could make sense for charms to be a major sacrifice if/when the school has some heft to it once again.

Necromancy, on the other hand, like conjurations or summoning, can be your school of choice for the whole 3 rune game.  Unlike charms, it does not require a weapon, nor significant investment in other schools.