### PR TITLE
Add some missiles to default autopickup

### DIFF
--- a/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
+++ b/crawl-ref/source/dat/defaults/autopickup_exceptions.txt
@@ -8,6 +8,9 @@ ae = <rune of Zot
 # Make it harder to miss out on zigfigs.
 ae += <figurine of a ziggurat
 
+# Autopickup good and emergency consumables by default.
+ae += <good_item
+
 ### exclusions ###
 
 # Exclude items useless in general or for your current character (such as

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2549,10 +2549,10 @@ bool is_emergency_item(const item_def &item)
         switch (item.sub_type)
         {
         case MI_DART:
-            return (get_ammo_brand(item) == SPMSL_CURARE
-                    || get_ammo_brand(item) == SPMSL_BLINDING);
+            return get_ammo_brand(item) == SPMSL_CURARE
+                   || get_ammo_brand(item) == SPMSL_BLINDING;
         case MI_BOOMERANG:
-            return (get_ammo_brand(item) == SPMSL_DISPERSAL);
+            return get_ammo_brand(item) == SPMSL_DISPERSAL;
         case MI_THROWING_NET:
             return true;
         default:

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2541,6 +2541,23 @@ bool is_emergency_item(const item_def &item)
         default:
             return false;
         }
+    case OBJ_MISSILES:
+        // Missiles won't help Felids.
+        if (you.has_mutation(MUT_NO_GRASPING))
+            return false;
+
+        switch (item.sub_type)
+        {
+        case MI_DART:
+            return (get_ammo_brand(item) == SPMSL_CURARE
+                    || get_ammo_brand(item) == SPMSL_BLINDING);
+        case MI_BOOMERANG:
+            return (get_ammo_brand(item) == SPMSL_DISPERSAL);
+        case MI_THROWING_NET:
+            return true;
+        default:
+            return false;
+        }
     default:
         return false;
     }


### PR DESCRIPTION
Curare, atropa, dispersal, and throwing nets are all highly useful items
that can save characters. This commit adds them to autopickup by default.

(9 years ago, curare was removed from autopickup in e11df56, for reasons
that have since been obviated. Everything old is new again!)