### PR TITLE
Change the spelling of some words to Australian English.

### DIFF
--- a/crawl-ref/docs/arena.txt
+++ b/crawl-ref/docs/arena.txt
@@ -176,4 +176,4 @@ The parameters include:
 
 * move_respawns: Moves respawned monsters to a new, random location as
       soon as they're placed, to avoid monsters clumping up in a massive
-      brawl at the center of the arena.
+      brawl at the centre of the arena.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -707,7 +707,7 @@ view_max_height = 21 (max 71)
 * Note that using large viewports can slow the game down.
 
 view_lock_x = true
-        Keeps the player character centered horizontally in the
+        Keeps the player character centred horizontally in the
         viewport, continuously scrolling the viewport to match the
         PC's movements. If this is not set, the player character can
         move horizontally within the viewport, and the viewport will
@@ -715,13 +715,13 @@ view_lock_x = true
         left or right edge.
 
 view_lock_y = true
-        Keeps the character centered vertically in the viewport.
+        Keeps the character centred vertically in the viewport.
 
 view_lock = true
         Aliased option that sets both view_lock_x and view_lock_y.
 
 center_on_scroll = false
-        If this is set, the viewport centers on the player character
+        If this is set, the viewport centres on the player character
         whenever it scrolls (this option is irrelevant if view_lock_x
         and view_lock_y are set).
 
@@ -730,7 +730,7 @@ symmetric_scroll = true
         with the character movement that caused the scroll.
 
         To illustrate, let's say the PC is at the lower edge of the
-        viewport, but is near the horizontal center. Now the PC moves
+        viewport, but is near the horizontal centre. Now the PC moves
         diagonally down and right, forcing the viewport to scroll up
         one line. If symmetric_scroll is set, the viewport will also
         scroll left one column to match the PC's diagonal movement. If
@@ -973,7 +973,7 @@ auto_exclude += <monster name>, <monster name>, ...
         (List option)
         Whenever you encounter a sleeping or stationary monster during
         exploration that is included in this list, a travel exclusion is
-        automatically set centered on this monster, meaning autoexplore won't
+        automatically set centred on this monster, meaning autoexplore won't
         ever bring you into its line of sight. If the monster dies or wakes up
         while you are in sight, this exclusion is automatically removed again.
 
@@ -986,8 +986,9 @@ auto_switch = false
         wielding and the one you switch to are both in slot 'a' or 'b'.
 
 travel_open_doors = true
-        If this is set to false, autoexplore/travel will not open doors,
-        instead stopping in front of them.
+        If this is set to false, autoexplore/travel will not open doors. If they
+        can explore or travel without opening a door they will do so. If not,
+        they will stop in front of a door they would need to go through.
 
 easy_unequip = true
         Allows auto removal of armour and jewellery when dropping it.
@@ -1435,7 +1436,7 @@ mlist_allow_alternate_layout = false
         This option is not supported in the tiles build.
 
 monster_item_view_coordinates = false
-        Display player-centered coordinates in the ^x view description.
+        Display player-centred coordinates in the ^x view description.
 
 monster_item_view_features += <regex>, <regex>
         (List option)
@@ -1471,7 +1472,7 @@ msg_webtiles_height = -1
 
 messages_at_top = false
         Put the message window at the top of the screen. This moves
-        the last message close to the center of the view when not
+        the last message close to the centre of the view when not
         using clear_messages=true.
 
 msg_condense_repeats = true

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -37,7 +37,7 @@ The contents of this text are:
                 level_map_cursor_step
 3-e     Viewport Display Options.
                 view_max_width, view_max_height, view_lock_x,
-                view_lock_y, view_lock, center_on_scroll,
+                view_lock_y, view_lock, centre_on_scroll,
                 symmetric_scroll, scroll_margin_x, scroll_margin_y,
                 scroll_margin, always_show_exclusions
 3-f     Travel and Exploration.
@@ -720,7 +720,7 @@ view_lock_y = true
 view_lock = true
         Aliased option that sets both view_lock_x and view_lock_y.
 
-center_on_scroll = false
+centre_on_scroll = false
         If this is set, the viewport centres on the player character
         whenever it scrolls (this option is irrelevant if view_lock_x
         and view_lock_y are set).
