### PR TITLE
Properly Punctuate small damage distortion

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -512,10 +512,9 @@ bool attack::distortion_affects_defender()
     {
     case SMALL_DMG:
         special_damage += 1 + random2avg(7, 2);
-        // No need to call attack_strength_punctuation here,
-        // since special damage < 7, so it will always return "."
-        special_damage_message = make_stringf("Space bends around %s.",
-                                              defender_name(false).c_str());
+        special_damage_message = make_stringf("Space bends around %s%s",
+                                              defender_name(false).c_str()
+                                              attack_strength_punctuation(special_damage).c_str());
         break;
     case BIG_DMG:
         special_damage += 3 + random2avg(24, 2);

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -512,7 +512,8 @@ bool attack::distortion_affects_defender()
     {
     case SMALL_DMG:
         special_damage += 1 + random2avg(7, 2);
-        special_damage_message = make_stringf("Space bends around %s%s",
+        special_damage_message = 
+            make_stringf("Space bends around %s%s",
                                               defender_name(false).c_str()
                                               attack_strength_punctuation(special_damage).c_str());
         break;


### PR DESCRIPTION
I don't even know how long this was broken, attack.cc has had a comment claiming that it was fine since disto can't do more than 7 damage, but 7 damage is one ! already. Ideally someone will also fix harm to work properly with attack_strength_punctuation, but that's above my pay grade.