### PR TITLE
Remove bad position clamp for peeking through stairs

### DIFF
--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -714,8 +714,6 @@ public:
         m_state = process_map_command(cmd, m_state);
         if (!m_state.map_alive)
             return;
-        if (map_bounds(m_state.lpos.pos))
-            m_state.lpos.pos = m_state.lpos.pos.clamped(known_map_bounds());
 
         if (m_state.lpos.id != level_id::current())
             goto_level();


### PR DESCRIPTION
This should fix the recent bug where using X and then [ or ] while on the stairs often did not take you to the other end of the stairs.

(see the commit message for details)