### PR TITLE
Tweak some Swamp witch vaults to better fit their creators' intentions

### DIFF
--- a/crawl-ref/source/dat/des/branches/swamp.des
+++ b/crawl-ref/source/dat/des/branches/swamp.des
@@ -1263,7 +1263,7 @@ www.cc+c.www
 ENDMAP
 
 NAME: grunt_witch_cave
-MONS: wizard
+MONS: fenstrider witch
 MONS: hydra
 {{
   dgn.delayed_decay(_G, 'd',
@@ -1600,7 +1600,7 @@ WEIGHT: 2
 MONS:  fenstrider witch
 ITEM:  book of callings, book of summonings
 SUBST: ' = %:20 d:1 e:1
-SUBST: 1 = 1:1 .:1
+NSUBST: 1 = 1:1 / 1:.
 MAP
         WWW
        WxxxW


### PR DESCRIPTION
grunt_witch_cave gets a real witch now that they exist.

cheibrodos_swamp_witchery seemingly wanted to place exactly one
witch in one of the huts randomly, but actually placed zero to
two witches. Replacing SUBST with NSUBST leads to the intended
behaviour.