### PR TITLE
Fix Hailstorm ally warning prompt (12362)

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3102,7 +3102,10 @@ spret cast_hailstorm(int pow, bool fail, bool tracer)
         const monster* mon = act->as_monster();
         return mon && !mon->is_icy()
             && !mons_is_firewood(*mon)
-            && !(you_worship(GOD_FEDHAS) && fedhas_protects(mon));
+            && !(you_worship(GOD_FEDHAS) && fedhas_protects(mon))
+            && !mons_is_projectile(*mon)
+            && !(mons_is_avatar(mon->type) && mons_aligned(&you, mon))
+            && !testbits(mon->flags, MF_DEMONIC_GUARDIAN);
     };
 
     if (tracer)


### PR DESCRIPTION
This commit silences the hailstorm ally warning prompt for battlesphere,
spectral weapon, orb of destruction, and demonic guardians.

Monsters with M_PROJECTILE, (allied) M_AVATAR, or MF_DEMONIC_GUARDIAN flags
are bypassed in bolt targeting by bolt::ignores_monster, and hailstorm cannot
actually deal damage to them.