### PR TITLE
Ice armour bug fixes

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2688,11 +2688,15 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         break;
 
     case ABIL_LUGONU_ABYSS_EXIT:
+        if (cancel_harmful_move(false))
+            return spret::abort;
         fail_check();
         down_stairs(DNGN_EXIT_ABYSS);
         break;
 
     case ABIL_LUGONU_BEND_SPACE:
+        if (cancel_harmful_move(false))
+            return spret::abort;
         fail_check();
         lugonu_bend_space();
         break;
@@ -2729,6 +2733,8 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
 
     case ABIL_LUGONU_ABYSS_ENTER:
     {
+        if (cancel_harmful_move(false))
+            return spret::abort;
         fail_check();
         // Deflate HP.
         dec_hp(random2avg(you.hp, 2), false);
@@ -2973,7 +2979,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         break;
 
     case ABIL_DITHMENOS_SHADOW_STEP:
-        if (_abort_if_stationary())
+        if (_abort_if_stationary() || cancel_harmful_move(false))
             return spret::abort;
         fail_check();
         if (!dithmenos_shadow_step()) // TODO dist arg
@@ -3076,7 +3082,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
             return spret::abort;
         }
 
-        if (_abort_if_stationary())
+        if (_abort_if_stationary() || cancel_harmful_move())
             return spret::abort;
 
         fail_check();
@@ -3122,7 +3128,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         break;
 
     case ABIL_USKAYAW_LINE_PASS:
-        if (_abort_if_stationary())
+        if (_abort_if_stationary() || cancel_harmful_move())
             return spret::abort;
         fail_check();
         if (!uskayaw_line_pass()) // TODO dist arg
@@ -3130,6 +3136,8 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         break;
 
     case ABIL_USKAYAW_GRAND_FINALE:
+        if (cancel_harmful_move(false))
+            return spret::abort;
         return uskayaw_grand_finale(fail); // TODO dist arg
 
     case ABIL_HEPLIAKLQANA_IDEALISE:

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4744,6 +4744,7 @@ bool ru_power_leap()
     }
 
     move_player_to_grid(beam.target, false);
+    apply_barbs_damage();
 
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();
@@ -5135,6 +5136,7 @@ bool uskayaw_line_pass()
         line_pass.fire();
         you.stop_being_constricted(false);
         move_player_to_grid(beam.target, false);
+        apply_barbs_damage();
     }
 
     crawl_state.cancel_cmd_again();
@@ -5472,6 +5474,8 @@ spret hepliaklqana_transference(bool fail)
 
     if (victim->is_player())
     {
+        if (cancel_harmful_move(false))
+            return spret::abort;
         ancestor->move_to_pos(target, true, true);
         victim->move_to_pos(destination, true, true);
     }

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5803,7 +5803,6 @@ spret wu_jian_wall_jump_ability()
     crawl_state.cancel_cmd_repeat();
 
     apply_barbs_damage();
-    remove_ice_movement();
     return spret::success;
 }
 

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -209,9 +209,10 @@ static bool _cancel_ice_move()
     return false;
 }
 
-bool cancel_harmful_move(bool rampaging)
+bool cancel_harmful_move(bool physically, bool rampaging)
 {
-    return _cancel_barbed_move(rampaging) || _cancel_ice_move();
+    return physically ? (_cancel_barbed_move(rampaging) || _cancel_ice_move())
+        : _cancel_ice_move();
 }
 
 void remove_ice_movement()

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -228,7 +228,7 @@ void remove_ice_movement()
     {
         you.duration[DUR_FROZEN_RAMPARTS] = 0;
         end_frozen_ramparts();
-        mpr("The frozen ramparts melt away as you move.");
+        mprf(MSGCH_DURATION, "The frozen ramparts melt away as you move.");
     }
 }
 

--- a/crawl-ref/source/movement.h
+++ b/crawl-ref/source/movement.h
@@ -7,7 +7,7 @@
 
 void apply_barbs_damage(bool rampaging = false);
 void remove_ice_movement();
-bool cancel_harmful_move(bool rampaging = false);
+bool cancel_harmful_move(bool physically = true, bool rampaging = false);
 void remove_water_hold();
 void apply_noxious_bog(const coord_def old_pos);
 bool apply_cloud_trail(const coord_def old_pos);

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -26,6 +26,7 @@
 #include "item-prop.h"
 #include "item-use.h"
 #include "message.h"
+#include "movement.h"
 #include "player-stats.h"
 #include "religion.h"
 #include "spl-damage.h"
@@ -77,6 +78,8 @@ void player::moveto(const coord_def &c, bool clear_net)
 
     clear_invalid_constrictions();
     end_searing_ray();
