### PR TITLE
Check right god for life-saving in god description

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -804,36 +804,40 @@ static formatted_string _describe_god_powers(god_type which_god)
     // mv: Some gods can protect you from harm.
     // The god isn't really protecting the player - only sometimes saving
     // his life.
-    if (have_passive(passive_t::protect_from_harm))
+    if (god_gives_passive(which_god, passive_t::protect_from_harm))
     {
         have_any = true;
 
-        int prot_chance = 10 + piety/10; // chance * 100
+        const char *how = "";
         const char *when = "";
 
-        if (which_god == GOD_ELYVILON)
+        if (which_god == you.religion)
         {
-            switch (elyvilon_lifesaving())
+            int prot_chance = 10 + piety/10; // chance * 100
+            if (which_god == GOD_ELYVILON)
             {
-                case lifesaving_chance::sometimes:
-                    when = ", especially when called upon";
-                    prot_chance += 100 - 3000/piety;
-                    break;
-                case lifesaving_chance::always:
-                    when = ", and always does so when called upon";
-                    prot_chance = 100;
-                    break;
-                default:
-                    break;
+                switch (elyvilon_lifesaving())
+                {
+                    case lifesaving_chance::sometimes:
+                        when = ", especially when called upon";
+                        prot_chance += 100 - 3000/piety;
+                        break;
+                    case lifesaving_chance::always:
+                        when = ", and always does so when called upon";
+                        prot_chance = 100;
+                        break;
+                    default:
+                        break;
+                }
             }
+
+        how = (prot_chance >= 85) ? "carefully " :
+              (prot_chance >= 55) ? "often " :
+              (prot_chance >= 25) ? "sometimes "
+                                  : "occasionally ";
         }
 
-        const char *how = (prot_chance >= 85) ? "carefully" :
-                          (prot_chance >= 55) ? "often" :
-                          (prot_chance >= 25) ? "sometimes"
-                                              : "occasionally";
-
-        desc.cprintf("%s %s watches over you%s.\n",
+        desc.cprintf("%s %swatches over you%s.\n",
                 uppercase_first(god_name(which_god)).c_str(),
                 how,
                 when);

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -265,6 +265,7 @@ enum ru_interference
     DO_REDIRECT_ATTACK
 };
 
+bool god_gives_passive(god_type god, passive_t passive);
 bool have_passive(passive_t passive);
 bool will_have_passive(passive_t passive);
 int rank_for_passive(passive_t passive);


### PR DESCRIPTION
Currently describing a god checks your passives when deciding whether to
print something for the protect_from_harm passive. This leads to errors
in both directions: the passive is spuriously indicated when describing
gods that don't give it if you happen to be worshipping a god that gives
it, and is not printed for gods that do give it if you're not
worshipping them.

After this commit the god description checks whether the god being
described gives that passive.