### PR TITLE
Colourize beam damage descriptions in WebTiles

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -740,7 +740,10 @@ static void _write_book(const spellbook_contents &book,
         const char spell_letter = entry != spell_map.end() ? entry->second : ' ';
         tiles.json_write_string("letter", string(1, spell_letter));
 
-        tiles.json_write_string("effect", _effect_string(spell, mon_owner));
+        string effect_str = _effect_string(spell, mon_owner);
+        if (!testbits(get_spell_flags(spell), spflag::MR_check))
+            effect_str = _colourize(effect_str, _spell_colour(spell));
+        tiles.json_write_string("effect", effect_str);
 
         string range_str = _range_string(spell, mon_owner, hd);
         if (range_str.size() > 0)

--- a/crawl-ref/source/webserver/game_data/static/ui-layouts.js
+++ b/crawl-ref/source/webserver/game_data/static/ui-layouts.js
@@ -50,9 +50,9 @@ function ($, comm, client, ui, enums, cr, util, scroller, main, gui, player) {
                 $item.append("<span>" + label + "</span>");
 
                 if (spell.effect !== undefined)
-                    $item.append("<span>"+spell.effect+" </span>");
+                    $item.append("<span>" + util.formatted_string_to_html(spell.effect) + " </span>");
                 if (spell.range_string !== undefined)
-                    $item.append("<span>" + util.formatted_string_to_html(spell.range_string) +" </span>");
+                    $item.append("<span>" + util.formatted_string_to_html(spell.range_string) + " </span>");
 
                 $list.append($item);
                 if (colour)


### PR DESCRIPTION
As a followup to 930a2b7a, this commit colourizes beam damage
descriptions on the xv screen:

![spells](https://user-images.githubusercontent.com/3328424/99120527-f0f78a00-25f2-11eb-8e15-df3cfc7087c3.png)