### PR TITLE
Fix fleeing Harold speech

### DIFF
--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -4450,7 +4450,7 @@ fleeing Harold
 __NEXT
 
 w:5
-@The_monster@ @yells@, "I'm getting too old for this!"
+@The_monster@ @_yells_@, "I'm getting too old for this!"
 %%%%
 Harold killed
 


### PR DESCRIPTION
Bug reported by Mintice in Discord, the speech shows yells with
at signs around it. I suppose the intention here was to have the
verb randomized as per the _yells_ list.