### PR TITLE
Don't show a bigger targeter for Hailstorm when worshipping Vehumet

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1270,7 +1270,7 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     // untargeted spells -- everything beyond here is a static targeter
     // TODO ignite poison
     case SPELL_HAILSTORM:
-        return make_unique<targeter_radius>(&you, LOS_NO_TRANS, range, 0, 2);
+        return make_unique<targeter_radius>(&you, LOS_NO_TRANS, 3, 0, 2);
     case SPELL_ISKENDERUNS_MYSTIC_BLAST:
         return make_unique<targeter_radius>(&you, LOS_SOLID_SEE, range);
     case SPELL_STARBURST:


### PR DESCRIPTION
`spell_range()` can return 4 instead of 3 for Hailstorm, because
Vehumet supports the use of this spell. But Hailstorm's range never
changes, since it's hardcoded as 3 in `cast_hailstorm()`.