### PR TITLE
Add option to configure rest/wait duration

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -48,7 +48,8 @@ The contents of this text are:
                 tc_exclude_circle, runrest_ignore_message,
                 runrest_stop_message, interrupt_<delay>, delay_safe_poison,
                 runrest_ignore_monster, rest_wait_both, rest_wait_ancestor,
-                rest_wait_percent, explore_auto_rest, auto_exclude
+                rest_wait_percent, rest_wait_turns, explore_auto_rest,
+                auto_exclude
 3-g     Command Enhancements.
                 auto_switch, travel_open_doors, easy_unequip, equip_unequip,
                 jewellery_prompt, easy_confirm, simple_targeting,
@@ -967,6 +968,9 @@ rest_wait_percent = 100
         When resting, if your HP or MP is below this percentage of being full,
         it will stop resting when this percent of maximum HP or MP is refilled.
         Resting after this point will still rest up to 100%.
+
+rest_wait_turns = 100
+        The number of turns to rest (wait) when both HP and MP are full.
 
 explore_auto_rest = true
         If true, auto-explore waits until your HP and MP are both at

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -273,6 +273,7 @@ const vector<GameOption*> game_options::build_options_list()
                           MSG_MIN_HEIGHT),
         new IntGameOption(SIMPLE_NAME(msg_webtiles_height), -1),
         new IntGameOption(SIMPLE_NAME(rest_wait_percent), 100, 0, 100),
+        new IntGameOption(SIMPLE_NAME(rest_wait_turns), 100, 1, 1000),
         new IntGameOption(SIMPLE_NAME(pickup_menu_limit), 1),
         new IntGameOption(SIMPLE_NAME(view_delay), DEFAULT_VIEW_DELAY, 0),
         new IntGameOption(SIMPLE_NAME(fail_severity_to_confirm), 3, -1, 3),

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1655,7 +1655,7 @@ static void _do_rest()
             && ancestor_full_hp())
         {
             mpr("You start waiting.");
-            _start_running(RDIR_REST, RMODE_WAIT_DURATION);
+            _start_running(RDIR_REST, Options.rest_wait_turns);
             return;
         }
         else

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -472,6 +472,8 @@ public:
     int         rest_wait_percent; // Stop resting after restoring this
                                    // fraction of HP or MP
 
+    int         rest_wait_turns; // Stop resting after this number of turns
+
     bool        regex_search; // whether to default to regex search for ^F
     bool        autopickup_search; // whether to annotate stash items with
                                    // autopickup status

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4371,7 +4371,7 @@ void runrest::initialise(int dir, int mode)
         set_run_check(2, right);
     }
 
-    if (runmode == RMODE_REST_DURATION || runmode == RMODE_WAIT_DURATION)
+    if (runmode == RMODE_REST_DURATION || runmode == RMODE_WAIT)
         start_delay<RestDelay>();
     else
         start_delay<RunDelay>();

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -46,7 +46,7 @@ enum run_mode_type
     RMODE_NOT_RUNNING    = 0,  // must remain equal to 0
     RMODE_CONTINUE,
     RMODE_START,
-    RMODE_WAIT_DURATION = 100,
+    RMODE_WAIT,
     RMODE_REST_DURATION = 9999999, // just rest until fully healed
     RMODE_CONNECTIVITY,        // Pathfinding connectivity check, not running.
 };


### PR DESCRIPTION
Currently the time to wait (pressing '5') while at full
HP and MP is fixed at 100 turns, this makes it configurable.