### PR TITLE
Don't make a note when you find an altar you can't use.

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -284,7 +284,7 @@ public:
     virtual monster_type mons_species(bool zombie_base = false) const = 0;
 
     virtual mon_holy_type holiness(bool temp = true) const = 0;
-    virtual bool undead_or_demonic() const = 0;
+    virtual bool undead_or_demonic(bool temp = true) const = 0;
     virtual bool holy_wrath_susceptible() const;
     virtual bool is_holy() const = 0;
     virtual bool is_nonliving(bool temp = true) const = 0;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3532,7 +3532,7 @@ mon_holy_type monster::holiness(bool /*temp*/) const
     return holi;
 }
 
-bool monster::undead_or_demonic() const
+bool monster::undead_or_demonic(bool /*temp*/) const
 {
     const mon_holy_type holi = holiness();
 

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -370,7 +370,7 @@ public:
     monster_type mons_species(bool zombie_base = false) const override;
 
     mon_holy_type holiness(bool /*temp*/ = true) const override;
-    bool undead_or_demonic() const override;
+    bool undead_or_demonic(bool /*temp*/ = true) const override;
     bool is_holy() const override;
     bool is_nonliving(bool /*temp*/ = true) const override;
     int how_unclean(bool check_god = true) const;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6054,10 +6054,11 @@ mon_holy_type player::holiness(bool temp) const
     return holi;
 }
 
-bool player::undead_or_demonic() const
+// With temp (default true), report temporary effects such as lichform.
+bool player::undead_or_demonic(bool temp) const
 {
     // This is only for TSO-related stuff, so demonspawn are included.
-    return undead_state() || species == SP_DEMONSPAWN;
+    return undead_state(temp) || species == SP_DEMONSPAWN;
 }
 
 bool player::is_holy() const

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -749,7 +749,7 @@ public:
     monster_type mons_species(bool zombie_base = false) const override;
 
     mon_holy_type holiness(bool temp = true) const override;
-    bool undead_or_demonic() const override;
+    bool undead_or_demonic(bool temp = true) const override;
     bool is_holy() const override;
     bool is_nonliving(bool temp = true) const override;
     int how_chaotic(bool check_spells_god) const override;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3145,35 +3145,46 @@ static bool _god_rejects_loveless(god_type god)
     }
 }
 
-bool player_can_join_god(god_type which_god)
+/**
+ * Return true if the player can worship which_god.
+ *
+ * @param which_god  god to query
+ * @param temp       If true (default), test if you can worship which_god now.
+ *                   If false, test if you may ever be able to worship the god.
+ * @return           Whether you can worship which_god.
+ */
+bool player_can_join_god(god_type which_god, bool temp)
 {
     if (you.has_mutation(MUT_FORLORN))
         return false;
 
-    if (is_good_god(which_god) && you.undead_or_demonic())
+    if (is_good_god(which_god) && you.undead_or_demonic(temp))
         return false;
 
-    if (which_god == GOD_YREDELEMNUL && you.is_nonliving())
+    if (which_god == GOD_YREDELEMNUL && you.is_nonliving(temp))
         return false;
 
     if (which_god == GOD_BEOGH && !species_is_orcish(you.species))
         return false;
 
-    if (which_god == GOD_GOZAG && you.gold < gozag_service_fee())
+    if (which_god == GOD_GOZAG && temp && you.gold < gozag_service_fee())
         return false;
 
-    if (you.get_mutation_level(MUT_NO_LOVE) && _god_rejects_loveless(which_god))
+    if (you.get_base_mutation_level(MUT_NO_LOVE, true, temp, temp)
+        && _god_rejects_loveless(which_god))
+    {
         return false;
+    }
 
 #if TAG_MAJOR_VERSION == 34
-    if (you.get_mutation_level(MUT_NO_ARTIFICE)
+    if (you.get_base_mutation_level(MUT_NO_ARTIFICE, true, temp, temp)
         && which_god == GOD_PAKELLAS)
     {
         return false;
     }
 #endif
 
-    return _transformed_player_can_join_god(which_god);
+    return !temp || _transformed_player_can_join_god(which_god);
 }
 
 // Handle messaging and identification for items/equipment on conversion.

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -65,7 +65,7 @@ void handle_god_time(int /*time_delta*/);
 int god_colour(god_type god);
 colour_t god_message_altar_colour(god_type god);
 int gozag_service_fee();
-bool player_can_join_god(god_type which_god);
+bool player_can_join_god(god_type which_god, bool temp = true);
 void join_religion(god_type which_god);
 void god_pitch(god_type which_god);
 god_type choose_god(god_type def_god = NUM_GODS);

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1967,9 +1967,12 @@ bool is_boring_terrain(dungeon_feature_type feat)
     if (!is_notable_terrain(feat))
         return true;
 
-    // Altars in the temple are boring.
-    if (feat_is_altar(feat) && player_in_branch(BRANCH_TEMPLE))
+    // Altars in the temple are boring, as are any you can never use.
+    if (feat_is_altar(feat) && (player_in_branch(BRANCH_TEMPLE)
+        || !player_can_join_god(feat_altar_god(feat), false)))
+    {
         return true;
+    }
 
     // Only note the first entrance to the Abyss/Pan/Hell
     // which is found.


### PR DESCRIPTION
Add a "temp" parameter to player_can_join_god() and player::undead_or_demonic(). If false, the functions ignore temporary effects from things like mutations and spells, and only consider permanent barriers such as the player's species and Ru sacrifices.

Use this to stop the game from making a note on finding an altar for a god the character will never be able to worship.