### PR TITLE
Fixes several issues with the xv monster evasion chance calculation.

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -262,7 +262,7 @@ int attack::calc_pre_roll_to_hit(bool random) {
  *
  * @param mhit The post-roll player's to-hit value.
  */
-int attack::post_roll_to_hit_modifiers(int mhit) {
+int attack::post_roll_to_hit_modifiers(int mhit, bool random) {
     int modifiers = 0;
 
     // Penalties for both players and monsters:
@@ -292,9 +292,9 @@ int attack::post_roll_to_hit_modifiers(int mhit) {
 
         // defender backlight bonus and umbra penalty.
         if (defender->backlit(false))
-            modifiers += 5;
+            modifiers += BACKLIGHT_TO_HIT_BONUS;
         if (!attacker->nightvision() && defender->umbra())
-            modifiers -= 3;
+            modifiers += UMBRA_TO_HIT_MALUS;
     }
 
     return modifiers;
@@ -315,7 +315,7 @@ int attack::calc_to_hit(bool random)
     if (attacker->is_player())
         mhit = maybe_random2(mhit, random);
 
-    mhit += post_roll_to_hit_modifiers(mhit);
+    mhit += post_roll_to_hit_modifiers(mhit, random);
 
     // We already did this roll for players.
     if (!attacker->is_player())

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -13,8 +13,8 @@ const int HIT_WEAK   = 7;
 const int HIT_MED    = 18;
 const int HIT_STRONG = 36;
 
-const int BACKLIGHT_TO_HIT_BONUS = 12;
-const int UMBRA_TO_HIT_MALUS = -8;
+const int BACKLIGHT_TO_HIT_BONUS = 5;
+const int UMBRA_TO_HIT_MALUS = -3;
 
 class attack
 {
@@ -98,7 +98,7 @@ public:
     // To-hit is a function of attacker/defender, defined in sub-classes
     virtual int calc_to_hit(bool random);
     int calc_pre_roll_to_hit(bool random);
-    int post_roll_to_hit_modifiers(int mhit);
+    virtual int post_roll_to_hit_modifiers(int mhit, bool random);
 
     // Exact copies of their melee_attack predecessors
     string actor_name(const actor *a, description_level_type desc,

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -2289,25 +2289,32 @@ bool melee_attack::apply_staff_damage()
     return true;
 }
 
-// Duplicates describe.cc:_apply_defender_effects().
 int melee_attack::calc_to_hit(bool random)
 {
     int mhit = attack::calc_to_hit(random);
     if (mhit == AUTOMATIC_HIT)
         return AUTOMATIC_HIT;
 
+    return mhit;
+}
+
+// Duplicates describe.cc:_apply_defender_effects().
+int melee_attack::post_roll_to_hit_modifiers(int mhit, bool random)
+{
+    int modifiers = attack::post_roll_to_hit_modifiers(mhit, random);
+
     // Just trying to touch is easier than trying to damage.
     if (you.duration[DUR_CONFUSING_TOUCH])
-        mhit += maybe_random_div(you.dex(), 2, random);
+        modifiers += maybe_random_div(you.dex(), 2, random);
 
     if (attacker->is_player() && !weapon && get_form()->unarmed_hit_bonus)
     {
         // TODO: Review this later (transformations getting extra hit
         // almost across the board seems bad) - Cryp71c
-        mhit += UC_FORM_TO_HIT_BONUS;
+        modifiers += UC_FORM_TO_HIT_BONUS;
     }
 
-    return mhit;
+    return modifiers;
 }
 
 void melee_attack::player_stab_check()

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -47,6 +47,7 @@ public:
     // Applies attack damage and other effects.
     bool attack();
     int calc_to_hit(bool random) override;
+    int post_roll_to_hit_modifiers(int mhit, bool random) override;
 
     static void chaos_affect_actor(actor *victim);
 

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -71,9 +71,16 @@ int ranged_attack::calc_to_hit(bool random)
     if (mhit == AUTOMATIC_HIT)
         return AUTOMATIC_HIT;
 
+    return mhit;
+}
+
+int ranged_attack::post_roll_to_hit_modifiers(int mhit, bool random)
+{
+    int modifiers = attack::post_roll_to_hit_modifiers(mhit, random);
+
     if (teleport)
     {
-        mhit +=
+        modifiers +=
             (attacker->is_player())
             ? maybe_random_div(you.attribute[ATTR_PORTAL_PROJECTILE],
                                PPROJ_TO_HIT_DIV, random)
@@ -81,9 +88,9 @@ int ranged_attack::calc_to_hit(bool random)
     }
 
     if (defender && defender->missile_repulsion())
-        mhit = (mhit - 1) / 2;
+        modifiers -= (mhit + 1) / 2;
 
-    return mhit;
+    return modifiers;
 }
 
 bool ranged_attack::attack()

--- a/crawl-ref/source/ranged-attack.h
+++ b/crawl-ref/source/ranged-attack.h
@@ -19,6 +19,7 @@ public:
     // Applies attack damage and other effects.
     bool attack();
     int calc_to_hit(bool random) override;
+    int post_roll_to_hit_modifiers(int mhit, bool random) override;
 
 private:
     /* Attack Phases */


### PR DESCRIPTION
Note that this modifies PR #1464 by Pleasing Fungus, not master.

* Generalizes '_apply_defender_effects' to all post-roll modifiers (including things like a confused player or inaccuracy.)
* Eliminated randomizing EV, since that's only done for monster attacks
* Added iterating over the mhit roll, and enumerating hits there.
* Moved applying post-roll modifiers to post-roll to properly handle repel missiles (whose post-roll modifier is a function of the rolled mhit.
* Switched auto-hit calculation to use Bayes theorem, because I think it's a lot more readable.
* Factored out post-roll modifiers in the attack classes into their own functions.
* Made the lighting modifiers in attack.cc use the relevant consts.