### PR TITLE
+1 spellcasting apt to all species

### DIFF
--- a/crawl-ref/source/dat/species/barachi.yaml
+++ b/crawl-ref/source/dat/species/barachi.yaml
@@ -22,6 +22,7 @@ aptitudes:
   dodging: 1
   shields: 1
   unarmed_combat: 1
+  spellcasting: 1
   conjurations: 1
   hexes: 1
   summoning: 2

--- a/crawl-ref/source/dat/species/deep-dwarf.yaml
+++ b/crawl-ref/source/dat/species/deep-dwarf.yaml
@@ -25,7 +25,7 @@ aptitudes:
   stealth: 3
   shields: 1
   unarmed_combat: -1
-  spellcasting: -2
+  spellcasting: -1
   conjurations: -1
   hexes: -2
   summoning: -1

--- a/crawl-ref/source/dat/species/deep-elf.yaml
+++ b/crawl-ref/source/dat/species/deep-elf.yaml
@@ -26,7 +26,7 @@ aptitudes:
   stealth: 3
   shields: -2
   unarmed_combat: -2
-  spellcasting: 3
+  spellcasting: 4
   conjurations: 1
   hexes: 3
   summoning: 1

--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -25,7 +25,7 @@ aptitudes:
   dodging: -1
   shields: -1
   unarmed_combat: -1
-  spellcasting: -2
+  spellcasting: -1
   conjurations: -1
   hexes: -1
   summoning: -1

--- a/crawl-ref/source/dat/species/demonspawn.yaml
+++ b/crawl-ref/source/dat/species/demonspawn.yaml
@@ -24,7 +24,6 @@ aptitudes:
   dodging: -1
   shields: -1
   unarmed_combat: -1
-  spellcasting: -1
   necromancy: 1
   translocations: -1
   transmutations: -1

--- a/crawl-ref/source/dat/species/deprecated-centaur.yaml
+++ b/crawl-ref/source/dat/species/deprecated-centaur.yaml
@@ -24,7 +24,7 @@ aptitudes:
   dodging: -3
   stealth: -4
   shields: -3
-  spellcasting: -3
+  spellcasting: -2
   conjurations: -1
   hexes: -1
   summoning: -1

--- a/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
+++ b/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
@@ -20,7 +20,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Mottled Draconian specific

--- a/crawl-ref/source/dat/species/draconian-base.yaml
+++ b/crawl-ref/source/dat/species/draconian-base.yaml
@@ -17,7 +17,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
 str: 10

--- a/crawl-ref/source/dat/species/draconian-black.yaml
+++ b/crawl-ref/source/dat/species/draconian-black.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Black Draconian specific

--- a/crawl-ref/source/dat/species/draconian-green.yaml
+++ b/crawl-ref/source/dat/species/draconian-green.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Green Draconian specific

--- a/crawl-ref/source/dat/species/draconian-grey.yaml
+++ b/crawl-ref/source/dat/species/draconian-grey.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Grey Draconian specific

--- a/crawl-ref/source/dat/species/draconian-pale.yaml
+++ b/crawl-ref/source/dat/species/draconian-pale.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Pale Draconian specific

--- a/crawl-ref/source/dat/species/draconian-purple.yaml
+++ b/crawl-ref/source/dat/species/draconian-purple.yaml
@@ -21,7 +21,7 @@ aptitudes:
   dodging: -1
   invocations: 1
   # Purple Draconian specific
-  spellcasting: 1
+  spellcasting: 2
   hexes: 1
   evocations: 1
 str: 10

--- a/crawl-ref/source/dat/species/draconian-red.yaml
+++ b/crawl-ref/source/dat/species/draconian-red.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # Red Draconian specific

--- a/crawl-ref/source/dat/species/draconian-white.yaml
+++ b/crawl-ref/source/dat/species/draconian-white.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # White Draconian specific

--- a/crawl-ref/source/dat/species/draconian-yellow.yaml
+++ b/crawl-ref/source/dat/species/draconian-yellow.yaml
@@ -19,7 +19,6 @@ aptitudes:
   throwing: -1
   armour: False
   dodging: -1
