### PR TITLE
Layout edits

### DIFF
--- a/crawl-ref/source/dat/des/builder/layout_caves.des
+++ b/crawl-ref/source/dat/des/builder/layout_caves.des
@@ -303,6 +303,12 @@ TAGS:   overwritable layout allow_dup unrand layout_type_open_caves
   -- corridor width up and down with noise scale too otherwise they end up hugely wrong size)
   local frooms = procedural.worley_diff{ scale = 0.15 }
   local fcorridors = procedural.worley_diff{ scale = 0.1 }
+  
+  if you.in_branch("Snake") then
+    frooms = procedural.transform.damped_distortion(frooms)
+    fcorridors = procedural.transform.damped_distortion(fcorridors)
+  end
+  
   local fhalls = procedural.sub(fcorridors,procedural.mul(frooms,0.5))
   local fbord = procedural.border{ padding = 4,additive = true }
   frooms = procedural.sub(frooms,fbord)

--- a/crawl-ref/source/dat/des/builder/layout_cc.des
+++ b/crawl-ref/source/dat/des/builder/layout_cc.des
@@ -44,9 +44,8 @@ ENDMAP
 #
 # This layout places many non-overlapping boxes, some hollow.
 #
-# TODO: Lair should only have rock walls.  It should have sometimes
-#       thicker walls, especially on deeper depths so it can be used
-#       for the whole branch.
+# TODO: Lair should have sometimes thicker walls, especially 
+#       on deeper depths so it can be used for the whole branch.
 #
 NAME:   layout_chaotic_city
 DEPTH:  Lair:1-3, Crypt, Dis
@@ -56,7 +55,8 @@ TAGS:   overwritable layout allow_dup unrand layout_type_city
 TAGS:   no_rotate no_vmirror no_hmirror
 {{
     if not is_validating() then
-      layout_chaotic_city(you.in_branch("Dis") and "metal_wall" or nil)
+      layout_chaotic_city(you.in_branch("Dis") and "metal_wall" or 
+      you.in_branch("Lair") and "rock_wall" or nil)
     end
 }}
 MAP

--- a/crawl-ref/source/dat/des/builder/layout_loops.des
+++ b/crawl-ref/source/dat/des/builder/layout_loops.des
@@ -67,10 +67,11 @@ end
 #
 # This is like random_wall_material function, except that it
 #  returns the material type instead of changing the map.
+# Note this originally applied to Lair as well as D.
 #
 {{
 function getRandomWallMaterial ()
-  if (you.in_branch("D") or you.in_branch("Lair"))
+  if you.in_branch("D")
      and you.absdepth() >= 4 and crawl.one_chance_in(20) then
     if crawl.one_chance_in(3) then
       return 'v'


### PR DESCRIPTION
A few adjustments to layouts in Lair and Snake.  These are largely cosmetic:

layout_chaotic_city
layout_loops_ring
These layouts now only place rock walls when generated in Lair.  Previously they could also place stone and metal.

layout_cave_pods
Add a distortion effect to the layout when it generates in Snake, giving the walls a wavy appearance.  This same effect is already used by the onion and onion_interference layouts in Snake.