### PR TITLE
-4 dex to each background; +4 dex to each species

### DIFF
--- a/crawl-ref/source/dat/species/barachi.yaml
+++ b/crawl-ref/source/dat/species/barachi.yaml
@@ -37,7 +37,7 @@ aptitudes:
 can_swim: true
 str: 9
 int: 8
-dex: 7
+dex: 11
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/deep-dwarf.yaml
+++ b/crawl-ref/source/dat/species/deep-dwarf.yaml
@@ -41,7 +41,7 @@ aptitudes:
   evocations: 3
 str: 11
 int: 8
-dex: 8
+dex: 12
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/deep-elf.yaml
+++ b/crawl-ref/source/dat/species/deep-elf.yaml
@@ -41,7 +41,7 @@ aptitudes:
   evocations: 1
 str: 5
 int: 12
-dex: 10
+dex: 14
 levelup_stat_frequency: 4
 levelup_stats:
   - int

--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -41,7 +41,7 @@ aptitudes:
   evocations: -1
 str: 11
 int: 12
-dex: 11
+dex: 15
 # No natural stat gain (double chosen instead)
 levelup_stats: []
 levelup_stat_frequency: 28

--- a/crawl-ref/source/dat/species/demonspawn.yaml
+++ b/crawl-ref/source/dat/species/demonspawn.yaml
@@ -35,7 +35,7 @@ aptitudes:
   invocations: 3
 str: 8
 int: 9
-dex: 8
+dex: 12
 levelup_stat_frequency: 4
 recommended_jobs:
   - JOB_GLADIATOR

--- a/crawl-ref/source/dat/species/deprecated-centaur.yaml
+++ b/crawl-ref/source/dat/species/deprecated-centaur.yaml
@@ -41,7 +41,7 @@ aptitudes:
 size: large
 str: 10
 int: 7
-dex: 4
+dex: 8
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
+++ b/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
@@ -27,7 +27,7 @@ aptitudes:
   fire_magic: 1
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-base.yaml
+++ b/crawl-ref/source/dat/species/draconian-base.yaml
@@ -22,7 +22,7 @@ aptitudes:
   invocations: 1
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-black.yaml
+++ b/crawl-ref/source/dat/species/draconian-black.yaml
@@ -27,7 +27,7 @@ aptitudes:
   earth_magic: -2
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-green.yaml
+++ b/crawl-ref/source/dat/species/draconian-green.yaml
@@ -26,7 +26,7 @@ aptitudes:
   poison_magic: 2
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-grey.yaml
+++ b/crawl-ref/source/dat/species/draconian-grey.yaml
@@ -28,7 +28,7 @@ aptitudes:
 can_swim: true
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-pale.yaml
+++ b/crawl-ref/source/dat/species/draconian-pale.yaml
@@ -28,7 +28,7 @@ aptitudes:
   evocations: 1
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-purple.yaml
+++ b/crawl-ref/source/dat/species/draconian-purple.yaml
@@ -26,7 +26,7 @@ aptitudes:
   evocations: 1
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-red.yaml
+++ b/crawl-ref/source/dat/species/draconian-red.yaml
@@ -27,7 +27,7 @@ aptitudes:
   ice_magic: -2
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-white.yaml
+++ b/crawl-ref/source/dat/species/draconian-white.yaml
@@ -27,7 +27,7 @@ aptitudes:
   ice_magic: 2
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/draconian-yellow.yaml
+++ b/crawl-ref/source/dat/species/draconian-yellow.yaml
@@ -25,7 +25,7 @@ aptitudes:
   # no Yellow Draconian specific apts
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/felid.yaml
+++ b/crawl-ref/source/dat/species/felid.yaml
@@ -38,7 +38,7 @@ aptitudes:
 size: little
 str: 4
 int: 9
-dex: 11
+dex: 15
 levelup_stat_frequency: 5
 levelup_stats:
   - int

--- a/crawl-ref/source/dat/species/formicid.yaml
+++ b/crawl-ref/source/dat/species/formicid.yaml
@@ -27,7 +27,7 @@ aptitudes:
   evocations: 1
 str: 12
 int: 7
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/gargoyle.yaml
+++ b/crawl-ref/source/dat/species/gargoyle.yaml
@@ -35,7 +35,7 @@ aptitudes:
   evocations: -1
 str: 11
 int: 8
-dex: 5
+dex: 9
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/ghoul.yaml
+++ b/crawl-ref/source/dat/species/ghoul.yaml
@@ -42,7 +42,7 @@ aptitudes:
 undead_type: US_HUNGRY_DEAD
 str: 11
 int: 3
