### PR TITLE
Split find_travel_pos().

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -917,11 +917,9 @@ static void _find_travel_pos(const coord_def& youpos, int *move_x, int *move_y)
 
     tp.set_src_dst(youpos, you.running.pos);
 
-    run_mode_type rmode = RMODE_TRAVEL;
-
-    coord_def dest = tp.pathfind(rmode, false);
+    coord_def dest = tp.pathfind(RMODE_TRAVEL, false);
     if (dest.origin())
-        dest = tp.pathfind(rmode, true);
+        dest = tp.pathfind(RMODE_TRAVEL, true);
     coord_def new_dest = dest;
 
     // We'd either have to travel through a runed door, in which case we'll be
@@ -949,8 +947,7 @@ static void _find_travel_pos(const coord_def& youpos, int *move_x, int *move_y)
     // .tx      Moving onto t puts us adjacent to an unseen grid.
     // ?#@      --> Pick x instead.
     // Only applies to diagonal moves.
-    if (rmode == RMODE_TRAVEL && !dest.origin() && dest.x != youpos.x
-        && dest.y != youpos.y)
+    if (!dest.origin() && dest.x != youpos.x && dest.y != youpos.y)
     {
         coord_def unseen = coord_def();
         for (adjacent_iterator ai(dest); ai; ++ai)

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1889,9 +1889,12 @@ void fill_travel_point_distance(const coord_def& youpos,
     travel_pathfind tp;
     tp.set_floodseed(youpos);
     tp.set_feature_vector(features);
-    coord_def dest = tp.pathfind(RMODE_NOT_RUNNING, false);
-    if (dest.origin())
-        dest = tp.pathfind(RMODE_NOT_RUNNING, true);
+
+    // Calling pathfind() twice like this changes the order of *features, but
+    // has no effect on travel_point_distance.
+    if (features)
+        tp.pathfind(RMODE_NOT_RUNNING, false);
+    tp.pathfind(RMODE_NOT_RUNNING, true);
 }
 
 extern map<branch_type, set<level_id> > stair_level;

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -68,7 +68,7 @@ bool is_known_branch_id(branch_type branch);
 bool is_unknown_stair(const coord_def &p);
 bool is_unknown_transporter(const coord_def &p);
 
-void find_travel_pos(const coord_def& youpos, int *move_x, int *move_y,
+void fill_travel_point_distance(const coord_def& youpos,
                      vector<coord_def>* coords = nullptr);
 
 bool is_stair_exclusion(const coord_def &p);

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -363,7 +363,7 @@ static void _reset_travel_colours(vector<coord_def> &features, bool on_level)
     features.clear();
 
     if (on_level)
-        find_travel_pos(you.pos(), nullptr, nullptr, &features);
+        fill_travel_point_distance(you.pos(), &features);
     else
     {
         travel_pathfind tp;


### PR DESCRIPTION
Split find_travel_pos() into two functions (one with move_x and move_y, one with features).

Remove some unnecessary code from the latter version.