### PR TITLE
Add spell damage info to the `I!` menu and morgues

### DIFF
--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -905,7 +905,7 @@ static void _sdump_spells(dump_params &par)
 
         text += "You " + verb + " the following spells:\n\n";
 
-        text += " Your Spells              Type           Power        Failure   Level" "\n";
+        text += " Your Spells              Type           Power      Damage    Failure   Level" "\n";
 
         for (int j = 0; j < 52; j++)
         {
@@ -938,13 +938,18 @@ static void _sdump_spells(dump_params &par)
 
                 spell_line += spell_power_string(spell);
 
-                spell_line = chop_string(spell_line, 54);
+                spell_line = chop_string(spell_line, 52);
+
+                const string spell_damage = spell_damage_string(spell);
+                spell_line += spell_damage.length() ? spell_damage : "N/A";
+
+                spell_line = chop_string(spell_line, 62);
 
                 spell_line += failure_rate_to_string(raw_spell_fail(spell));
 
-                spell_line = chop_string(spell_line, 66);
+                spell_line = chop_string(spell_line, 74);
 
-                spell_line += make_stringf("%-5d", spell_difficulty(spell));
+                spell_line += make_stringf("%d", spell_difficulty(spell));
 
                 spell_line += "\n";
 
@@ -963,7 +968,7 @@ static void _sdump_spells(dump_params &par)
     {
         verb = par.se? "contained" : "contains";
         text += "Your spell library " + verb + " the following spells:\n\n";
-        text += " Spells                   Type           Power        Failure   Level" "\n";
+        text += " Spells                   Type           Power      Damage    Failure   Level" "\n";
 
         auto const library = get_sorted_spell_list(true, false);
 
@@ -997,16 +1002,21 @@ static void _sdump_spells(dump_params &par)
             else
                 spell_line += "Unusable";
 
-            spell_line = chop_string(spell_line, 54);
+            spell_line = chop_string(spell_line, 52);
+
+            const string spell_damage = spell_damage_string(spell);
+            spell_line += spell_damage.length() ? spell_damage : "N/A";
+
+            spell_line = chop_string(spell_line, 62);
 
             if (memorisable)
                 spell_line += failure_rate_to_string(raw_spell_fail(spell));
             else
                 spell_line += "N/A";
 
-            spell_line = chop_string(spell_line, 66);
+            spell_line = chop_string(spell_line, 74);
 
-            spell_line += make_stringf("%-5d", spell_difficulty(spell));
+            spell_line += make_stringf("%d", spell_difficulty(spell));
 
             spell_line += "\n";
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -156,9 +156,11 @@ static string _spell_extra_description(spell_type spell, bool viewing)
 
     // spell power, spell range, noise
     const string rangestring = spell_range_string(spell);
+    const string damagestring = spell_damage_string(spell);
 
-    desc << chop_string(spell_power_string(spell), 13)
-         << chop_string(rangestring, 9)
+    desc << chop_string(spell_power_string(spell), 10)
+         << chop_string(damagestring.length() ? damagestring : "N/A", 10)
+         << chop_string(rangestring, 10)
          << chop_string(spell_noise_string(spell, 10), 14);
 
     desc << "</" << colour_to_str(highlight) <<">";
@@ -182,7 +184,7 @@ int list_spells(bool toggle_with_I, bool viewing, bool allow_preselect,
         ToggleableMenuEntry* me =
             new ToggleableMenuEntry(
                 titlestring + "         Type                          Failure  Level",
-                titlestring + "         Power        Range    Noise         ",
+                titlestring + "         Power     Damage    Range     Noise ",
                 MEL_TITLE);
         spell_menu.set_title(me, true, true);
     }


### PR DESCRIPTION
A third of player spells - 35 out of 110 [1] - have damage info, but this information is well hidden.

This commit adds a quick way to compare spells and to see all the numbers at once.

It'll look like this:

![spell_damage](https://user-images.githubusercontent.com/3328424/109640499-7a05e300-7b48-11eb-9fe3-d23f7d1077d2.png)

Not sure what was the purpose of trailing spaces after the spell levels in morgues. Removing them doesn't mess up line wrapping on the `?#` screen in console and both -tiles, as far as I can see.

-----

1. There are eight more spells that could have damage info: Tornado, Summon Lightning Spire, Poisonous Vapours, Olgreb's Toxic Radiance, Airstrike, Eringya's Noxious Bog, Borgnjor's Vile Clutch, and Chain Lightning.