-dex: 4
+dex: 8
 levelup_stat_frequency: 5
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/gnoll.yaml
+++ b/crawl-ref/source/dat/species/gnoll.yaml
@@ -40,7 +40,7 @@ aptitudes:
   evocations: 8
 str: 10
 int: 10
-dex: 10
+dex: 14
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/halfling.yaml
+++ b/crawl-ref/source/dat/species/halfling.yaml
@@ -32,7 +32,7 @@ aptitudes:
 size: small
 str: 9
 int: 6
-dex: 9
+dex: 13
 levelup_stat_frequency: 5
 levelup_stats:
   - dex

--- a/crawl-ref/source/dat/species/hill-orc.yaml
+++ b/crawl-ref/source/dat/species/hill-orc.yaml
@@ -36,7 +36,7 @@ aptitudes:
   invocations: 3
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 5
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/human.yaml
+++ b/crawl-ref/source/dat/species/human.yaml
@@ -13,7 +13,7 @@ aptitudes:
   invocations: 1
 str: 8
 int: 8
-dex: 8
+dex: 12
 levelup_stat_frequency: 4
 recommended_jobs:
   - JOB_BERSERKER

--- a/crawl-ref/source/dat/species/kobold.yaml
+++ b/crawl-ref/source/dat/species/kobold.yaml
@@ -27,7 +27,7 @@ aptitudes:
 size: small
 str: 5
 int: 9
-dex: 10
+dex: 14
 levelup_stat_frequency: 5
 mutations:
   1:

--- a/crawl-ref/source/dat/species/merfolk.yaml
+++ b/crawl-ref/source/dat/species/merfolk.yaml
@@ -38,7 +38,7 @@ aptitudes:
 can_swim: true
 str: 8
 int: 7
-dex: 9
+dex: 13
 levelup_stat_frequency: 5
 fake_mutations:
   - long: You revert to your normal form in water.

--- a/crawl-ref/source/dat/species/minotaur.yaml
+++ b/crawl-ref/source/dat/species/minotaur.yaml
@@ -39,7 +39,7 @@ aptitudes:
   evocations: -1
 str: 12
 int: 5
-dex: 5
+dex: 9
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/mummy.yaml
+++ b/crawl-ref/source/dat/species/mummy.yaml
@@ -39,7 +39,7 @@ aptitudes:
 undead_type: US_UNDEAD
 str: 11
 int: 7
-dex: 7
+dex: 11
 levelup_stat_frequency: 5
 mutations:
   1:

--- a/crawl-ref/source/dat/species/naga.yaml
+++ b/crawl-ref/source/dat/species/naga.yaml
@@ -24,7 +24,7 @@ aptitudes:
 size: large
 str: 10
 int: 8
-dex: 6
+dex: 10
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/octopode.yaml
+++ b/crawl-ref/source/dat/species/octopode.yaml
@@ -20,7 +20,7 @@ aptitudes:
 can_swim: true
 str: 7
 int: 10
-dex: 7
+dex: 11
 levelup_stat_frequency: 5
 species_flags:
   - hairless

--- a/crawl-ref/source/dat/species/ogre.yaml
+++ b/crawl-ref/source/dat/species/ogre.yaml
@@ -38,7 +38,7 @@ aptitudes:
 size: large
 str: 11
 int: 9
-dex: 4
+dex: 8
 levelup_stat_frequency: 3
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/palentonga.yaml
+++ b/crawl-ref/source/dat/species/palentonga.yaml
@@ -41,7 +41,7 @@ aptitudes:
 size: large
 str: 11
 int: 8
-dex: 5
+dex: 9
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/spriggan.yaml
+++ b/crawl-ref/source/dat/species/spriggan.yaml
@@ -37,7 +37,7 @@ aptitudes:
 size: little
 str: 4
 int: 9
-dex: 11
+dex: 15
 levelup_stat_frequency: 5
 levelup_stats:
   - int

--- a/crawl-ref/source/dat/species/tengu.yaml
+++ b/crawl-ref/source/dat/species/tengu.yaml
@@ -36,7 +36,7 @@ aptitudes:
   invocations: -1
 str: 8
 int: 8
-dex: 9
+dex: 13
 levelup_stat_frequency: 4
 mutations:
   1:

--- a/crawl-ref/source/dat/species/troll.yaml
+++ b/crawl-ref/source/dat/species/troll.yaml
@@ -41,7 +41,7 @@ aptitudes:
 size: large
 str: 15
 int: 4
-dex: 5
+dex: 9
 levelup_stat_frequency: 3
 levelup_stats:
   - str

--- a/crawl-ref/source/dat/species/vampire.yaml
+++ b/crawl-ref/source/dat/species/vampire.yaml
@@ -38,7 +38,7 @@ aptitudes:
 undead_type: US_SEMI_UNDEAD
 str: 7
 int: 10
