### PR TITLE
Document python-is-python3 for Ubuntu

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -71,8 +71,9 @@ To use packaged dependencies:
 These instructions may work for other DPKG-based distros.
 
 ```sh
+# python-is-python3 is required for Ubuntu 20.04 and newer
 sudo apt install build-essential libncursesw5-dev bison flex liblua5.1-0-dev \
-libsqlite3-dev libz-dev pkg-config python3-yaml binutils-gold
+libsqlite3-dev libz-dev pkg-config python3-yaml binutils-gold python-is-python3
 
 # Dependencies for tiles builds
 sudo apt install libsdl2-image-dev libsdl2-mixer-dev libsdl2-dev \


### PR DESCRIPTION
We are stuck in a limbo of supporting ancient webtiles servers with
Python 2 installed only as 'python', and also newer OSes where Python 3
is only available as 'python3'.

Ideally the Makefile can try all three names for Python automatically
and use the first it finds. But until someone adds this behaviour we
should document the correct approach.