### PR TITLE
Improve ancestor management

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6597,7 +6597,7 @@ int _ench_pow_to_dur(int pow)
 bool always_shoot_through_monster(const actor *originator, const monster &victim)
 {
     return mons_is_projectile(victim)
-        || (mons_is_avatar(victim.type)
+        || ((mons_is_avatar(victim.type) || mons_is_hepliaklqana_ancestor(victim.type))
             && originator && mons_aligned(originator, &victim));
 }
 

--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -951,6 +951,7 @@ static formatted_string _describe_god_powers(god_type which_god)
 
     case GOD_HEPLIAKLQANA:
         have_any = true;
+        desc.cprintf("Your projectile can through your ancestor.\n");
         desc.cprintf("Your life essence is reduced. (-10%% HP)\n");
         break;
 

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2370,8 +2370,8 @@ item_def* monster_die(monster& mons, killer_type killer,
                 mprf("%s has departed this plane of existence.",
                      hepliaklqana_ally_name().c_str());
             }
-            // respawn in ~30-60 turns
-            you.duration[DUR_ANCESTOR_DELAY] = random_range(300, 600);
+            // respawn in ~5-15 turns
+            you.duration[DUR_ANCESTOR_DELAY] = random_range(50, 150);
         }
     }
 


### PR DESCRIPTION
1. Allow projectiles to pass through ancestors
This change will slightly break Hep's balance, but instead I expect that the player's management QoL will be much better. (Thank PleasingFungus)

2. Respawn of ancestor faster.
It's tiring to take care of ancestor so that they don't die. Therefore, it will be respawn faster to reduce the management burden of the player. Although respawn has become very fast, the absence of an ancestor for 5-15 turns in urgent combat situations is still threat to the player. Therefore, I expect that the value of 'idealise' will not be completely tarnished.