### PR TITLE
Add Hepliaklqana Heroes Vault

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1238,6 +1238,84 @@ xxwwwwwxx
 xxxxxxxxx
 ENDMAP
 
+NAME:   beargit_hepliaklqana_dungeon_heroes
+TAGS:   temple_overflow_hepliaklqana temple_overflow_1
+TAGS:   no_monster_gen patrolling no_trap_gen
+DEPTH:  D:4-, Depths
+SHUFFLE: 12d
+# Battlemage
+: if crawl.one_chance_in(3) then
+:   if you.in_branch("D") and you.depth() < 10 then
+KMONS:  1 = blork the orc; quarterstaff, orc wizard; quarterstaff . robe
+KMONS:  2 = spectral orc wizard name:ancestral_orc_wizard name_replace
+ITEM:   randbook owner:Hepliaklqana spells:stone_arrow numspells:1
+:   elseif you.in_branch("D") then
+MONS:   ogre mage; lajatang . potion of haste
+MONS:   spectral ogre mage name:ancestral_ogre_mage name_replace
+ITEM:   randbook owner:Hepliaklqana spells:bolt_of_magma numspells:1
+:   else
+MONS:   deep elf annihilator; lajatang ego:freezing . potion of haste
+MONS:   ancient lich name:ancestral_lich name_replace
+ITEM:   randbook owner:Hepliaklqana spells:lehudib's_crystal_spear numspells:1
+:   end
+
+# Hexer
+: elseif crawl.coinflip() then
+:   if you.in_branch("D") and you.depth() < 10 then
+MONS:   orc wizard; dagger ego:draining . robe
+MONS:   spectral orc wizard name:ancestral_orc_wizard name_replace
+ITEM:   randbook owner:Hepliaklqana spells:slow numspells:1 / \
+        randbook owner:Hepliaklqana spells:confusing_touch numspells:1
+:   elseif you.in_branch("D") then
+MONS:   orc sorcerer; dagger ego:draining . robe . potion of haste
+MONS:   spectral orc sorcerer name:ancestral_orc_sorcerer name_replace \
+        perm_ench:haste
+ITEM:   wand of paralyze
+:   else
+MONS:   vampire knight; quick blade ego:antimagic
+MONS:   ancient lich name:ancestral_lich name_replace
+# Mass confuse is not a player spell
+ITEM:   randbook owner:Hepliaklqana spells:alistair's_intoxication numspells:1
+:   end
+
+# Knight
+: else
+:   if you.in_branch("D") and you.depth() < 10 then
+MONS:   orc warrior; flail . kite shield . chain mail
+MONS:   spectral orc warrior name:ancestral_orc_warrior name_replace
+ITEM:   nothing
+:   elseif you.in_branch("D") then
+MONS:   orc knight; broad axe ego:flaming . tower shield . \
+        chain mail . potion of haste
+MONS:   spectral orc knight name:ancestral_orc_knight name_replace \
+        perm_ench:haste
+ITEM:   nothing w:100 / tower shield ego:reflection
+:   else
+MONS:   deep elf blademaster; broad axe good_item . \
+        tower shield . chain mail . potion of haste
+MONS:   spectral deep elf blademaster name:ancestral_deep_elf_blademaster \
+        name_replace perm_ench:haste
+ITEM:   nothing w:100 / broad axe ego:speed / tower shield ego:reflection
+:   end
+: end
+KFEAT:   _ = altar_hepliaklqana
+MARKER:  _ = lua:fog_machine { cloud_type = "thin mist", \
+                              pow_min = 100, pow_max = 200, \
+                              delay = 100, size = 1, walk_dist = 1 }
+TILE:   G = dngn_gravestone
+: interest_check(_G)
+MAP
+    cc.cc
+    c...c
+ccccc.c.cccc
+c.2........c
+cd_G..c.c...
+c.1........c
+ccccc.c.cccc
+    c...c
+    cc.cc
+ENDMAP
+
 ### Kikubaaqudgha overflow altars #############################################
 
 NAME:   lemuel_zombie_altar_kikubaaqudgha

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1241,79 +1241,87 @@ ENDMAP
 NAME:   beargit_hepliaklqana_dungeon_heroes
 TAGS:   temple_overflow_hepliaklqana temple_overflow_1
 TAGS:   no_monster_gen patrolling no_trap_gen
