### PR TITLE
Keep "[Y]es or [N]o only, please" messages out of the log.

### DIFF
--- a/crawl-ref/source/prompt.cc
+++ b/crawl-ref/source/prompt.cc
@@ -147,7 +147,7 @@ bool yesno(const char *str, bool allow_lowercase, int default_answer, bool clear
             if (use_popup && status) // redundant, but will quiet a warning
                 status->text = pr;
             else
-                mpr(pr);
+                mprf(MSGCH_PROMPT, "%s", pr.c_str());
         }
     }
 }


### PR DESCRIPTION
Move the "[Y]es or [N]o only, please" message from MSGCH_PLAIN to MSGCH_PROMPT in yesno() and yesnoquit(). This has two effects.

1. The message no longer appears in the previous message list. The original yes/no question does not appear here, so this message previously appeared in the log with no context. If you're looking through the list to work out what happened, this message doesn't help.

2. The message is blue rather than white by default. This could be changed, but it would take more work.