### PR TITLE
Make autoexplore/travel wait for barbs to time out.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5160,7 +5160,8 @@ bool player::is_sufficiently_rested() const
     // Only return false if resting will actually help.
     return (!player_regenerates_hp() || hp >= _rest_trigger_level(hp_max))
             && (magic_points >= _rest_trigger_level(max_magic_points)
-                || !player_regenerates_mp());
+                || !player_regenerates_mp())
+            && !you.duration[DUR_BARBS];
 }
 
 bool player::in_water() const


### PR DESCRIPTION
As things stood, trying to travel with barbs stuck in you would see the game ask for confirmation, move a single square (if you accept) and then stop because of the HP loss.

This change makes it so that the game waits for the spikes to time out before moving.

You can't remove barbs if you are confused or asleep, but you can't travel then either, and player::is_sufficiently_rested() isn't used for anything else.