### PR TITLE
Nerf the dex meta.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2040,7 +2040,7 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
 static int _player_armour_adjusted_dodge_bonus(int scale)
 {
     const int dodge_bonus =
-        (80 + you.skill(SK_DODGING, 10) * you.dex() * 9) * scale
+        (800 + you.skill(SK_DODGING, 10) * you.dex() * 8) * scale
         / (20 - _player_evasion_size_factor()) / 10 / 10;
 
     const int armour_dodge_penalty = you.unadjusted_body_armour_penalty() - 3;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2040,8 +2040,8 @@ static int _player_scale_evasion(int prescaled_ev, const int scale)
 static int _player_armour_adjusted_dodge_bonus(int scale)
 {
     const int dodge_bonus =
-        (70 + you.skill(SK_DODGING, 10) * you.dex()) * scale
-        / (20 - _player_evasion_size_factor()) / 10;
+        (80 + you.skill(SK_DODGING, 10) * you.dex() * 9) * scale
+        / (20 - _player_evasion_size_factor()) / 10 / 10;
 
     const int armour_dodge_penalty = you.unadjusted_body_armour_penalty() - 3;
     if (armour_dodge_penalty <= 0)


### PR DESCRIPTION
I think this is the best way to retain a linear formula without impacting the rest of
the game too much; slope and intercept can be adjusted further if necessary.

Ended up going with 20% reduction after aliscans pointed out that I messed up
the intercept value (whoops); 20% should be reasonable after all.