### PR TITLE
Enable cursor in map-view for console

### DIFF
--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -799,6 +799,7 @@ bool show_map(level_pos &lpos, bool travel_mode, bool allow_offlevel)
     if (!lpos.id.is_valid() || !allow_offlevel)
         lpos.id = level_id::current();
 
+    cursor_control ccon(true);
     levelview_excursion le(travel_mode);
     auto map_view = make_shared<UIMapView>(lpos, le, travel_mode, allow_offlevel);
 


### PR DESCRIPTION
08ff59a6b337511f8596aeb26a0c06b099ee3b7f made the map cursor disappear, at least for me on Windows 10, console.