### PR TITLE
travel_open_doors extra setting

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -2308,8 +2308,8 @@ Shift-direction or / direction
 o
   Auto-explore. Setting the option explore_greedy to true makes auto-explore run
   to interesting items (those that get picked up automatically) or piles
-  (checking the contents). Autoexploration will open doors on its own except if
-  you set travel_open_doors to false.
+  (checking the contents). Autoexploration will open doors on its own unless
+  you set travel_open_doors to avoid or approach.
 
 G or Ctrl-G
   Interlevel travel (to arbitrary dungeon levels or waypoints). Remembers old

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -985,8 +985,8 @@ auto_exclude += <monster name>, <monster name>, ...
 
 auto_switch = false
         This option will allow you to automatically switch to an appropriate
-        weapon when attacking in melee, as long as the one you are wielding
-        and the one you switch to are both in slot 'a' or 'b'.
+        weapon when firing or attacking in melee, as long as the one you are
+        wielding and the one you switch to are both in slot 'a' or 'b'.
 
 travel_open_doors = (avoid | approach | open)
         Configure how autoexplore/travel interacts with doors.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -988,9 +988,15 @@ auto_switch = false
         weapon when attacking in melee, as long as the one you are wielding
         and the one you switch to are both in slot 'a' or 'b'.
 
-travel_open_doors = true
-        If this is set to false, autoexplore/travel will not open doors,
-        instead stopping in front of them.
+travel_open_doors = (avoid | approach | open)
+        Change how autoexplore/travel interact with closed doors.
+           avoid = If they can explore (or reach their destination) without
+                   opening doors, they will do. If not, the stop by a closed
+                   door.
+        approach = They walk up to a door if it's on their route, and stop in
+                   front of it.
+            open = They open any closed doors in their path. (default)
+        This does not affect runed door, which they always avoid.
 
 easy_unequip = true
         Allows auto removal of armour and jewellery when dropping it.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -989,13 +989,13 @@ auto_switch = false
         and the one you switch to are both in slot 'a' or 'b'.
 
 travel_open_doors = (avoid | approach | open)
-        Change how autoexplore/travel interact with closed doors.
-           avoid = If they can explore (or reach their destination) without
-                   opening doors, they will do. If not, the stop by a closed
-                   door.
-        approach = They walk up to a door if it's on their route, and stop in
-                   front of it.
-            open = They open any closed doors in their path. (default)
+        Configure how autoexplore/travel interacts with doors.
+           avoid = Autoexplore/travel will treat closed doors like walls. If
+                   the only way for exploration or travel to continue is through
+                   a closed door, it will stop by a closed door.
+        approach = Autoexplore/travel will not open doors, instead stopping
+                   in front of any door in its path.
+            open = Autoexplore/travel will open doors. (default)
         This does not affect runed door, which they always avoid.
 
 easy_unequip = true

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -214,7 +214,7 @@ public:
         : GameOption(_names), value(_val), default_value(_default),
           choices(_choices) { }
     void reset() const override {value = default_value;}
