### PR TITLE
Handle dynamic DPI in webtiles glyphs mode

### DIFF
--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -96,11 +96,11 @@ function ($, view_data, main, tileinfo_player, icons, dngn, enums,
 
         glyph_mode_font_name: function ()
         {
-            var glyph_scale;
+            var glyph_scale = window.devicePixelRatio;
             if (this.ui_state == enums.ui.VIEW_MAP)
-                glyph_scale = options.get("tile_map_scale");
+                glyph_scale *= options.get("tile_map_scale");
             else
-                glyph_scale = options.get("tile_viewport_scale");
+                glyph_scale *= options.get("tile_viewport_scale");
 
             return (Math.floor(this.glyph_mode_font_size * glyph_scale / 100)
                 + "px " + this.glyph_mode_font);

--- a/crawl-ref/source/webserver/game_data/static/game.js
+++ b/crawl-ref/source/webserver/game_data/static/game.js
@@ -230,10 +230,8 @@ function ($, comm, client, dungeon_renderer, display, minimap, enums, messages,
     {
         if (options.get("tile_display_mode") == "tiles") return;
 
-        var device_ratio = window.devicePixelRatio;
         var glyph_font, glyph_size;
-
-        glyph_size = options.get("glyph_mode_font_size") * device_ratio;
+        glyph_size = options.get("glyph_mode_font_size");
         glyph_font = options.get("glyph_mode_font");
 
         if (!document.fonts.check(glyph_size + "px " + glyph_font))


### PR DESCRIPTION
This PR fixes handling of dynamic DPI situations (e.g., dragging the window between hidpi and non-hidpi displays) in webtiles glyphs mode that I accidentally broke in 4531bab [#1512].