### PR TITLE
Fix ?/m entry for rockslimes

### DIFF
--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -2037,7 +2037,7 @@ river rat
 
 A rodent with hair of a most peculiar green colour, and a powerful bite. It
 tends to form great swarms with its kin.
-%%%
+%%%%
 rockslime
 
 An oozing avalanche, scouring the ground beneath it as it rumbles forward.


### PR DESCRIPTION
Because of a missing delimiter, `?/mrockslime` showed the river rat's
description.