### PR TITLE
Fix the divider position when tile_force_overlay is set

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -920,11 +920,6 @@ void TilesFramework::do_layout()
         // the top and message window at the bottom.
         m_stat_x_divider = m_windowsz.x - sidebar_pw - map_stat_margin;
 
-        // Calculate message_y_divider. First off, if we have already decided to
-        // use the overlay, we can place the divider to the bottom of the screen.
-        if (message_overlay)
-            message_y_divider = m_windowsz.y;
-
         // Then, the optimal situation without the overlay - we can fit both
         // Options.view_max_height and at least Options.msg_min_height in the space.
 
@@ -959,6 +954,11 @@ void TilesFramework::do_layout()
             else
                 message_y_divider = m_windowsz.y - min_msg_h;
         }
+
+        // Calculate message_y_divider. First off, if we have already decided to
+        // use the overlay, we can place the divider to the bottom of the screen.
+        if (message_overlay)
+            message_y_divider = m_windowsz.y;
     }
 
     // stick message display to the bottom of the window


### PR DESCRIPTION
When tile_force_overlay is set the divider should always be set to the
end of the of the screen. Move the code that sets that to later in the
code so it doesn't get overwritten.

Without this fix, the space reserved for the message window is still
left unused at the bottom of the screen while the message overlay is
moved to the top of the screen.