### PR TITLE
Give x-v a selection menu when there are many describable things

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1065,35 +1065,6 @@ vector<SelItem> select_items(const vector<const item_def*> &items,
     return selected;
 }
 
-// Show the user an inventory menu with the stack of items
-// to be described
-void describe_items(const vector<const item_def*> &items, const char *title)
-{
-    if (items.empty())
-        return;
-
-    if (items.size() == 1)
-    {
-        describe_item_popup(*items[0]);
-        return;
-    }
-
-    InvMenu menu;
-    menu.set_type(menu_type::invlist);
-    menu.set_title(title);
-    menu.load_items(items);
-    menu.set_flags(MF_SINGLESELECT | MF_ALLOW_FORMATTING);
-
-    menu.on_single_selection = [](const MenuEntry& me)
-    {
-        const InvEntry * inv = dynamic_cast<const InvEntry*>(&me);
-        return describe_item_popup(*inv->item);
-    };
-
-    menu.show();
-}
-
-
 bool item_is_selected(const item_def &i, int selector)
 {
     const object_class_type itype = i.base_type;

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -239,8 +239,6 @@ vector<SelItem> select_items(
                         const char *title, bool noselect = false,
                         menu_type mtype = menu_type::pickup);
 
-void describe_items(const vector<const item_def*> &items, const char * title);
-
 vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items);
 
 void display_inventory();


### PR DESCRIPTION
This expands 2a96157, which lets you select from an item in a stack when x-v-ing, to list monsters and features as well. Now you are not blocked from examining items when there is a monster on the tile or from examining features when there is a monster or item.

Unfortunately if you use ctrl-x or ctrl-f with the menu in travel mode to see where something is and then want to check the description, you can end up needing to select the same item twice from similar menus. This isn't new with this commit but this does sort of double down on that. I'm open to suggestions.