-    string loadFromString(std::string field, rc_line_type) const override
+    string loadFromString(const std::string &field, rc_line_type) const override
     {
         const T *choice = map_find(choices, field);
         if (choice == 0)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -156,7 +156,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(easy_quit_item_prompts,
                            { "easy_quit_item_prompts", "easy_quit_item_lists" },
                            true),
-        new BoolGameOption(SIMPLE_NAME(travel_open_doors), true),
         new BoolGameOption(easy_unequip,
                            { "easy_unequip", "easy_armour", "easy_armor" },
                            true),
@@ -1078,6 +1077,7 @@ void game_options::reset_options()
     easy_confirm           = easy_confirm_type::safe;
     allow_self_target      = confirm_prompt_type::prompt;
     skill_focus            = SKM_FOCUS_ON;
+    travel_open_doors      = travel_open_doors_type::_open;
 
     user_note_prefix       = "";
 
@@ -2778,6 +2778,18 @@ void game_options::read_option_line(const string &str, bool runscript)
             confirm_butcher = confirm_butcher_type::never;
         else if (field == "auto")
             confirm_butcher = confirm_butcher_type::normal;
+    }
+
+    else if (key == "travel_open_doors")
+    {
+#define X(s, i) \
+        if (field == #s) \
+            travel_open_doors = travel_open_doors_type::_ ## s; \
+        else
+
+        TRAVEL_OPEN_DOORS_LIST // See travel-open-doors-type.h for options.
+        report_error("Bad travel_open_doors value: %s", field.c_str());
+#undef X
     }
     else if (key == "lua_file" && runscript)
     {

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -304,6 +304,13 @@ const vector<GameOption*> game_options::build_options_list()
         new ColourThresholdOption(stat_colour, {"stat_colour", "stat_color"},
                                   "3:red", _first_less),
         new StringGameOption(SIMPLE_NAME(sound_file_path), ""),
+        new MultipleChoiceGameOption<travel_open_doors_type>(
+            SIMPLE_NAME(travel_open_doors), travel_open_doors_type::open,
+            {{"avoid", travel_open_doors_type::avoid},
+             {"approach", travel_open_doors_type::approach},
+             {"open", travel_open_doors_type::open},
+             {"false", travel_open_doors_type::_false},
+             {"true", travel_open_doors_type::_true}}),
 
 #ifdef DGL_SIMPLE_MESSAGING
         new BoolGameOption(SIMPLE_NAME(messaging), false),
@@ -1077,7 +1084,6 @@ void game_options::reset_options()
     easy_confirm           = easy_confirm_type::safe;
     allow_self_target      = confirm_prompt_type::prompt;
     skill_focus            = SKM_FOCUS_ON;
-    travel_open_doors      = travel_open_doors_type::_open;
 
     user_note_prefix       = "";
 
@@ -2778,18 +2784,6 @@ void game_options::read_option_line(const string &str, bool runscript)
             confirm_butcher = confirm_butcher_type::never;
         else if (field == "auto")
             confirm_butcher = confirm_butcher_type::normal;
-    }
-
-    else if (key == "travel_open_doors")
-    {
-#define X(s, i) \
-        if (field == #s) \
-            travel_open_doors = travel_open_doors_type::_ ## s; \
-        else
-
-        TRAVEL_OPEN_DOORS_LIST // See travel-open-doors-type.h for options.
-        report_error("Bad travel_open_doors value: %s", field.c_str());
-#undef X
     }
     else if (key == "lua_file" && runscript)
     {

--- a/crawl-ref/source/l-option.cc
+++ b/crawl-ref/source/l-option.cc
@@ -55,11 +55,41 @@ static int option_autopick(lua_State *ls, const char */*name*/, void */*data*/,
     return 1;
 }
 
+static int option_travel_open_doors(lua_State *ls, const char *name,
+                                    void *data, bool get)
+{
+    if (get)
+    {
+#define X(s, i) \
+        if (travel_open_doors_type::_ ## s == \
+            *((travel_open_doors_type*)(data))) \
+        { \
+            lua_pushstring(ls, #s); \
+        } \
+        else
+
+        TRAVEL_OPEN_DOORS_LIST
+        {} // We've covered the whole enum, so don't need a default case.
+#undef X
+        return 1;
+    }
+    else
+    {
+        if (lua_isstring(ls, 3))
+        {
+            const string s = string(name) + "=" + string(lua_tostring(ls, 3));
+            Options.read_option_line(s);
+        }
+        return 0;
+    }
+}
+
 static option_handler handlers[] =
 {
     // Boolean options come first
     { "autoswitch",    &Options.auto_switch, option_hboolean },
-    { "travel_open_doors",    &Options.travel_open_doors, option_hboolean },
+    { "travel_open_doors", &Options.travel_open_doors,
+                           option_travel_open_doors},
     { "easy_armour",   &Options.easy_unequip, option_hboolean },
     { "easy_unequip",  &Options.easy_unequip, option_hboolean },
     { "note_skill_max",       &Options.note_skill_max, option_hboolean },

--- a/crawl-ref/source/l-option.cc
+++ b/crawl-ref/source/l-option.cc
@@ -5,9 +5,9 @@
  * To set options with the same processing as `.crawlrc` or `init.txt`, use
  * @{crawl.setopt}.
  *
- * This table provides access to the following crawl options: `autoswitch,
- * travel_open_doors, easy_armour, easy_unequip, note_skill_max,
- * clear_messages, blink_brightens_background, bold_brightens_foreground,
+ * This table provides access to the following crawl options:
+ * autoswitch, easy_armour, easy_unequip, note_skill_max, clear_messages,
+ * blink_brightens_background, bold_brightens_foreground,
  * best_effort_brighten_background, best_effort_brighten_foreground,
  * allow_extended_colours, pickup_thrown, easy_exit_menu,
  * dos_use_background_intensity, autopickup_on`; documented in
@@ -55,41 +55,10 @@ static int option_autopick(lua_State *ls, const char */*name*/, void */*data*/,
     return 1;
 }
 
-static int option_travel_open_doors(lua_State *ls, const char *name,
-                                    void *data, bool get)
-{
-    if (get)
-    {
-#define X(s, i) \
-        if (travel_open_doors_type::_ ## s == \
-            *((travel_open_doors_type*)(data))) \
-        { \
-            lua_pushstring(ls, #s); \
-        } \
-        else
-
-        TRAVEL_OPEN_DOORS_LIST
-        {} // We've covered the whole enum, so don't need a default case.
-#undef X
-        return 1;
-    }
-    else
-    {
-        if (lua_isstring(ls, 3))
-        {
-            const string s = string(name) + "=" + string(lua_tostring(ls, 3));
-            Options.read_option_line(s);
-        }
-        return 0;
-    }
-}
-
 static option_handler handlers[] =
 {
     // Boolean options come first
     { "autoswitch",    &Options.auto_switch, option_hboolean },
-    { "travel_open_doors", &Options.travel_open_doors,
-                           option_travel_open_doors},
     { "easy_armour",   &Options.easy_unequip, option_hboolean },
     { "easy_unequip",  &Options.easy_unequip, option_hboolean },
     { "note_skill_max",       &Options.note_skill_max, option_hboolean },

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1110,9 +1110,7 @@ void move_player_action(coord_def move)
     }
 
     // BCR - Easy doors single move
-    if ((Options.travel_open_doors || !you.running)
-        && !attacking
-        && feat_is_closed_door(env.grid(targ)))
+    if (!attacking && feat_is_closed_door(env.grid(targ)))
     {
         open_door_action(move);
         move.reset();

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -20,6 +20,7 @@
 #include "screen-mode.h"
 #include "skill-focus-mode.h"
 #include "tag-pref.h"
+#include "travel-open-doors-type.h"
 
 using std::vector;
 
@@ -232,7 +233,7 @@ public:
 
     FixedBitVector<NUM_OBJECT_CLASSES> autopickups; // items to autopickup
     bool        auto_switch;     // switch melee&ranged weapons according to enemy range
-    bool        travel_open_doors;     // open doors while exploring
+    travel_open_doors_type travel_open_doors; // open doors while exploring
     bool        easy_unequip;    // allow auto-removing of armour / jewellery
     bool        equip_unequip;   // Make 'W' = 'T', and 'P' = 'R'.
     bool        jewellery_prompt; // Always prompt for slot when changing jewellery.

--- a/crawl-ref/source/travel-open-doors-type.h
+++ b/crawl-ref/source/travel-open-doors-type.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// This list contains the possible values for Options.travel_open_doors.
+// This used to be a boolean, so "true" and "false" are mapped to their
+// equivalents.
+// Where there is more than one name for a value, the one the game should give
+// for it (in l-option.cc, or anywhere else) should come first.
+// This uses a macro so that l-options.cc doesn't need a copy of the list.
+#define TRAVEL_OPEN_DOORS_LIST \
+    X(avoid, 1) \
+    X(approach, 2) \
+    X(open, 3) \
+    X(false, _approach) \
+    X(true, _open)
+
+#define X(s, i) _ ## s = i,
+enum class travel_open_doors_type
+{
+    TRAVEL_OPEN_DOORS_LIST
+};
+#undef X

--- a/crawl-ref/source/travel-open-doors-type.h
+++ b/crawl-ref/source/travel-open-doors-type.h
@@ -5,17 +5,11 @@
 // equivalents.
 // Where there is more than one name for a value, the one the game should give
 // for it (in l-option.cc, or anywhere else) should come first.
-// This uses a macro so that l-options.cc doesn't need a copy of the list.
-#define TRAVEL_OPEN_DOORS_LIST \
-    X(avoid, 1) \
-    X(approach, 2) \
-    X(open, 3) \
-    X(false, _approach) \
-    X(true, _open)
-
-#define X(s, i) _ ## s = i,
 enum class travel_open_doors_type
 {
-    TRAVEL_OPEN_DOORS_LIST
+    avoid,
+    approach,
+    open,
+    _false = approach,
+    _true = open,
 };
-#undef X

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -345,14 +345,25 @@ static bool _feat_is_blocking_door(const dungeon_feature_type grid)
 }
 
 // Returns true if the feature type "grid" is a closed door which autotravel
-// will not pass through.
+// will not pass through. Print a message if no game time has passed since the
+// player pressed (say) "o", so that there is some response.
 // This should only be used for the choice to open the door itself.
 static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
 {
-    if (Options.travel_open_doors == travel_open_doors_type::_open)
-        return feat_is_runed(grid);
-    else
-        return feat_is_closed_door(grid);
+    if (Options.travel_open_doors == travel_open_doors_type::_open
+        ? !feat_is_runed(grid) : !feat_is_closed_door(grid))
+    {
+        return false;
+    }
+
+    if (you.elapsed_time == you.elapsed_time_at_last_input)
+    {
+        string barrier;
+        if (feat_is_runed(grid)) barrier = "unopened runed door";
+        else barrier = "unopened door";
+        mpr("Could not " + you.running.runmode_name() + ", " + barrier + ".");
+    }
+    return true;
 }
 
 /*

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -129,7 +129,9 @@ static bool ignore_player_traversability = false;
 // Map of terrain types that are forbidden.
 static FixedVector<int8_t,NUM_FEATURES> forbidden_terrain;
 
+#ifdef DEBUG_DIAGNOSTICS
 //#define DEBUG_TRAVEL
+#endif
 
 /*
  * Warn if interlevel travel is going to take you outside levels in

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1475,6 +1475,7 @@ bool travel_pathfind::square_slows_movement(const coord_def &c)
 void travel_pathfind::check_square_greed(const coord_def &c)
 {
     if (greedy_dist == UNFOUND_DIST
+        && (!ignore_hostile || point_distance[c.x][c.y] > 0)
         && is_greed_inducing_square(c)
         && _is_travelsafe_square(c, ignore_hostile, ignore_danger))
     {

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -130,7 +130,7 @@ static bool ignore_player_traversability = false;
 static FixedVector<int8_t,NUM_FEATURES> forbidden_terrain;
 
 #ifdef DEBUG_DIAGNOSTICS
-//#define DEBUG_TRAVEL
+#define DEBUG_TRAVEL
 #endif
 
 /*
@@ -340,32 +340,36 @@ static bool _monster_blocks_travel(const monster_info *mons)
 // autoexplore/travel will not normally approach in order to go through it.
 static bool _feat_is_blocking_door(const dungeon_feature_type grid)
 {
-    if (Options.travel_open_doors == travel_open_doors_type::_avoid)
+    if (Options.travel_open_doors == travel_open_doors_type::avoid)
         return feat_is_closed_door(grid);
     else
         return feat_is_runed(grid);
 }
 
-// Returns true if the feature type "grid" is a closed door which autotravel
-// will not pass through. Print a message if no game time has passed since the
-// player pressed (say) "o", so that there is some response.
-// This should only be used for the choice to open the door itself.
-static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
+// Returns {flag, barrier}.
+// "flag" is true if the feature type "grid" is a closed door which autotravel
+// will not pass through, false otherwise.
+// "barrier" is a description of "grid" if autotravel will not pass through it,
+// and no game time has passed since the player pressed (say) "o", "" otherwise.
+// This function should only be used for the choice to open the door itself.
+static pair<bool, string> _feat_is_blocking_door_strict(
+    const dungeon_feature_type grid)
 {
-    if (Options.travel_open_doors == travel_open_doors_type::_open
+    if (Options.travel_open_doors == travel_open_doors_type::open
         ? !feat_is_runed(grid) : !feat_is_closed_door(grid))
     {
-        return false;
+        return {false, ""};
     }
 
     if (you.elapsed_time == you.elapsed_time_at_last_input)
     {
         string barrier;
-        if (feat_is_runed(grid)) barrier = "unopened runed door";
-        else barrier = "unopened door";
-        mpr("Could not " + you.running.runmode_name() + ", " + barrier + ".");
+        if (feat_is_runed(grid))
+            return {true, "unopened runed door"};
+        else
+            return {true, "unopened door"};
     }
-    return true;
+    return {true, ""};
 }
 
 /*
@@ -769,7 +773,7 @@ static void _explore_find_target_square()
                 whereto.reset();
             }
             // use orig_terrain() as that's what cell_is_runed() does.
-            else if (Options.travel_open_doors == travel_open_doors_type::_avoid
+            else if (Options.travel_open_doors == travel_open_doors_type::avoid
                      && feat_is_closed_door(orig_terrain(whereto)))
             {
                 closed_door_pause = true;
@@ -1780,7 +1784,7 @@ bool travel_pathfind::path_examine_point(const coord_def &c)
  * If move_x and move_y are given, pathfinding runs from you.running.pos to
  * youpos, and the move contains the next movement relative to youpos to move
  * closer to you.running.pos. If a runed door (or a closed door, if
- * travel_open_doors isn't _open) is encountered or a transporter needs to be
+ * travel_open_doors isn't open) is encountered or a transporter needs to be
  * taken, these are set to 0, and the caller checks for this.
  *
  * XXX The two modes of this function (with and without move_x/move_y) should
@@ -1815,14 +1819,20 @@ void find_travel_pos(const coord_def& youpos,
     // We'd either have to travel through a runed door, in which case we'll be
     // stopping, or a transporter, in which case we need to issue a command to
     // enter.
+    pair<bool, string> barrier;
     if (need_move
-        && (_feat_is_blocking_door_strict(env.grid(new_dest))
+        && ((barrier = _feat_is_blocking_door_strict(env.grid(new_dest))).first
             || env.grid(youpos) == DNGN_TRANSPORTER
                && env.grid(new_dest) == DNGN_TRANSPORTER_LANDING
                && youpos.distance_from(new_dest) > 1))
     {
         *move_x = 0;
         *move_y = 0;
+        if (!barrier.second.empty())
+        {
+            mpr("Could not " + you.running.runmode_name() + ", "
+                + barrier.second + ".");
+        }
         return;
     }
 

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -56,6 +56,7 @@
 #include "terrain.h"
 #include "tiles-build-specific.h"
 #include "traps.h"
+#include "travel-open-doors-type.h"
 #include "unicode.h"
 #include "unwind.h"
 #include "view.h"
@@ -333,6 +334,27 @@ static bool _monster_blocks_travel(const monster_info *mons)
            && !fedhas_passthrough(mons);
 }
 
+// Returns true if the feature type "grid" is a closed door which
+// autoexplore/travel will not normally approach in order to go through it.
+static bool _feat_is_blocking_door(const dungeon_feature_type grid)
+{
+    if (Options.travel_open_doors == travel_open_doors_type::_avoid)
+        return feat_is_closed_door(grid);
+    else
+        return feat_is_runed(grid);
+}
+
+// Returns true if the feature type "grid" is a closed door which autotravel
+// will not pass through.
+// This should only be used for the choice to open the door itself.
+static bool _feat_is_blocking_door_strict(const dungeon_feature_type grid)
+{
+    if (Options.travel_open_doors == travel_open_doors_type::_open)
+        return feat_is_runed(grid);
+    else
+        return feat_is_closed_door(grid);
+}
+
 /*
  * Returns true if the square at (x,y) is a dungeon feature the character
  * can't (under normal circumstances) safely cross.
@@ -357,7 +379,7 @@ static bool _is_reseedable(const coord_def& c, bool ignore_danger = false)
 
     return feat_is_water(grid)
            || grid == DNGN_LAVA
-           || feat_is_runed(grid)
+           || _feat_is_blocking_door(grid)
            || is_trap(c)
            || !ignore_danger && _monster_blocks_travel(cell.monsterinfo())
            || g_Slime_Wall_Check && slime_wall_neighbour(c)
@@ -440,7 +462,7 @@ static bool _is_travelsafe_square(const coord_def& c, bool ignore_hostile,
     // Only try pathing through temporary obstructions we remember, not
     // those we can actually see (since the latter are clearly still blockers)
     try_fallback = try_fallback
-                    && (!you.see_cell(c) || feat_is_runed(grid));
+                    && (!you.see_cell(c) || _feat_is_blocking_door(grid));
 
     // Also make note of what's displayed on the level map for
     // plant/fungus checks.
@@ -483,7 +505,7 @@ static bool _is_travelsafe_square(const coord_def& c, bool ignore_hostile,
             return true;
     }
 
-    if (feat_is_runed(levelmap_cell.feat()) && !try_fallback)
+    if (!try_fallback && _feat_is_blocking_door(levelmap_cell.feat()))
         return false;
 
     return feat_is_traversable_now(grid, try_fallback);
@@ -711,6 +733,7 @@ static void _set_target_square(const coord_def &target)
 static void _explore_find_target_square()
 {
     bool runed_door_pause = false;
+    bool closed_door_pause = false;
 
     travel_pathfind tp;
     tp.set_floodseed(you.pos(), true);
@@ -725,10 +748,20 @@ static void _explore_find_target_square()
         fallback_tp.set_floodseed(you.pos(), true);
         whereto = fallback_tp.pathfind(static_cast<run_mode_type>(you.running.runmode), true);
 
-        if (whereto.distance_from(you.pos()) == 1 && cell_is_runed(whereto))
+        if (whereto.distance_from(you.pos()) == 1)
         {
-            runed_door_pause = true;
-            whereto.reset();
+            if (cell_is_runed(whereto))
+            {
+                runed_door_pause = true;
+                whereto.reset();
+            }
+            // use orig_terrain() as that's what cell_is_runed() does.
+            else if (Options.travel_open_doors == travel_open_doors_type::_avoid
+                     && feat_is_closed_door(orig_terrain(whereto)))
+            {
+                closed_door_pause = true;
+                whereto.reset();
+            }
         }
     }
 
@@ -773,11 +806,17 @@ static void _explore_find_target_square()
             if (unknown_trans)
                 reasons.push_back("unvisited transporter");
 
+            if (closed_door_pause)
+                reasons.push_back("unopened door");
+
             if (estatus & EST_GREED_UNFULFILLED)
                 inacc.push_back("items");
             // A runed door already implies an unexplored place.
-            if (!runed_door_pause && estatus & EST_PARTLY_EXPLORED)
+            if (!runed_door_pause && !closed_door_pause &&
+                estatus & EST_PARTLY_EXPLORED)
+            {
                 inacc.push_back("places");
+            }
 
             if (!inacc.empty())
             {
@@ -1716,6 +1755,7 @@ bool travel_pathfind::path_examine_point(const coord_def &c)
     return found_target;
 }
 
+
 /**
  * Run the travel_pathfind algorithm, either from the given position in
  * floodout mode to populate travel_point_distance relative to that starting
@@ -1725,8 +1765,9 @@ bool travel_pathfind::path_examine_point(const coord_def &c)
  *
  * If move_x and move_y are given, pathfinding runs from you.running.pos to
  * youpos, and the move contains the next movement relative to youpos to move
- * closer to you.running.pos. If a runed door is encountered or a transporter
- * needs to be taken, these are set to 0, and the caller checks for this.
+ * closer to you.running.pos. If a runed door (or a closed door, if
+ * travel_open_doors isn't _open) is encountered or a transporter needs to be
+ * taken, these are set to 0, and the caller checks for this.
  *
  * XXX The two modes of this function (with and without move_x/move_y) should
  * be split into two different functions, since they aren't really related.
@@ -1761,7 +1802,7 @@ void find_travel_pos(const coord_def& youpos,
     // stopping, or a transporter, in which case we need to issue a command to
     // enter.
     if (need_move
-        && (cell_is_runed(new_dest)
+        && (_feat_is_blocking_door_strict(env.grid(new_dest))
             || env.grid(youpos) == DNGN_TRANSPORTER
                && env.grid(new_dest) == DNGN_TRANSPORTER_LANDING
                && youpos.distance_from(new_dest) > 1))


### PR DESCRIPTION
Add an option for explore & travel to treat closed doors more like walls than floor.

Previously, travel_open_doors had two values.
If true, the travel command would open a door if it was quicker than going around. The explore command would open the door if this was the quickest way to get to something interesting.

I have retained these, and added a third in which it treats it in the same way it treats a runed door.

There are two changes to the way explore behaves regardless of travel_open_doors. If autopickup is on, and there is a known object behind a runed door, it used to give a "Partly explored" message. It now moves to the door and stops there (it already did this if the area behind the runed door was partly explored). And, if you try to explore or autotravel, but don't move for any amount of time, it gives a message to tell you.

I've added the code to set "set option" code to game_options::read_option_line in the section "easy_confirm" is in. As it's exposed to lua, I've also added code in l-option.cc. 

An alternative would be to make a GameOption-style class for it. There are already a few options which accept one of a fixed list of values, so this feels more like a separate enhancement to me.