+    // Remove spells that break upon movement
+    remove_ice_movement();
 }
 
 bool player::move_to_pos(const coord_def &c, bool clear_net, bool /*force*/)

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -349,7 +349,7 @@ bool check_moveto_exclusion(const coord_def& p, const string &move_verb,
  */
 bool check_moveto(const coord_def& p, const string &move_verb, bool physically)
 {
-    return !(physically && cancel_harmful_move(move_verb == "rampage"))
+    return !(physically && cancel_harmful_move(physically, move_verb == "rampage"))
            && check_moveto_terrain(p, move_verb, "")
            && check_moveto_cloud(p, move_verb)
            && check_moveto_trap(p, move_verb)

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -17,6 +17,7 @@
 #include "message.h"
 #include "mon-place.h"
 #include "mon-util.h"
+#include "movement.h" // passwall
 #include "place.h"
 #include "religion.h"
 #include "spl-util.h"
@@ -380,6 +381,10 @@ bool passwall_path::check_moveto() const
 
 spret cast_passwall(const coord_def& c, int pow, bool fail)
 {
+    // prompt player to end position-based ice spells
+    if (cancel_harmful_move(false))
+        return spret::abort;
+
     coord_def delta = c - you.pos();
     passwall_path p(you, delta, spell_range(SPELL_PASSWALL, pow));
     string fail_msg;

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -242,6 +242,12 @@ static bool _find_cblink_target(coord_def &target, bool safe_cancel,
             continue;
         }
 
+        if (cancel_harmful_move(false))
+        {
+            clear_messages();
+            continue;
+        }
+
         target = beam.target; // Grid in los, no problem.
         return true;
     }
@@ -330,6 +336,10 @@ spret frog_hop(bool fail)
     coord_def target;
     targeter_smite tgt(&you, hop_range, 0, HOP_FUZZ_RADIUS);
     tgt.obeys_mesmerise = true;
+
+    if (cancel_harmful_move())
+        return spret::abort;
+
     while (true)
     {
         if (!_find_cblink_target(target, true, "hop", &tgt))
@@ -363,6 +373,7 @@ spret frog_hop(bool fail)
     crawl_state.cancel_cmd_repeat();
     mpr("Boing!");
     you.increase_duration(DUR_NO_HOP, 12 + random2(13));
+    apply_barbs_damage();
 
     return spret::success; // TODO
 }
@@ -693,6 +704,9 @@ spret cast_blink(bool fail)
     // effects that cast the spell through the player, I guess (e.g. xom)
     if (you.no_tele(false, false, true))
         return fail ? spret::fail : spret::success; // probably always SUCCESS
+
+    if (cancel_harmful_move(false))
+        return spret::abort;
 
     fail_check();
     uncontrolled_blink();

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -32,7 +32,7 @@
 #include "mon-behv.h"
 #include "mon-tentacle.h"
 #include "mon-util.h"
-#include "movement.h" // remove_ice_movement for palentonga charge
+#include "movement.h" // palentonga charge
 #include "nearby-danger.h"
 #include "orb.h"
 #include "output.h"
@@ -603,7 +603,6 @@ spret palentonga_charge(bool fail, dist *target)
     move_player_to_grid(dest_pos, true);
     noisy(12, you.pos());
     apply_barbs_damage();
-    remove_ice_movement();
     _charge_cloud_trail(orig_pos);
     for (auto it = target_path.begin(); it != target_path.end() - 2; ++it)
         _charge_cloud_trail(*it);

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -653,9 +653,7 @@ void floor_transition(dungeon_feature_type how,
 
     // We "stepped".
     if (!forced)
-    {
         apply_barbs_damage();
-    }
 
     // Magical level changes (which currently only exist "downwards") need this.
     clear_trapping_net();

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -655,7 +655,6 @@ void floor_transition(dungeon_feature_type how,
     if (!forced)
     {
         apply_barbs_damage();
-        remove_ice_movement();
     }
 
     // Magical level changes (which currently only exist "downwards") need this.


### PR DESCRIPTION
There were several inconsistencies in the types of movement that would end Ozocubu's armour and frozen ramparts and/or trigger barb damage: for example, palentonga's rolling charge and Wu Jian's wall jump would trigger these effects, but barachian's hop and Ru's power leap would not. Furthermore, the effect of frozen ramparts is tied to the player's position at the time of casting, making it intuitive for any change of position to end the effect. This PR resolves these issues by making Ozocubu's armour and frozen ramparts end whenever the player's position changes (providing a prompt when the player attempts to change their position voluntarily), and by making barb damage trigger whenever the player's position changes in a way that thematically requires physical movement.