### PR TITLE
Allow Rampaging on randart armour

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -329,7 +329,9 @@ int actor::spirit_shield(bool calc_unid, bool items) const
 
 bool actor::rampaging(bool calc_unid, bool items) const
 {
-    return items && wearing_ego(EQ_ALL_ARMOUR, SPARM_RAMPAGING, calc_unid);
+    return items &&
+           (wearing_ego(EQ_ALL_ARMOUR, SPARM_RAMPAGING, calc_unid)
+            || scan_artefacts(ARTP_RAMPAGING, calc_unid));
 }
 
 int actor::apply_ac(int damage, int max_damage, ac_type ac_rule,

--- a/crawl-ref/source/artefact-prop-type.h
+++ b/crawl-ref/source/artefact-prop-type.h
@@ -62,5 +62,6 @@ enum artefact_prop_type
     ARTP_FRAGILE,
     ARTP_SHIELDING,
     ARTP_HARM,
+    ARTP_RAMPAGING,
     ARTP_NUM_PROPERTIES
 };

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -590,6 +590,10 @@ static bool _artp_can_go_on_item(artefact_prop_type prop, const item_def &item,
         case ARTP_HARM:
             return item_class == OBJ_ARMOUR;
             // only get harm on delay equipment
+        case ARTP_RAMPAGING:
+            return item_class == OBJ_ARMOUR
+                   && !item.is_type(OBJ_ARMOUR, ARM_BARDING);
+            // only on delay equipment to prevent "toggle" swap behaviour
         default:
             return true;
     }
@@ -725,6 +729,8 @@ static const artefact_prop_data artp_data[] =
         nullptr, []() { return 1; }, 0, 0 },
     { "SH", ARTP_VAL_ANY, 0, nullptr, nullptr, 0, 0 }, // ARTP_SHIELDING,
     { "Harm", ARTP_VAL_BOOL, 25, // ARTP_HARM,
+        []() {return 1;}, nullptr, 0, 0},
+    { "Rampage", ARTP_VAL_BOOL, 25, // ARTP_RAMPAGING,
         []() {return 1;}, nullptr, 0, 0},
 };
 COMPILE_CHECK(ARRAYSZ(artp_data) == ARTP_NUM_PROPERTIES);

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -298,6 +298,7 @@ static vector<string> _randart_propnames(const item_def& item,
         { ARTP_CAUSE_TELEPORTATION,   prop_note::plain },
         { ARTP_NOISE,                 prop_note::plain },
         { ARTP_HARM,                  prop_note::plain },
+        { ARTP_RAMPAGING,             prop_note::plain },
         { ARTP_CORRODE,               prop_note::plain },
         { ARTP_DRAIN,                 prop_note::plain },
         { ARTP_SLOW,                  prop_note::plain },
@@ -569,6 +570,8 @@ static string _randart_descrip(const item_def &item)
         { ARTP_FRAGILE, "It will be destroyed if unequipped.", false },
         { ARTP_SHIELDING, "It affects your SH (%d).", false},
         { ARTP_HARM, "It increases damage dealt and taken.", false},
+        { ARTP_RAMPAGING, "It bestows one free step when moving towards enemies.",
+          false},
     };
 
     // Give a short description of the base type, for base types with no
@@ -1834,7 +1837,7 @@ static string _describe_armour(const item_def &item, bool verbose)
             break;
 
         case SPARM_RAMPAGING:
-            description += "Its wearer goes twice as far when moving towards enemies.";
+            description += "Its wearer takes one free step when moving towards enemies.";
             break;
         }
     }

--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -288,7 +288,7 @@ bool is_hasty_item(const item_def& item, bool calc_unid)
         {
         const int item_brand = get_armour_ego_type(item);
         retval = (item_brand == SPARM_RUNNING
-                  || item_brand == SPARM_RAMPAGING);
+                  || get_armour_rampaging(item, true));
         }
         break;
     case OBJ_POTIONS:

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -2418,6 +2418,20 @@ int get_armour_repel_missiles(const item_def &arm, bool check_artp)
     return false;
 }
 
+bool get_armour_rampaging(const item_def &arm, bool check_artp)
+{
+    ASSERT(arm.base_type == OBJ_ARMOUR);
+
+    // check for ego resistance
+    if (get_armour_ego_type(arm) == SPARM_RAMPAGING)
+        return true;
+
+    if (check_artp && is_artefact(arm))
+        return artefact_property(arm, ARTP_RAMPAGING);
+
+    return false;
+}
+
 int get_jewellery_res_fire(const item_def &ring, bool check_artp)
 {
     ASSERT(ring.base_type == OBJ_JEWELLERY);

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -211,6 +211,7 @@ int get_armour_res_magic(const item_def &arm, bool check_artp) PURE;
 int get_armour_res_corr(const item_def &arm) PURE;
 int get_armour_repel_missiles(const item_def &arm, bool check_artp) PURE;
 bool get_armour_see_invisible(const item_def &arm, bool check_artp) PURE;
+bool get_armour_rampaging(const item_def &arm, bool check_artp) PURE;
 
 int get_jewellery_res_fire(const item_def &ring, bool check_artp) PURE;
 int get_jewellery_res_cold(const item_def &ring, bool check_artp) PURE;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -1661,6 +1661,10 @@ static int _get_monster_armour_value(const monster *mon,
     if (get_armour_ego_type(item) == SPARM_RUNNING)
         value += 5;
 
+    // Another sizable bonus for rampaging.
+    if (get_armour_rampaging(item, true))
+        value += 5;
+
     return value;
 }
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -263,6 +263,9 @@ static void _equip_artefact_effect(item_def &item, bool *show_msgs, bool unmeld,
     if (proprt[ARTP_CONTAM] && msg && !unmeld)
         mpr("You feel a build-up of mutagenic energy.");
 
+    if (proprt[ARTP_RAMPAGING] && msg && !unmeld)
+        mpr("You feel ready to rampage towards enemies.");
+
     if (!unmeld && !item.cursed() && proprt[ARTP_CURSE])
         do_curse_item(item, !msg);
 
@@ -373,6 +376,9 @@ static void _unequip_artefact_effect(item_def &item,
         mpr("Mutagenic energies flood into your body!");
         contaminate_player(7000, true);
     }
+
+    if (proprt[ARTP_RAMPAGING] && !you.rampaging() && msg && !meld)
+        mpr("You no longer feel able to rampage towards enemies.");
 
     if (proprt[ARTP_DRAIN] && !meld)
         drain_player(150, true, true);

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -1554,6 +1554,7 @@ static void _debug_rap_stats(FILE *ostat)
         "ARTP_FRAGILE",
         "ARTP_SHIELDING",
         "ARTP_HARM",
+        "ARTP_RAMPAGING",
     };
     COMPILE_CHECK(ARRAYSZ(rap_names) == ARTP_NUM_PROPERTIES);
 


### PR DESCRIPTION
Rampaging is currently pretty rare in practice:

* Ego boots are extremely rare spawns at itemgen.
* Many species cannot equip boots.
* Some characters end up with melded boots due to build choices.
* The positioning choices and skilling choices offered by rampaging
  are more impactful when presented earlier in the game.

This commit aims to make rampaging available to a wider range of
characters, by adding it as a potential randart armour property.

ARTP_RAMPAGING generates as 'potentially_good', similar to Harm.

-----
As another way to address rampaging rarity, @PleasingFungus had previously suggested adding rampaging to a new or existing unique monster. That still seems like a good idea to me, but my own attempts at writing a branch to that effect have been uninspired so far. 

In the meantime, here's an artprop.