### PR TITLE
Add options to control background color and alpha of the message window overlay

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -107,9 +107,10 @@ The contents of this text are:
                 tile_tag_pref, tile_window_width, tile_window_height,
                 tile_map_pixels, tile_viewport_scale, tile_map_scale,
                 tile_cell_pixels, tile_filter_scaling, tile_force_overlay,
-                tile_full_screen, tile_single_column_menus,
-                tile_font_crt_file, tile_font_stat_file, tile_font_msg_file,
-                tile_font_tip_file, tile_font_lbl_file, tile_font_crt_family,
+                tile_overlay_col, tile_overlay_alpha_percent, tile_full_screen,
+                tile_single_column_menus, tile_font_crt_file,
+                tile_font_stat_file, tile_font_msg_file, tile_font_tip_file,
+                tile_font_lbl_file, tile_font_crt_family,
                 tile_font_stat_family, tile_font_msg_family,
                 tile_font_lbl_family, tile_font_crt_size, tile_font_stat_size,
                 tile_font_msg_size, tile_font_tip_size, tile_font_lbl_size,
@@ -120,7 +121,8 @@ The contents of this text are:
                 tile_show_threat_levels, tile_layout_priority,
                 tile_display_mode, tile_level_map_hide_messages,
                 tile_level_map_hide_sidebar, tile_player_tile,
-                tile_weapon_offsets, tile_shield_offsets, tile_web_mouse_control
+                tile_weapon_offsets, tile_shield_offsets,
+                tile_web_mouse_control
 4-  Character Dump.
 4-a     Saving.
                 dump_on_save
@@ -2020,6 +2022,18 @@ tile_force_overlay = false
         tile_font_msg_size smaller will make the overlay smaller while retaining
         the same number of lines. Increase the view_max_height option if you
         find yourself with unused screen estate.
+
+tile_overlay_col = #646464
+        Background color of the message window overlay, as when
+        tile_force_overlay is set to true. Used in conjunction with
+        tile_overlay_alpha_percent.
+
+tile_overlay_alpha_percent = 40
+        Transparency value for the message window overlay background, as when
+        tile_force_overlay is set to true. Setting this option to 0 will cause
+        the message window to only display text without any background. And
+        setting this option to 100 will force an opaque backgroud to the
+        message window.
 
 tile_full_screen = auto
         Setting this option to true or false will force full screen mode to be

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -107,7 +107,7 @@ The contents of this text are:
                 tile_tag_pref, tile_window_width, tile_window_height,
                 tile_map_pixels, tile_viewport_scale, tile_map_scale,
                 tile_cell_pixels, tile_filter_scaling, tile_force_overlay,
-                tile_overlay_col, tile_overlay_alpha_percent, tile_full_screen,
+                tile_overlay_colour, tile_overlay_alpha_percent, tile_full_screen,
                 tile_single_column_menus, tile_font_crt_file,
                 tile_font_stat_file, tile_font_msg_file, tile_font_tip_file,
                 tile_font_lbl_file, tile_font_crt_family,
@@ -2023,7 +2023,7 @@ tile_force_overlay = false
         the same number of lines. Increase the view_max_height option if you
         find yourself with unused screen estate.
 
-tile_overlay_col = #646464
+tile_overlay_colour = #646464
         Background color of the message window overlay, as when
         tile_force_overlay is set to true. Used in conjunction with
         tile_overlay_alpha_percent.

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -319,6 +319,8 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(tile_menu_icons), true),
         new BoolGameOption(SIMPLE_NAME(tile_filter_scaling), false),
         new BoolGameOption(SIMPLE_NAME(tile_force_overlay), false),
+        new TileColGameOption(SIMPLE_NAME(tile_overlay_col), "#646464"),
+        new IntGameOption(SIMPLE_NAME(tile_overlay_alpha_percent), 40, 0, 100),
         new BoolGameOption(SIMPLE_NAME(tile_show_minihealthbar), true),
         new BoolGameOption(SIMPLE_NAME(tile_show_minimagicbar), true),
         new BoolGameOption(SIMPLE_NAME(tile_show_demon_tier), false),

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -319,7 +319,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(tile_menu_icons), true),
         new BoolGameOption(SIMPLE_NAME(tile_filter_scaling), false),
         new BoolGameOption(SIMPLE_NAME(tile_force_overlay), false),
