### PR TITLE
Fix autofight not prioritizing petrified enemies

### DIFF
--- a/crawl-ref/source/dat/clua/autofight.lua
+++ b/crawl-ref/source/dat/clua/autofight.lua
@@ -248,7 +248,7 @@ local function get_monster_info(dx,dy,no_move)
   info.can_attack = (info.attack_type > 0) and 1 or info.attack_type
   info.safe = m:is_safe() and -1 or 0
   info.constricting_you = m:is_constricting_you() and 1 or 0
-  -- Only prioritize good stabs: sleep and paralysis.
+  -- Only prioritize top-tier stabs: sleep, petrification, and paralysis.
   info.very_stabbable = (m:stabbability() >= 1) and 1 or 0
   info.injury = m:damage_level()
   info.threat = m:threat()

--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -474,10 +474,9 @@ static bool cant_see_you(const monster_info *mi)
  * The return value is a number representing the percentage of a top-tier stab
  * you can currently get by attacking the monster. Possible values are:
  *
- * - 1.0 Sleep and paralysis stabs.
- * - 0.5 Net, web, and petrification stabs.
- * - 0.25 Confusion, fear, and invisibility stabs.
- * - 0.166666666 Distraction stabs.
+ * - 1.0 Sleep, petrified, and paralysis stabs.
+ * - 0.25 Net, web, petrifying, confusion, fear, invisibility, and distraction
+ *   stabs
  * - 0.0 No stab bonus.
  *
  * @treturn number
@@ -486,17 +485,17 @@ static bool cant_see_you(const monster_info *mi)
 LUAFN(moninf_get_stabbability)
 {
     MONINF(ls, 1, mi);
-    if (mi->is(MB_DORMANT) || mi->is(MB_SLEEPING) || mi->is(MB_PARALYSED))
-        lua_pushnumber(ls, 1.0);
-    else if (mi->is(MB_CAUGHT) || mi->is(MB_WEBBED) || mi->is(MB_PETRIFYING)
-             || mi->is(MB_PETRIFIED))
+    if (mi->is(MB_DORMANT) || mi->is(MB_SLEEPING) || mi->is(MB_PETRIFIED)
+            || mi->is(MB_PARALYSED))
     {
-        lua_pushnumber(ls, 0.5);
+        lua_pushnumber(ls, 1.0);
     }
-    else if (mi->is(MB_CONFUSED) || mi->is(MB_FLEEING) || cant_see_you(mi))
+    else if (mi->is(MB_CAUGHT) || mi->is(MB_WEBBED) || mi->is(MB_PETRIFYING)
+             || mi->is(MB_CONFUSED) || mi->is(MB_FLEEING) || cant_see_you(mi)
+             || mi->is(MB_DISTRACTED))
+    {
         lua_pushnumber(ls, 0.25);
-    else if (mi->is(MB_DISTRACTED))
-        lua_pushnumber(ls, 0.16666666);
+    }
     else
         lua_pushnumber(ls, 0);
 


### PR DESCRIPTION
After 9c76b8a6, there are only two stabbing tiers. Also, the player
gets a top-tier stab bonus when attacking petrified enemies.

This commit updates autofight rules so petrified enemies get the same
priority as sleeping or paralysed ones.