### PR TITLE
Unrandart powers

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1168,6 +1168,7 @@ TILE:     urand_finger
 COLOUR:   ETC_BONE
 LIFE:     1
 VALUE:    400
+DESCRIP:  It enables you to equip an extra ring.
 
 # start TAG_MAJOR_VERSION == 34
 ENUM:     SPIDER

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -222,6 +222,7 @@ VALUE:   800
 
 NAME:    staff of Olgreb
 INSCRIP: rPois∞
+DESCRIP: It grants immunity to poison.
 OBJ:     OBJ_WEAPONS/WPN_STAFF
 PLUS:    +9
 COLOUR:  ETC_POISON
@@ -451,6 +452,9 @@ TILE_EQ:  glaive_of_the_guard
 BRAND:    SPWPN_ELECTROCUTION
 AC:       5
 INSCRIP:  spectral,
+DESCRIP:  It retains the spirit of the tree from which it was made. In the hands
+ of one skilled in evocations this spirit is drawn out to fight along side the
+ wielder.
 
 ENUM:     ZEALOT_SWORD
 NAME:     zealot's sword
@@ -691,6 +695,8 @@ TILE:     urand_storm_bow
 TILE_EQ:  storm_bow
 BRAND:    SPWPN_ELECTROCUTION
 INSCRIP:  penet
+DESCRIP:  Ammo fired by it passes through the targets it hits, potentially
+ hitting all targets in its path until it reaches maximum range.
 
 NAME:    tower shield of Ignorance
 OBJ:     OBJ_ARMOUR/ARM_TOWER_SHIELD
@@ -1373,6 +1379,9 @@ ENUM:     THERMIC_ENGINE
 NAME:     Maxwell's thermic engine
 OBJ:      OBJ_WEAPONS/WPN_DOUBLE_SWORD
 INSCRIP:  freeze,
+DESCRIP:  It has been specially enchanted to freeze those struck by it, causing
+ extra injury to most foes and up to half again as much damage against
+ particularly susceptible opponents.
 PLUS:     +2
 COLOUR:   ETC_VEHUMET
 TILE:     urand_thermic_engine

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -222,7 +222,11 @@ VALUE:   800
 
 NAME:    staff of Olgreb
 INSCRIP: rPois∞
-DESCRIP: It grants immunity to poison.
+DESCRIP: It enhances your poison magic.\nIt
+ grants immunity to poison.\nIt
+ can be evoked to poison those around you for a time.\nIt
+ may poison the flesh of those it strikes, and is more effective with a high
+ Evocations skill.
 OBJ:     OBJ_WEAPONS/WPN_STAFF
 PLUS:    +9
 COLOUR:  ETC_POISON
@@ -1385,7 +1389,8 @@ OBJ:      OBJ_WEAPONS/WPN_DOUBLE_SWORD
 INSCRIP:  freeze,
 DESCRIP:  It has been specially enchanted to freeze those struck by it, causing
  extra injury to most foes and up to half again as much damage against
- particularly susceptible opponents.
+ particularly susceptible opponents.\n\nIt
+ becomes more effective when it hits something. This effect fades over time.
 PLUS:     +2
 COLOUR:   ETC_VEHUMET
 TILE:     urand_thermic_engine

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -831,6 +831,9 @@ FIRE:    2
 COLD:    -2
 BOOL:    special
 INSCRIP: Flames
+DESCRIP: It surrounds you with a cloud of flames.\nIt
+ grants immunity to clouds of flame.\nIt
+ enhances your fire magic.
 
 NAME:    gauntlets of War
 OBJ:     OBJ_ARMOUR/ARM_GLOVES

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -104,6 +104,23 @@
 # * tilerim:  Adds a black outline to the tile, see above section.
 # * unided:   Properties start unidentified.
 
+# DESCRIP: Description of the powers of the artefact which are specific to this
+# artefact.
+#
+# This could include anything defined in art-func.h, or any reference to the
+# UNRAND_* flag other than in art-data.h or art-enum.h.
+#
+# The description of a power can be split across more than one line. The
+# subsequent lines should be just below the first one, and should start with
+# a space (with no header name).
+# If there are multiple powers, the later ones can be added in the same way,
+# but with a + at the start of the line instead of a space.
+
+# DBRAND: Description of a brand which is specific to this artefact.
+#
+# The syntax for this is identical to DESCRIP. The DBRAND will appear before
+# the DESCRIP, and each line will be displayed with a blank line after it.
+
 # ENUM: Forces the artefact's enumeration literal to something specific.
 # For example, "ENUM: FOO" gives the enumeration "UNRAND_FOO". The
 # default enumeration is determined as follows:
