### PR TITLE
Describe Ozocubu's Refrigeration and Drain Life in monster

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -1380,6 +1380,8 @@ bolt mons_spell_beam(const monster* mons, spell_type spell_cast, int power,
     case SPELL_SPIT_ACID:
     case SPELL_ACID_SPLASH:
     case SPELL_ELECTRICAL_BOLT:
+    case SPELL_DRAIN_LIFE:
+    case SPELL_OZOCUBUS_REFRIGERATION:
         zappy(spell_to_zap(real_spell), power, true, beam);
         break;
 


### PR DESCRIPTION
The spells weren't handled by ``mons_spell_beam()``, so the monster
utility wasn't showing their damage.

Unlike monster, xv can already show the damage for these spells, since
it gets the numbers in a different way.