### PR TITLE
Add diablo church arrival vault

### DIFF
--- a/crawl-ref/source/dat/des/arrival/large.des
+++ b/crawl-ref/source/dat/des/arrival/large.des
@@ -1115,3 +1115,55 @@ MAP
       xxxxxxGxxxxxx
         xxxxxxxxx
 ENDMAP
+
+##############################################################################
+# 37x22
+NAME:   beargit_arrival_diablo_church
+TAGS:   arrival no_trap_gen no_item_gen no_monster_gen
+ORIENT: float
+MONS:   rat / nothing w:50
+FTILE:  `t = floor_grass, 1'G_> = floor_limestone
+COLOUR: ` = green, 1'G = white
+KPROP:  ` = no_tele_into
+SUBST:  V = VVVT, H = ....H
+: dgn.delayed_decay(_G, 'H', 'human skeleton / elf skeleton')
+MAP
+       ccccccc
+       ctttttc
+       ct```tc
+       ccnnncc
+        c.{.c
+        c...c
+  ccccccc+++ccccccccc
+  cV............+...+
+  cV............ccccc
+  ccc..cc...cc..ccc
+  ccc..cc...cc..ccc
+  ctc...........ctc
+  ctn...........ntc
+ cctc...........ctc
+ cttc...........ctc
+ ct`n...........ntccc
+ cttc...........ctc1+
+  ccc..cc...cc..cccHc
+  ctc..cc...cc..ctcHc
+  ctn...........ntcHc
+  ctc...........ctcHc
+  ctc...........ctc.cc
+  ctn...........ntc..c
+  ctc...........ctcc.c
+ cccc..cc...cc..ccc..c
+ccccc..cc...cc..ccc+cc
++...................c
++...................c
+cccccccc+c+c+cccccccc
+      cG'''''Gc
+      c'''''''c
+      cG''>''Gc
+      cc'''''cc
+       cc'''cc
+        cc'cc
+        ccncc
+        ctttc
+        ccccc
+ENDMAP


### PR DESCRIPTION
adds a church based on the tristram cathedral from the first
diablo game. Hell has desecrated the altar, but a player must
first contend with the Imp guarding it if they dare. a hatch is
provided so you can worship and run or hatch if you get an
unlucky teleport. To the sides of the church there is a crypt and
through the windows the player can see the lust forest they leave
behind. There's also a baptism font (usually dry) because why not.