-        new TileColGameOption(SIMPLE_NAME(tile_overlay_col), "#646464"),
+        new TileColGameOption(SIMPLE_NAME(tile_overlay_colour), "#646464"),
         new IntGameOption(SIMPLE_NAME(tile_overlay_alpha_percent), 40, 0, 100),
         new BoolGameOption(SIMPLE_NAME(tile_show_minihealthbar), true),
         new BoolGameOption(SIMPLE_NAME(tile_show_minimagicbar), true),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -561,6 +561,8 @@ public:
     int         tile_map_pixels;
 
     bool        tile_force_overlay;
+    VColour     tile_overlay_col;           // Background color for message overlay
+    int         tile_overlay_alpha_percent; // Background alpha percent for message overlay
     // display settings
     int         tile_update_rate;
     int         tile_runrest_rate;

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -561,7 +561,7 @@ public:
     int         tile_map_pixels;
 
     bool        tile_force_overlay;
-    VColour     tile_overlay_col;           // Background color for message overlay
+    VColour     tile_overlay_colour;           // Background color for message overlay
     int         tile_overlay_alpha_percent; // Background alpha percent for message overlay
     // display settings
     int         tile_update_rate;

--- a/crawl-ref/source/tilereg-msg.cc
+++ b/crawl-ref/source/tilereg-msg.cc
@@ -47,9 +47,10 @@ bool MessageRegion::update_tip_text(string& tip)
     return true;
 }
 
-void MessageRegion::set_overlay(bool is_overlay)
+void MessageRegion::set_overlay(bool is_overlay, const VColour &col)
 {
     m_overlay = is_overlay;
+    m_overlay_col = col;
 }
 
 void MessageRegion::render()
@@ -112,8 +113,7 @@ void MessageRegion::render()
             glmanager->reset_transform();
 
             ShapeBuffer buff;
-            VColour col(100, 100, 100, 100);
-            buff.add(sx, sy, ex, sy + height, col);
+            buff.add(sx, sy, ex, sy + height, m_overlay_col);
             buff.draw();
         }
     }

--- a/crawl-ref/source/tilereg-msg.h
+++ b/crawl-ref/source/tilereg-msg.h
@@ -8,7 +8,7 @@ class MessageRegion : public TextRegion
 public:
     MessageRegion(FontWrapper *font_arg);
 
-    void set_overlay(bool is_overlay);
+    void set_overlay(bool is_overlay, const VColour &col);
 
     virtual int handle_mouse(wm_mouse_event &event) override;
     virtual void render() override;
@@ -18,6 +18,7 @@ public:
 protected:
     string m_alt_text;
     bool m_overlay;
+    VColour m_overlay_col;
 };
 
 #endif

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -979,7 +979,7 @@ void TilesFramework::do_layout()
     m_region_tile->tile_ih = tile_ih;
 
     // Resize and place the message window.
-    VColour overlay_col = Options.tile_overlay_col;
+    VColour overlay_col = Options.tile_overlay_colour;
     overlay_col.a = (255 * Options.tile_overlay_alpha_percent)/100;
     m_region_msg->set_overlay(message_overlay, overlay_col);
     if (message_overlay)

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -979,7 +979,9 @@ void TilesFramework::do_layout()
     m_region_tile->tile_ih = tile_ih;
 
     // Resize and place the message window.
-    m_region_msg->set_overlay(message_overlay);
+    VColour overlay_col = Options.tile_overlay_col;
+    overlay_col.a = (255 * Options.tile_overlay_alpha_percent)/100;
+    m_region_msg->set_overlay(message_overlay, overlay_col);
     if (message_overlay)
     {
         m_region_msg->place(0, 0, 0); // TODO: Maybe add an option to place


### PR DESCRIPTION
Add two new options, tile_overlay_col and tile_overlay_alpha_percent,
to control the background of the message window overlay.

The default color follows the same hard coded value used before while
alpha was rounded to the closest round percentage number. The previous
alpha value was 100 (in the 0-255 range), while the 40% new default
should be equivalent to 102.