### PR TITLE
Display Rampage on the % screen

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2435,6 +2435,9 @@ static vector<formatted_string> _get_overview_resistances(
     const int harm = you.extra_harm(calc_unid);
     out += _resist_composer("Harm", cwidth, harm) + "\n";
 
+    const int rampage = you.rampaging(calc_unid);
+    out += _resist_composer("Rampage", cwidth, rampage) + "\n";
+
     const int rclar = you.clarity(calc_unid);
     const int stasis = you.stasis();
     // TODO: what about different levels of anger/berserkitis?


### PR DESCRIPTION
Artefacts with long names have their properties trimmed on the % screen. For example, it can be just `m - +2 pair of gloves of the Vanishing Shrikes {`.
Harm, Rnd*Rage, and other egos are all displayed in the second column of resistances on the overview screen. This PR adds a similar indicator for Rampage.
