### PR TITLE
Replace Artificer starting Short Blade skill with Armour

### DIFF
--- a/crawl-ref/source/dat/descript/backgrounds.txt
+++ b/crawl-ref/source/dat/descript/backgrounds.txt
@@ -16,8 +16,8 @@ vulnerable to attacks from afar.
 %%%%
 Artificer
 
-Artificers start with a few magical devices and are competent at using such
-tools.
+Artificers are opportunists who start with three powerful wands.  They aim to
+scrounge their other equipment from the dungeon floor--or from its residents!  
 %%%%
 Berserker
 

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -64,7 +64,7 @@ static const map<job_type, job_def> job_data =
       "wand of enslavement charges:15", "wand of random effects charges:15" },
     WCHOICE_NONE,
     { { SK_EVOCATIONS, 3 }, { SK_DODGING, 2 }, { SK_FIGHTING, 1 },
-      { SK_WEAPON, 1 }, { SK_STEALTH, 1 }, },
+      { SK_ARMOUR, 1 }, { SK_STEALTH, 1 }, },
 } },
 
 { JOB_BERSERKER, {

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -63,7 +63,7 @@ static const map<job_type, job_def> job_data =
     { "short sword", "leather armour", "wand of flame charges:15",
       "wand of enslavement charges:15", "wand of random effects charges:15" },
     WCHOICE_NONE,
-    { { SK_EVOCATIONS, 3 }, { SK_DODGING, 2 }, { SK_FIGHTING, 1 },
+    { { SK_EVOCATIONS, 3 }, { SK_DODGING, 1 }, { SK_FIGHTING, 1 },
       { SK_ARMOUR, 1 }, { SK_STEALTH, 1 }, },
 } },
 

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -60,7 +60,7 @@ static const map<job_type, job_def> job_data =
     4, 3, 5,
     { SP_DEEP_DWARF, SP_HALFLING, SP_KOBOLD, SP_SPRIGGAN, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
-    { "short sword", "leather armour", "wand of flame charges:15",
+    { "club", "leather armour", "wand of flame charges:15",
       "wand of enslavement charges:15", "wand of random effects charges:15" },
     WCHOICE_NONE,
     { { SK_EVOCATIONS, 3 }, { SK_DODGING, 1 }, { SK_FIGHTING, 1 },

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -253,6 +253,14 @@ void give_items_skills(const newgame_def& ng)
         }
         break;
 
+    case JOB_ARTIFICER:
+    {
+        if (species_apt(SK_ARMOUR) < species_apt(SK_DODGING))
+            you.skills[SK_DODGING]++;
+        else
+            you.skills[SK_ARMOUR]++;
+        break;
+    }
     case JOB_CHAOS_KNIGHT:
     {
         you.religion = GOD_XOM;


### PR DESCRIPTION
Artificers start with skill in Short Blades, a weapon type that many abandon.  In addition, the current description does not sufficiently signal to the player that the background is melee-focused.

Removing skill in Short Blades eliminates the opportunity cost of switching weapon types.  Adding Armour skill reinforces the idea that the player will be in melee a lot and ought to pick up a better weapon and start training it, and upgrade their armor.  The starting Dodging skill is reduced to 1, with an extra level added to Dodging or Armour per aptitudes as for AK and CK.

Starting with a club does not force the player to spend charges on early monsters before a weapon is found.