### PR TITLE
Stepdown removal

### DIFF
--- a/crawl-ref/source/dat/species/spriggan.yaml
+++ b/crawl-ref/source/dat/species/spriggan.yaml
@@ -18,7 +18,7 @@ aptitudes:
   slings: 2
   bows: 2
   armour: -3
-  dodging: 4
+  dodging: 3
   stealth: 5
   shields: -3
   unarmed_combat: -2
@@ -37,7 +37,7 @@ aptitudes:
 size: little
 str: 4
 int: 9
-dex: 11
+dex: 10
 levelup_stat_frequency: 5
 levelup_stats:
   - int

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2075,20 +2075,17 @@ static int _player_evasion(ev_ignore_type evit)
 
     const int vertigo_penalty = you.duration[DUR_VERTIGO] ? 5 * scale : 0;
 
-    const int prestepdown_evasion =
+    const int natural_evasion =
         size_base_ev
         + _player_armour_adjusted_dodge_bonus(scale)
         - _player_adjusted_evasion_penalty(scale)
         - you.adjusted_shield_penalty(scale)
         - vertigo_penalty;
 
-    const int poststepdown_evasion =
-        stepdown_value(prestepdown_evasion, 20*scale, 30*scale, 60*scale, -1);
-
     const int evasion_bonuses = _player_evasion_bonuses() * scale;
 
     const int final_evasion =
-        _player_scale_evasion(poststepdown_evasion, scale) + evasion_bonuses;
+        _player_scale_evasion(natural_evasion, scale) + evasion_bonuses;
 
     return unscale_round_up(final_evasion, scale);
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2022,7 +2022,7 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
  * What is the player's bonus to EV from dodging when not paralysed, after
  * accounting for size & body armour penalties?
  *
- * First, calculate base dodge bonus (linear with dodging * stepdowned dex),
+ * First, calculate base dodge bonus (linear with dodging * dex),
  * and armour dodge penalty (base armour evp, increased for small races &
  * decreased for large, then with a magic "3" subtracted from it to make the
  * penalties not too harsh).
@@ -2044,10 +2044,8 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
  */
 static int _player_armour_adjusted_dodge_bonus(int scale)
 {
-    const int ev_dex = stepdown(you.dex(), 18, ROUND_CLOSE, MAX_STAT_VALUE);
-
     const int dodge_bonus =
-        (70 + you.skill(SK_DODGING, 10) * ev_dex) * scale
+        (70 + you.skill(SK_DODGING, 10) * you.dex()) * scale
         / (20 - _player_evasion_size_factor()) / 10;
 
     const int armour_dodge_penalty = you.unadjusted_body_armour_penalty() - 3;


### PR DESCRIPTION
Removes two opaque stepdowns on evasion. I think knowledge of the dex stepdown has more or less filtered out to the playerbase, but the EV one is not well-known. The practical upshot is that players with more than 18 dex get a bit more EV if they have some dodging skill, and players with more than 30 "base" EV and a lot of dex can get significantly more EV. For most characters, this shouldn't be a huge deal: 25 dex robe human gets 3 more ev at 20 dodging compared to before, 7 if they take dodging all the way to 27. However, it does significantly buff characters that can get a very large amount of dexterity since dex and dodging skill are multiplicative. I went ahead and nerfed spriggans slightly since they're the most likely species to get out of control, but otherwise I've left everything alone. It's probably worth monitoring how big of a buff players get in practice and then adjusting accordingly, but I think it shouldn't be too hard to compensate for and improving the clarity of the formulas seems worthwhile.