### PR TITLE
Don't waste time casting Sublimation of Blood when at max MP

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3193,7 +3193,7 @@ static string _player_spell_desc(spell_type spell)
         // of applying slightly different formatting.
         description << "\n<red>"
                     << uppercase_first(casting_uselessness_reason(spell, true))
-                    << "<red>\n";
+                    << "</red>\n";
     }
     else if (spell_is_useless(spell, true, false))
     {

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1138,6 +1138,12 @@ string casting_uselessness_reason(spell_type spell, bool temp)
 
         if (!enough_mp(spell_mana(spell), true, false))
             return "you don't have enough magic to cast this spell.";
+
+        if (spell == SPELL_SUBLIMATION_OF_BLOOD
+            && you.magic_points == you.max_magic_points)
+        {
+            return "your reserves of magic are already full.";
+        }
     }
 
     // Check for banned schools (Currently just Ru sacrifices)
@@ -1336,8 +1342,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         {
             return "you have no blood to sublime.";
         }
-        if (you.magic_points == you.max_magic_points && temp)
-            return "your reserves of magic are already full.";
         break;
 
     case SPELL_TORNADO:

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1334,14 +1334,8 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         break;
 
     case SPELL_SUBLIMATION_OF_BLOOD:
-        // XXX: write player_can_bleed(bool temp) & use that
-        if (you.species == SP_GARGOYLE
-            || you.species == SP_GHOUL
-            || you.species == SP_MUMMY
-            || (temp && !form_can_bleed(you.form)))
-        {
+        if (!you.can_bleed(temp))
             return "you have no blood to sublime.";
-        }
         break;
 
     case SPELL_TORNADO:


### PR DESCRIPTION
After 4502bb1e, the player can cast Sublimation when at max MP. The description still has the "This spell would have no effect right now" warning, and the spell is correctly greyed out on the quiver in this situation, though.

Fix this by moving Sublimation's MP check into a function that is called before subtracting the MP cost. This adds a spell-specific check to casting-specific ones, but it's good to have all MP-related checks in one place. Also, it's clearer than temporarily refunding the spell cost, as it was before 4502bb1e.
