### PR TITLE
Adds 25 new vaults (primarily arrival, float, altar)

### DIFF
--- a/crawl-ref/source/dat/des/altar/altar.des
+++ b/crawl-ref/source/dat/des/altar/altar.des
@@ -294,6 +294,72 @@ x.G.x
 ..@..
 ENDMAP
 
+# Simple decision for the player on whether the altar is worth stepping on
+# or otherwise avoiding (digging etc) one or more traps
+NAME:  amcnicky_altar_trapped
+TAGS:  no_monster_gen
+DEPTH: D:3-, Vaults
+SUBST: p:~., q:~....., r:~.......
+MAP
+xxxxx
+x...xxxx.
+x.C.~pqr.
+x...xxxx.
+xxxxx
+ENDMAP
+
+# Gold given fairly modest weightings, could be lowered further if
+# determined that this would be too much of a bump to the player
+# Could also add a chance to subst gold for enemies
+# Average gold generation:
+# Inner ring, 2.79 piles
+# Outer ring, 2.09 piles
+NAME:   amcnicky_altar_gilded
+TAGS:   transparent
+DEPTH:  D:3-, Vaults, Lair, Orc, Elf, Crypt
+NSUBST: p = *=.$:45
+NSUBST: q = *=.$:15
+MAP
+.........
+.mmmmmmm.
+.mqqqqqm.
+.mqpppqm.
+.+qpCpqm.
+.mqpppqm.
+.mqqqqqm.
+.mmmmmmm.
+.........
+ENDMAP
+
+# Chance of rolling all % items: 61%
+NAME:   amcnicky_altar_medium_temple
+TAGS:   no_monster_gen
+DEPTH:  D:3-, Vaults, Lair, Orc, Elf, Crypt
+SUBST:  p:%%%%%*, q:%%%%%%%*, r:%%%%%*, s:xx+, u:xx+, y:...wwwl, z:...wwwl
+MAP
+     ............
+    ..............
+   ................
+  ....xxsxxxxuxx....
+ ....xxx.xxx..xxx....
+....xxxx.zzz..xxxx...
+...xxxG.......Gxxx...
+...xxx.....0....Gx...
+...xx..0...0.....x...
+...x..yyyyyyy.9.px...
+...+..yyyyyyy..Cqx...
+...x..yyyyyyy.9.rx...
+...xx..0...0.....x...
+...xxx.....0....Gx...
+...xxxG.......Gxxx...
+....xxxx.zzz..xxxx...
+ ....xxx.xxx..xxx....
+  ....xxsxxxxuxx....
+   ................
+    ..............
+     ............
+ENDMAP
+
 ##############################################################################
 # III   Altars to minor gods
 #
@@ -384,6 +450,51 @@ cccyy..yycc
      @@
 ENDMAP
 
+# Using the 'can_overwrite' tag to simulate Lugonu corrupting the dungeon
+# validate possibly not needed, but better safe than sorry to check that
+# we can still traverse whatever Lugonu has chosen to put their foot in.
+# The use of this many @s is also probably overkill, but want to take
+# all measures I can think of to stop can_overwrite messing up level
+# traversal with this vault since it can overwrite.
+NAME:     amcnicky_altar_lugonu_corruption
+TAGS:     transparent can_overwrite no_monster_gen
+DEPTH:    D:3-, Vaults, Lair, Orc, Elf, Crypt, Depths, Slime:1-4, Shoals,\
+            Spider, Snake, Swamp
+# Lugonu cares not about moderate vault placement
+MARKER:   q  = lua:fog_machine { cloud_type="purple smoke", walk_dist=1, \
+            size=1, pow_max=5, delay=10, buildup_amnt=7, buildup_time=7, \
+            spread_rate=2, start_clouds=1, colour="pruple" }
+FTILE:    .upqrG1@ = FLOOR_NERVES
+KFEAT:    p = altar_lugonu
+KFEAT:    r = enter_abyss
+KPROP:    p = no_cloud_gen
+MONS:     lurking horror / thrashing horror
+MONS:     spatial vortex / shining eye
+MONS:     chaos spawn / spatial vortex
+MONS:     ufetubus / floating eye
+SUBST: . = .:75 p:10 r:5 1:10
+: if you.absdepth() <4 then
+SUBST: 1:4
+: end
+: if you.absdepth() <6 then
+SUBST: 1:3
+: end
+: if you.absdepth() <10 then
+SUBST: 1:2
+: end
+SUBST:  1 = 1:80 2:10 3:5 4:5
+SUBST:  2 = 2:80 3:10 4:10
+SUBST:  3 = 3:80 4:20
+validate {{ return has_exit_from_glyph('r') }}
+MAP
+ @@@q.
+@.1.1..
+@1...Gq.
+@u.p.rG.
+@1...Gq.
+@.1.1..
+ @@@q.
+ENDMAP
 
 ### Altars possibly to Beogh #################################################
 

