### PR TITLE
Allow Chei followers to use quickblades.

### DIFF
--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -270,8 +270,6 @@ bool is_hasty_item(const item_def& item, bool calc_unid)
 {
     if (item.base_type == OBJ_WEAPONS)
     {
-        if (item.sub_type == WPN_QUICK_BLADE)
-            return true;
         if (calc_unid || item_brand_known(item))
             return get_weapon_brand(item) == SPWPN_SPEED;
     }


### PR DESCRIPTION
This was a very silly thematic restriction that eliminated a potentially
interesting character choice. The weapon of speed restriction is pretty silly
too, but those are at least supposed to be magically fast or something;
quickblades are just a weapon type with low attack delay. Chei does not care
about the player reducing their attack delay by gaining weapon skill, nor does
Chei care about the player taking quick actions like removing a ring or
unwielding a weapon, so there is no reason to ban a weapon type merely because
it has low delay.