### PR TITLE
Clarify annotations in Ctrl+O and in the manual

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -2435,12 +2435,11 @@ Ctrl-O
   Show dungeon overview (branches, shops, etc.).
 
 !
-  Annotate current level. You can enter any text. This annotation is then listed
-  in the dungeon overview (Ctrl-O) and also shown whenever you enter that level
-  again. If you use this command when standing on a staircase, you may also
-  annotate the level that staircase leads to. Should your annotation contain an
-  exclamation mark (!), you will be prompted before entering the level. An empty
-  string clears annotations.
+  Annotate a level. You can annotate any level of a branch of which you have
+  found the entrance. You can enter any text. This annotation is then listed in
+  the dungeon overview (Ctrl-O) and also shown whenever you enter that level
+  again. Should your annotation contain an exclamation mark (!), you will be
+  prompted before entering the level. An empty string clears annotations.
 
 Character information
 --------------------------------------

--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -577,7 +577,7 @@ static string _get_notes(bool display)
         return disp;
 
     if (display)
-        return "\n<green>Annotations:</green> (press <white>!</white> to annotate current level)\n" + disp;
+        return "\n<green>Annotations:</green> (press <white>!</white> to add a new annotation)\n" + disp;
     return "\n<green>Annotations:</green>\n" + disp;
 }
 


### PR DESCRIPTION
After commit 8436896, any level can be annotated. Update instructions
in Ctrl+O and in the manual accordingly.