### PR TITLE
Enable fullscreen PWA for WebTiles on iOS

### DIFF
--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -8,6 +8,8 @@
     </script>
     <script src="/static/scripts/contrib/require.js" data-main="/static/scripts/app"></script>
     <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   </head>
   <body>
     <noscript>Please enable javascript!</noscript>


### PR DESCRIPTION
Currently, adding the webtiles interface to the desktop on iOS or iPadOS creates what is effectively a bookmark. It opens in the browser, with the domain displaying, and tabs available.

By adding these meta tags, if a user creates a PWA for WebTiles on iOS, it will launch in full screen as a separate application to the browser, without the standard tabs interface.

This should be a fairly low risk change, as users have to opt in to creating a PWA. The biggest issue is that this hides the browser navigation if you’re using a PWA, so you might theoretically be able to navigate to part of the site that you couldn’t easily return from.

This might seem like an edge case, but it would be awesome to be able to play DCSS full screen on an iPad with a keyboard.