### PR TITLE
Make amulets take 5 turns to remove or equip

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -36,8 +36,7 @@ An amulet with no special properties.
 amulet of reflection
 
 An amulet which exerts a force that blocks some incoming attacks, and can even
-reflect any blocked ranged attacks back towards the attacker. In order to
-function, it must first attune itself to the wearer's body at full health.
+reflect any blocked ranged attacks back towards the attacker.
 %%%%
 amulet of regeneration
 
@@ -48,8 +47,7 @@ amulet of the acrobat
 
 An amulet that allows the user to tumble and roll to evade the blows of their
 enemies, but only while moving and waiting. While taking other actions the
-amulet conveys no benefits. In order to function, it must first attune itself
-to the wearer's body at full health.
+amulet conveys no benefits.
 %%%%
 animal skin
 

--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -259,9 +259,9 @@ public:
     }
 };
 
-class ArmourOffDelay : public Delay
+class EquipOffDelay : public Delay
 {
-    item_def& armour;
+    item_def& equip;
     bool was_prompted = false;
 
     void start() override;
@@ -269,15 +269,15 @@ class ArmourOffDelay : public Delay
     void tick() override
     {
         mprf(MSGCH_MULTITURN_ACTION, "You continue taking off %s.",
-             armour.name(DESC_YOUR).c_str());
+             equip.name(DESC_YOUR).c_str());
     }
 
     bool invalidated() override;
 
     void finish() override;
 public:
-    ArmourOffDelay(int dur, item_def& item) :
-                   Delay(dur), armour(item)
+    EquipOffDelay(int dur, item_def& item) :
+                   Delay(dur), equip(item)
     { }
 
     bool try_interrupt() override;
@@ -286,6 +286,8 @@ public:
     {
         return "armour_off";
     }
+private:
+    string eq_category();
 };
 
 class JewelleryOnDelay : public Delay

--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -232,9 +232,9 @@ public:
     virtual const char* name() const = 0;
 };
 
-class ArmourOnDelay : public Delay
+class EquipOnDelay : public Delay
 {
-    item_def& armour;
+    item_def& equip;
     bool was_prompted = false;
 
     void start() override;
@@ -242,13 +242,13 @@ class ArmourOnDelay : public Delay
     void tick() override
     {
         mprf(MSGCH_MULTITURN_ACTION, "You continue putting on %s.",
-             armour.name(DESC_YOUR).c_str());
+             equip.name(DESC_YOUR).c_str());
     }
 
     void finish() override;
 public:
-    ArmourOnDelay(int dur, item_def& item) :
-                  Delay(dur), armour(item)
+    EquipOnDelay(int dur, item_def& item) :
+                 Delay(dur), equip(item)
     { }
 
     bool try_interrupt() override;
@@ -261,7 +261,7 @@ public:
 
 class EquipOffDelay : public Delay
 {
-    item_def& equip;
+    const item_def& equip;
     bool was_prompted = false;
 
     void start() override;
@@ -276,7 +276,7 @@ class EquipOffDelay : public Delay
 
     void finish() override;
 public:
-    EquipOffDelay(int dur, item_def& item) :
+    EquipOffDelay(int dur, const item_def& item) :
                    Delay(dur), equip(item)
     { }
 
@@ -286,19 +286,17 @@ public:
     {
         return "armour_off";
     }
-private:
-    string eq_category();
 };
 
 class JewelleryOnDelay : public Delay
 {
-    const item_def& jewellery;
+    item_def& jewellery;
 
     void tick() override;
 
     void finish() override;
 public:
-    JewelleryOnDelay(int dur, const item_def& item) :
+    JewelleryOnDelay(int dur, item_def& item) :
                      Delay(dur), jewellery(item)
     { }
 

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1335,7 +1335,7 @@ bool takeoff_armour(int item)
 
     you.turn_is_over = true;
 
-    start_delay<ArmourOffDelay>(ARMOUR_EQUIP_DELAY - 1, invitem);
+    start_delay<EquipOffDelay>(ARMOUR_EQUIP_DELAY - 1, invitem);
 
     return true;
 }
@@ -2195,15 +2195,22 @@ bool remove_ring(int slot, bool announce)
     }
 
     const int removed_ring_slot = you.equip[hand_used];
-
-    if (!_safe_to_remove_or_wear(you.inv[removed_ring_slot], true))
+    item_def &invitem = you.inv[removed_ring_slot];
+    if (!_safe_to_remove_or_wear(invitem, true))
         return false;
 
     // Remove the ring.
+    you.turn_is_over = true;
+    if (hand_used == EQ_AMULET)
+    {
+        start_delay<EquipOffDelay>(ARMOUR_EQUIP_DELAY - 1, invitem);
+        return true;
+    }
+
 #ifdef USE_SOUND
     parse_sound(REMOVE_JEWELLERY_SOUND);
 #endif
-    mprf("You remove %s.", you.inv[removed_ring_slot].name(DESC_YOUR).c_str());
+    mprf("You remove %s.", invitem.name(DESC_YOUR).c_str());
 #ifdef USE_TILE_LOCAL
     const unsigned int old_talents = your_talents(false).size();
 #endif
@@ -2217,7 +2224,6 @@ bool remove_ring(int slot, bool announce)
 #endif
 
     you.time_taken /= 2;
-    you.turn_is_over = true;
 
     return true;
 }

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -30,7 +30,7 @@ bool safe_to_remove(const item_def &item, bool quiet = false);
 bool puton_ring(int slot = -1, bool allow_prompt = true,
                 bool check_for_inscriptions = true);
 