--- a/crawl-ref/source/dat/des/arrival/simple.des
+++ b/crawl-ref/source/dat/des/arrival/simple.des
@@ -2386,3 +2386,114 @@ xxx........Gxxx
  xxxwwwwwxx+x
    xxxxxxx
 ENDMAP
+
+###############################################################################
+NAME:     amcnicky_arrival_double_pillar
+TAGS:     arrival no_monster_gen no_item_gen no_pool_fixup
+ORIENT:   float
+SHUFFLE:  JK
+SUBST:    p:xxxWWWlv, J:x, K:@
+MAP
+JKKKKKKKJ
+J.......J
+J.pp....J
+J.pp....J
+x......xx
+x.xxxx.xx
+x.x....xx
+xxx.{.xxx
+xx....x.x
+xx.xxxx.x
+xx......x
+J....pp.J
+J....pp.J
+J.......J
+JKKKKKKKJ
+ENDMAP
+
+NAME:     amcnicky_arrival_single_pillar
+TAGS:     arrival no_monster_gen no_item_gen no_pool_fixup
+SHUFFLE:  JK
+SUBST:    p:xxxWWWlv, J:x, K:@
+MAP
+JKKKKKKKJ
+J.......J
+J.pp....J
+J.pp....J
+x......xx
+x.xxxx.xx
+x.x....xx
+xxx.{.xxx
+@+....x
+xxxxxxx
+ENDMAP
+
+NAME:   amcnicky_arrival_feature_with_door
+TAGS:   arrival no_monster_gen no_pool_fixup no_trap_gen
+ORIENT: float
+SUBST:  p:xxxtttvblWV
+MAP
+       x@x
+xxxxxxxx+xxxxx
+x{...........@
+xxxxxx.......x
+     xx..p..xx
+      xx...xx
+       xx.xx
+        xxx
+ENDMAP
+
+NAME:   amcnicky_arrival_flooded_fountain
+TAGS:   arrival no_monster_gen no_pool_fixup no_trap_gen
+ORIENT: float
+MAP
+ xxxxxxx
+ xw{...x
+xxxxx..x
+xVwww..x
+xwww...x
+xwww...x
+xww....x
+xw.....xx
+x......+@
+xT.....xx
+x......x
+x...xx.x
+x...xx.x
+x......x
+x......x
+xT.....x
+xxxxxxxx
+ENDMAP
+
+NAME:   amcnicky_arrival_choice
+TAGS:   arrival no_monster_gen no_trap_gen
+ORIENT: float
+SUBST:  p:}}>
+MAP
+    xxx
+xxxxxpx
+x{....x
+xxxxx.x
+    x+x
+    x@x
+ENDMAP
+
+NAME:     amcnicky_arrival_underground_garden
+TAGS:     arrival no_monster_gen no_trap_gen
+ORIENT:   float
+MAP
+xxxxtxtxxtxxttxx
+x{............xx
+xxxxxxxtxtxtt.xx
+xtttttttttttt.xx
+xttt.....ttt..tx
+xtt..........ttx
+xt....t.t....xtx
+xt.....T.....ttx
+xt....t.t....ttx
+xtt.........tttx
+xttt.......ttttx
+xttttt...ttttttx
+xxxxxt@@@txxxxxx
+ENDMAP

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -3496,3 +3496,93 @@ xx...x+   +xxx+   +x...xx
          xx...xx
           xxxxx
 ENDMAP
+
+##############################################################
+NAME:     amcnicky_arrival_blooded_trapdoor
+TAGS:     arrival no_monster_gen no_pool_fixup no_trap_gen
+ORIENT:   float
+KPROP:    u = bloody
+SHUFFLE:  pqr
+SUBST:    s:xxxtW, p:x, q:x, r:@, u:.
+MAP
+   xpppx
+   xuuux
+xxxxu>uxxxxxqqq
+x...uuu.......q
+x.{........ss.q
+x..........ss.x
+xxxxxxx.......x
+      xxrrrrxxx
+ENDMAP
+
+NAME:     amcnicky_arrival_gap_in_the_tavern_cellar
+TAGS:     arrival no_monster_gen no_pool_fixup no_trap_gen
+ORIENT:   float
+KITEM:    t = deep dwarf skeleton
+SHUFFLE:  su, pq
+KPROP:    p = bloody
+SUBST:    r:xxxxvvWl, s:@, u:x, p:., q:.
+MAP
+    xxxxxxxx
+    xT....Tx
+xxxxx......x
+x..........x
+x.{........x
+x.........Vx
+xxxxxT.....xv
+    xxxxxxxpvv
+   xxxxxxxvvqvv
+   s....xxxxvpvv
+   s.rr.qpxxvvqv
+   s.rr.pppqqppx
+   s....xxxxxxxx
+   uuuuux
+ENDMAP
+
+NAME:     amcnicky_arrival_wind_blow
+TAGS:     arrival no_monster_gen no_trap_gen
+ORIENT:   float
+KITEM:    p = deep dwarf skeleton
+MAP
+    xxxxxx
+    x{..px
+    xxx..xx
+      x...xxx
+     xx..p..x
+     xp.....xx  xxxx
+    xxp......x xx..@
+xxxxx...xx...xxx...@
+x.......xxx......xx@
+x......xx xx.....xx@
+x.xx...x   x.......@
+x.xx...xx  xxxxxx..@
+x.......xx      xxxx
+x........x
+xxxxxxx..x
+      x@@x
+ENDMAP
+
+NAME:     amcnicky_arrival_abandonned_market
+TAGS:     arrival no_monster_gen no_trap_gen
+ORIENT:   float
+KITEM:    q = deep dwarf skeleton
+KFEAT:    p = abandoned_shop
+MAP
+xxxxxxxxxxxxxxxxxxxxx
+xxxxxppxxppxxppxxpppx
+xxxxx..............px
+x{...........q.....xx
+xx.................xx
+xxx.....q..........xx
+xxxxx..............px
+xxxxxxxpppxxxxxx...px
+      xxxxxxqpp..q.xx
+           x.ppq...xxxx
+           x..qq...px.@
+           x.xx....xx.@
+           xqxxq...+..@
+           xqq.....xx.@
+           x.......pxxx
+           xppxxxppxxxx
+           xxxxxxxxxxxx
+ENDMAP

--- a/crawl-ref/source/dat/des/variable/float.des
+++ b/crawl-ref/source/dat/des/variable/float.des
@@ -835,6 +835,33 @@ Ellllllll.
   ..!...
 ENDMAP
 
+NAME:    amcnicky_nick_rare_triplestair_openwater
+ORIENT:  float
+TAGS:    extra luniq_staircase uniq_triplestair_openwater decor
+DEPTH:   D:2-, Lair, Depths
+WEIGHT:  4
+MAP
+ xxxxxxxxxxxxxxxxxxxx
+xxWWWWWWWWWWWWWWWWWWxx
+xWWWWWWWWWWWWWWWWWWWWx
+xWWWWWwwwwwwwwwWWWWWWx
+xWWWWwww.....wwwWWWWWx
+xWWWWww.{...(.wwWWWWWx
+xWWWWww...[...wwWWWWWx
+xWWWWwww.....wwwWWWWWx
+xWWWWwwww...wwwwWWWWWx
+xWWWWWwww...wwwWWWWWWx
+xWWWWWWww...wwWWWWWWWx
+xWWWWWWww...wwWWWWWWWx
+xxxWWWWww...wwWWWWxxxx
+  xxxxWww...wwWxxxx
+     xxww...wwxx
+      xww...wwx
+      xxw...wxx
+       xw...wx
+       xw@@@wx
+ENDMAP
+
 ##############################################################################
 # Celtic spiral tile pattern (rotated 45 degrees)
 # http://en.wikipedia.org/wiki/Celtic_maze
@@ -9929,4 +9956,284 @@ xxx.xx.xxx0...........0xxx.xx.xxx
 x..x..x11xx...........xx11x..x..x
 x1.x.1x11*xxx...{...xxx*11x1.x.1x
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ENDMAP
+
+NAME:   amcnicky_float_guardroom
+DEPTH:  D:3-, Depths
+ORIENT: float
+TAGS:   no_item_gen no_monster_gen
+SUBST:  0 = .:20 0:70 9:10
+SUBST:  9 = .:20 0:20 9:50 8:10
+SUBST:  % = .:20 $:40 %:26 *:10 |:4
+SUBST:  p = .:70 +:30
+MAP
+    xxxxxxxxxx
+  xxx%%999%%%x
+  @.x........x
+  x.x00....00x
+xxxpx00....00x
+x00.xxxx+xxxxxxx
+x00............x
+xxxxxxpxxxxxxxpx
+     x.x   x00.x
+      @    x00.x
+           x00.x
+           xx...@
+            xxxx
+ENDMAP
+
+NAME:   amcnicky_float_beach_large
+WEIGHT: 5 (D:3-), 2 (Depths)
+DEPTH:  D:3-, Depths
+ORIENT: float
+TAGS:   no_item_gen no_monster_gen
+FTILE:  . = floor_sand
+FTILE:  ; = floor_pebble
+FTILE:  0 = floor_sand
+FTILE:  9 = floor_sand
+FTILE:  % = floor_sand
+SUBST:  0 = .:20 0:70 9:10
+SUBST:  9 = .:20 0:20 9:52 8:8
+SUBST:  % = .:20 $:40 %:28 *:10 |:2
+SUBST:  p = .:70 +:30
+MAP
+  xxxx
+ @+;;x
+  xx;x
+xxxx;xxxx
+x..0.0..x
+x.0.0.0.x
+x..www..x
+x.0www..x
+x..www..x
+x0.www..x
+x..www9.x
+x.0www..x
+x..www..x
+x0.www..x
+x..www..x
+x.0...%%x
+x.....%%x
+xxxxxxxxx
+ENDMAP
+
+NAME:   amcnicky_float_beach_small
+WEIGHT: 5 (D:3-), 2 (Depths)
+DEPTH:  D:3-, Depths
+ORIENT: float
+TAGS:   no_item_gen no_monster_gen
+FTILE:  . = floor_sand
+FTILE:  ; = floor_pebble
+FTILE:  0 = floor_sand
+FTILE:  9 = floor_sand
+FTILE:  % = floor_sand
+SUBST:  0 = .:20 0:70 9:10
+SUBST:  9 = .:20 0:20 9:56 8:4
+SUBST:  % = .:20 $:40 %:28 *:10 |:2
+SUBST:  p = .:70 +:30
+MAP
+  xxxx
+ @+;;x
+  xx;x
+xxxx;xxxx
+x..0.0..x
+x..www..x
+x.0www..x
+x..www9.x
+x.0www..x
+x0....%%x
+xxxxxxxxx
+ENDMAP
+
+NAME:   amcnicky_float_corridor_feature
+DEPTH:  D:5-, Depths, Crypt
+ORIENT: float
+TAGS:   extra no_item_gen
+SUBST:  p: .:6 G:40 t:20 <:10 >:10 n:4 l:4 $:4 Y:2
+MAP
+  @
+xx.xx
+xp.px
+xx.xx
+xx.xx
+xp.px
+xx.xx
+xx.xx
+xp.px
+xx.xx
+  @
+ENDMAP
+
+NAME:   amcnicky_float_open_feature
+DEPTH:  D:5-, Depths, Lair
+ORIENT: float
+TAGS:   no_item_gen
+SUBST:  0 = .:40 0:50 9:10
+SUBST:  p: .:37 G:20 t:10 <:10 >:10 n:4 l:4 $:4 Y:1
+SUBST:  q: x@
+SUBST:  r: .:66 w:34
+SUBST:  s: .:66 x:33
+SUBST:  u: .:66 x:33
+SUBST:  y: .:66 x:33
+SUBST:  % = .:65 $:10 %:12 *:4 |:1
+MAP
+  xxxxxqxxxxx
+ xxp.......pxx
+xxp..00000..pxx
+xp..u.u.u.u..px
+xy.rrrrrrrrr.yx
+xrrrrrrrrrrrrrx
+x..rrrrrrrrr..x
+xy..u%u%u%u..yx
+xp...........px
+xxp.sss.sss.pxx
+ xxpsss.ssspxx
+  xxxxx@xxxxx
+ENDMAP
+
+NAME:   amcnicky_float_pool_small
+WEIGHT: 5
+DEPTH:  D:5-, Depths, Lair
+ORIENT: float
+TAGS:   no_pool_fixup extra
+SUBST:  p: w:60 W:30 l:10
+MAP
+  xxxx
+ @...x
+  xx.x
+  xx.xx
+ xx...xx
+xx..p..xx
+x..ppp..x
+xx..p..xx
+ xx...xx
+  xx.xx
+   x.xxx
+   x...@
+   xxxxx
+ENDMAP
+
+NAME:   amcnicky_float_pool_medium
+WEIGHT: 5
+DEPTH:  D:5-, Depths, Lair
+ORIENT: float
+TAGS:   no_pool_fixup
+SUBST:  p: w:60 W:30 l:10
+SUBST:  q= .:50 0:50
+MAP
+    xxxx
+   @...x
+    xx.x
+    xx.xx
+   xx...xx
+  xx..p..xx
+ xx..ppp..xx
+xx.qpppppq.xx
+x..ppppppp..x
+x.ppppppppp.x
+x..ppppppp..x
+xx.qpppppq.xx
+ xx..ppp..xx
+  xx..p..xx
+   xx...xx
+    xx.xx
+     x.x
+     x.xxxx
+     x.....@
+     xxxxxx
+ENDMAP
+
+# Vault walls and blood hint that something tougher awaits
+NAME:   amcnicky_float_rare_duel
+WEIGHT: 2
+DEPTH:  D:5-, Depths, Crypt, Lair
+ORIENT: float
+TAGS:   no_pool_fixup extra
+KPROP:  p = bloody
+SUBST:  %= %:20 *:60 |:20
+SUBST:  E= .:50 8:20 9:30
+MAP
+       vvv
+      vv%v
+     vvG.vv
+ xxvvvG.E.v
+@+$pp+..8.v
+ xxvvvG.E.v
+     vvG.vv
+      vv%v
+       vvv
+ENDMAP
+
+# Decision making with traps - which path do you take?
+NAME:   amcnicky_float_corridor_trapped
+WEIGHT: 4
+DEPTH:  D:4-, Depths, Crypt
+ORIENT: float
+TAGS:   extra no_item_gen no_monster_gen no_tele_into
+MAP
+  xxxx
+ xx~~xxx
+@..~~~..@
+ xxx~~xx
+   xxxx
+ENDMAP
+
+# The next 2 vaults involve lava, so using thematic weightings to
+# lean towards where lava seems most common in Depths
+NAME: amcnicky_float_rare_at_lavas_edge
+WEIGHT: 2 (D:3-), 2 (Crypt), 6 (Depths)
+DEPTH:  D:3-, Depths, Crypt
+ORIENT: float
+SUBST:  0 = .:50 0:40 9:10
+MAP
+       xxxxxxxxxxxxxx
+    xxxxllllllllllllxx
+   xxllllllllllllllllxx
+  xxllllllllllllllllllxx
+  xllllllllllllllllllllxx
+  xlllllllllllllllllllllxx
+ xxllllllllllllllllllllllxx
+ xllllllllllllllllllllllllxx
+ xlllllllllllllllllllllllllx
+xxlllllllllllllllllllllllllx
+xllllllllllllllllllllllllllxx
+xlllllllllllllllllllllllllllx
+xllllllllllllllllllll.xxllllx
+xllllllllllllllllllll..xxlllxx
+xllllllllllllllllllll.0.xxlllx
+xxlllllllllllllllllll....xxllx
+ xlllllllllllllllllll..0..xxlx
+ xxlllllllllllllllll.......xxx
+  xllllllllllllllll..0.0..0.x
+  xxlllllllllllll..0.........@
+   xxlllllllll..........0..0.@
+    xxllllllllx..0...0......x
+     xxlllllllxx........0..xx
+      xxxllllllxxxxxx....xxx
+        xxxxllllllllxxxxxx
+           xxxxxxxxxx
+ENDMAP
+
+NAME:   amcnicky_float_rare_corridor_liquid
+WEIGHT: 2 (D:3-), 2 (Crypt), 6 (Depths)
+DEPTH:  D:3-, Depths
+ORIENT: float
+TAGS:   extra
+SUBST:  p: w:50 l:50
+MAP
+ xxxxxxxxxxx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xmmmmmmmmmx
+@...........@
+ xmmmmmmmmmx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xpppppppppx
+ xxxxxxxxxxx
 ENDMAP


### PR DESCRIPTION
More specifically, this rebased commit submits 25 new vaults as follows:
 - 10 new arrival vaults
 - 11 new floating vaults
 - 3 new mini vaults
 - 1 new special altar vault for Lugonu, which involves can_overwrite
	to simulate corruption of the dungeon

Liquids/lava used are given lower vault weightings or lower SUBST
weightings, and most vaults have a good level of shuffle/subst to
increase variation.

Let me know any questions or tweaks you would like to see.

Thanks,

amcnicky