### PR TITLE
MiAK lost his recommended species tag

### DIFF
--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -28,7 +28,7 @@ static const map<job_type, job_def> job_data =
     "AK", "Abyssal Knight",
     4, 4, 4,
     { SP_HILL_ORC, SP_PALENTONGA, SP_TROLL, SP_MERFOLK, SP_BASE_DRACONIAN,
-      SP_DEMONSPAWN, },
+      SP_MINOTAUR, SP_DEMONSPAWN, },
     { "leather armour" },
     WCHOICE_PLAIN,
     { { SK_FIGHTING, 3 }, { SK_ARMOUR, 1 }, { SK_DODGING, 1 },


### PR DESCRIPTION
Selecting Minotaur as a special lists Abyssal Knight as a recommended job, but selecting Abyssal Knight does not list Minotaur as a recommended species. It looks like this was dropped during the Centaur/Palentonga merge. Readded.