@@ -222,11 +239,11 @@ VALUE:   800
 
 NAME:    staff of Olgreb
 INSCRIP: rPois∞
-DESCRIP: It enhances your poison magic.\nIt
- grants immunity to poison.\nIt
- can be evoked to poison those around you for a time.\nIt
- may poison the flesh of those it strikes, and is more effective with a high
- Evocations skill.
+DESCRIP: It enhances your poison magic.
++It grants immunity to poison.
++It can be evoked to poison those around you for a time.
+DBRAND: It may poison the flesh of those it strikes, and is more effective with
+ a high Evocations skill.
 OBJ:     OBJ_WEAPONS/WPN_STAFF
 PLUS:    +9
 COLOUR:  ETC_POISON
@@ -456,8 +473,8 @@ TILE_EQ:  glaive_of_the_guard
 BRAND:    SPWPN_ELECTROCUTION
 AC:       5
 INSCRIP:  spectral,
-DESCRIP:  When it strikes, its spirit leaps out and fights alongside the
- wielder.\n
+DBRAND:   When it strikes, its spirit leaps out and fights alongside the
+ wielder.
 
 ENUM:     ZEALOT_SWORD
 NAME:     zealot's sword
@@ -698,7 +715,7 @@ TILE:     urand_storm_bow
 TILE_EQ:  storm_bow
 BRAND:    SPWPN_ELECTROCUTION
 INSCRIP:  penet
-DESCRIP:  Ammo fired by it passes through the targets it hits, potentially
+DBRAND:   Ammo fired by it passes through the targets it hits, potentially
  hitting all targets in its path until it reaches maximum range.
 
 NAME:    tower shield of Ignorance
@@ -834,9 +851,9 @@ FIRE:    2
 COLD:    -2
 BOOL:    special
 INSCRIP: Flames
-DESCRIP: It surrounds you with a cloud of flames.\nIt
- grants immunity to clouds of flame.\nIt
- enhances your fire magic.
+DESCRIP: It surrounds you with a cloud of flames.
++It grants immunity to clouds of flame.
++It enhances your fire magic.
 
 NAME:    gauntlets of War
 OBJ:     OBJ_ARMOUR/ARM_GLOVES
@@ -1386,10 +1403,11 @@ ENUM:     THERMIC_ENGINE
 NAME:     Maxwell's thermic engine
 OBJ:      OBJ_WEAPONS/WPN_DOUBLE_SWORD
 INSCRIP:  freeze,
-DESCRIP:  It has been specially enchanted to freeze those struck by it, causing
+DBRAND:   It has been specially enchanted to freeze those struck by it, causing
  extra injury to most foes and up to half again as much damage against
- particularly susceptible opponents.\n\nIt
- becomes more effective when it hits something. This effect fades over time.
+ particularly susceptible opponents.
+DESCRIP:  It becomes more effective when it hits something. This effect fades
+ over time.
 PLUS:     +2
 COLOUR:   ETC_VEHUMET
 TILE:     urand_thermic_engine

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -456,9 +456,8 @@ TILE_EQ:  glaive_of_the_guard
 BRAND:    SPWPN_ELECTROCUTION
 AC:       5
 INSCRIP:  spectral,
-DESCRIP:  It retains the spirit of the tree from which it was made. In the hands
- of one skilled in evocations this spirit is drawn out to fight along side the
- wielder.
+DESCRIP:  When it strikes, its spirit leaps out and fights alongside the
+ wielder.\n
 
 ENUM:     ZEALOT_SWORD
 NAME:     zealot's sword

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -50,6 +50,7 @@ struct unrandart_entry
     const char *unid_name;   // un-id'd name of unrandart
     const char *type_name;   // custom item type
     const char *inscrip;     // extra inscription
+    const char *dbrand;      // description of extra brand
     const char *descrip;     // description of extra power
 
     object_class_type base_type;

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -50,6 +50,7 @@ struct unrandart_entry
     const char *unid_name;   // un-id'd name of unrandart
     const char *type_name;   // custom item type
     const char *inscrip;     // extra inscription
