### PR TITLE
Add a flashy Wu Jian overflow altar vault

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -108,6 +108,16 @@ function callback.xom_greatest_gift(data, triggerable, triggerer, marker, ev)
   end
 end
 
+function callback.five_deadly_venoms(data, triggerable, triggerer, marker, ev)
+  crawl.god_speaks("Wu Jian", "For a moment, you catch a glimpse of warriors who walked this path long ago.")
+  local positions = dgn.find_marker_positions_by_prop(
+    "positions", "five_deadly_venoms")
+  for i, pos in ipairs(positions) do
+    local x, y = pos:xy()
+    dgn.create_monster(x, y, "generate_awake dur:1 " .. data.venoms[i])
+  end
+end
+
 function species_mock(e)
   if you.race() == "Barachi" then
     return "cane toad"
@@ -2352,6 +2362,44 @@ x``t.'`'`"WWx
 x'`'`.``'`"Wx
 xxxxxx.xxxxxx
      x@x
+ENDMAP
+
+NAME:  pdpol_wu_jian_five_deadly_venoms
+DEPTH: D:2-, Lair
+TAGS:  no_item_gen no_monster_gen temple_overflow_1 temple_overflow_wu_jian
+KFEAT:  _ = altar_wu_jian
+MARKER: F = lua:fog_machine { \
+            cloud_type="thin mist", size = 1, \
+            pow_max = 3, pow_min = 3, delay = 10, \
+            start_clouds = 0 }
+{{
+  local trig_marker = TriggerableFunction:new {
+    func="callback.five_deadly_venoms",
+    repeated=false,
+    data={
+      venoms={
+        "spectral demonic crawler name:centipede name_species name_replace name_descriptor",
+        "spectral black mamba",
+        "spectral scorpion",
+        "spectral leopard gecko",
+        "spectral cane toad"
+      }
+    }
+  }
+  trig_marker:add_triggerer(DgnTriggerer:new { type = "player_move" })
+  lua_marker("_", trig_marker)
+  lua_marker("F", portal_desc { positions = "five_deadly_venoms" })
+}}
+MAP
+   ccc
+   cFc
+  ccncc
+ccc...ccc
+cFn._.nFc
+cccn.nccc
+ cFc.cFc
+ ccc.ccc
+   c@c
 ENDMAP
 
 ### Xom overflow altars #######################################################

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -2365,7 +2365,7 @@ xxxxxx.xxxxxx
 ENDMAP
 
 NAME:  pdpol_wu_jian_five_deadly_venoms
-DEPTH: D:2-, Lair
+DEPTH: D:2-9
 TAGS:  no_item_gen no_monster_gen temple_overflow_1 temple_overflow_wu_jian
 KFEAT:  _ = altar_wu_jian
 MARKER: F = lua:fog_machine { \


### PR DESCRIPTION
This vault is a nod to a classic 70's Kung Fu flick called Five Deadly Venoms.
The titular characters of the movie have nicknames and martial arts
styles that are reasonably well-represented by existing monsters and
tiles in DCSS and thought Wu Jian deserves a fancy Lua'd up altar like
some other deities!

[Movie clip for reference](https://www.youtube.com/watch?v=znPXlUgcMWA)

I figured I'd put this out there to see if you guys like it, I thought it was a fun idea but did wonder if the demonic crawler name replace and abjuration timer were maybe a little hackier than permissible.