### PR TITLE
build: Make the catch2-tests target look for tests

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -303,22 +303,9 @@ windowmanager-sdl.o \
 glwrapper-ogl.o \
 fontwrapper-ft.o
 
-TEST_OBJECTS = \
-catch2-tests/test_branch.o \
-catch2-tests/test_describe.o \
-catch2-tests/test_english.o \
-catch2-tests/test_files.o \
-catch2-tests/test_items.o \
-catch2-tests/test_mon-util.o \
-catch2-tests/test_ng-init-branches.o \
-catch2-tests/test_player.o \
-catch2-tests/test_player_fixture.o \
-catch2-tests/test_randbook.o \
-catch2-tests/test_species.o \
-catch2-tests/test_tags.o \
-catch2-tests/test_ui.o \
-catch2-tests/test_viewmap.o \
-catch2-tests/test_spl-util.o
+TEST_OBJECTS = $(patsubst %.cc,%.o, \
+    $(filter-out catch2-tests/test_main.cc, \
+    $(wildcard catch2-tests/*.cc)))
 
 WEBTILES_OBJECTS = \
 tileweb.o \


### PR DESCRIPTION
Currently, adding a new set of catch2 tests requires:

  1. Add a new test_xyz.cc file in the source/catch2-tests
  2. Add test_xyz.o to TEST_OBJECTS in Makefile.obj

This commit removes the need to perform step 2 by making
the TEST_OBJECTS automatically search for the tests in
the source/catch2-tests/ directory. The change would
streamline the process and help to avoid potential merge
conflicts that arise when multiple developers try to
commit new sets of catch2 tests simultaneously.