### PR TITLE
Don't assault firewood

### DIFF
--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1073,8 +1073,10 @@ spret cast_manifold_assault(int pow, bool fail, bool real)
     vector<monster*> targets;
     for (monster_near_iterator mi(&you, LOS_NO_TRANS); mi; ++mi)
     {
-        if (mi->wont_attack() || mi->neutral())
+        if (mi->friendly() || mi->neutral())
             continue; // this should be enough to avoid penance?
+        if (mons_is_firewood(**mi))
+            continue;
         if (!you.can_see(**mi))
             continue;
         targets.emplace_back(*mi);


### PR DESCRIPTION
Also, fix an overlap between ``wont_attack()`` and ``neutral()`` in a condition.

The former means ``ATT_FRIENDLY || ATT_GOOD_NEUTRAL || ATT_STRICT_NEUTRAL``,
the latter means ``ATT_NEUTRAL || ATT_GOOD_NEUTRAL || ATT_STRICT_NEUTRAL``.