### PR TITLE
Change the brand of Glaive of Guard to spect

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -449,7 +449,7 @@ PLUS:     +8
 COLOUR:   ETC_ELECTRICITY
 TILE:     urand_guard
 TILE_EQ:  glaive_of_the_guard
-BRAND:    SPWPN_ELECTROCUTION
+BRAND:    SPWPN_SPECTRAL
 AC:       5
 BOOL:     seeinv, berserk
 


### PR DESCRIPTION
I saw the development idea and worked on it. However, I don't think we need to turn this weapon into a double brand weapon because we already have a thermic engine.
https://github.com/crawl/crawl/wiki/Unrand-Review