### PR TITLE
travel_open_doors extra setting

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -985,9 +985,15 @@ auto_switch = false
         weapon when firing or attacking in melee, as long as the one you are
         wielding and the one you switch to are both in slot 'a' or 'b'.
 
-travel_open_doors = true
-        If this is set to false, autoexplore/travel will not open doors,
-        instead stopping in front of them.
+travel_open_doors = (avoid | approach | open)
+        Change how autoexplore/travel interact with closed doors.
+		   avoid = If they can explore (or reach their destination) without
+		           opening doors, they will do. If not, the stop by a closed
+				   door.
+		approach = They walk up to a door if it's on their route, and stop in
+		           front of it.
+		    open = They open any closed doors in their path. (default)
+		This does not affect runed door, which they always avoid.
 
 easy_unequip = true
         Allows auto removal of armour and jewellery when dropping it.

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -156,7 +156,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(easy_quit_item_prompts,
                            { "easy_quit_item_prompts", "easy_quit_item_lists" },
                            true),
-        new BoolGameOption(SIMPLE_NAME(travel_open_doors), true),
         new BoolGameOption(easy_unequip,
                            { "easy_unequip", "easy_armour", "easy_armor" },
                            true),
@@ -1063,6 +1062,7 @@ void game_options::reset_options()
     easy_confirm           = easy_confirm_type::safe;
     allow_self_target      = confirm_prompt_type::prompt;
     skill_focus            = SKM_FOCUS_ON;
+    travel_open_doors      = travel_open_doors_type::_open;
 
     user_note_prefix       = "";
 
@@ -2698,6 +2698,18 @@ void game_options::read_option_line(const string &str, bool runscript)
             confirm_butcher = confirm_butcher_type::never;
         else if (field == "auto")
             confirm_butcher = confirm_butcher_type::normal;