@@ -738,7 +738,7 @@ symmetric_scroll = true
         not horizontally. symmetric_scroll can be less disorienting
         than free scrolling.
 
-        This option is not relevant if view_lock or center_on_scroll
+        This option is not relevant if view_lock or centre_on_scroll
         are set.
 
 scroll_margin_x = 2

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -893,7 +893,7 @@ namespace arena
 
         if (contest_cancelled)
         {
-            mpr("Canceled contest at user request");
+            mpr("Cancelled contest at user request");
             ui::delay(Options.view_delay);
             clear_messages();
             return;

--- a/crawl-ref/source/dat/database/godname.txt
+++ b/crawl-ref/source/dat/database/godname.txt
@@ -73,7 +73,7 @@ Pakellas the Inventive
 %%%%
 Uskayaw lastname
 
-Uskayaw the Reveler
+Uskayaw the Reveller
 %%%%
 Hepliaklqana lastname
 

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -109,7 +109,7 @@ giants and covered with bloodstains.
 %%%%
 A hide-covered altar of Uskayaw
 
-An altar to Uskayaw the Reveler. It appears to be hollow and covered in a hide,
+An altar to Uskayaw the Reveller. It appears to be hollow and covered in a hide,
 giving it a resonant surface. Carvings on the side depict grouped figures that
 could be dancing or loving or fighting.
 %%%%

--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -184,7 +184,7 @@ absolutely forbidden the use of spell magic.
 %%%%
 Uskayaw
 
-Uskayaw the Reveler is a god of ecstatic dance. On the surface, Uskayaw
+Uskayaw the Reveller is a god of ecstatic dance. On the surface, Uskayaw
 appreciates many forms of worship, but in the dungeon most worshippers stick to
 the dance of combat. Uskayaw appreciates the passion and rhythm of combat,
 rewarding followers for each strike they deliver and for the damage they deal

--- a/crawl-ref/source/english.cc
+++ b/crawl-ref/source/english.cc
@@ -16,7 +16,7 @@
 
 const char * const standard_plural_qualifiers[] =
 {
-    " of ", " labeled ", nullptr
+    " of ", " labelled ", nullptr
 };
 
 bool is_vowel(const char32_t chr)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5067,7 +5067,7 @@ bool uskayaw_stomp()
         return false;
     }
 
-    mpr("You stomp with the beat, sending a shockwave through the revelers "
+    mpr("You stomp with the beat, sending a shockwave through the revellers "
             "around you!");
     apply_monsters_around_square(_get_stomped, you.pos());
     return true;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -190,7 +190,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(msg_condense_short), true),
         new BoolGameOption(SIMPLE_NAME(view_lock_x), true),
         new BoolGameOption(SIMPLE_NAME(view_lock_y), true),
-        new BoolGameOption(SIMPLE_NAME(center_on_scroll), false),
+        new BoolGameOption(SIMPLE_NAME(centre_on_scroll), false),
         new BoolGameOption(SIMPLE_NAME(symmetric_scroll), true),
         new BoolGameOption(SIMPLE_NAME(always_show_exclusions), true),
         new BoolGameOption(SIMPLE_NAME(note_all_skill_levels), false),
