### PR TITLE
Aesthetic enhancement of webtiles glyph mode

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -113,9 +113,10 @@ The contents of this text are:
                 tile_font_stat_family, tile_font_msg_family,
                 tile_font_lbl_family, tile_font_crt_size, tile_font_stat_size,
                 tile_font_msg_size, tile_font_tip_size, tile_font_lbl_size,
-                tile_font_ft_light, tile_show_minihealthbar,
-                tile_show_minimagicbar, tile_show_demon_tier, tile_water_anim,
-                tile_misc_anim, tile_realtime_anim, tile_show_player_species,
+                tile_font_ft_light, glyph_mode_font, glyph_mode_font_size,
+                tile_show_minihealthbar, tile_show_minimagicbar,
+                tile_show_demon_tier, tile_water_anim, tile_misc_anim,
+                tile_realtime_anim, tile_show_player_species,
                 tile_show_threat_levels, tile_layout_priority,
                 tile_display_mode, tile_level_map_hide_messages,
                 tile_level_map_hide_sidebar, tile_player_tile,
@@ -2067,6 +2068,16 @@ tile_font_lbl_size  = 14
 
 tile_font_ft_light = false
         Selects 'light' font hinting.
+
+glyph_mode_font = monospace
+        Font used to render the dungeon in the glyph mode for WebTiles. If set
+        to monospace (default) or the font is not available, browser's default
+        monospaced font will be used.
+        This option is only available on WebTiles.
+
+glyph_mode_font_size = 24
+        Font size for the dungeon view in the glyph mode for WebTiles.
+        This option is only available on WebTiles.
 
 tile_show_minihealthbar = true
 tile_show_minimagicbar  = true

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -393,6 +393,8 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(SIMPLE_NAME(tile_font_msg_family), "monospace"),
         new StringGameOption(SIMPLE_NAME(tile_font_stat_family), "monospace"),
         new StringGameOption(SIMPLE_NAME(tile_font_lbl_family), "monospace"),
+        new StringGameOption(SIMPLE_NAME(glyph_mode_font), "monospace"),
+        new IntGameOption(SIMPLE_NAME(glyph_mode_font_size), 24, 0, INT_MAX),
 #endif
 #ifdef USE_FT
         new BoolGameOption(SIMPLE_NAME(tile_font_ft_light), false),
@@ -4556,6 +4558,9 @@ void game_options::write_webtiles_options(const string& name)
     tiles.json_write_int("tile_font_stat_size", Options.tile_font_stat_size);
     tiles.json_write_int("tile_font_msg_size", Options.tile_font_msg_size);
     tiles.json_write_int("tile_font_lbl_size", Options.tile_font_lbl_size);
+
+    tiles.json_write_string("glyph_mode_font", Options.glyph_mode_font);
+    tiles.json_write_int("glyph_mode_font_size", Options.glyph_mode_font_size);
 
     tiles.json_write_bool("show_game_time", Options.show_game_time);
 

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -536,6 +536,8 @@ public:
     string      tile_font_msg_family;
     string      tile_font_stat_family;
     string      tile_font_lbl_family;
+    string      glyph_mode_font;
+    int         glyph_mode_font_size;
 #endif
     int         tile_font_crt_size;
     int         tile_font_msg_size;

--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -7,12 +7,7 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
 
     function DungeonCellRenderer()
     {
-        // see also, renderer_settings in game.js. In fact, do these values
-        // do anything?
-        var ratio = window.devicePixelRatio;
         this.set_cell_size(32, 32);
-        this.glyph_mode_font_size = 24 * ratio;
-        this.glyph_mode_font = "monospace";
     }
 
     var fg_term_colours, bg_term_colours;

--- a/crawl-ref/source/webserver/game_data/static/dungeon_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/dungeon_renderer.js
@@ -251,13 +251,9 @@ function ($, cr, map_knowledge, options, dngn, util, view_data, enums) {
 
             if (options.get("tile_display_mode") == "glyphs")
             {
-                // font size ratio: handled in cell_renderer.js
-                var margin = 2 * ratio;
-                this.ctx.font = this.glyph_mode_font_name();
-                var metrics = this.ctx.measureText("@");
-                this.set_cell_size(metrics.width + margin,
-                        Math.floor(this.glyph_mode_font_size * scale / 100)
-                        + margin);
+                this.glyph_mode_update_font_metrics();
+                this.set_cell_size(this.glyph_mode_font_width,
+                                    this.glyph_mode_line_height);
             }
             else if ((min_diameter * cell_size.w / ratio > width)
                 || (min_diameter * cell_size.h / ratio > height))

--- a/crawl-ref/source/webserver/game_data/static/game.js
+++ b/crawl-ref/source/webserver/game_data/static/game.js
@@ -106,6 +106,7 @@ function ($, comm, client, dungeon_renderer, display, minimap, enums, messages,
             layout(layout_parameters, true);
         display.invalidate(true);
         display.display();
+        glyph_mode_font_init();
     });
 
     function toggle_full_window_dungeon_view(full)
