### PR TITLE
Fix plant wither duration

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4504,7 +4504,7 @@ int monster::hurt(const actor *agent, int amount, beam_type flavour,
 
         blame_damage(agent, amount);
 
-        if (mons_is_fragile(*this))
+        if (mons_is_fragile(*this) && !has_ench(ENCH_SLOWLY_DYING))
         {
             // Die in 3-5 turns.
             this->add_ench(mon_enchant(ENCH_SLOWLY_DYING, 1, nullptr,


### PR DESCRIPTION
This commit fixes a bug with plant withering:

Previously, the duration of ENCH_SLOWLY_DYING was being incremented each
time a plant took damage, which led to plants dying very slowly indeed if
the player attacked them repeatedly.