### PR TITLE
Fix scarf of harm not working

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -280,7 +280,7 @@ bool actor::reflection(bool calc_unid, bool items) const
 bool actor::extra_harm(bool calc_unid, bool items) const
 {
     return items &&
-           (wearing(EQ_CLOAK, SPARM_HARM, calc_unid)
+           (wearing_ego(EQ_CLOAK, SPARM_HARM, calc_unid)
             || scan_artefacts(ARTP_HARM, calc_unid));
 }
 


### PR DESCRIPTION
Commit 19c8d55 added harm to scarves, but used the 'wearing' function,
which is only valid for getting jewellery subtypes. Need to use
'wearing_ego' to get the scarf ego instead.