### PR TITLE
Following PR#1538, resubmit new mini vaults

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_features.des
+++ b/crawl-ref/source/dat/des/variable/mini_features.des
@@ -2664,6 +2664,38 @@ xxxxx
 xxxxx
 ENDMAP
 
+NAME:   amcnicky_mini_pool_small
+WEIGHT: 5
+DEPTH:  D:5-, Depths, Lair
+TAGS:   decor extra transparent
+SUBST:  p: w:60 W:30 l:10
+MAP
+  xx.xx
+ xx...xx
+xx..p..xx
+x..ppp..x
+xx..p..xx
+ xx...xx
+  xx.xx
+ENDMAP
+
+NAME:   amcnicky_mini_rare_corridor_liquid
+WEIGHT: 2 (D:3-), 2 (Crypt), 6 (Depths)
+DEPTH:  D:3-, Depths
+TAGS:   extra transparent decor
+SUBST:  p: w:50 l:50
+MAP
+xxxxxxxxxxx
+xpppppppppx
+xpppppppppx
+xmmmmmmmmmx
+@.........@
+xmmmmmmmmmx
+xpppppppppx
+xpppppppppx
+xxxxxxxxxxx
+ENDMAP
+
 #####################################################################
 #
 # <<2>> Inaccessible items

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -7565,6 +7565,52 @@ MAP
 ...........
 ENDMAP
 
+
+NAME:   amcnicky_mini_beach_small
+WEIGHT: 5 (D:3-), 2 (Depths)
+DEPTH:  D:3-, Depths
+TAGS:   no_item_gen no_monster_gen
+FTILE:  . = floor_sand
+FTILE:  ; = floor_pebble
+FTILE:  0 = floor_sand
+FTILE:  9 = floor_sand
+FTILE:  % = floor_sand
+NSUBST:  0 = 2:. / 2:0 / 1:09
+#Total weight 100
+NSUBST:  % = *=.:20 $:40 %:26 *:10 |:4
+SUBST:   q : .+x
+MAP
+xxxx;xxxx
+x..0.0..x
+q..www..q
+q.0www..q
+x..www9.x
+x.0www..x
+x0....%%x
+xxxxxxxxx
+ENDMAP
+
+
+NAME:   amcnicky_mini_pool_medium
+WEIGHT: 5
+DEPTH:  D:5-, Depths, Lair
+TAGS:   no_pool_fixup ruin_depths
+SUBST:  p: w:60 W:30 l:10
+SUBST:  q= .:50 0:50
+MAP
+   xx...xx
+  xx..p..xx
+ xx..ppp..xx
+xx.qpppppq.xx
+x..ppppppp..x
+x.ppppppppp.x
+x..ppppppp..x
+xx.qpppppq.xx
+ xx..ppp..xx
+  xx..p..xx
+   xx...xx
+ENDMAP
+
 NAME:   special_room
 TAGS:   allow_dup luniq no_item_gen ruin_spider ruin_slime
 TAGS:   no_monster_gen layout_rooms layout_corridors layout_passages


### PR DESCRIPTION
Final PR in the series, submitting amended mini vaults following a first
round review by ebering. Vaults in this collection:

<mini_features.des>
amcnicky_mini_pool_small
A decorative minivault containing a small randomised pool

amcnicky_mini_rare_corridor_liquid
A rare vault which allows the dungeon generator to, on occasion, produce
a corridor surrounded on either side by liquid, perhaps to be read as
either a bridge over liquid below, or as a passageway between the
liquid's depths. Uses the extra tag.

<mini_monsters.des>
amcnicky_mini_beach_small
Similar to the beach vault submitted elsewhere in this collection, this
mini vault allows the dungeon to rarely generate a small beach or oasis.

amcnicky_mini_pool_medium
A slightly larger version of pool_small that can generate monsters, and
also appear ruined when generated within Depths.