### PR TITLE
Prevent slimy shafting (/u/zeunysos)

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -6084,7 +6084,8 @@ static coord_def _get_feat_dest(coord_def base_pos, dungeon_feature_type feat,
                 dest_pos = random_in_bounds();
             }
             while (grd(dest_pos) != DNGN_FLOOR
-                   || env.pgrid(dest_pos) & FPROP_NO_TELE_INTO);
+                   || env.pgrid(dest_pos) & FPROP_NO_TELE_INTO
+                   || count_adjacent_slime_walls(dest_pos) != 0);
         }
 
         if (!shaft)


### PR DESCRIPTION
In some circumstances, it was possible to be shafted adjacent to a
slime wall, and take damage before having a chance to act.

This commit adds a slime wall adjacency check to shaft destinations.

-----
As a side note, that do while in `_get_feat_dest` scares me a bit, and maybe it could use an assert or something(?), but I'm just going for the quick fix here.