### PR TITLE
Remove Evocation scaling from Spectral

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1351,10 +1351,8 @@ static string _describe_weapon(const item_def &item, bool verbose)
                     "affected.";
             break;
         case SPWPN_SPECTRAL:
-            description += "It retains the spirit of the tree from which "
-                           "it was made. In the hands of one skilled in "
-                           "evocations this spirit is drawn out to fight "
-                           "along side the wielder.";
+            description += "When it strikes, its spirit leaps out and "
+                           " fights alongside the wielder.";
             break;
         case SPWPN_NORMAL:
             ASSERT(enchanted);

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -605,16 +605,9 @@ static void _equip_weapon_effect(item_def& item, bool showMsgs, bool unmeld)
                 case SPWPN_ACID:
                     mprf("%s begins to ooze corrosive slime!", item_name.c_str());
                     break;
+
                 case SPWPN_SPECTRAL:
-                    if (you.skill(SK_EVOCATIONS) == 0)
-                        mpr("You have a feeling of ineptitude.");
-                    else if (you.skill(SK_EVOCATIONS) <= 6)
-                        mprf("You feel a bond with your %s.", item_name.c_str());
-                    else
-                    {
-                        mprf("You feel a deep bond with your %s!",
-                             item_name.c_str());
-                    }
+                    mprf("You feel a bond with your %s.", item_name.c_str());
                     break;
 
                 default:

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -8179,13 +8179,12 @@ void refresh_weapon_protection()
 }
 
 /**
- * Refreshes a player's spectral weaapon on hit.
+ * Refreshes a player's spectral weapon on hit.
  */
 void handle_spectral_brand()
 {
-    const int pow = you.skill(SK_EVOCATIONS, 4);
-    if (you.skill(SK_EVOCATIONS) > 0 && !find_spectral_weapon(&you))
-        cast_spectral_weapon(&you, pow, you.religion);
+    if (!find_spectral_weapon(&you))
+        cast_spectral_weapon(&you, 50, you.religion);
 }
 
 // Is the player immune to a particular hex because of their


### PR DESCRIPTION
Currently, the spectral brand is the most complex weapon ego in the game.
It has two significant drawbacks:

1. It can significantly increase the damage the wielder takes, since the
spectral weapon shares damage with the player.
2. It requires Evocations training to use.

Both due to the overall complexity and the perceived weakness of this
brand, I'm inclined to simplify by removing one of these effects. Pain
sharing makes the brand a bit harder to evaluate, since most brands have
no downside at all vs an unbranded weapon (chaos being the notable exception).
Evocations scaling has several other problems, though:

- It confuses players on a regular basis. People miss the subtle messages about
  'ineptitude' and fail to understand why the spectral weapon isn't triggering -
  'is it broken?' Some of them ask other players and get the confusion sorted out
  but others, presumably, just continue thinking it's bugged!
- It's the only effect where Evocations training gives benefit to a passive effect,
  rather than an evocable item or ability. This isn't the end of the world, but it
  is an odd exception.
- Evocations skill is currently very useful for most characters even without this
  - most games present a large number of powerful, Evocations-scaling items that
  strongly incentivize Evocations training. It's somewhere between unuseful and
  counterproductive to add one more.

It's possible that the damage sharing effect should also go away or be reduced
in magnitude - the downsides of "need to mess with positioning" and "don't have
another brand" might be enough to balance spectral. We'll see!