### PR TITLE
Fix a couple of compiler warnings from GCC.

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4179,7 +4179,7 @@ const char* get_size_adj(const size_type size, bool ignore_medium)
     return size_adj[size];
 }
 
-string _monster_currently_description(const monster_info &mi)
+static string _monster_currently_description(const monster_info &mi)
 {
     // is it morally wrong to use pos to get the actual monster? Possibly...
     if (!in_bounds(mi.pos) || !monster_at(mi.pos))

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -737,7 +737,7 @@ private:
         return true;
     }
 
-    colour_t entry_colour(const sortable_spell& entry)
+    int entry_colour(const sortable_spell& entry)
     {
         if (vehumet_is_offering(entry.spell))
             return LIGHTBLUE;


### PR DESCRIPTION
Make _monster_currently_description() static.
Make SpellLibraryMenu::entry_colour() return int.

The second is a bit weird, as it doesn't change the thing GCC warns about. The warning goes away when both alternatives are signed values, but it seems a bit silly when either alternative will fit in an int.