### PR TITLE
Rename Wizards to Hedge Wizards

### DIFF
--- a/crawl-ref/source/dat/descript/backgrounds.txt
+++ b/crawl-ref/source/dat/descript/backgrounds.txt
@@ -62,6 +62,11 @@ Gladiator
 Gladiators are ready for the arena with light armour, nets, and a weapon of
 their choice.
 %%%%
+Hedge Wizard
+
+Hedge Wizards learn many minor magics, letting them backstab or escape their
+bewildered foes.
+%%%%
 Hunter
 
 Hunters carry a ranged weapon of their choice, and are also equipped with light
@@ -110,9 +115,4 @@ Warper
 
 Warpers start with a weapon of their choice and a scroll of blinking. They
 begin with a number of Translocations spells in their library.
-%%%%
-Wizard
-
-Wizards start with the wide range of spells present in a book of Minor Magic in
-their spell library.
 %%%%

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -273,8 +273,8 @@ static const map<job_type, job_def> job_data =
 } },
 
 { JOB_WIZARD, {
-    "Wz", "Wizard",
-    -1, 10, 3,
+    "Wz", "Hedge Wizard",
+    2, 6, 4,
     { SP_DEEP_ELF, SP_NAGA, SP_BASE_DRACONIAN, SP_OCTOPODE, SP_HUMAN,
       SP_MUMMY, },
     { "robe", "hat", "book of Minor Magic" },

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -102,7 +102,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CONJURER, {
     "Cj", "Conjurer",
-    0, 7, 5,
+    -1, 10, 3,
     { SP_DEEP_ELF, SP_NAGA, SP_TENGU, SP_BASE_DRACONIAN, SP_DEMIGOD, },
     { "robe", "book of Conjurations" },
     WCHOICE_NONE,


### PR DESCRIPTION
Wizards are a weird background. Their name and starting stats both
point towards a 'pure magic' playstyle, but their starting book
is quite poorly suited to such an approach - they aren't
well-equipped to 'blast' foes, and are much better advised taking
advantage of their imps and mephitic clouds to do a little
backstabbing.

This playstyle seems fine and distinctive, so let's make it
clearer to players. Renaming them to 'hedge wizards' shows that
they aren't expected to be masters of 'high magic' (pure blasting),
as does tweaking their stat spread closer to skalds'. (If we want
the extremely high-int spread to be on some background, Cj would
be a reasonable choice.)