-  spellcasting: -1
   hexes: -1
   invocations: 1
   # no Yellow Draconian specific apts

--- a/crawl-ref/source/dat/species/felid.yaml
+++ b/crawl-ref/source/dat/species/felid.yaml
@@ -24,7 +24,6 @@ aptitudes:
   dodging: 3
   stealth: 4
   shields: False
-  spellcasting: -1
   conjurations: -1
   hexes: 4
   translocations: 4

--- a/crawl-ref/source/dat/species/formicid.yaml
+++ b/crawl-ref/source/dat/species/formicid.yaml
@@ -16,6 +16,7 @@ aptitudes:
   dodging: -1
   stealth: 3
   shields: 2
+  spellcasting: 1
   conjurations: -1
   hexes: 2
   translocations: -1

--- a/crawl-ref/source/dat/species/gargoyle.yaml
+++ b/crawl-ref/source/dat/species/gargoyle.yaml
@@ -22,7 +22,6 @@ aptitudes:
   dodging: -2
   stealth: 2
   shields: 1
-  spellcasting: -1
   conjurations: 1
   hexes: -1
   summoning: -1

--- a/crawl-ref/source/dat/species/ghoul.yaml
+++ b/crawl-ref/source/dat/species/ghoul.yaml
@@ -27,7 +27,7 @@ aptitudes:
   stealth: 2
   shields: -1
   unarmed_combat: 1
-  spellcasting: -2
+  spellcasting: -1
   conjurations: -2
   hexes: -2
   summoning: -1

--- a/crawl-ref/source/dat/species/gnoll.yaml
+++ b/crawl-ref/source/dat/species/gnoll.yaml
@@ -24,7 +24,7 @@ aptitudes:
   stealth: 8
   shields: 8
   unarmed_combat: 8
-  spellcasting: 8
+  spellcasting: 9
   conjurations: 6
   hexes: 6
   summoning: 6

--- a/crawl-ref/source/dat/species/halfling.yaml
+++ b/crawl-ref/source/dat/species/halfling.yaml
@@ -21,7 +21,7 @@ aptitudes:
   stealth: 2
   shields: 1
   unarmed_combat: -2
-  spellcasting: -3
+  spellcasting: -2
   conjurations: -2
   hexes: -2
   summoning: -2

--- a/crawl-ref/source/dat/species/hill-orc.yaml
+++ b/crawl-ref/source/dat/species/hill-orc.yaml
@@ -26,7 +26,7 @@ aptitudes:
   stealth: -1
   shields: 1
   unarmed_combat: 1
-  spellcasting: -3
+  spellcasting: -2
   translocations: -2
   transmutations: -3
   fire_magic: 1

--- a/crawl-ref/source/dat/species/human.yaml
+++ b/crawl-ref/source/dat/species/human.yaml
@@ -9,7 +9,6 @@ aptitudes:
   mp_mod: 0
   mr: 3
   stealth: 1
-  spellcasting: -1
   invocations: 1
 str: 8
 int: 8

--- a/crawl-ref/source/dat/species/kobold.yaml
+++ b/crawl-ref/source/dat/species/kobold.yaml
@@ -21,6 +21,7 @@ aptitudes:
   dodging: 2
   stealth: 4
   shields: -2
+  spellcasting: 1
   invocations: 1
   evocations: 2
 

--- a/crawl-ref/source/dat/species/merfolk.yaml
+++ b/crawl-ref/source/dat/species/merfolk.yaml
@@ -24,7 +24,6 @@ aptitudes:
   dodging: 3
   stealth: 2
   unarmed_combat: 1
-  spellcasting: -1
   conjurations: -2
   necromancy: -2
   translocations: -2

--- a/crawl-ref/source/dat/species/minotaur.yaml
+++ b/crawl-ref/source/dat/species/minotaur.yaml
@@ -24,7 +24,7 @@ aptitudes:
   stealth: -1
   shields: 2
   unarmed_combat: 1
-  spellcasting: -4
+  spellcasting: -3
   conjurations: -3
   hexes: -4
   summoning: -3

