### PR TITLE
Adjust Sprint III cloud generators

### DIFF
--- a/crawl-ref/source/dat/des/sprint/sprint_mu.des
+++ b/crawl-ref/source/dat/des/sprint/sprint_mu.des
@@ -516,7 +516,7 @@ KMONS: i = hydra
 KMONS: j = patrolling spriggan ; q:5 dart ego:atropa | q:5 dart ego:datura
 KMONS: k = patrolling spriggan druid
 KMONS: q = electric eel
-KFEAT: q = deep_water
+KFEAT: q = shallow_water
 KMONS: r = hydra simulacrum / fire dragon simulacrum / polar bear simulacrum /\
  wolf simulacrum / black mamba simulacrum
 KITEM: r = any, any, any, any, any, superb_item / w:1 wand of acid /\
@@ -547,8 +547,8 @@ X.6px!!"!"!!!!tttttttx23tttttttttttttttttt
 X.68x!!!"!!!!!tttttttxxx+ttttttttttttttttt
 Xxx+xxxx+xxxxxxxtttttttthxx..xxWWWWWw.icrr
 X...........a...tttttg..xxhxx.xWWWWw..icrr
-Xx=mxxxxxxxxxxxx+ttttt.xxAxxhxx+WWqwwxxcc+
-X...xWp.b........ttttt..x.xx...xWw......*.
+Xx=mxxxxxxxxxxxx+ttttt.xxAxxhxx+WWWwwxxcc+
+X...xWp.b........ttttt..x.xx...xWq......*.
 X...=WW.fbxxxxxxxxttttt.xx.xx.sxw..=xxxccc
 Xee.mWWW..bf....dpptttt.xx.xxxxx...x....jk
 Xee.xWWWWpfbpp...dptttg....xxu.....xttt%_j
@@ -1212,7 +1212,7 @@ KFEAT: " = floor
 COLOUR: " = yellow
 MARKER: L = lua:fog_machine { \
                  pow_max = 10, delay_min = 10, delay_max = 40, \
-                 size = 2, size_buildup_amnt = 5, \
+                 size = 2, size_buildup_amnt = 2, \
                  size_buildup_time = 25, cloud_type = "freezing vapour" \
              }
 COLOUR: # = red
@@ -1244,11 +1244,11 @@ v......v+v+nv..v.v.v.v.v.v.v.v.
 v.I.I..v.+..+..+v.vqv.vqv.vqv.v
 v..I...v.vvvv..v.v.v.v.v.v.v.v.
 v.I.I..+.vKvvvvvvvvXXXXXXXXXXXX
-v......vvv.v..L....X...o+AAAAX.
+v......vvv.v.L.....X...o+AAAAX.
 v.bnb..v...v.......X....XAAAAX.
 v.b%n..+...+.......+....XAAAAX.
 v.bbb..v...v.....MMX....XAAAAX.
-v......vvv+v.....MNX....XAAAAX.
+v......vvv+v.L...MNX....XAAAAX.
 vvvvvvvv$..vvvvvvvvXijkmXAAAA+.
 ENDMAP
 
@@ -1322,7 +1322,7 @@ KITEM: ? = superb_item, superb_item, scroll of enchant weapon ident:all q:6
 : acq_on_sight(_G, '!', {"weapon","weapon"})
 MARKER:  G = lua:fog_machine { \
                 pow_max = 25, delay_min = 100, delay_max = 150, \
-                size = 2, size_buildup_amnt = 29, \
+                size = 2, size_buildup_amnt = 10, \
                 size_buildup_time = 1000, cloud_type = "flame" }
 COLOUR: #vG = red
 KFEAT: # = closed_door
@@ -1460,7 +1460,7 @@ MONS: Tiamat, yellow draconian stormcaller / yellow draconian shifter
 MONS: white draconian scorcher
 MARKER: i = lua:fog_machine { \
         pow_max = 10, delay_min = 100, delay_max = 150, \
-        size = 2, size_buildup_amnt = 15, \
+        size = 2, size_buildup_amnt = 7, \
         size_buildup_time = 1000, cloud_type = "freezing vapour" }
 MONS: patrolling storm dragon / patrolling electric golem
 MONS: red draconian stormcaller


### PR DESCRIPTION
Fixes issue 12302. Existing cloud generators kill sleeping monsters in several places across the map within the first few hundred turns. This tones down aggressive cloud spawn, while keeping the danger in the affected rooms.