### PR TITLE
Added SDL_image to dependency requirements in INSTALL.md

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -120,6 +120,7 @@ Dependencies](#packaged-dependencies) above):
 * freetype (tiles builds only)
 * DejaVu fonts (tiles builds only)
 * SDL2 (tiles builds only)
+* SDL2_image (tiles builds only)
 * libpng (tiles builds only)
 
 Then follow [the above compilation steps](#compiling).


### PR DESCRIPTION
Most distros package SDL2 separately from its child libraries (SDL2_image, SDL2_ttf, etc).
Adding this to the dependencies for other OS distributions to reduce confusion.
Should clear up #1363 