@@ -1593,6 +1593,7 @@ static const char* config_defaults[] =
 void read_init_file(bool runscript)
 {
     Options.reset_options();
+    Options.read_option_line("center_on_scroll := centre_on_scroll"); // alias
 
     // Load Lua builtins.
 #ifdef CLUA_BINDINGS
@@ -1832,7 +1833,10 @@ void game_options::read_options(LineInput &il, bool runscript,
     bool l_init        = false;
 
     if (clear_aliases)
+    {
         aliases.clear();
+        Options.add_alias("center_on_scroll", "centre_on_scroll"); // old name
+    }
 
     dlua_chunk luacond(filename);
     dlua_chunk luacode(filename);

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -1728,7 +1728,7 @@ string item_def::name_aux(description_level_type desc, bool terse, bool ident,
         if (know_type)
             buff << "of " << scroll_type_name(item_typ);
         else
-            buff << "labeled " << make_name(subtype_rnd, MNAME_SCROLL);
+            buff << "labelled " << make_name(subtype_rnd, MNAME_SCROLL);
         break;
 
     case OBJ_JEWELLERY:

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -204,7 +204,7 @@ public:
     bool        view_lock_y;
 
     // For an unlocked viewport, this will centre the viewport when scrolling.
-    bool        center_on_scroll;
+    bool        centre_on_scroll;
 
     // If symmetric_scroll is set, for diagonal moves, if the view
     // scrolls at all, it'll scroll diagonally.

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -1164,7 +1164,7 @@ coord_def noise_grid::noise_perceived_position(actor *act,
 #ifdef DEBUG_NOISE_PROPAGATION
     dprf(DIAG_NOISE, "[NOISE] Noise perceived by %s at (%d,%d) "
          "centroid (%d,%d) source (%d,%d) "
-         "heard at (%d,%d), distance: %d (traveled %d)",
+         "heard at (%d,%d), distance: %d (travelled %d)",
          act->name(DESC_PLAIN, true).c_str(),
          final_perceived_point.x, final_perceived_point.y,
          noise_centroid.x, noise_centroid.y,
@@ -1284,7 +1284,7 @@ static void _actor_apply_noise(actor *act,
 {
 #ifdef DEBUG_NOISE_PROPAGATION
     dprf(DIAG_NOISE, "[NOISE] Actor %s (%d,%d) perceives noise (%d) "
-         "from (%d,%d), real source (%d,%d), distance: %d, noise traveled: %d",
+         "from (%d,%d), real source (%d,%d), distance: %d, noise travelled: %d",
          act->name(DESC_PLAIN, true).c_str(),
          act->pos().x, act->pos().y,
          noise_intensity_millis,

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -68,7 +68,7 @@ static const char *skill_titles[NUM_SKILLS][6] =
     {"Short Blades",   "Cutter",        "Slicer",          "Swashbuckler",    "Cutthroat",      "Politician"},
     {"Long Blades",    "Slasher",       "Carver",          "Fencer",          "@Adj@ Blade",    "Swordmaster"},
     {"Axes",           "Chopper",       "Cleaver",         "Severer",         "Executioner",    "Axe Maniac"},
-    {"Maces & Flails", "Cudgeler",      "Basher",          "Bludgeoner",      "Shatterer",      "Skullcrusher"},
+    {"Maces & Flails", "Cudgeller",      "Basher",          "Bludgeoner",      "Shatterer",      "Skullcrusher"},
     {"Polearms",       "Poker",         "Spear-Bearer",    "Impaler",         "Phalangite",     "@Adj@ Porcupine"},
     {"Staves",         "Twirler",       "Cruncher",        "Stickfighter",    "Pulveriser",     "Chief of Staff"},
     {"Slings",         "Vandal",        "Slinger",         "Whirler",         "Slingshot",      "@Adj@ Catapult"},

--- a/crawl-ref/source/viewgeom.cc
+++ b/crawl-ref/source/viewgeom.cc
@@ -349,10 +349,10 @@ void crawl_view_geometry::set_player_at(const coord_def &c, bool centre)
         else if (c.y + LOS_RADIUS > vgrdc.y + viewhalfsz.y - ymarg)
             vgrdc.y = c.y + LOS_RADIUS - viewhalfsz.y + ymarg;
 
-        if (vgrdc != oldc && Options.center_on_scroll)
+        if (vgrdc != oldc && Options.centre_on_scroll)
             vgrdc = c;
 
-        if (!Options.center_on_scroll && Options.symmetric_scroll
+        if (!Options.centre_on_scroll && Options.symmetric_scroll
             && !Options.view_lock_x
             && !Options.view_lock_y
             && (c - last_player_pos).abs() == 2


### PR DESCRIPTION
I've changed the spelling of a few words which are either displayed to the user, or are in documentation for it. I haven't changed the changelog, however, or anything in source/contrib.

The words I've changed are:

Canceled -> Cancelled (arena.cc)
center -> centre (arena.txt initfile.cc options.h options_guide.txt viewgeom.cc)
centered -> centred (options_guide.txt)
centers -> centres (options_guide.txt)
Cudgeler -> Cudgeller (skills.cc)
labeled -> labelled (english.cc item-name.cc)
reveler -> reveller (god-abil.cc)
Reveler -> Reveller (features.txt, godname.txt, gods.txt)
traveled -> travelled (shout.cc)

It also renames the "center_on_scroll" option as "centre_on_scroll" throughout the code. I've added an alias in initfile.cc so that the user can give either spelling.