### PR TITLE
Don't repeat acquirement identification message (dinky)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3372,7 +3372,8 @@ void read_scroll(item_def& scroll)
 #if TAG_MAJOR_VERSION == 34
         && which_scroll != SCR_RECHARGING
 #endif
-        && which_scroll != SCR_AMNESIA)
+        && which_scroll != SCR_AMNESIA
+        && which_scroll != SCR_ACQUIREMENT)
     {
         mprf("It %s a %s.",
              scroll.quantity < prev_quantity ? "was" : "is",


### PR DESCRIPTION
Currently the message sequence when reading un-id acquirement is:

 This is a scroll of acquirement!
_Something appears at your feet! It was a scroll of acquirement.

The second message is not necessary as it only applies to scrolls
which produce an immediate effect without a prompt/menu.