### PR TITLE
Tweak enslave soul when used on clones

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2425,13 +2425,13 @@ static spret _do_ability(const ability_def& abil, bool fail)
         }
 
         monster* mons = monster_at(beam.target);
-        
+
         if (mons->is_illusion())
         {
             simple_monster_message(*mons, "'s clone doesn't have a soul to enslave!");
             return spret::success;
         }
-        
+
         if (mons == nullptr || !you.can_see(*mons)
             || !yred_can_enslave_soul(mons))
         {


### PR DESCRIPTION
Using enslave soul on a clone results in an info leak at no cost to the
player.  Change the behavior to provide a message that the target is a
clone and player loses MP, piety, and a turn.

Resolves: #12340