### PR TITLE
Don't crumble acquirement scrolls (12336)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3126,7 +3126,6 @@ void read_scroll(item_def& scroll)
     case SCR_ACQUIREMENT:
         if (!alreadyknown)
         {
-            mpr(pre_succ_msg);
             mpr("This is a scroll of acquirement!");
         }
 

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3125,10 +3125,8 @@ void read_scroll(item_def& scroll)
 
     case SCR_ACQUIREMENT:
         if (!alreadyknown)
-        {
             mpr("This is a scroll of acquirement!");
-        }
-
+        
         // included in default force_more_message
         // Identify it early in case the player checks the '\' screen.
         set_ident_type(scroll, true);


### PR DESCRIPTION
Unidentified acquirements scrolls are now cancellable after they are
read, so they should not crumble to dust.