### PR TITLE
cut down hell floors to 2; increase hell spawn rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cquery_cache/
 .DS_Store
 .vscode/
+.ssh/
 
 *.sublime-workspace
 *.sublime-project

--- a/crawl-ref/source/branch-data.h
+++ b/crawl-ref/source/branch-data.h
@@ -157,7 +157,7 @@ const Branch branches[NUM_BRANCHES] =
       LIGHTGREY, LIGHTRED,
       'H', {}, branch_noise::normal },
 
-    { BRANCH_DIS, BRANCH_VESTIBULE, 1, 1, 7, 28,
+    { BRANCH_DIS, BRANCH_VESTIBULE, 1, 1, 2, 28,
       brflag::no_items | brflag::dangerous_end,
       DNGN_ENTER_DIS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Dis", "the Iron City of Dis", "Dis",
@@ -165,7 +165,7 @@ const Branch branches[NUM_BRANCHES] =
       CYAN, BROWN,
       'I', { RUNE_DIS }, branch_noise::normal },
 
-    { BRANCH_GEHENNA, BRANCH_VESTIBULE, 1, 1, 7, 28,
+    { BRANCH_GEHENNA, BRANCH_VESTIBULE, 1, 1, 2, 28,
       brflag::no_items | brflag::dangerous_end,
       DNGN_ENTER_GEHENNA, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Gehenna", "Gehenna", "Geh",
@@ -173,7 +173,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, RED,
       'G', { RUNE_GEHENNA }, branch_noise::normal },
 
-    { BRANCH_COCYTUS, BRANCH_VESTIBULE, 1, 1, 7, 28,
+    { BRANCH_COCYTUS, BRANCH_VESTIBULE, 1, 1, 2, 28,
       brflag::no_items | brflag::dangerous_end,
       DNGN_ENTER_COCYTUS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Cocytus", "Cocytus", "Coc",
@@ -181,7 +181,7 @@ const Branch branches[NUM_BRANCHES] =
       LIGHTBLUE, LIGHTCYAN,
       'X', { RUNE_COCYTUS }, branch_noise::normal },
 
-    { BRANCH_TARTARUS, BRANCH_VESTIBULE, 1, 1, 7, 28,
+    { BRANCH_TARTARUS, BRANCH_VESTIBULE, 1, 1, 2, 28,
       brflag::no_items | brflag::dangerous_end,
       DNGN_ENTER_TARTARUS, DNGN_ENTER_HELL, DNGN_ENTER_HELL,
       "Tartarus", "Tartarus", "Tar",

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -40,7 +40,7 @@ Animate Armour spell
 
 Call upon the spirit of your worn armour to fight alongside you. The spirit moves
 slowly, but draws strength from the inherent protection of your own armour. At
-higher power, the spirit's protective enchantments grow stronger.
+higher power, the spirit becomes more durable.
 %%%%
 Animate Dead spell
 

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1536,8 +1536,8 @@ static int _num_mons_wanted()
     else if (player_in_branch(BRANCH_CRYPT))
         size = 10;
 	else if (in_pan)
-		size = 40;
-		// 8 -> 40
+		size = 8;
+		// seperated for future modification
     else if (player_in_hell())
         size = 60;
 		// 23 -> 60

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1531,12 +1531,16 @@ static int _num_mons_wanted()
 
     int size = 12;
 
-    if (player_in_branch(BRANCH_SWAMP) || in_pan)
+    if (player_in_branch(BRANCH_SWAMP))
         size = 8;
     else if (player_in_branch(BRANCH_CRYPT))
         size = 10;
+	else if (in_pan)
+		size = 40;
+		// 8 -> 40
     else if (player_in_hell())
-        size = 23;
+        size = 60;
+		// 23 -> 60
 
     int mon_wanted = roll_dice(3, size);
 

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -944,7 +944,7 @@ string monster_info::_core_name() const
             if (inv[MSLOT_ARMOUR])
             {
                 const item_def& item = *inv[MSLOT_ARMOUR];
-                s = "animated " + item.name(DESC_PLAIN, false, false, true, false);
+                s = "animated " + item.name(DESC_PLAIN, false, false, true, false, ISFLAG_KNOW_PLUSES);
             }
             break;
 

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -153,6 +153,7 @@ spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
 
     mgen_data mg = _pal_data(MONS_ANIMATED_ARMOUR, 2, god,
                              SPELL_ANIMATE_ARMOUR);
+    mg.hd = 15 + div_rand_round(pow, 10);
     monster* spirit = create_monster(mg);
     if (!spirit)
     {
@@ -165,7 +166,6 @@ spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
     fake_armour.base_type = OBJ_ARMOUR;
     fake_armour.sub_type = armour->sub_type;
     fake_armour.quantity = 1;
-    fake_armour.plus = pow / 10;
     fake_armour.rnd = armour->rnd;
     fake_armour.flags |= ISFLAG_SUMMONED | ISFLAG_KNOW_PLUSES;
     item_set_appearance(fake_armour);


### PR DESCRIPTION
### Summary
- hell floors cut down from 7 to 2
- hell monster spawn rate increased from 23 to 60;

### Why?
most of dcss players do 3-rune run. not much tries 15-rune run. one of the main reasons is that end-game contents are long and tedious.
- there's not much left for player to grow;
- pandemonium and hell are too long;
  - endlessly wandering about in pande, same scenery, same monsters except rune floor
  - each hell hosts 7 floor, and you are already tired from all that quest from main dungeon to zot

### Conclusion
so, some accessibility must be provided before adding end-game contents, which would not be done neartime; since adding contents take long time to develop.
this PR tries to add a bit of accessibility to end-game contents by shotening hell first. shortening pande is planned too;