### PR TITLE
Deminogod "rework"

### DIFF
--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -6,7 +6,7 @@ adjective: "Divine"
 difficulty: Advanced
 difficulty_priority: 80
 aptitudes:
-  xp: -2
+  xp: -1
   hp: 1
   mp_mod: 2
   mr: 4
@@ -39,10 +39,10 @@ aptitudes:
   poison_magic: -1
   invocations: False
   evocations: -1
-str: 11
-int: 12
-dex: 11
-# No natural stat gain (double chosen instead)
+str: 9
+int: 10
+dex: 9
+# No natural stat gain (quadruple chosen instead)
 levelup_stats: []
 levelup_stat_frequency: 28
 mutations:

--- a/crawl-ref/source/player-stats.cc
+++ b/crawl-ref/source/player-stats.cc
@@ -148,7 +148,7 @@ bool attribute_increase()
 #endif
     mouse_control mc(MOUSE_MODE_PROMPT);
 
-    const int statgain = you.species == SP_DEMIGOD ? 2 : 1;
+    const int statgain = you.species == SP_DEMIGOD ? 4 : 1;
 
     bool tried_lua = false;
     int keyin;


### PR DESCRIPTION
No, not the random god abilities on levelup one. This is a small commit that tries to lean into the current demigod gimmick of having very big, player-directed stats. Demigod starting stats are reduced by 2 each in exchange for a buff to their stat choice - instead of adding two points to a single stat every third level, they add four points. This should flatten out their difficulty curve compared to other species a little bit and, I hope, make them feel slightly more interesting. Total attributes break even with old demigod at xl 9, which seems about right - non-demigod characters will usually have divine help by that point. 

I also raised their xp apt to -1. I don't feel particularly strongly about this, but the -2 xp apt tended to "feel bad" despite not really being much worse than -1 past like, D:4, and I don't think it was central to their gimmick.