-DEPTH:  D:4-, Depths
-SHUFFLE: 12d
-# Battlemage
-: if crawl.one_chance_in(3) then
-:   if you.in_branch("D") and you.depth() < 10 then
-KMONS:  1 = blork the orc; quarterstaff, orc wizard; quarterstaff . robe
-KMONS:  2 = spectral orc wizard name:ancestral_orc_wizard name_replace
-ITEM:   randbook owner:Hepliaklqana spells:stone_arrow numspells:1
-:   elseif you.in_branch("D") then
-MONS:   ogre mage; lajatang . potion of haste
-MONS:   spectral ogre mage name:ancestral_ogre_mage name_replace
-ITEM:   randbook owner:Hepliaklqana spells:bolt_of_magma numspells:1
-:   else
-MONS:   deep elf annihilator; lajatang ego:freezing . potion of haste
-MONS:   ancient lich name:ancestral_lich name_replace
-ITEM:   randbook owner:Hepliaklqana spells:lehudib's_crystal_spear numspells:1
-:   end
+DEPTH:  D:2-, Depths
+SHUFFLE: 123
+SHUFFLE: _-G
 
-# Hexer
-: elseif crawl.coinflip() then
-:   if you.in_branch("D") and you.depth() < 10 then
-MONS:   orc wizard; dagger ego:draining . robe
-MONS:   spectral orc wizard name:ancestral_orc_wizard name_replace
-ITEM:   randbook owner:Hepliaklqana spells:slow numspells:1 / \
-        randbook owner:Hepliaklqana spells:confusing_touch numspells:1
-:   elseif you.in_branch("D") then
-MONS:   orc sorcerer; dagger ego:draining . robe . potion of haste
-MONS:   spectral orc sorcerer name:ancestral_orc_sorcerer name_replace \
-        perm_ench:haste
-ITEM:   wand of paralyze
+#   Only 1 dangerous monster early
+: if you.in_branch("D") and you.depth() < 7 then
+:   if crawl.one_chance_in(3) then
+#   Knight only
+SUBST: 1 = ., 2 = .
+:   elseif crawl.coinflip() then
+#   Hexer only
+SUBST: 1 = ., 3 = .
 :   else
-MONS:   vampire knight; quick blade ego:antimagic
-MONS:   ancient lich name:ancestral_lich name_replace
-# Mass confuse is not a player spell
-ITEM:   randbook owner:Hepliaklqana spells:alistair's_intoxication numspells:1
-:   end
-
-# Knight
-: else
-:   if you.in_branch("D") and you.depth() < 10 then
-MONS:   orc warrior; flail . kite shield . chain mail
-MONS:   spectral orc warrior name:ancestral_orc_warrior name_replace
-ITEM:   nothing
-:   elseif you.in_branch("D") then
-MONS:   orc knight; broad axe ego:flaming . tower shield . \
-        chain mail . potion of haste
-MONS:   spectral orc knight name:ancestral_orc_knight name_replace \
-        perm_ench:haste
-ITEM:   nothing w:100 / tower shield ego:reflection
-:   else
-MONS:   deep elf blademaster; broad axe good_item . \
-        tower shield . chain mail . potion of haste
-MONS:   spectral deep elf blademaster name:ancestral_deep_elf_blademaster \
-        name_replace perm_ench:haste
-ITEM:   nothing w:100 / broad axe ego:speed / tower shield ego:reflection
+#   Battlemage only
+SUBST: 2 = ., 3 = .
 :   end
 : end
