### PR TITLE
Fix shop purchase potion/scroll stacking

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -943,6 +943,11 @@ void item_check()
 
 void identify_item(item_def& item)
 {
+    // items_stack() has strict flag conditions to prevent a shop info leak,
+    // so we need set_ident_type() here to permit stacking shop purchases.
+    if (is_stackable_item(item))
+        set_ident_type(item, true);
+
     set_ident_flags(item, ISFLAG_IDENT_MASK);
 
     if (is_artefact(item) && !(item.flags & ISFLAG_NOTED_ID))


### PR DESCRIPTION
This was broken in 83025b5. It turns out that items_stack() has some fairly
particular conditions that don't necessarily match ISFLAG_IDENT_MASK, due
to a potential lua info leak. For some background on this, see:
crawl-dev-20151123.lg

If this commit somehow breaks identify again, I apologize in advance.