### PR TITLE
Fix a rampaging bug (12353, Flugkiller)

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -582,8 +582,8 @@ static spret _rampage_forward(coord_def move)
             return spret::fail;
 
         // Don't rampage if our tracer path is broken by something we can't
-        // pass through before it reaches a monster.
-        if (!you.can_pass_through(p))
+        // safely pass through before it reaches a monster.
+        if (!you.can_pass_through(p) || is_feat_dangerous(grd(p)))
             return spret::fail;
 
         const monster* mon = monster_at(p);


### PR DESCRIPTION
This fixes a rampage interaction with deep water / lava.

Previously, the rampaging tracer wasn't properly failing on dangerous
terrain. This was causing the rampage to abort at its moveto check instead,
which erroneously blocked the second half of the move.

-----
This PR fixes [mantis issue 12353](https://crawl.develz.org/mantis/view.php?id=12353).