### PR TITLE
Fix equipment identification

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -941,6 +941,20 @@ void item_check()
     }
 }
 
+void identify_item(item_def& item)
+{
+    set_ident_flags(item, ISFLAG_IDENT_MASK);
+
+    if (is_artefact(item) && !(item.flags & ISFLAG_NOTED_ID))
+    {
+        item.flags |= ISFLAG_NOTED_ID;
+
+        // Make a note of it.
+        take_note(Note(NOTE_ID_ITEM, 0, 0, item.name(DESC_A),
+                       origin_desc(item)));
+    }
+}
+
 // Identify the object the player stepped on.
 // Books are fully identified.
 // Wands are only type-identified.
@@ -980,17 +994,7 @@ static bool _id_floor_item(item_def &item)
         // autopickup hack for previously-unknown items
         if (item_needs_autopickup(item))
             item.props["needs_autopickup"] = true;
-
-        set_ident_flags(item, ISFLAG_IDENT_MASK);
-
-        if (is_artefact(item) && !(item.flags & ISFLAG_NOTED_ID))
-        {
-            item.flags |= ISFLAG_NOTED_ID;
-
-            // Make a note of it.
-            take_note(Note(NOTE_ID_ITEM, 0, 0, item.name(DESC_A),
-                           origin_desc(item)));
-        }
+        identify_item(item);
         return true;
     }
 

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -91,6 +91,7 @@ void lose_item_stack(const coord_def& where);
 
 string item_message(vector<const item_def *> const &items);
 void item_check();
+void identify_item(item_def& item);
 void request_autopickup(bool do_pickup = true);
 void id_floor_items();
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -170,6 +170,8 @@ void equip_effect(equipment_type slot, int item_slot, bool unmeld, bool msg)
 
     const interrupt_block block_unmeld_interrupts(unmeld);
 
+    identify_item(item);
+
     if (slot == EQ_WEAPON)
         _equip_weapon_effect(item, msg, unmeld);
     else if (slot >= EQ_CLOAK && slot <= EQ_BODY_ARMOUR)

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -825,8 +825,7 @@ static bool _purchase(shop_struct& shop, const level_pos& pos, int index)
     {
         // Identify the item and its type.
         // This also takes the ID note if necessary.
-        set_ident_type(item, true);
-        set_ident_flags(item, ISFLAG_IDENT_MASK);
+        identify_item(item);
     }
 
     // Shopkeepers will place goods you can't carry outside the shop.


### PR DESCRIPTION
bb19ded didn't properly identify items that were already in the player's
inventory. This commit restores equip identify behavior, to fix this
and handle any unforeseen cases of items being placed directly into the
player's inventory.