-bool puton_ring(const item_def &to_puton, bool allow_prompt = true,
+bool puton_ring(item_def &to_puton, bool allow_prompt = true,
                 bool check_for_inscriptions = true);
 
 void read(item_def* scroll = nullptr);

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -745,13 +745,13 @@ static void _spirit_shield_message(bool unmeld)
 {
     if (!unmeld && you.spirit_shield() < 2)
     {
-        dec_mp(you.magic_points);
         mpr("You feel your power drawn to a protective spirit.");
 #if TAG_MAJOR_VERSION == 34
         if (you.species == SP_DEEP_DWARF
             && !(have_passive(passive_t::no_mp_regen)
                  || player_under_penance(GOD_PAKELLAS)))
         {
+            dec_mp(you.magic_points);
             mpr("Now linked to your health, your magic stops regenerating.");
         }
 #endif
@@ -1132,20 +1132,6 @@ static void _equip_regeneration_item(const item_def &item)
     return;
 }
 
-static void _equip_amulet_of_the_acrobat()
-{
-    if (you.hp == you.hp_max)
-    {
-        you.activated.set(EQ_AMULET);
-        mpr("You feel ready to tumble and roll out of harm's way.");
-    }
-    else
-    {
-        you.activated.set(EQ_AMULET, false);
-        mpr("Your injuries prevent the amulet from attuning itself.");
-    }
-}
-
 bool acrobat_boost_active()
 {
     return you.activated[EQ_AMULET]
@@ -1162,7 +1148,6 @@ static void _equip_amulet_of_mana_regeneration()
     else if (you.magic_points == you.max_magic_points)
     {
         you.props[MANA_REGEN_AMULET_ACTIVE] = 1;
-        mpr("The amulet hums as it attunes itself to your energized body.");
     }
     else
     {
@@ -1173,17 +1158,8 @@ static void _equip_amulet_of_mana_regeneration()
 
 static void _equip_amulet_of_reflection()
 {
-    if (you.hp == you.hp_max)
-    {
-        you.activated.set(EQ_AMULET);
-        you.redraw_armour_class = true;
-        mpr("You feel a shielding aura gather around you.");
-    }
-    else
-    {
-        you.activated.set(EQ_AMULET, false);
-        mpr("The amulet cannot attune itself to your injured body.");
-    }
+    you.redraw_armour_class = true;
+    mpr("You feel a shielding aura gather around you.");
 }
 
 static void _equip_jewellery_effect(item_def &item, bool unmeld,
@@ -1268,7 +1244,7 @@ static void _equip_jewellery_effect(item_def &item, bool unmeld,
 
     case AMU_ACROBAT:
         if (!unmeld)
-            _equip_amulet_of_the_acrobat();
+            mpr("You feel ready to tumble and roll out of harm's way.");
         break;
 
     case AMU_MANA_REGENERATION:

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -840,29 +840,10 @@ static void _handle_emergency_flight()
     }
 }
 
-// Regen equipment and amulet of the acrobat only begins to function when full
-// health is reached while they are worn.
+// Regen equipment only begins to function when full health is reached.
 static void _update_equipment_attunement_by_health()
 {
-    if (you.hp != you.hp_max)
-        return;
-
-    if (!you.activated[EQ_AMULET] && you.wearing(EQ_AMULET, AMU_ACROBAT))
-    {
-        mprf("Your amulet attunes itself to your body. You feel like doing "
-             "cartwheels.");
-        you.activated.set(EQ_AMULET);
-    }
-
-    if (!you.activated[EQ_AMULET] && you.wearing(EQ_AMULET, AMU_REFLECTION))
-    {
-        mprf("Your amulet attunes itself to your body. You feel a shielding "
-             "aura gather around you.");
-        you.activated.set(EQ_AMULET);
-        you.redraw_armour_class = true;
-    }
-
-    if (you.get_mutation_level(MUT_NO_REGENERATION))
+    if (you.hp != you.hp_max || you.get_mutation_level(MUT_NO_REGENERATION))
         return;
 
     vector<string> eq_list;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2213,8 +2213,7 @@ int player_shield_class()
 
     shield += qazlal_sh_boost() * 100;
     shield += tso_sh_boost() * 100;
-    shield += you.activated[EQ_AMULET] * you.wearing(EQ_AMULET, AMU_REFLECTION)
-              * AMU_REFLECT_SH * 100;
+    shield += you.wearing(EQ_AMULET, AMU_REFLECTION) * AMU_REFLECT_SH * 100;
     shield += you.scan_artefacts(ARTP_SHIELDING) * 200;
 
     return (shield + 50) / 100;
@@ -5510,7 +5509,7 @@ bool player::shielded() const
            || duration[DUR_DIVINE_SHIELD]
            || get_mutation_level(MUT_LARGE_BONE_PLATES) > 0
            || qazlal_sh_boost() > 0
-           || you.wearing(EQ_AMULET, AMU_REFLECTION) && you.activated[EQ_AMULET]
+           || you.wearing(EQ_AMULET, AMU_REFLECTION)
            || you.scan_artefacts(ARTP_SHIELDING);
 }
 


### PR DESCRIPTION
We've added a ton of special logic to amulets to emulate the strategic restrictions of armour equipment/removal. Let's cut out the middle step and just make them take a while to wear or remove.

"acrobat and "reflect lose their attunement, and "gspirit doesn't drain MP (except for deep dwarves). Possibly "regen and "mpreg could lose their attunement, but I'm uncertain about them. "faith definitely keeps its penalty.