### PR TITLE
Stop acquirement of +4 stat rings

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1340,18 +1340,20 @@ int acquirement_create_item(object_class_type class_wanted,
             // That might have changed the item's subtype.
             item_colour(acq_item);
         }
-        else if (acq_item.base_type == OBJ_JEWELLERY)
+        else if (acq_item.base_type == OBJ_JEWELLERY
+                 && !is_unrandom_artefact(acq_item))
         {
             switch (acq_item.sub_type)
             {
-            case RING_PROTECTION:
             case RING_STRENGTH:
             case RING_INTELLIGENCE:
             case RING_DEXTERITY:
+                acq_item.plus = GOOD_STAT_RING_PLUS;
+                break;
+            case RING_PROTECTION:
             case RING_EVASION:
             case RING_SLAYING:
-                // Make sure plus is >= 1.
-                acq_item.plus = max(abs((int) acq_item.plus), 1);
+                acq_item.plus = GOOD_RING_PLUS;
                 break;
 
             case RING_ATTENTION:

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1618,22 +1618,23 @@ static bool _try_make_jewellery_unrandart(item_def& item, int force_type,
 }
 
 /**
- * A 'good' plus for stat rings is +6, for other rings it's +4.
+ * A 'good' plus for stat rings is GOOD_STAT_RING_PLUS, for other rings it's
+ * GOOD_RING_PLUS.
  *
  * @param subtype       The type of ring in question.
  * @return              4 or 6.
  *                      (minor numerical variations are boring.)
  */
-static int _good_jewellery_plus(int subtype)
+static short _good_jewellery_plus(int subtype)
 {
     switch (subtype)
     {
         case RING_STRENGTH:
         case RING_DEXTERITY:
         case RING_INTELLIGENCE:
-            return 6;
+            return GOOD_STAT_RING_PLUS;
         default:
-            return 4;
+            return GOOD_RING_PLUS;
     }
 }
 
@@ -1643,13 +1644,13 @@ static int _good_jewellery_plus(int subtype)
  * @param subtype       The type of ring in question.
  * @return              A 'plus' for that ring. 0 for most types.
  */
-static int _determine_ring_plus(int subtype)
+static short _determine_ring_plus(int subtype)
 {
     if (!jewellery_type_has_plusses(subtype))
         return 0;
 
     if (one_chance_in(5)) // 20% of such rings are cursed {dlb}
-        return -4;
+        return BAD_RING_PLUS;
     return _good_jewellery_plus(subtype);
 }
 

--- a/crawl-ref/source/makeitem.h
+++ b/crawl-ref/source/makeitem.h
@@ -9,6 +9,11 @@
 
 static const int NO_AGENT = -1;
 
+// item_def::plus is a short
+constexpr short GOOD_STAT_RING_PLUS = 6;
+constexpr short GOOD_RING_PLUS = 4;
+constexpr short BAD_RING_PLUS = -4;
+
 int create_item_named(string name, coord_def pos, string *error);
 
 int items(bool allow_uniques, object_class_type force_class, int force_type,


### PR DESCRIPTION
These rings aren't supposed to exist anymore as of 2607d5cfa1. However
acquirement was making them by producing -4 bad stat rings and then
setting the rings' plus value to abs(the old plus).

This commit has acquirement directly set the plus for acquired rings to
the "good" value for that base type. This does not affect unrandarts but
may modify randarts.