### PR TITLE
Fix a leftover scarf of cloud immunity (Yermak)

### DIFF
--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -1509,7 +1509,7 @@ MARKER:     ! = lua:fog_machine { \
 # player complete the rest of the map.
 ITEM:       potion of haste / potion of resistance w:5 / any potion w:20 \
             / scroll of silence w:5 / scroll of fog w:5 / any scroll w:20
-ITEM:       scarf ego:cloud_immunity / book of clouds / wand of clouds \
+ITEM:       scarf ego:repulsion / book of clouds / wand of clouds \
             / staff of air
 # Main loot, including some thematic items that are good even if you don't care
 # about flight.


### PR DESCRIPTION
As a followup to f75c35ca, this commit replaces a scarf of cloud
immunity with a scarf of repulsion in the Cloud Mage wizlab.

It was reported by Yermak on ##crawl-dev on 2020-06-19.