+
+: if you.in_branch("D") and you.depth() < 4 then
+# One of these 3
+KMONS: 1 = orc wizard; quarterstaff . robe
+KMONS: 2 = Jessica; dagger ego:draining . robe . wand of random effects, \
+           orc wizard; dagger ego:draining . robe . wand of random effects / \
+           kobold; dagger ego:draining . wand of random effects
+KMONS: 3 = orc warrior; flail . kite shield . chain mail
+: elseif you.in_branch("D") and you.depth() < 7 then
+# One of these 3
+KMONS: 1 = blork the orc; quarterstaff . robe, orc wizard; quarterstaff . robe
+KMONS: 2 = sigmund; scythe ego:draining . robe . wand of random effects, \
+           orc wizard; dagger ego:draining . robe . wand of random effects / \
+           gnoll; whip ego:draining . wand of random effects
+KMONS: 3 = orc warrior; flail . kite shield . chain mail
+: elseif you.in_branch("D") and you.depth() < 12 then
+MONS: gargoyle; quarterstaff / orc wizard; quarterstaff . robe
+MONS: human; dagger ego:draining . wand of paralysis
+MONS: orc warrior; flail . kite shield . chain mail
+: elseif you.in_branch("D") then
+MONS: ogre mage; lajatang ego:freezing . potion of haste
+MONS: spriggan; dagger ego:draining . wand of paralysis . potion of haste / \
+      merfolk siren; dagger ego:draining . wand of paralysis . potion of haste
+MONS: orc knight; chain mail . broad axe w:40 | broad axe ego:flaming . \
+      tower shield w:40 | tower shield ego:reflection . potion of haste / \
+      tengu warrior; chain mail . broad axe w:40 | broad axe ego:flaming . \
+      tower shield w:40 | tower shield ego:reflection . potion of haste / \
+      naga warrior; chain mail . broad axe w:40 | broad axe ego:flaming . \
+      tower shield w:40 | tower shield ego:reflection . potion of haste
+: else
+MONS: deep elf annihilator; lajatang ego:freezing . potion of haste . \
+      potion of haste / \
+      draconian annihilator; lajatang ego:freezing . potion of haste . \
+      potion of haste . cloak
+MONS: vampire knight; quick blade ego:antimagic w:20 / \
+      spriggan defender; quick blade ego:antimagic w:20 . wand of paralysis . \
+      potion of haste . potion of haste . buckler
+MONS: minotaur; chain mail . broad axe randart w:90 | arga . \
+      tower shield w:40 | tower shield ego:reflection . potion of haste . \
+      potion of haste . javelin / \
+      orc warlord; chain mail . broad axe randart w:90 | arga . \
+      tower shield w:40 | tower shield ego:reflection . potion of haste
+: end
 KFEAT:   _ = altar_hepliaklqana
-MARKER:  _ = lua:fog_machine { cloud_type = "thin mist", \
+KFEAT:   - = altar_ecumenical
+MARKER:  ` = lua:fog_machine { cloud_type = "thin mist", \
                               pow_min = 100, pow_max = 200, \
-                              delay = 100, size = 1, walk_dist = 1 }
+                              delay = 100, size = 2, walk_dist = 1 }
 TILE:   G = dngn_gravestone
 : interest_check(_G)
 MAP
-    cc.cc
+    ccccc
     c...c
-ccccc.c.cccc
-c.2........c
-cd_G..c.c...
-c.1........c
-ccccc.c.cccc
+    c.-.c
+    c.2.c     cc
+ccccc...ccccccc.
+c.......`..`..`.
+c._1..c.........
+c.......`..`..`.
+ccccc...ccccccc.
+    c.3.c     cc
+    c.G.c
     c...c
-    cc.cc
+    ccccc
 ENDMAP
 
 ### Kikubaaqudgha overflow altars #############################################


### PR DESCRIPTION
Add's a vault dedicated to the three paths Hepliakqana heroes can take. The monsters in this vault are equipped similarly to the ancestors. The monster's ancestors are permanently hasted at later levels (or they are liches in the case of spellcasters). Some of the Heroes (for Knight) don't quite match the ancestor because a guaranteed broad axe of speed seems too good. Instead players have a 9% chance of that drop in the case where the knight spawns in depths.

Might need some balancing (maybe don't spawn orc knight on d:10). Not entirely sure about how overflow altars work in later stages like depths.