### PR TITLE
Remove some water from mumra_spider_spiderweb

### DIFF
--- a/crawl-ref/source/dat/des/branches/spider.des
+++ b/crawl-ref/source/dat/des/branches/spider.des
@@ -385,10 +385,11 @@ DEPTH:   Spider, !Spider:$
 WEIGHT:  5
 # Water etc.
 SUBST:   w = z
-SUBST:   W = W w:15 x:4
-SUBST:   . = .:6 W
-SUBST:   z = W:5 w:50 .:2
+SUBST:   W = W w:5 ^:3 x:2
+SUBST:   . = . W:4
+SUBST:   z = W. ^:5
 SUBST:   X = w x
+KFEAT:   ^ = web
 # Monster sets, and some items
 NSUBST:  1 = 2:t / *:w
 SUBST:   2 = 2 *:4
@@ -412,7 +413,7 @@ MAP
    ...xxxxW.Wxxwwx4xxxxxxxxxxwW.Wxx..
   .3xxxxxW.2xxxxxwwxxxxxxxxxwxxW.Wxx...
   .xxxxx7.WxxxxxxxxwwxxxxxxwxxxxW7Wxxx.
-  .x4xx.WWxxxxxxx2>..w.22.wxxxxxxW.www.
+  .x4xx.WWxxxxxxx2...w.22.wxxxxxxW.www.
   .xxw.WXxxxxxx2..2|x2w..w.xxxxwwwW.Wx.
  ..xx7WXxxxxx2..2.x2www.w..2wwwxxxW7Wx.
 ..xxW.Wxxxxx2.x...ww11wwxwww2xxxxxXW.x.


### PR DESCRIPTION
The vault has several spiders trapped behind deep water, as they can
no longer cling to walls.

This commit frees the spiders and reduces the number of water and deep
water tiles in the vault. Also, it removes an escape hatch in the
inner area, since the vault is not a teleport closet anymore.

-----

A code archaeology fact of the day: when monster clinging was removed in 0.13, there was exactly the same problem with spiders trapped behind deep water. `mumra_spider_spiderweb` and other Spider vaults were fixed in bdc56382, but the changes were reverted in 40eb2104 when clinging was brought back.
