### PR TITLE
Fix foxfire attacking out of LoS

### DIFF
--- a/crawl-ref/source/mon-behv.cc
+++ b/crawl-ref/source/mon-behv.cc
@@ -1525,7 +1525,8 @@ bool summon_can_attack(const monster* mons, const coord_def &p)
         || !mons->is_summoned()
             && !mons->has_ench(ENCH_FAKE_ABJURATION)
             && !mons_is_hepliaklqana_ancestor(mons->type)
-            && !mons->has_ench(ENCH_PORTAL_PACIFIED))
+            && !mons->has_ench(ENCH_PORTAL_PACIFIED)
+            && mons->type != MONS_FOXFIRE)
     {
         return true;
     }


### PR DESCRIPTION
Currently a foxfire will attack a monster it's aggroed to that is just outside LoS (while the foxfire is in LoS.) Since a foxfire attacks 5 times per turn for 1 damage, this is actually somewhat usefully abusable in the early game vs 0 AC monsters (you can get 3-4 extra damage out of a foxfire by manipulating this.)

This change makes it follow the rules of normal summons and refuse to attack monsters out of player LoS.