### PR TITLE
Remove verbage for extra airstrike damage

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5484,9 +5484,7 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
         if (you.can_see(*foe))
         {
                 mprf("The air twists around and %sstrikes %s%s%s",
-                        foe->airborne() ? "violently " : "",
                         foe->name(DESC_THE).c_str(),
-                        foe->airborne() ? " in flight" : "",
                         attack_strength_punctuation(damage_taken).c_str());
         }
 


### PR DESCRIPTION
8719b9d removed Airstrike bonus damage, but left in the descriptor for the monster Airstrike spell. This should reword the phrase: "The air twists around and violently strikes you in flight!" to "The air twists around and strikes you!"