### PR TITLE
Improve sound option description

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -454,9 +454,9 @@ sound ^= <regex>:<path to sound file>, <regex>:<path>, ...
         (Requires "Sound support"; check your version info)
         (Ordered list option)
         Plays the sound file if a message contains regex. In case of 
-	multiple matching regexes, only the sound of the last regex 
-	is played. The regex should not include commas or colons. 
-		For example
+        multiple matching regexes, only the sound of the last regex 
+        is played. The regex should not include commas or colons. 
+        For example
              sound += LOW HITPOINT WARNING:sound\sounds2\danger3.wav
         There are certain pre-defined regexes, as well, which can be
         used to get a sound to trigger for something that cannot

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -453,8 +453,10 @@ macro_dir = settings/
 sound ^= <regex>:<path to sound file>, <regex>:<path>, ...
         (Requires "Sound support"; check your version info)
         (Ordered list option)
-        Plays the sound file if a message contains regex. The regex
-        should not include commas or colons. For example
+        Plays the sound file if a message contains regex. In case of 
+	multiple matching regexes, only the sound of the last regex 
+	is played. The regex should not include commas or colons. 
+		For example
              sound += LOW HITPOINT WARNING:sound\sounds2\danger3.wav
         There are certain pre-defined regexes, as well, which can be
         used to get a sound to trigger for something that cannot

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -450,7 +450,7 @@ macro_dir = settings/
         For tile games, wininit.txt will also be stored here.
         It should end with the path delimiter.
 
-sound ^= <regex>:<path to sound file>, <regex>:<path>, ...
+sound ^= <regex>:<path to sound file>, <regex>:<path>,
         (Requires "Sound support"; check your version info)
         (Ordered list option)
         Plays the sound file if a message contains regex. In case of 


### PR DESCRIPTION
Added details for playing sounds via regular expressions

For sounds, added a sentence that only the last matching
 regular expression is considered.

This is related to #1408, as there it seems unknown how to distinguish messages with different amount of exclamation marks.

The extended description of the sound option alleviates this. 