### PR TITLE
Sort items in a shop in a more predictable order using ORDER_DEFAULT

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -969,6 +969,7 @@ ShopMenu::ShopMenu(shop_struct& _shop, const level_pos& _pos, bool _can_purchase
     set_tag("shop");
 
     init_entries();
+    resort();
 
     update_help();
 
@@ -1170,11 +1171,27 @@ void ShopMenu::resort()
     switch (order)
     {
     case ORDER_DEFAULT:
+        {
+        const bool id = shoptype_identifies_stock(shop.type);
         sort(begin(items), end(items),
-             [](MenuEntry* a, MenuEntry* b)
+             [id](MenuEntry* a, MenuEntry* b)
              {
-                 return a->data < b->data;
+                auto a_item = dynamic_cast<ShopEntry*>(a)->item;
+                auto b_item = dynamic_cast<ShopEntry*>(b)->item;
+
+                // "fizzy potion" is "potion", "potion of curing" is
+                // "potion of curing".
+                int cmp = a_item->name(DESC_DBNAME, false, id)
+                    .compare(b_item->name(DESC_DBNAME, false, id));
+
+                if (cmp)
+                    return cmp < 0;
+
+                // "fizzy potion" emerges unchanged.
+                return a_item->name(DESC_PLAIN, false, id)
+                    < b_item->name(DESC_PLAIN, false, id);
              });
+        }
         break;
     case ORDER_PRICE:
         sort(begin(items), end(items),


### PR DESCRIPTION
As it was, ORDER_DEFAULT sorted items according to the order in which they were originally created by the game. This seems like an unhelpful default to me, and there is no option to control it.

This change means that, when you go into a shop, items are sorted by DESC_DBNAME, and by DESC_PLAIN where this doesn't distinguish them.

Similar items are together (all robes, all +0 robes, all wands, etc.), and most things are in alphabetical order. If you switch to "sort by price", this order is used for items which cost the same amount.

I find that this makes it easier to scan through the contents of a shop for anything I might like.

I have not changed the order in which items in shops appear in character dumps. Items on the floor already appeared in an order the player is never shown in-game, so this is at least consistent.

Artefact jewellery and spellbooks appear in an odd position. They're rare, and are highlighted, so this shouldn't cause any problems.