### PR TITLE
Disable spellcasting skill gain for new berserkers.

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -630,6 +630,8 @@ static void _setup_generic(const newgame_def& ng,
     init_skill_order();
     init_can_currently_train();
     init_train();
+    if (you.religion == GOD_TROG)
+        join_trog_skills();
     init_training();
 
     // Apply autoinscribe rules to inventory.

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3591,7 +3591,7 @@ static void _join_ru()
 }
 
 /// Setup for joining the furious barbarians of Trog.
-static void _join_trog()
+void join_trog_skills()
 {
     if (!you.has_mutation(MUT_DISTRIBUTED_TRAINING))
         for (int sk = SK_SPELLCASTING; sk <= SK_LAST_MAGIC; ++sk)
@@ -3656,7 +3656,7 @@ static const map<god_type, function<void ()>> on_join = {
     { GOD_PAKELLAS, _join_pakellas },
 #endif
     { GOD_RU, _join_ru },
-    { GOD_TROG, _join_trog },
+    { GOD_TROG, join_trog_skills },
     { GOD_ZIN, _join_zin },
 };
 

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -66,6 +66,7 @@ int god_colour(god_type god);
 colour_t god_message_altar_colour(god_type god);
 int gozag_service_fee();
 bool player_can_join_god(god_type which_god, bool temp = true);
+void join_trog_skills(void);
 void join_religion(god_type which_god);
 void god_pitch(god_type which_god);
 god_type choose_god(god_type def_god = NUM_GODS);


### PR DESCRIPTION
If automatic training was set, and the skills the player actually used all reached 27, the game would start to train the other skills, including the magic skills. This means that someone could offend Trog by training magic skills without casting a spell or visiting the skill management screen.

This change turns magic skills off at the start of the game for a berserker (as already happened when you joined Trog at an altar), and avoids that possibility.

It's pretty easy to experience this problem if you play Meatsprint as a ghoul berserker.