### PR TITLE
Delete some unnecessary things from travel_pathfind.

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1115,7 +1115,7 @@ travel_pathfind::travel_pathfind()
       need_for_greed(false), autopickup(false),
       unexplored_place(), greedy_place(), unexplored_dist(0), greedy_dist(0),
       refdist(nullptr), reseed_points(), features(nullptr), unreachables(),
-      point_distance(travel_point_distance), points(0), next_iter_points(0),
+      point_distance(travel_point_distance), next_iter_points(0),
       traveled_distance(0), circ_index(0)
 {
 }
@@ -1260,10 +1260,6 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
                                  !actor_slime_wall_immune(&you));
     unwind_slime_wall_precomputer slime_neighbours(g_Slime_Wall_Check);
 
-    // How many points are we currently considering? We start off with just one
-    // point, and spread outwards like a flood-filler.
-    points = 1;
-
     // How many points we'll consider next iteration.
     next_iter_points = 0;
 
@@ -1292,8 +1288,9 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
 
     bool found_target = false;
 
-    for (; points > 0; ++traveled_distance, circ_index = !circ_index,
-                        points = next_iter_points, next_iter_points = 0)
+    for (int points = 1; points > 0; ++traveled_distance,
+        circ_index = !circ_index, points = next_iter_points,
+        next_iter_points = 0)
     {
         for (int i = 0; i < points; ++i)
         {

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -593,10 +593,6 @@ protected:
 
     travel_distance_col *point_distance;
 
-    // How many points are we currently considering? We start off with just one
-    // point, and spread outwards like a flood-filler.
-    int points;
-
     // How many points we'll consider next iteration.
     int next_iter_points;
 

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -501,20 +501,12 @@ public:
     // position) and destination.
     void set_src_dst(const coord_def &src, const coord_def &dst);
 
-    // Request that the point distance array be annotated with magic numbers for
-    // excludes and waypoints.
-    void set_annotate_map(bool annotate);
-
-    // Sets the travel_distance_grid_t to use instead of travel_point_distance.
-    void set_distance_grid(travel_distance_grid_t distgrid);
-
-    // Set feature vector to use; if non-nullptr, also sets annotate_map to true.
+    // Set feature vector to use; if non-nullptr, also sets annotate_map to
+    // true.
     void set_feature_vector(vector<coord_def> *features);
 
     // Extract features without pathfinding
     void get_features();
-
-    const set<coord_def> get_unreachables() const;
 
     // The next square to go to to move towards the travel destination. Return
     // value is undefined if pathfind was not called with RMODE_TRAVEL.
@@ -524,19 +516,13 @@ public:
     // pathfind was not called with RMODE_EXPLORE or RMODE_EXPLORE_GREEDY.
     const coord_def explore_target() const;
 
-    // Nearest greed-inducing square. Return value is undefined if
-    // pathfind was not called with RMODE_EXPLORE_GREEDY.
-    const coord_def greedy_square() const;
-
-    // Nearest unexplored territory. Return value is undefined if
-    // pathfind was not called with RMODE_EXPLORE or
-    // RMODE_EXPLORE_GREEDY.
-    const coord_def unexplored_square() const;
-
     inline void set_ignore_danger()
     {
         ignore_danger = true;
     }
+
+    // Determine if the level is fully explored, when called after pathfind().
+    int explore_status();
 
 protected:
     bool is_greed_inducing_square(const coord_def &c) const;


### PR DESCRIPTION
Make travel_pathfind::points a local variable in pathfind().

Move _find_explore_status() into travel_pathfind.

Delete set_annotate_map(), set_distance_grid(), greedy_square(), travel_move(), unexplored_square() and get_unreachables(). The functions which had referred to them (if any) now refer to the underlying variables.