### PR TITLE
Update INSTALL.md

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -6,7 +6,6 @@
 * [Compiling](#compiling)
   * [Ubuntu / Debian](#ubuntu--debian)
   * [Fedora](#fedora)
-  * [Void Linux](#void)
   * [Other Linux / Unix](#other-linux--unix)
   * [macOS](#macOS)
   * [Windows](#windows)


### PR DESCRIPTION
Instructions for Void Linux were removed in f485615. The table of contents should not have dead links.