### PR TITLE
Turn wear-id into floor-id

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -656,11 +656,6 @@ void JewelleryOnDelay::finish()
 void EquipOnDelay::finish()
 {
     const unsigned int old_talents = your_talents(false).size();
-
-    set_ident_flags(equip, ISFLAG_IDENT_MASK);
-    if (is_artefact(equip))
-        equip.flags |= ISFLAG_NOTED_ID;
-
     const bool is_amulet = equip.base_type == OBJ_JEWELLERY;
     const equipment_type eq_slot = is_amulet ? EQ_AMULET :
                                                get_armour_slot(equip);

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -243,6 +243,12 @@ static inline bool is_weapon(const item_def &item)
     return item.base_type == OBJ_WEAPONS || item.base_type == OBJ_STAVES;
 }
 
+inline constexpr bool item_type_is_equipment(object_class_type base_type)
+{
+        return base_type == OBJ_WEAPONS || base_type == OBJ_ARMOUR
+               || base_type == OBJ_JEWELLERY || base_type == OBJ_STAVES;
+}
+
 void remove_whitespace(string &str);
 
 void auto_id_inventory();

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -944,6 +944,8 @@ void item_check()
 // Identify the object the player stepped on.
 // Books are fully identified.
 // Wands are only type-identified.
+// Equipment items are fully identified,
+// but artefact equipment skips some type-id checks.
 static bool _id_floor_item(item_def &item)
 {
     if (item.base_type == OBJ_BOOKS)
@@ -969,6 +971,34 @@ static bool _id_floor_item(item_def &item)
                 set_item_autopickup(item, AP_FORCE_OFF);
             return true;
         }
+    }
+    else if (item_type_is_equipment(item.base_type))
+    {
+        if (fully_identified(item))
+            return false;
+
+        // autopickup hack for previously-unknown items
+        if (item_needs_autopickup(item))
+            item.props["needs_autopickup"] = true;
+
+        if (is_artefact(item))
+        {
+            if (!(item.flags & ISFLAG_NOTED_ID))
+            {
+                item.flags |= ISFLAG_NOTED_ID;
+
+                // Make a note of it.
+                take_note(Note(NOTE_ID_ITEM, 0, 0, item.name(DESC_A),
+                               origin_desc(item)));
+            }
+        }
+
+        // prop hack for _equip_jewellery_effect and Xom stimulation.
+        // This does not type-identify artefacts.
+        item.props["newly_identified"] = set_ident_type(item, true);
+
+        set_ident_flags(item, ISFLAG_IDENT_MASK);
+        return true;
     }
 
     return false;

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -820,7 +820,8 @@ static bool _purchase(shop_struct& shop, const level_pos& pos, int index)
 
     origin_purchased(item);
 
-    if (shoptype_identifies_stock(shop.type))
+    if (shoptype_identifies_stock(shop.type)
+        || item_type_is_equipment(item.base_type))
     {
         // Identify the item and its type.
         // This also takes the ID note if necessary.


### PR DESCRIPTION
Following much the same reasoning as in f6d4cf81.

With the removal of curses, players are currently incentivized to wear-id
(almost) everything they can. This commit is targeted as a tedium reduction:

Every item you could equip-id before, you can now identify by stepping on.

Dev notes: The equip-id code was spread out and a little hairy.

In the course of moving the logic over, I've unified the floor-id codepath
for identifying OBJ_WEAPONS, OBJ_STAVES, OBJ_ARMOUR, and OBJ_JEWELLERY.

I've tried to preserve the old wear-id behavior as closely as possible
while remaining reasonable here, but there was some spurious logic
(effective noops and duplicate flags being set) that I've removed in the
course of refactoring this.

That "newly_identified" prop is not well tested, but hey, that's what
trunk is for.