@@ -225,13 +226,32 @@ function ($, comm, client, dungeon_renderer, display, minimap, enums, messages,
         document.title = data.text;
     }
 
-    var device_ratio = window.devicePixelRatio;
-    var renderer_settings = {
-        glyph_mode_font_size: 24 * device_ratio,
-        glyph_mode_font: "monospace"
-    };
+    function glyph_mode_font_init()
+    {
+        if (options.get("tile_display_mode") == "tiles") return;
 
-    $.extend(dungeon_renderer, renderer_settings);
+        var device_ratio = window.devicePixelRatio;
+        var glyph_font, glyph_size;
+
+        if (!options.get("glyph_mode_font_size"))
+            glyph_size = 24 * device_ratio;
+        else
+            glyph_size = options.get("glyph_mode_font_size") * device_ratio;
+
+        if (!options.get("glyph_mode_font"))
+            glyph_font = "monospace";
+        else
+            glyph_font = options.get("glyph_mode_font");
+
+        if (!document.fonts.check(glyph_size + "px " + glyph_font))
+            glyph_font = "monospace";
+
+        var renderer_settings = {
+            glyph_mode_font_size: glyph_size,
+            glyph_mode_font: glyph_font
+        };
+        $.extend(dungeon_renderer, renderer_settings);
+    }
 
     $(document).ready(function () {
         $(window)

--- a/crawl-ref/source/webserver/game_data/static/monster_list.js
+++ b/crawl-ref/source/webserver/game_data/static/monster_list.js
@@ -168,10 +168,16 @@ function ($, map_knowledge, cr, dungeon_renderer, options, util) {
 
             renderer.set_cell_size(dungeon_renderer.cell_width,
                                    dungeon_renderer.cell_height);
-            for (var key in dungeon_renderer)
+            if (options.get("tile_display_mode") != "tiles")
             {
-                if (key.match(/^glyph_mode/))
-                    renderer[key] = dungeon_renderer[key];
+                for (var key in dungeon_renderer)
+                {
+                    // dungeon_renderer.ui_state is also required so the glyph
+                    // size returned by the renderer.glyph_mode_font_name()
+                    // correctly reflects the 'tile_map_scale'
+                    if (key.match(/^glyph_mode/) || key == "ui_state")
+                        renderer[key] = dungeon_renderer[key];
+                }
             }
             var w = renderer.cell_width;
             var displayed_monsters = Math.min(monsters.length, 6);

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -277,6 +277,7 @@ body {
 
 #monster_list .health {
     display: inline-block;
+    vertical-align: middle;
 }
 
 #monster_list .uninjured {


### PR DESCRIPTION
Currently, webtiles glyph mode looked quite different from the console version, especially with high-DPI scaling enabled. This is because it was using the font size with some margins added as the cell height; and the glyph were vertically aligned to the center of the em-square to prevent them from being clipped. However, some glyph will be clipped anyway, as the font size rarely corresponds to the font height. For example, if a player is using box-drawing characters such as `█ (U+2588)`, `░ (U+2591)`, `▒
(U+2592)` and `▓ (U+2593)` to display various types of walls, the walls will appear to be unconnected or clipped.

This PR aims to make the dungeon view looks more like how it is rendered in the console version by following the glyph metrics exactly as prescribed by the font. With the change, the dungeon view of the console version and the webtiles glyph mode will be more similar and the box-drawing characters will look fine, provided that the monospaced font used is properly authored in the first place.

Additionally, two options `glyph_mode_font` and `glyph_mode_font_size` have been added allowing customization of the font being used to render the dungeon view in the webtiles glyph mode. And a few minor adjustments have been made to align the health status in the monster list and make the glyph rendered in the monster list scale accordingly to the crawl-internal zooming feature.