### PR TITLE
Mark an ossuary enterance as transparent 2

### DIFF
--- a/crawl-ref/source/dat/des/portals/ossuary.des
+++ b/crawl-ref/source/dat/des/portals/ossuary.des
@@ -161,6 +161,7 @@ MAP
 ENDMAP
 
 NAME: nicolae_ossuary_entry_catacombs
+TAGS:   transparent
 FTILE: O1s+ABC = floor_sandstone
 COLOUR: 1s = yellow
 NSUBST: A = + / c, B = + / c, C = + / c, s = 1:O / 4:1 / *:1.....


### PR DESCRIPTION
Resolves another vault which has the same issue in #1639