### PR TITLE
Supress a compiler warning on Windows

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -148,7 +148,7 @@ static void _init_consoles()
     // The AttachConsole() function is XP/2003 Server and up, so we
     // need to do the GetModuleHandle()/GetProcAddress() dance.
     typedef BOOL (WINAPI *ac_func)(DWORD);
-    ac_func attach_console = (ac_func)GetProcAddress(
+    ac_func attach_console = (ac_func)(void *)GetProcAddress(
         GetModuleHandle(TEXT("kernel32.dll")), "AttachConsole");
 
     if (attach_console)
@@ -175,7 +175,7 @@ static void _shutdown_console()
 {
 #ifdef TARGET_OS_WINDOWS
     typedef BOOL (WINAPI *fc_func)();
-    fc_func free_console = (fc_func)GetProcAddress(
+    fc_func free_console = (fc_func)(void *)GetProcAddress(
         GetModuleHandle(TEXT("kernel32.dll")), "FreeConsole");
     if (free_console)
         free_console();


### PR DESCRIPTION
These last remaining warnings on Windows have been bugging me:

```
tilesdl.cc: In function 'void _init_consoles()':
tilesdl.cc:151:30: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'ac_func' {aka 'int (*)(long unsigned int)'} [-Wcast-function-type]
  151 |     ac_func attach_console = (ac_func)GetProcAddress(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~
  152 |         GetModuleHandle(TEXT("kernel32.dll")), "AttachConsole");
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tilesdl.cc: In function 'void _shutdown_console()':
tilesdl.cc:178:28: warning: cast between incompatible function types from 'FARPROC' {aka 'long long int (*)()'} to 'fc_func' {aka 'int (*)()'} [-Wcast-function-type]
  178 |     fc_func free_console = (fc_func)GetProcAddress(
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~
  179 |         GetModuleHandle(TEXT("kernel32.dll")), "FreeConsole");
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

After some googling, it looks like the most recommended workaround is to cast GetProcAddress to (void *) first. Example discussion [here](https://lists.gnu.org/archive/html/bug-gnulib/2018-08/msg00092.html).

I have tested it on MSYS2, everything works fine and the warning is gone.