### PR TITLE
Cancel Heroism and Finesse on angering or abandoning Okawaru

### DIFF
--- a/crawl-ref/source/duration-data.h
+++ b/crawl-ref/source/duration-data.h
@@ -331,17 +331,12 @@ static const duration_def duration_data[] =
       LIGHTBLUE, "Hero",
       "heroism", "",
       "You possess the skills of a mighty hero.", D_NO_FLAGS,
-      {{ "You feel like a meek peon again.", []() {
-          you.redraw_evasion      = true;
-          you.redraw_armour_class = true;
-      }}}},
+      {{"", okawaru_remove_heroism}}},
     { DUR_FINESSE,
       LIGHTBLUE, "Finesse",
       "finesse", "",
       "Your blows are lightning fast.", D_NO_FLAGS,
-      {{ "", []() {
-          mprf(MSGCH_DURATION, "%s", you.hands_act("slow", "down.").c_str());
-      }}}},
+      {{"", okawaru_remove_finesse}}},
     { DUR_LIFESAVING,
       LIGHTGREY, "Prot",
       "protection", "lifesaving",

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5904,3 +5904,17 @@ void wu_jian_heavenly_storm()
     you.props[WU_JIAN_HEAVENLY_STORM_KEY] = WU_JIAN_HEAVENLY_STORM_INITIAL;
     invalidate_agrid(true);
 }
+
+void okawaru_remove_heroism()
+{
+    mprf(MSGCH_DURATION, "You feel like a meek peon again.");
+    you.duration[DUR_HEROISM] = 0;
+    you.redraw_evasion      = true;
+    you.redraw_armour_class = true;
+}
+
+void okawaru_remove_finesse()
+{
+    mprf(MSGCH_DURATION, "%s", you.hands_act("slow", "down.").c_str());
+    you.duration[DUR_FINESSE] = 0;
+}

--- a/crawl-ref/source/god-abil.h
+++ b/crawl-ref/source/god-abil.h
@@ -179,3 +179,6 @@ bool wu_jian_can_wall_jump(const coord_def& target, string &error_ret);
 bool wu_jian_do_wall_jump(coord_def targ);
 spret wu_jian_wall_jump_ability();
 void wu_jian_heavenly_storm();
+
+void okawaru_remove_heroism();
+void okawaru_remove_finesse();

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -849,6 +849,13 @@ static void _inc_penance(god_type god, int val)
                 you.attribute[ATTR_DIVINE_ENERGY] = 0;
 #endif
         }
+        else if (god == GOD_OKAWARU)
+        {
+            if (you.duration[DUR_HEROISM])
+                okawaru_remove_heroism();
+            if (you.duration[DUR_FINESSE])
+                okawaru_remove_finesse();
+        }
 
         if (you_worship(god))
         {
@@ -2988,6 +2995,13 @@ void excommunication(bool voluntary, god_type new_god)
         you.attribute[ATTR_SERPENTS_LASH] = 0;
         if (you.props.exists(WU_JIAN_HEAVENLY_STORM_KEY))
             wu_jian_end_heavenly_storm();
+        break;
+
+    case GOD_OKAWARU:
+        if (you.duration[DUR_HEROISM])
+            okawaru_remove_heroism();
+        if (you.duration[DUR_FINESSE])
+            okawaru_remove_finesse();
         break;
 
     default:


### PR DESCRIPTION
Currently, only Heroism, Finesse, and Elyvilon's Divine Protection
don't expire immediately when the player is placed under penance. It
seems thematically appropriate for Divine Protection, but even Elyvilon
removes all divine effects on abandonment.

This commit puts Okawaru in line with other gods.