### PR TITLE
Make the "1 corona" status message grammatically correct, and others.

### DIFF
--- a/crawl-ref/source/mon-info-flag-name.h
+++ b/crawl-ref/source/mon-info-flag-name.h
@@ -59,7 +59,7 @@ static const vector<monster_info_flag_name> monster_info_flag_names = {
     { MB_RESISTANCE, "resistant", "unusually resistant", "resistant"},
     { MB_INVISIBLE, "invisible", "slightly transparent", "invisible"},
     { MB_REGENERATION, "regenerating", "regenerating", "regenerating"},
-    { MB_STRONG_WILLED, "strong-willed", "strong-willed", "strong-willedmr"},
+    { MB_STRONG_WILLED, "strong-willed", "strong-willed", "strong-willed"},
     { MB_INJURY_BOND, "sheltered", "sheltered from injuries", "sheltered"},
     { MB_GOZAG_INCITED, "incited", "incited by Gozag", "incited"},
     { MB_CLOUD_RING_THUNDER, "clouds", "surrounded by thunder", "clouds" },

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1742,12 +1742,12 @@ static bool _has_wand(const monster_info& mi)
 static string _condition_string(int num, int count,
                                 const monster_info_flag_name& name)
 {
-    if (1 == count)
-        return name.short_singular;
-    else if (count == num)
-        return name.plural;
+    const string& word = (1 == num) ? name.short_singular : name.plural;
+
+    if (count == num)
+        return word;
     else
-        return make_stringf("%d %s", num, name.plural.c_str());
+        return make_stringf("%d %s", num, word.c_str());
 }
 
 void mons_conditions_string(string& desc, const vector<monster_info>& mi,
@@ -1797,7 +1797,7 @@ void mons_conditions_string(string& desc, const vector<monster_info>& mi,
 
         if (missile_count)
         {
-            conditions.push_back(_condition_string(launcher_count, count,
+            conditions.push_back(_condition_string(missile_count, count,
                                                    {MB_UNSAFE, "missile",
                                                     "missile", "missiles"}));
         }


### PR DESCRIPTION
1. Fix the handling of singulars and plurals in _condition_string(). It had been saying "(1 reflect damage)", where it should have been "reflects".

2. Fix a typo in a flag name in monster_info_flag_names.

3. Fix a copy/paste error in mons_conditions_string() which prevented missile-wielders from being reported correctly in the monster list.