### PR TITLE
A small description fix and a story about known shafts

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -109,8 +109,8 @@ action will cancel the Dig status.
 %%%%
 Shaft Self ability
 
-Sends you to a random position one to two floors down, as if you jumped into a
-shaft trap. It takes some time to dig the shaft.
+Sends you to a random position one to three floors down, as if you jumped into
+a shaft trap. It takes some time to dig the shaft.
 %%%%
 Rolling Charge ability
 


### PR DESCRIPTION
This PR fixes Shaft Self description, because the ability has an equal chance of taking the player 1, 2, or 3 levels down.

Although all shafts work the same way now, the following still might be interesting.

### The Unknown History of Known Shafts

Shafts became a single-use dungeon feature in [0.6](https://github.com/crawl/crawl/commit/60739d90). The same commit changed how shafts work: known shafts were supposed to send the player fewer floors down than unknown ones.

Unknown shafts had an equal chance to drop the player 1, 2, or 3 levels down. Known shafts, including Formicid-made ones, worked differently:

| Version / chance  |  1 level |  2 levels |  3 levels |
| :---              |     ---: |      ---: |      ---: |
| 0.6 - 0.18        |      5/8 |       2/8 |       1/8 |
| 0.18 - 0.23       |      2/3 |       1/3 |         - |

This lasted for several versions until the [0.23's trap reform](https://github.com/crawl/crawl/commit/ed226419) replaced unknown shafts with exploration trap effects. Additionally, all shafts got an equal chance to send the player 1, 2, or 3 levels down.

But that initial 0.6 commit had a small bug that survived through all these years until its removal in [0.25](https://github.com/crawl/crawl/commit/2bcd1f60#diff-00dc2f38a2f07817350e9ed6fd20928b4d581a83ad2558cd6836d00f202e98e6L1413).

A shaft's destination was calculated in [`traps.cc:generic_shaft_dest(level_pos lpos, bool known = false)`](https://github.com/crawl/crawl/blob/stone_soup-0.6/crawl-ref/source/traps.cc#L1396). Other code didn't use this function directly and called it only via a [wrapper function](https://github.com/crawl/crawl/blob/stone_soup-0.6/crawl-ref/source/traps.cc#L1449) [(note-1)](#notes):

```cpp
level_id generic_shaft_dest(coord_def pos, bool known = false)
{
    return generic_shaft_dest(level_pos(level_id::current(), pos));
}
```

Because the wrapper didn't pass `known` into the actual function, the default value for `known`, false, was used all the time.

So, all 0.6 - 0.23 shafts, including Formicid-made ones, were considered unknown and always had an equal chance to take the player 1, 2, or 3 levels deeper.

---

##### Notes:

1.  The function and its wrapper had the same name, and the only difference between them was the type of the first parameter. The function was [renamed](https://github.com/crawl/crawl/commit/20e7edd9) to `_generic_shaft_dest` later, which made it easier to notice that it was only called via a wrapper: [grepping 0.11 source code for generic_shaft_dest](http://s-z.org/neil/git/?p=crawl.git&a=search&h=20e7edd9&st=grep&s=generic_shaft_dest).
