### PR TITLE
Zot clock tweaks and a bugfix

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1588,10 +1588,24 @@ static void _experience_check()
     handle_real_time();
     msg::stream << "Play time: " << make_time_string(you.real_time())
                 << " (" << you.num_turns << " turns)."
-                << endl
-                << "Zot will find you in " << turns_until_zot() << " turns"
-                << " if you stay in this branch and explore no new floors."
                 << endl;
+
+    if (!crawl_state.game_is_sprint())
+    {
+        string zot_clock_info;
+        if (player_has_orb())
+            zot_clock_info = "You are forever immune to Zot's power.";
+        else if (player_in_branch(BRANCH_ABYSS))
+            zot_clock_info =  "You have unlimited time to explore this branch.";
+        else
+        {
+            zot_clock_info = "Zot will find you in " + to_string(turns_until_zot())
+                           + " turns if you stay in this branch and explore no"
+                           + " new floors.";
+        }
+        msg::stream << zot_clock_info << endl;
+    }
+
 #ifdef DEBUG_DIAGNOSTICS
     mprf(MSGCH_DIAGNOSTICS, "Turns spent on this level: %d",
          env.turns_on_level);

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -1380,6 +1380,9 @@ void decr_zot_clock()
 
 void incr_zot_clock()
 {
+    if (!zot_clock_active())
+        return;
+
     const int old_lvl = bezotting_level();
     _zot_clock() += you.time_taken;
     if (!bezotted())

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -1258,12 +1258,6 @@ int speed_to_duration(int speed)
     return div_rand_round(100, speed);
 }
 
-// How many auts does the clock roll back every time the player
-// enters a new floor?
-static const int ZOT_CLOCK_PER_FLOOR = 6000 * BASELINE_DELAY;
-// After how many auts without visiting new floors does the player die instantly?
-static const int MAX_ZOT_CLOCK = 27000 * BASELINE_DELAY;
-
 #if TAG_MAJOR_VERSION == 34
 static int _old_zot_clock(const string& branch_name) {
     // The old clock was measured in turns (deca-auts), not aut.
@@ -1416,4 +1410,13 @@ void incr_zot_clock()
     }
 
     take_note(Note(NOTE_MESSAGE, 0, 0, "Glimpsed the power of Zot."));
+}
+
+void set_turns_until_zot(int turns_left)
+{
+    if (turns_left < 0 || turns_left > MAX_ZOT_CLOCK / BASELINE_DELAY)
+        return;
+
+    int &clock = _zot_clock();
+    clock = MAX_ZOT_CLOCK - turns_left * BASELINE_DELAY;
 }

--- a/crawl-ref/source/timed-effects.h
+++ b/crawl-ref/source/timed-effects.h
@@ -22,6 +22,12 @@ void setup_environment_effects();
 void run_environment_effects();
 int speed_to_duration(int speed);
 
+// How many auts does the clock roll back every time the player
+// enters a new floor?
+static const int ZOT_CLOCK_PER_FLOOR = 6000 * BASELINE_DELAY;
+// After how many auts without visiting new floors does the player die instantly?
+static const int MAX_ZOT_CLOCK = 27000 * BASELINE_DELAY;
+
 bool bezotted();
 bool bezotted_in(branch_type br);
 bool zot_clock_active();
@@ -29,3 +35,4 @@ int bezotting_level();
 int turns_until_zot();
 void decr_zot_clock();
 void incr_zot_clock();
+void set_turns_until_zot(int turns_left);

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -34,7 +34,7 @@
 #include "status.h"
 #include "stringutil.h"
 #include "tag-version.h"
-#include "timed-effects.h" // decr_zot_clock
+#include "timed-effects.h" // zot clock
 #include "transform.h"
 #include "unicode.h"
 #include "view.h"
@@ -987,5 +987,22 @@ void wizard_xom_acts()
 
     dprf("Okay, Xom is doing '%s'.", xom_effect_to_name(event).c_str());
     xom_take_action(event, severity);
+}
+
+void wizard_set_zot_clock()
+{
+    const int max_zot_clock = MAX_ZOT_CLOCK / BASELINE_DELAY;
+
+    string prompt = make_stringf("Enter new Zot clock value "
+                                 "(current = %d, from 0 to %d): ",
+                                 turns_until_zot(), max_zot_clock);
+    int turns_left = prompt_for_int(prompt.c_str(), true);
+
+    if (turns_left == -1)
+        canned_msg(MSG_OK);
+    else if (turns_left > max_zot_clock)
+        mprf("Zot clock should be between 0 and %d", max_zot_clock);
+    else
+        set_turns_until_zot(turns_left);
 }
 #endif

--- a/crawl-ref/source/wiz-you.h
+++ b/crawl-ref/source/wiz-you.h
@@ -41,4 +41,5 @@ job_type find_job_from_string(const string &job_str);
 void wizard_change_job_to(job_type job);
 void wizard_xom_acts();
 void wizard_suppress();
+void wizard_set_zot_clock();
 #endif

--- a/crawl-ref/source/wizard.cc
+++ b/crawl-ref/source/wizard.cc
@@ -121,7 +121,7 @@ static void _do_wizard_command(int wiz_command)
     case 'm': wizard_create_spec_monster_name(); break;
     // case CONTROL('M'): break; // XXX do not use, menu command
 
-    // case 'n': break;
+    case 'n': wizard_set_zot_clock(); break;
     // case 'N': break;
     // case CONTROL('N'): break;
 
@@ -422,6 +422,7 @@ int list_wizard_commands(bool do_redraw_screen)
                        "<w>#</w>      load character from a dump file\n"
                        "<w>&</w>      list all divine followers\n"
                        "<w>=</w>      show info about skill points\n"
+                       "<w>n</w>      set Zot clock to a value\n"
                        "\n"
                        "<yellow>Create level features</yellow>\n"
                        "<w>L</w>      place a vault by name\n"
@@ -429,7 +430,7 @@ int list_wizard_commands(bool do_redraw_screen)
                        "<w>,</w>/<w>.</w>    create up/down staircase\n"
                        "<w>(</w>      turn cell into feature\n"
                        "<w>\\</w>      make a shop\n"
-                       "<w>K</w> mark all vaults as unused\n"
+                       "<w>K</w>      mark all vaults as unused\n"
                        "\n"
                        "<yellow>Other level related commands</yellow>\n"
                        "<w>Ctrl-A</w> generate new Abyss area\n"


### PR DESCRIPTION
This PR fixes the Zot clock so it actually stops when it shouldn't be active, i.e. when in the Abyss, during the orb run, and in Sprint mode.

Also, it adds a wizard command to set the number of remaining turns until Zot.
