### PR TITLE
Make Cloak of Starlight more interesting

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -924,7 +924,8 @@ PLUS:     +1
 COLOUR:   ETC_ICE
 TILE:     urand_starlight
 TILE_EQ:  white
-EV:       4
+INSCRIP:  Radiant
+EV:       2
 COLD:     1
 STEALTH:  -2
 BOOL:     elec

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -423,7 +423,8 @@ any weapon, or to retaliate against most attacks when using a long blade.
 %%%%
 cloak of Starlight
 
-A phosphorescent cloak, woven of pure light beams.
+A phosphorescent cloak, woven of pure light beams. Its starry radiance has a
+small chance to temporarily blind foes, with stronger foes more likely to resist.
 %%%%
 ratskin cloak
 


### PR DESCRIPTION
This commit adds an additional property {Radiance} to the cloak of
starlight following a brief discussion in ##crawl-dev. The new effect
works as follows:

Each turn, all blindable monsters in LOS are subject to a chance to be
blinded. This chance consists of two parts.
1. 50% chance to do nothing.
2. If [1] is successful, make a roll which is inversely
   proportional to both distance from the player and monster hit die.
If both rolls are successful, temporarily blind the monster.

Example success rates for this effect will be commented below and no
doubt should be subject to further tweaks based on playtesting. The
feeling for the current rates is that this is a powerful item when found
early (maybe very powerful), falling off a little to a modest, but
noticeable, effect in the later game.

EV bonus is reduced to 2, though this of course overall is a buff to the
item.