### PR TITLE
Clarify that amulet of the acrobat doesn't work while taking stairs

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -40,9 +40,12 @@ function, it must first attune itself to the wearer's body at full health.
 %%%%
 amulet of the acrobat
 
-An amulet that allows the user to tumble and roll to evade the blows of their
-enemies, but only while moving and waiting. While taking other actions the
-amulet conveys no benefits.
+This amulet lets the wearer tumble and roll to evade blows from enemies. This
+provides a large boost to the wearer's evasion abilities (EV +15). However, the
+amulet only works while the wearer is moving or waiting.
+
+While the wearer is taking stairs, attacking an enemy, reading a scroll, or
+performing any other action, the amulet conveys no benefits.
 %%%%
 animal skin
 


### PR DESCRIPTION
I would suggest that, when updating the changelog, you add this entry:

"The amulet of the acrobat now makes it explicit in its description that it
doesn't work while taking stairs."

Many players still don't know that the amulet of the acrobat doesn't work while
taking stairs. If you create my suggested changelog entry, at least those
players who read the changelog will learn about this fact. In the end, the
changelog addition may prevent quite a few needless character deaths.