### PR TITLE
Compiler warnings

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -637,7 +637,7 @@ void validate_mutations(bool debug_msg)
     ASSERT(total_temp == you.attribute[ATTR_TEMP_MUTATIONS]);
 }
 
-string _terse_mut_name(mutation_type mut)
+static string _terse_mut_name(mutation_type mut)
 {
     const int current_level = you.get_mutation_level(mut);
     const int base_level = you.get_base_mutation_level(mut);

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -689,7 +689,7 @@ static bool _is_appendage_mutation(mutation_type mut)
     return false;
 }
 
-vector<string> _get_mutations(bool terse)
+static vector<string> _get_mutations(bool terse)
 {
     vector<string> result;
 


### PR DESCRIPTION
Make a couple of functions static. This removes warnings GCC gives for them with -Wmissing-declarations.