### PR TITLE
Have Vehumet support Eringya's Noxious Bog

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1397,7 +1397,8 @@ bool vehumet_supports_spell(spell_type spell)
         || spell == SPELL_INNER_FLAME
         || spell == SPELL_IGNITION
         || spell == SPELL_FROZEN_RAMPARTS
-        || spell == SPELL_ABSOLUTE_ZERO)
+        || spell == SPELL_ABSOLUTE_ZERO
+        || spell == SPELL_NOXIOUS_BOG)
     {
         return true;
     }


### PR DESCRIPTION
Though Bog doesn't do its damage by hurling something, given precedent of
both Frozen Ramparts and Toxic Radiance: it does do direct damage,
albeit over time, as its main purpose. Thus, Vehumet should support it.

This commit follows the logic in `c6dd0926df0a3b2a1a04d66e495a1bbcbd61f404` of Noxious Bog being a damage spell, first and foremost.