-dex: 9
+dex: 13
 levelup_stat_frequency: 5
 levelup_stats:
   - int

--- a/crawl-ref/source/dat/species/vine-stalker.yaml
+++ b/crawl-ref/source/dat/species/vine-stalker.yaml
@@ -27,7 +27,7 @@ aptitudes:
   evocations: -1
 str: 10
 int: 8
-dex: 9
+dex: 13
 levelup_stat_frequency: 4
 levelup_stats:
   - str

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -26,7 +26,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ABYSSAL_KNIGHT, {
     "AK", "Abyssal Knight",
-    4, 4, 4,
+    4, 4, 0,
     { SP_HILL_ORC, SP_PALENTONGA, SP_TROLL, SP_MERFOLK, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
     { "leather armour" },
@@ -37,7 +37,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_AIR_ELEMENTALIST, {
     "AE", "Air Elementalist",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_TENGU, SP_BASE_DRACONIAN, SP_NAGA, SP_VINE_STALKER, },
     { "robe", "book of Air" },
     WCHOICE_NONE,
@@ -47,7 +47,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ARCANE_MARKSMAN, {
     "AM", "Arcane Marksman",
-    2, 5, 5,
+    2, 5, 1,
     { SP_FORMICID, SP_DEEP_ELF, SP_KOBOLD, SP_SPRIGGAN, SP_TROLL, },
     { "robe", "book of Debilitation" },
     WCHOICE_RANGED,
@@ -57,7 +57,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ARTIFICER, {
     "Ar", "Artificer",
-    4, 3, 5,
+    4, 3, 1,
     { SP_DEEP_DWARF, SP_HALFLING, SP_KOBOLD, SP_SPRIGGAN, SP_BASE_DRACONIAN,
       SP_DEMONSPAWN, },
     { "club", "leather armour", "wand of flame charges:15",
@@ -69,7 +69,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_BERSERKER, {
     "Be", "Berserker",
-    9, -1, 4,
+    9, -1, 0,
     { SP_HILL_ORC, SP_HALFLING, SP_OGRE, SP_MERFOLK, SP_MINOTAUR, SP_GARGOYLE,
       SP_PALENTONGA, },
     { "animal skin" },
@@ -79,7 +79,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_BRIGAND, {
     "Br", "Brigand",
-    3, 3, 6,
+    3, 3, 2,
     { SP_TROLL, SP_HALFLING, SP_SPRIGGAN, SP_DEMONSPAWN, SP_VAMPIRE,
       SP_VINE_STALKER, },
     { "dagger plus:2", "robe", "cloak", "dart ego:poisoned q:8",
@@ -91,7 +91,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CHAOS_KNIGHT, {
     "CK", "Chaos Knight",
-    4, 4, 4,
+    4, 4, 0,
     { SP_HILL_ORC, SP_TROLL, SP_GNOLL, SP_MERFOLK, SP_MINOTAUR,
       SP_BASE_DRACONIAN, SP_DEMONSPAWN, },
     { "leather armour plus:2" },
@@ -102,7 +102,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CONJURER, {
     "Cj", "Conjurer",
-    -1, 10, 3,
+    -1, 10, -1,
     { SP_DEEP_ELF, SP_NAGA, SP_TENGU, SP_BASE_DRACONIAN, SP_DEMIGOD, },
     { "robe", "book of Conjurations" },
     WCHOICE_NONE,
@@ -112,7 +112,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_EARTH_ELEMENTALIST, {
     "EE", "Earth Elementalist",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_DEEP_DWARF, SP_SPRIGGAN, SP_GARGOYLE, SP_DEMIGOD,
       SP_GHOUL, SP_OCTOPODE, },
     { "book of Geomancy", "stone q:30", "robe", },
@@ -123,7 +123,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ENCHANTER, {
     "En", "Enchanter",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_FELID, SP_KOBOLD, SP_SPRIGGAN, SP_NAGA, SP_VAMPIRE, },
     { "dagger plus:1", "robe", "book of Maledictions" },
     WCHOICE_NONE,
@@ -133,7 +133,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_FIGHTER, {
     "Fi", "Fighter",
-    8, 0, 4,
+    8, 0, 0,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_TROLL, SP_MINOTAUR, SP_GARGOYLE,
       SP_PALENTONGA, },
     { "scale mail", "kite shield", "potion of might" },
@@ -144,7 +144,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_FIRE_ELEMENTALIST, {
     "FE", "Fire Elementalist",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_HILL_ORC, SP_NAGA, SP_TENGU, SP_DEMIGOD, SP_GARGOYLE, },
     { "robe", "book of Flames" },
     WCHOICE_NONE,
@@ -154,7 +154,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_GLADIATOR, {
     "Gl", "Gladiator",
-    6, 0, 6,
+    6, 0, 2,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_MERFOLK, SP_MINOTAUR, SP_GARGOYLE,
       SP_GNOLL, },
     { "leather armour", "helmet", "throwing net q:3" },
@@ -165,7 +165,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_HUNTER, {
     "Hu", "Hunter",
-    4, 3, 5,
+    4, 3, 1,
     { SP_HILL_ORC, SP_HALFLING, SP_KOBOLD, SP_OGRE, SP_TROLL, },
     { "short sword", "leather armour" },
     WCHOICE_RANGED,
@@ -175,7 +175,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_ICE_ELEMENTALIST, {
     "IE", "Ice Elementalist",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_MERFOLK, SP_NAGA, SP_BASE_DRACONIAN, SP_DEMIGOD,
       SP_GARGOYLE, },
     { "robe", "book of Frost" },
@@ -186,7 +186,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_DELVER, {
     "De", "Delver",
-    4, 2, 6,
+    4, 2, 2,
     { SP_FELID, SP_SPRIGGAN, SP_KOBOLD, SP_VAMPIRE, },
     { "leather armour", "scroll of fog", "scroll of magic mapping",
       "scroll of fear", "potion of haste", "wand of digging charges:3" },
@@ -196,7 +196,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_MONK, {
     "Mo", "Monk",
-    3, 2, 7,
+    3, 2, 3,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_TROLL, SP_PALENTONGA, SP_MERFOLK,
       SP_GARGOYLE, SP_DEMONSPAWN, },
     { "robe" },
@@ -207,7 +207,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_NECROMANCER, {
     "Ne", "Necromancer",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_DEEP_DWARF, SP_HILL_ORC, SP_DEMONSPAWN, SP_MUMMY,
       SP_VAMPIRE, },
     { "robe", "book of Necromancy" },
@@ -218,7 +218,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_SUMMONER, {
     "Su", "Summoner",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_HILL_ORC, SP_VINE_STALKER, SP_MERFOLK, SP_TENGU,
       SP_VAMPIRE, },
     { "robe", "book of Callings" },
@@ -229,7 +229,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_TRANSMUTER, {
     "Tm", "Transmuter",
-    2, 5, 5,
+    2, 5, 1,
     { SP_NAGA, SP_MERFOLK, SP_BASE_DRACONIAN, SP_DEMIGOD, SP_DEMONSPAWN,
       SP_TROLL, },
     { "robe", "book of Changes" },
@@ -240,7 +240,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_VENOM_MAGE, {
     "VM", "Venom Mage",
-    0, 7, 5,
+    0, 7, 1,
     { SP_DEEP_ELF, SP_SPRIGGAN, SP_NAGA, SP_MERFOLK, SP_TENGU, SP_FELID,
       SP_DEMONSPAWN, },
     { "robe", "Young Poisoner's Handbook" },
@@ -251,7 +251,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_WANDERER, {
     "Wn", "Wanderer",
-    0, 0, 0, // Randomised
+    0, 0, -4, // Randomised
     { SP_HILL_ORC, SP_SPRIGGAN, SP_GNOLL, SP_MERFOLK, SP_BASE_DRACONIAN,
       SP_HUMAN, SP_DEMONSPAWN, },
     { }, // Randomised
@@ -261,7 +261,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_WARPER, {
     "Wr", "Warper",
-    3, 5, 4,
+    3, 5, 0,
     { SP_FELID, SP_HALFLING, SP_DEEP_DWARF, SP_SPRIGGAN, SP_PALENTONGA,
       SP_BASE_DRACONIAN, },
     { "leather armour", "book of Spatial Translocations", "scroll of blinking",
@@ -274,7 +274,7 @@ static const map<job_type, job_def> job_data =
 
 { JOB_WIZARD, {
     "Wz", "Hedge Wizard",
-    2, 6, 4,
+    2, 6, 0,
     { SP_DEEP_ELF, SP_NAGA, SP_BASE_DRACONIAN, SP_OCTOPODE, SP_HUMAN,
       SP_MUMMY, },
     { "dagger", "robe", "hat", "book of Minor Magic" },


### PR DESCRIPTION
This has no effect on balance, as the changes exactly cancel out.

The background contributions for str and int span reasonable, intuitive
ranges. Many backgrounds provide zero additional str, and many
backgrounds provide zero additional int. However every background
provides at least four dex. This rescaling makes background stat
contributions more clearly reflect "discretionary" assignment.

Note that it also makes the weird role of Wanderer clearer, in that
Wanderer has an outside chance to have even less dex than Conjurer.