### PR TITLE
Two fixes for the spectral and protection brands

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -512,6 +512,7 @@ static void _add_randart_weapon_brand(const item_def &item,
             13, SPWPN_PAIN,
             13, SPWPN_ANTIMAGIC,
             13, SPWPN_PROTECTION,
+            13, SPWPN_SPECTRAL,
              3, SPWPN_DISTORTION,
              3, SPWPN_CHAOS);
     }

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -594,6 +594,7 @@ static const weapon_def Weapon_prop[] =
         DAMV_CRUSHING, 8, 10, 40, {
             { SPWPN_NORMAL,     50 },
             { SPWPN_SPECTRAL,   18 },
+            { SPWPN_PROTECTION, 18 },
             { SPWPN_DRAINING,    8 },
             { SPWPN_VORPAL,      8 },
             { SPWPN_SPEED,       8 },
@@ -610,6 +611,7 @@ static const weapon_def Weapon_prop[] =
             { SPWPN_ELECTROCUTION,  12 },
             { SPWPN_VAMPIRISM,      12 },
             { SPWPN_SPECTRAL,        9 },
+            { SPWPN_PROTECTION,      9 },
             { SPWPN_VENOM,           7 },
             { SPWPN_PAIN,            7 },
             { SPWPN_ANTIMAGIC,       4 },


### PR DESCRIPTION
This PR allows randarts to generate with the spectral ego, as was intended.

The removal of the protection brand from lajatangs and quarterstaves looks unintentional
because it wasn't mentioned in 65aa84ea, so the second commit fixes that.