### PR TITLE
Add clua documentation for spells.fail_severity()

### DIFF
--- a/crawl-ref/source/l-spells.cc
+++ b/crawl-ref/source/l-spells.cc
@@ -173,8 +173,13 @@ LUAFN(l_spells_fail)
     PLUARET(number, failure_rate_to_int(raw_spell_fail(spell)));
 }
 
-/*** The failure severity of the spell.
- * TODO: Document these numbers
+/*** The miscast severity of the spell as a number in [0,5].
+ * 0: light grey, no chance of damaging miscast
+ * 1: white, <= 10% max HP damage
+ * 2: yellow, <= 30% max HP damage
+ * 3: light red, <= 50% max HP damage
+ * 4: red, <= 70% max HP damage
+ * 5: magenta, > 70% max HP damage (potentially lethal)
  * @tparam string name
  * @treturn int
  * @function fail_severity

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2436,7 +2436,7 @@ int fail_severity(spell_type spell)
     const int level = spell_difficulty(spell);
 
     // Impossible to get a damaging miscast
-    if (level * level * raw_fail <= 150)
+    if (level * level * raw_fail <= MISCAST_THRESHOLD)
         return 0;
 
     const int max_damage = max_miscast_damage(spell);


### PR DESCRIPTION
This series of commits:
* Adds clua documentation for spells.fail_severity()
* Replaces a miscast threshold magic number in spl-cast.cc with MISCAST_THRESHOLD
* Staticifies MISCAST_THRESHOLD and MISCAST_DIVISOR