+    }
+
+    else if (key == "travel_open_doors")
+    {
+#define X(s, i) \
+        if (field == #s) \
+            travel_open_doors = travel_open_doors_type::_ ## s; \
+        else
+
+        TRAVEL_OPEN_DOORS_LIST // See travel-open-doors-type.h for options.
+        report_error("Bad travel_open_doors value: %s", field.c_str());
+#undef X
     }
     else if (key == "lua_file" && runscript)
     {

--- a/crawl-ref/source/l-option.cc
+++ b/crawl-ref/source/l-option.cc
@@ -55,11 +55,41 @@ static int option_autopick(lua_State *ls, const char */*name*/, void */*data*/,
     return 1;
 }
 
+static int option_travel_open_doors(lua_State *ls, const char *name,
+                                    void *data, bool get)
+{
+    if (get)
+    {
+#define X(s, i) \
+        if (travel_open_doors_type::_ ## s == \
+            *((travel_open_doors_type*)(data))) \
+        { \
+            lua_pushstring(ls, #s); \
+        } \
+        else
+
+        TRAVEL_OPEN_DOORS_LIST
+        {} // We've covered the whole enum, so don't need a default case.
+#undef X
+        return 1;
+    }
+    else
+    {
+        if (lua_isstring(ls, 3))
+        {
+            const string s = string(name) + "=" + string(lua_tostring(ls, 3));
+            Options.read_option_line(s);
+        }
+        return 0;
+    }
+}
+
 static option_handler handlers[] =
 {
     // Boolean options come first
     { "autoswitch",    &Options.auto_switch, option_hboolean },
-    { "travel_open_doors",    &Options.travel_open_doors, option_hboolean },
+    { "travel_open_doors", &Options.travel_open_doors,
+                           option_travel_open_doors},
     { "easy_armour",   &Options.easy_unequip, option_hboolean },
     { "easy_unequip",  &Options.easy_unequip, option_hboolean },
     { "note_skill_max",       &Options.note_skill_max, option_hboolean },

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1071,9 +1071,7 @@ void move_player_action(coord_def move)
     }
 
     // BCR - Easy doors single move
-    if ((Options.travel_open_doors || !you.running)
-        && !attacking
-        && feat_is_closed_door(env.grid(targ)))
+    if (!attacking && feat_is_closed_door(env.grid(targ)))
     {
         open_door_action(move);
         move.reset();

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -20,6 +20,7 @@
 #include "screen-mode.h"
 #include "skill-focus-mode.h"
 #include "tag-pref.h"
+#include "travel-open-doors-type.h"
 
 using std::vector;
 
@@ -232,7 +233,7 @@ public:
 
     FixedBitVector<NUM_OBJECT_CLASSES> autopickups; // items to autopickup
     bool        auto_switch;     // switch melee&ranged weapons according to enemy range
-    bool        travel_open_doors;     // open doors while exploring
+    travel_open_doors_type travel_open_doors; // open doors while exploring
     bool        easy_unequip;    // allow auto-removing of armour / jewellery
     bool        equip_unequip;   // Make 'W' = 'T', and 'P' = 'R'.
     bool        jewellery_prompt; // Always prompt for slot when changing jewellery.

--- a/crawl-ref/source/travel-open-doors-type.h
+++ b/crawl-ref/source/travel-open-doors-type.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// This list contains the possible values for Options.travel_open_doors.
+// This used to be a boolean, so "true" and "false" are mapped to their
+// equivalents.
+// Where there is more than one name for a value, the one the game should give
+// for it (in l-option.cc, or anywhere else) should come first.
+// This uses a macro so that l-options.cc doesn't need a copy of the list.
+#define TRAVEL_OPEN_DOORS_LIST \
+    X(avoid, 1) \
+    X(approach, 2) \
+    X(open, 3) \
+    X(false, _approach) \
+    X(true, _open)
+
+#define X(s, i) _ ## s = i,
+enum class travel_open_doors_type
+{
+    TRAVEL_OPEN_DOORS_LIST
+};
+#undef X

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -353,9 +353,13 @@ static bool _feat_is_blocking_door(const dungeon_feature_type grid)
 static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
 {
     if (Options.travel_open_doors == travel_open_doors_type::_open)
+    {
         if (!feat_is_runed(grid)) return false;
+    }
     else
+    {
         if (!feat_is_closed_door(grid)) return false;
+    }
 
     if (you.elapsed_time == you.elapsed_time_at_last_input)
     {

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -129,7 +129,9 @@ static bool ignore_player_traversability = false;
 // Map of terrain types that are forbidden.
 static FixedVector<int8_t,NUM_FEATURES> forbidden_terrain;
 
+#ifdef DEBUG_DIAGNOSTICS
 //#define DEBUG_TRAVEL
+#endif
 
 /*
  * Warn if interlevel travel is going to take you outside levels in

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -56,6 +56,7 @@
 #include "terrain.h"
 #include "tiles-build-specific.h"
 #include "traps.h"
+#include "travel-open-doors-type.h"
 #include "unicode.h"
 #include "unwind.h"
 #include "view.h"
@@ -333,6 +334,27 @@ static bool _monster_blocks_travel(const monster_info *mons)
            && !fedhas_passthrough(mons);
 }
 
+// Returns true if the feature type "grid" is a closed door which
+// autoexplore/travel will not normally approach in order to go through it.
+static bool _feat_is_blocking_door(const dungeon_feature_type grid)
+{
+    if (Options.travel_open_doors == travel_open_doors_type::_avoid)
+        return feat_is_closed_door(grid);
+    else
+        return feat_is_runed(grid);
+}
+
+// Returns true if the feature type "grid" is a closed door which autotravel
+// will not pass through.
+// This should only be used for the choice to open the door itself.
+static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
+{
+    if (Options.travel_open_doors == travel_open_doors_type::_open)
+        return feat_is_runed(grid);
+    else
+        return feat_is_closed_door(grid);
+}
+
 /*
  * Returns true if the square at (x,y) is a dungeon feature the character
  * can't (under normal circumstances) safely cross.
@@ -357,7 +379,7 @@ static bool _is_reseedable(const coord_def& c, bool ignore_danger = false)
 
     return feat_is_water(grid)
            || grid == DNGN_LAVA
-           || feat_is_runed(grid)
+           || _feat_is_blocking_door(grid)
            || is_trap(c)
            || !ignore_danger && _monster_blocks_travel(cell.monsterinfo())
            || g_Slime_Wall_Check && slime_wall_neighbour(c)
@@ -440,7 +462,7 @@ static bool _is_travelsafe_square(const coord_def& c, bool ignore_hostile,
     // Only try pathing through temporary obstructions we remember, not
     // those we can actually see (since the latter are clearly still blockers)
     try_fallback = try_fallback
-                    && (!you.see_cell(c) || feat_is_runed(grid));
+                    && (!you.see_cell(c) || _feat_is_blocking_door(grid));
 
     // Also make note of what's displayed on the level map for
     // plant/fungus checks.
@@ -483,7 +505,7 @@ static bool _is_travelsafe_square(const coord_def& c, bool ignore_hostile,
             return true;
     }
 
-    if (feat_is_runed(levelmap_cell.feat()) && !try_fallback)
+    if (!try_fallback && _feat_is_blocking_door(levelmap_cell.feat()))
         return false;
 
     return feat_is_traversable_now(grid, try_fallback);
@@ -717,6 +739,7 @@ static void _set_target_square(const coord_def &target)
 static void _explore_find_target_square()
 {
     bool runed_door_pause = false;
+    bool closed_door_pause = false;
 
     travel_pathfind tp;
     tp.set_floodseed(you.pos(), true);
@@ -731,10 +754,20 @@ static void _explore_find_target_square()
         fallback_tp.set_floodseed(you.pos(), true);
         whereto = fallback_tp.pathfind(static_cast<run_mode_type>(you.running.runmode), true);
 
-        if (whereto.distance_from(you.pos()) == 1 && cell_is_runed(whereto))
+        if (whereto.distance_from(you.pos()) == 1)
         {
-            runed_door_pause = true;
-            whereto.reset();
+            if (cell_is_runed(whereto))
+            {
+                runed_door_pause = true;
+                whereto.reset();
+            }
+            // use orig_terrain() as that's what cell_is_runed() does.
+            else if (Options.travel_open_doors == travel_open_doors_type::_avoid
+                     && feat_is_closed_door(orig_terrain(whereto)))
+            {
+                closed_door_pause = true;
+                whereto.reset();
+            }
         }
     }
 
@@ -779,10 +812,14 @@ static void _explore_find_target_square()
             if (unknown_trans)
                 reasons.push_back("unvisited transporter");
 
+            if (closed_door_pause)
+                reasons.push_back("unopened door");
+
             if (estatus & EST_GREED_UNFULFILLED)
                 inacc.push_back("items");
             // A runed door already implies an unexplored place.
-            if (!runed_door_pause && estatus & EST_PARTLY_EXPLORED)
+            if (!runed_door_pause && !closed_door_pause &&
+                estatus & EST_PARTLY_EXPLORED)
                 inacc.push_back("places");
 
             if (!inacc.empty())
@@ -1722,6 +1759,7 @@ bool travel_pathfind::path_examine_point(const coord_def &c)
     return found_target;
 }
 
+
 /**
  * Run the travel_pathfind algorithm, either from the given position in
  * floodout mode to populate travel_point_distance relative to that starting
@@ -1731,8 +1769,9 @@ bool travel_pathfind::path_examine_point(const coord_def &c)
  *
  * If move_x and move_y are given, pathfinding runs from you.running.pos to
  * youpos, and the move contains the next movement relative to youpos to move
- * closer to you.running.pos. If a runed door is encountered or a transporter
- * needs to be taken, these are set to 0, and the caller checks for this.
+ * closer to you.running.pos. If a runed door (or a closed door, if
+ * travel_open_doors isn't _open) is encountered or a transporter needs to be
+ * taken, these are set to 0, and the caller checks for this.
  *
  * XXX The two modes of this function (with and without move_x/move_y) should
  * be split into two different functions, since they aren't really related.
@@ -1763,11 +1802,11 @@ void find_travel_pos(const coord_def& youpos,
         dest = tp.pathfind(rmode, true);
     coord_def new_dest = dest;
 
-    // We'd either have to travel through a runed door, in which case we'll be
-    // stopping, or a transporter, in which case we need to issue a command to
-    // enter.
+    // We'd either have to travel through a runed door (or a closed door if
+    // travel_open_doors is _avoid), in which case we'll be stopping, or a
+    // transporter, in which case we need to issue a command to enter.
     if (need_move
-        && (cell_is_runed(new_dest)
+        && (_feat_is_blocking_door_strict(env.grid(new_dest))
             || env.grid(youpos) == DNGN_TRANSPORTER
                && env.grid(new_dest) == DNGN_TRANSPORTER_LANDING
                && youpos.distance_from(new_dest) > 1))

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -353,22 +353,18 @@ static bool _feat_is_blocking_door(const dungeon_feature_type grid)
 static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
 {
     if (Options.travel_open_doors == travel_open_doors_type::_open)
-	{
         if (!feat_is_runed(grid)) return false;
-	}
     else
-	{
         if (!feat_is_closed_door(grid)) return false;
-	}
 
-	if (you.elapsed_time == you.elapsed_time_at_last_input)
-	{
-		string barrier;
-		if (feat_is_runed(grid)) barrier = "unopened runed door";
-		else barrier = "unopened door";
-		mpr("Could not " + you.running.runmode_name() + ", " + barrier + ".");
-	}
-	return true;
+    if (you.elapsed_time == you.elapsed_time_at_last_input)
+    {
+        string barrier;
+        if (feat_is_runed(grid)) barrier = "unopened runed door";
+        else barrier = "unopened door";
+        mpr("Could not " + you.running.runmode_name() + ", " + barrier + ".");
+    }
+    return true;
 }
 
 /*
@@ -836,7 +832,9 @@ static void _explore_find_target_square()
             // A runed door already implies an unexplored place.
             if (!runed_door_pause && !closed_door_pause &&
                 estatus & EST_PARTLY_EXPLORED)
+            {
                 inacc.push_back("places");
+            }
 
             if (!inacc.empty())
             {

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -345,14 +345,28 @@ static bool _feat_is_blocking_door(const dungeon_feature_type grid)
 }
 
 // Returns true if the feature type "grid" is a closed door which autotravel
-// will not pass through.
+// will not pass through. Print a message if no game time has passed since the
+// player pressed (say) "o", so that there is some response.
 // This should only be used for the choice to open the door itself.
 static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
 {
     if (Options.travel_open_doors == travel_open_doors_type::_open)
-        return feat_is_runed(grid);
+	{
+        if (!feat_is_runed(grid)) return false;
+	}
     else
-        return feat_is_closed_door(grid);
+	{
+        if (!feat_is_closed_door(grid)) return false;
+	}
+
+	if (you.elapsed_time == you.elapsed_time_at_last_input)
+	{
+		string barrier;
+		if (feat_is_runed(grid)) barrier = "unopened runed door";
+		else barrier = "unopened door";
+		mpr("Could not " + you.running.runmode_name() + ", " + barrier + ".");
+	}
+	return true;
 }
 
 /*


### PR DESCRIPTION
This adds a third value for the travel_open_doors option which means that autoexplore & travel treat closed doors in the same way they treat runed ones; they try to explore or travel to the destination without opening them.

The value list is in a header, with is copied around using a macro. A class for this sort of option would be better, but then it could be used for some other options (like easy_confirm), and then it's a bit out of scope for this PR.

I've also added messages for when the player tries to explore or travel, but doesn't move at all. The message isn't the same as the one you get when autoexplore selects a runed door as a target, as I wanted to avoid conjugating the verb.

Finally, I've put "#ifdef DEBUG_DIAGNOSTICS" around the "//#define DEBUG_TRAVEL" line in travel.cc, as it doesn't do anything useful otherwise. It's not really related to the above changes, but it does communicate something useful about the flag.