### PR TITLE
Reduce the experience cost of high-level skills

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1937,13 +1937,17 @@ float apt_to_factor(int apt)
 
 unsigned int skill_exp_needed(int lev, skill_type sk, species_type sp)
 {
-    const int exp[28] =
-          { 0, 50, 150, 300, 500, 750,          // 0-5
-            1050, 1400, 1800, 2250, 2800,       // 6-10
-            3450, 4200, 5050, 6000, 7050,       // 11-15
-            8200, 9450, 10800, 12300, 13950,    // 16-20
-            15750, 17700, 19800, 22050, 24450,  // 21-25
-            27000, 29750 };
+    int exp[28];
+    for (int skill_level = 0; skill_level < 28; skill_level++)
+    {
+        exp[skill_level] = 25 * skill_level * (skill_level + 1);
+        if (skill_level > 9)
+            exp[skill_level] += 25 * (skill_level - 8) * (skill_level - 9) / 2;
+        if (skill_level > 18)
+            exp[skill_level] += 25 * (skill_level - 17) * (skill_level - 18) / 2;
+        if (skill_level > 26)
+            exp[skill_level] += 25 * (skill_level - 25) * (skill_level - 26) / 2;
+    }
 
     ASSERT_RANGE(lev, 0, MAX_SKILL_LEVEL + 1);
     return exp[lev] * species_apt_factor(sk, sp);


### PR DESCRIPTION
The cost of increasing a skill from 20 to 27 was more than the cost of increasing a skill from 0 to 20, making
training extremely high level skills (e.g. for level 9 spells or slow two-handed weapons) a poor investment for most
of the game. This commit makes the implicit quadratic-with-break-point formula explicit, and divides the break point
contributions to skill costs above level 9 by 2. This has the following implications:
* Skill costs up to level 9 are unaffected;
* The new cost of skill level 15 is half-way between the old costs of level 14 and 15;
* The new cost of skill level 20 is approximately the same as the old cost of skill level 19;
* The new cost of skill level 27 is approximately the same as the old cost of skill level 25;
* The decreases in costs are roughly equivalent to a +1 increase in aptitude by skill level 23,
  and the impact is always smaller than a +2 increase in aptitude.