### PR TITLE
Fix a wizmode shop placement crash

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1507,10 +1507,12 @@ static const char *shop_types[] =
     "antique armour",
     "antiques",
     "jewellery",
-    "gadget",
+#if TAG_MAJOR_VERSION == 34
+    "removed gadget",
+#endif
     "book",
 #if TAG_MAJOR_VERSION == 34
-    "food",
+    "removed food",
 #endif
     "distillery",
     "scroll",
@@ -1524,6 +1526,10 @@ static const char *shop_types[] =
  */
 shop_type str_to_shoptype(const string &s)
 {
+#if TAG_MAJOR_VERSION == 34
+    if (s == "removed gadget" || s == "removed food")
+        return SHOP_UNASSIGNED;
+#endif
     if (s == "random" || s == "any")
         return SHOP_RANDOM;
 


### PR DESCRIPTION
At present, trying to place a gadget shop or a food shop will cause
the game to crash.

This commit adds a missing TAG_MAJOR_VERSION == 34 for gadget shops,
and adds a guard against placing either gadget or food shops.