### PR TITLE
Fix crawlrc-dependent blank screen/crash on turn 0

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -472,12 +472,6 @@ static void _setup_generic(const newgame_def& ng,
 
     _give_basic_knowledge();
 
-    // Must be after _give_basic_knowledge
-    add_held_books_to_library();
-
-    if (you.char_class == JOB_WANDERER)
-        memorise_wanderer_spell();
-
     // A first pass to link the items properly.
     for (int i = 0; i < ENDOFPACK; ++i)
     {
@@ -489,6 +483,12 @@ static void _setup_generic(const newgame_def& ng,
         item.slot = index_to_letter(item.link);
         item_colour(item);  // set correct special and colour
     }
+
+    // Must be after _give_basic_knowledge
+    add_held_books_to_library();
+
+    if (you.char_class == JOB_WANDERER)
+        memorise_wanderer_spell();
 
     if (you.equip[EQ_WEAPON] > 0)
         swap_inv_slots(0, you.equip[EQ_WEAPON], false);

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -514,7 +514,9 @@ bool library_add_spells(vector<spell_type> spells)
     {
         vector<string> spellnames(new_spells.size());
         transform(new_spells.begin(), new_spells.end(), spellnames.begin(), spell_title);
-        mprf("You add the spell%s %s to your library.",
+        mprf(you.num_turns < 1
+             ? "You begin with the spell%s %s in your library."
+             : "You add the spell%s %s to your library.",
              spellnames.size() > 1 ? "s" : "",
              comma_separated_line(spellnames.begin(),
                                   spellnames.end()).c_str());


### PR DESCRIPTION
After b274e4624c7c, we print "You add the spells ... to your library"
even when memorizing from a starting spellbook on turn 0.  This can
cause issues for players who have a force_more_message that matches that
text: for those players, any spellbook background starts with a blank
screen (a promptless force_more), and Earth Elementalists just crash.

Two changes:
* Fix the crash by moving add_held_books_to_library down a few lines, so
it happens after items are linked.
* Change the printed message so that on turn 0 it says "You begin with
the spells" instead of "You add the spells"; that way, it's possible to
target (only) the mid-game version with a force_more_message.