+    const char *descrip;     // description of extra power
 
     object_class_type base_type;
     uint8_t           sub_type;

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -648,24 +648,24 @@ static string _artefact_descrip(const item_def &item)
 {
     if (!is_artefact(item)) return "";
 
-	string unrand_desc, dbrand;
+    string unrand_desc, dbrand;
     if (is_unrandom_artefact(item))
-	{
-	    auto entry = get_unrand_entry(item.unrand_idx);
-	    if (entry->descrip) unrand_desc = string("\n")+entry->descrip;
-	    if (entry->dbrand) dbrand = string("\n")+entry->dbrand;
-	}
+    {
+        auto entry = get_unrand_entry(item.unrand_idx);
+        if (entry->descrip) unrand_desc = string("\n")+entry->descrip;
+        if (entry->dbrand) dbrand = string("\n")+entry->dbrand;
+    }
 
     string rand_desc = _randart_descrip(item);
     string out = unrand_desc + rand_desc;
 
-	// Each brand is followed by a blank line.
-	// The returned string will also be followed by a blank line, so
-	// don't double up if only returning dbrand.
-	if (!dbrand.empty() && !out.empty())
-		out = dbrand + "\n" + out;
-	else
-		out = dbrand + out;
+    // Each brand is followed by a blank line.
+    // The returned string will also be followed by a blank line, so
+    // don't double up if only returning dbrand.
+    if (!dbrand.empty() && !out.empty())
+        out = dbrand + "\n" + out;
+    else
+        out = dbrand + out;
 
     // XXX: Can't happen, right?
     if (!item_ident(item, ISFLAG_KNOW_PROPERTIES) && item_type_known(item))

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1848,9 +1848,9 @@ static string _describe_armour(const item_def &item, bool verbose)
         }
     }
 
-	string art_desc = _artefact_descrip(item);
-	if (!art_desc.empty())
-		description += "\n" + art_desc;
+    string art_desc = _artefact_descrip(item);
+    if (!art_desc.empty())
+        description += "\n" + art_desc;
 
     if (!is_artefact(item))
     {
@@ -1955,9 +1955,9 @@ static string _describe_jewellery(const item_def &item, bool verbose)
     }
 
     // Artefact properties.
-	string art_desc = _artefact_descrip(item);
-	if (!art_desc.empty())
-		description += "\n" + art_desc;
+    string art_desc = _artefact_descrip(item);
+    if (!art_desc.empty())
+        description += "\n" + art_desc;
 
     return description;
 }

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -644,24 +644,28 @@ static string _randart_descrip(const item_def &item)
 
 // If item is an unrandart with a DESCRIP field, return its contents.
 // Otherwise, return "".
-static string _unrandart_descrip(const item_def &item)
-{
-    if (!is_unrandom_artefact(item)) return "";
-    auto entry = get_unrand_entry(item.unrand_idx);
-    if (!entry->descrip) return "";
-    return string("\n")+entry->descrip;
-}
-
-// If item is an unrandart with a DESCRIP field, return its contents.
-// Otherwise, return "".
 static string _artefact_descrip(const item_def &item)
 {
     if (!is_artefact(item)) return "";
 
-    string unrand_desc = _unrandart_descrip(item);
-    string rand_desc = _randart_descrip(item);
+	string unrand_desc, dbrand;
+    if (is_unrandom_artefact(item))
+	{
+	    auto entry = get_unrand_entry(item.unrand_idx);
+	    if (entry->descrip) unrand_desc = string("\n")+entry->descrip;
+	    if (entry->dbrand) dbrand = string("\n")+entry->dbrand;
+	}
 
+    string rand_desc = _randart_descrip(item);
     string out = unrand_desc + rand_desc;
+
+	// Each brand is followed by a blank line.
+	// The returned string will also be followed by a blank line, so
+	// don't double up if only returning dbrand.
+	if (!dbrand.empty() && !out.empty())
+		out = dbrand + "\n" + out;
+	else
+		out = dbrand + out;
 
     // XXX: Can't happen, right?
     if (!item_ident(item, ISFLAG_KNOW_PROPERTIES) && item_type_known(item))

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1955,22 +1955,9 @@ static string _describe_jewellery(const item_def &item, bool verbose)
     }
 
     // Artefact properties.