--- a/crawl-ref/source/dat/species/mummy.yaml
+++ b/crawl-ref/source/dat/species/mummy.yaml
@@ -23,7 +23,7 @@ aptitudes:
   stealth: -1
   shields: -2
   unarmed_combat: -2
-  spellcasting: 2
+  spellcasting: 3
   conjurations: -2
   hexes: -1
   summoning: -2

--- a/crawl-ref/source/dat/species/naga.yaml
+++ b/crawl-ref/source/dat/species/naga.yaml
@@ -18,7 +18,6 @@ aptitudes:
   dodging: -2
   stealth: 5
   shields: -2
-  spellcasting: -1
   poison_magic: 3
   invocations: 1
 size: large

--- a/crawl-ref/source/dat/species/octopode.yaml
+++ b/crawl-ref/source/dat/species/octopode.yaml
@@ -13,7 +13,6 @@ aptitudes:
   mr: 3
   armour: False
   stealth: 4
-  spellcasting: -1
   poison_magic: 2
   invocations: 1
   evocations: 1

--- a/crawl-ref/source/dat/species/ogre.yaml
+++ b/crawl-ref/source/dat/species/ogre.yaml
@@ -21,7 +21,7 @@ aptitudes:
   stealth: -2
   shields: -1
   unarmed_combat: -1
-  spellcasting: 1
+  spellcasting: 2
   conjurations: -1
   hexes: -1
   summoning: -1

--- a/crawl-ref/source/dat/species/palentonga.yaml
+++ b/crawl-ref/source/dat/species/palentonga.yaml
@@ -24,7 +24,6 @@ aptitudes:
   dodging: -2
   stealth: -3
   shields: -2
-  spellcasting: -1
   conjurations: -1
   hexes: 0
   summoning: -2

--- a/crawl-ref/source/dat/species/spriggan.yaml
+++ b/crawl-ref/source/dat/species/spriggan.yaml
@@ -22,7 +22,7 @@ aptitudes:
   stealth: 5
   shields: -3
   unarmed_combat: -2
-  spellcasting: 2
+  spellcasting: 3
   conjurations: -3
   hexes: 2
   summoning: -2

--- a/crawl-ref/source/dat/species/tengu.yaml
+++ b/crawl-ref/source/dat/species/tengu.yaml
@@ -22,7 +22,6 @@ aptitudes:
   dodging: 1
   stealth: 1
   unarmed_combat: 1
-  spellcasting: -1
   conjurations: 3
   hexes: -3
   summoning: 2

--- a/crawl-ref/source/dat/species/troll.yaml
+++ b/crawl-ref/source/dat/species/troll.yaml
@@ -24,7 +24,7 @@ aptitudes:
   dodging: -2
   stealth: -5
   shields: -2
-  spellcasting: -5
+  spellcasting: -4
   conjurations: -3
   hexes: -4
   summoning: -3

--- a/crawl-ref/source/dat/species/vampire.yaml
+++ b/crawl-ref/source/dat/species/vampire.yaml
@@ -25,7 +25,6 @@ aptitudes:
   stealth: 5
   shields: -1
   unarmed_combat: 1
-  spellcasting: -1
   conjurations: -3
   hexes: 4
   necromancy: 1

--- a/crawl-ref/source/dat/species/vine-stalker.yaml
+++ b/crawl-ref/source/dat/species/vine-stalker.yaml
@@ -24,6 +24,7 @@ aptitudes:
   dodging: -2
   stealth: 3
   shields: -1
+  spellcasting: 1
   evocations: -1
 str: 10
 int: 8


### PR DESCRIPTION
Spellcasting has received some indirect nerfs. It no longer serves
to reduce hunger costs, and the "1 level spellcasting = 0.25
levels of every spell school at once" has been devalued by the
removal of the charms school. There are also fewer total spell
levels in the game since the charms removal and positional magic
overhaul, which reduces the value of spell slots. This also makes
0 the standard "human-level" aptitude for spellcasting, bringing
it in line with almost all other skills.