### PR TITLE
Distinguish between "1 poisoned" and "all poisoned" in the visible monster list.

### DIFF
--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1731,12 +1731,12 @@ static bool _has_wand(const monster_info& mi)
 static string _condition_string(int num, int count,
                                 const monster_info_flag_name& name)
 {
-    if (1 < num && num < count)
-        return make_stringf("%d %s", num, name.plural.c_str());
-    else if (1 < num)
+    if (1 == count)
+        return name.short_singular;
+    else if (count == num)
         return name.plural;
     else
-        return name.short_singular;
+        return make_stringf("%d %s", num, name.plural.c_str());
 }
 
 void mons_conditions_string(string& desc, const vector<monster_info>& mi,


### PR DESCRIPTION
Previously, if there were 6 sheep, the monster list would show:
(poisoned) if 1 had been poisoned;
(2 poisoned) if 2 had; and
(poisoned) if all had.

This changes the first case to (1 poisoned). It displays (poisoned), as now, if only one sheep is left.

This makes it easier to see when (in this case) a sheep needs more poison.