### PR TITLE
Update to Blade Hands description

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -141,11 +141,23 @@ deplete magical power.
 %%%%
 Blade Hands spell
 
-Causes long, scythe-shaped blades to grow from the caster's hands, increasing
-melee damage significantly.
+{{
+    local hands = you.hand() .. "s"
+    local description =
+               "Causes long, scythe-shaped blades to grow from the " ..
+               "caster's " .. hands .. ", increasing melee damage " ..
+               "significantly.\n\nWhile transformed, equipped weapons, " ..
+               "shields, and gloves are melded, and casting spells " ..
+               "becomes somewhat more difficult."
 
-While transformed, any equipped weapons are melded, and casting spells becomes
-somewhat more difficult.
+    if hands == "paws" then
+        return description .. " In addition, the clacking of blades " ..
+               "on the ground makes the caster slightly less stealthy."
+    else
+        return description
+    end
+}}
+
 %%%%
 Blink Allies Away spell
 

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -69,7 +69,12 @@ LUARET1(you_race, string, species_name(you.species).c_str())
  * @treturn string
  * @function class
  */
-LUARET1(you_class, string, get_job_name(you.char_class))
+ LUARET1(you_class, string, get_job_name(you.char_class))
+/*** Get noun for player's hands.
+ * @treturn string
+ * @function hand
+ */
+ LUARET1(you_hand, string, species_hand_name(you.species).c_str())
 /*** Is player in wizard mode?
  * @treturn boolean
  * @function wizard
@@ -1217,6 +1222,7 @@ static const struct luaL_reg you_clib[] =
     { "ability_table", l_you_abil_table },
     { "name"        , you_name },
     { "race"        , you_race },
+    { "hand"        , you_hand },
     { "class"       , you_class },
     { "genus"       , l_you_genus },
     { "monster"     , l_you_monster },


### PR DESCRIPTION
The old Blade Hands description used the word "hands" regardless of
the manipulator type for the species. In addition, it failed to mention
that it would meld shields and gloves. A function was added to l-you.cc
to get the hand type of the player species, and the Blade Hands
description now checks hand type to determine the noun used for the
player's manipulators. The description was also changed to say that
shields and gloves are also melded.