-    if (is_artefact(item))
-    {
-        string rand_desc = _randart_descrip(item);
-        if (!rand_desc.empty())
-        {
-            description += "\n";
-            description += rand_desc;
-        }
-        if (!item_ident(item, ISFLAG_KNOW_PROPERTIES) ||
-            !item_ident(item, ISFLAG_KNOW_TYPE))
-        {
-            description += "\nThis ";
-            description += (jewellery_is_amulet(item) ? "amulet" : "ring");
-            description += " may have hidden properties.";
-        }
-    }
+	string art_desc = _artefact_descrip(item);
+	if (!art_desc.empty())
+		description += "\n" + art_desc;
 
     return description;
 }

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -665,7 +665,7 @@ static string _artefact_descrip(const item_def &item)
 
     // XXX: Can't happen, right?
     if (!item_ident(item, ISFLAG_KNOW_PROPERTIES) && item_type_known(item))
-        out += "\nThis weapon may have some hidden properties.";
+        out += "\nIt may have some hidden properties.";
 
     return out;
 }
@@ -1848,20 +1848,11 @@ static string _describe_armour(const item_def &item, bool verbose)
         }
     }
 
-    if (is_artefact(item))
-    {
-        string rand_desc = _randart_descrip(item);
-        if (!rand_desc.empty())
-        {
-            description += "\n";
-            description += rand_desc;
-        }
+	string art_desc = _artefact_descrip(item);
+	if (!art_desc.empty())
+		description += "\n" + art_desc;
 
-        // Can't happen, right? (XXX)
-        if (!item_ident(item, ISFLAG_KNOW_PROPERTIES) && item_type_known(item))
-            description += "\nThis armour may have some hidden properties.";
-    }
-    else
+    if (!is_artefact(item))
     {
         const int max_ench = armour_max_enchant(item);
         if (max_ench > 0)

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -217,11 +217,11 @@ sub finish_art
         $artefact->{"${func_name}_func"} = $val;
     }
 
-	# Put a blank line between a pair of brands.
+    # Put a blank line between a pair of brands.
     if ($artefact->{DBRAND})
-	{
-		$artefact->{DBRAND} =~ s/\\n/\\n\\n/g
-	}
+    {
+        $artefact->{DBRAND} =~ s/\\n/\\n\\n/g
+    }
 
     # Default values.
     my $field;

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -31,6 +31,7 @@ my %field_type = (
     CORRODE  => "bool",
     CURSE    => "bool",
     DEX      => "num",
+    DESCRIP  => "str",
     DRAIN    => "bool",
     ELEC     => "bool",
     EV       => "num",
@@ -516,7 +517,8 @@ sub process_line
 }
 
 my @art_order = (
-    "NAME", "APPEAR", "TYPE", "INSCRIP", "\n",
+    "NAME", "APPEAR", "TYPE", "\n",
+    "INSCRIP", "DESCRIP", "\n",
     "base_type", "sub_type", "\n",
     "fallback_base_type", "fallback_sub_type", "FB_BRAND", "\n",
     "plus", "plus2", "COLOUR", "VALUE", "\n",
@@ -604,7 +606,7 @@ sub art_to_str
         {
             my $temp = $artefact->{$part};
             $temp =~ s/"/\\"/g;
-            $str .= (($part eq "TYPE" || $part eq "INSCRIP") && $temp eq "")
+            $str .= ($temp eq "" && $part =~ /^(TYPE|INSCRIP|DESCRIP)$/n)
                 ? "nullptr" : "\"$temp\"";
         }
         else


### PR DESCRIPTION
1, Describe the special powers the staff of Olgreb, the storm bow and Maxwell's Thermic Engine have in art-data.txt rather than describe.cc.
2. Expand the special power descriptions for the staff of Olgreb and Maxwell's Thermic Engine, so that they cover all of the items' special powers.
3. Add descriptions for the special powers of the salamander hide armour and the macabre finger necklace.

The text from unrand.txt does cover the same sort of power, but (a) it also includes flavour text, making the item's properties less clear, and (b) it isn't included in a character dump, so that they list some of an artefact's properties, but not others.

I added some armour and jewellery as these are in a different part of the code. There are dozens of artefacts which have properties like this.