### PR TITLE
Simplify the foxfire card, And Replace name with swarms card

### DIFF
--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -110,12 +110,11 @@ vast room.
 Drawing this card will summon a dancing weapon. Its quality, brand, and
 friendliness are all affected by card power.
 %%%%
-Foxfire card
+the Swarms card
 
-The card depicts a swamp at night, suffused with an eerie glow.
+The card depicts a swarm of midday bees filled with humming noises.
 
-Drawing this card will summon forth flying swarms. Some of their members may
-be hostile.
+Drawing this card will summon forth bees swarms.
 %%%%
 the Rangers card
 

--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -112,7 +112,7 @@ friendliness are all affected by card power.
 %%%%
 the Swarm card
 
-The card depicts a swarm of midday bees filled with humming noises.
+The card depicts a bear surrounded by a swarm of bees. It hums ominously.
 
 Drawing this card will summon forth bees swarms.
 %%%%

--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -114,7 +114,7 @@ the Swarm card
 
 The card depicts a bear surrounded by a swarm of bees. It hums ominously.
 
-Drawing this card will summon forth bees swarms.
+Drawing this card will summon bees.
 %%%%
 the Rangers card
 

--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -110,7 +110,7 @@ vast room.
 Drawing this card will summon a dancing weapon. Its quality, brand, and
 friendliness are all affected by card power.
 %%%%
-the Swarms card
+the Swarm card
 
 The card depicts a swarm of midday bees filled with humming noises.
 

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1332,7 +1332,7 @@ static void _summon_bee(int power)
     const int how_many = 1 + random2((power_level + 1) * 3);
 
     for (int i = 0; i < how_many; ++i)
-        _friendly(flytypes, 5 - power_level);
+        _friendly(MONS_KILLER_BEE, 3);
 }
 
 static void _summon_rangers(int power)

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1329,7 +1329,6 @@ static void _summon_dancing_weapon(int power)
 static void _summon_bee(int power)
 {
     const int power_level = _get_power_level(power);
-    const monster_type flytypes = MONS_KILLER_BEE;
     const int how_many = 1 + random2((power_level + 1) * 3);
 
     for (int i = 0; i < how_many; ++i)

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -160,7 +160,7 @@ const char* card_name(card_type card)
     case CARD_ELEMENTS:        return "the Elements";
     case CARD_SUMMON_DEMON:    return "the Pentagram";
     case CARD_SUMMON_WEAPON:   return "the Dance";
-    case CARD_SUMMON_BEE:      return "Swarm";
+    case CARD_SUMMON_BEE:      return "the Swarm";
     case CARD_RANGERS:         return "the Rangers";
     case CARD_VITRIOL:         return "Vitriol";
     case CARD_CLOUD:           return "the Cloud";

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -93,7 +93,7 @@ deck_archetype deck_of_summoning =
     { CARD_ELEMENTS,        5 },
     { CARD_SUMMON_DEMON,    5 },
     { CARD_SUMMON_WEAPON,   5 },
-    { CARD_SUMMON_FLYING,   5 },
+    { CARD_SUMMON_BEE,      5 },
     { CARD_RANGERS,         5 },
     { CARD_ILLUSION,        5 },
 };
@@ -160,7 +160,7 @@ const char* card_name(card_type card)
     case CARD_ELEMENTS:        return "the Elements";
     case CARD_SUMMON_DEMON:    return "the Pentagram";
     case CARD_SUMMON_WEAPON:   return "the Dance";
-    case CARD_SUMMON_FLYING:   return "Foxfire";
+    case CARD_SUMMON_BEE:      return "Swarm";
     case CARD_RANGERS:         return "the Rangers";
     case CARD_VITRIOL:         return "Vitriol";
     case CARD_CLOUD:           return "the Cloud";
@@ -1326,43 +1326,14 @@ static void _summon_dancing_weapon(int power)
     mon->ghost_demon_init();
 }
 
-static void _summon_flying(int power)
+static void _summon_bee(int power)
 {
     const int power_level = _get_power_level(power);
-
-    const monster_type flytypes[] =
-    {
-        MONS_WYVERN, MONS_KILLER_BEE,
-        MONS_VAMPIRE_MOSQUITO, MONS_HORNET
-    };
-    const int num_flytypes = ARRAYSZ(flytypes);
-
-    // Choose what kind of monster.
-    monster_type result;
-    const int how_many = 2 + random2(3) + power_level * 3;
-    bool hostile_invis = false;
-
-    do
-    {
-        result = flytypes[random2(num_flytypes - 2) + power_level];
-    }
-    while (is_good_god(you.religion) && result == MONS_VAMPIRE_MOSQUITO);
+    const monster_type flytypes = MONS_KILLER_BEE;
+    const int how_many = 2 + random2(3) + ((power_level * 2) + 1) * 3;
 
     for (int i = 0; i < how_many; ++i)
-    {
-        const bool hostile = one_chance_in(power_level + 4);
-
-        create_monster(
-            mgen_data(result,
-                      hostile ? BEH_HOSTILE : BEH_FRIENDLY, you.pos(), MHITYOU,
-                      MG_AUTOFOE).set_summoned(&you, 3, 0));
-
-        if (hostile && mons_class_flag(result, M_INVIS) && !you.can_see_invisible())
-            hostile_invis = true;
-    }
-
-    if (hostile_invis)
-        mpr("You sense the presence of something unfriendly.");
+        _friendly(flytypes, 5 - power_level);
 }
 
 static void _summon_rangers(int power)
@@ -1662,7 +1633,7 @@ void card_effect(card_type which_card,
     case CARD_ELEMENTS:         _elements_card(power); break;
     case CARD_RANGERS:          _summon_rangers(power); break;
     case CARD_SUMMON_WEAPON:    _summon_dancing_weapon(power); break;
-    case CARD_SUMMON_FLYING:    _summon_flying(power); break;
+    case CARD_SUMMON_BEE:       _summon_bee(power); break;
     case CARD_TORMENT:          _torment_card(); break;
     case CARD_CLOUD:            _cloud_card(power); break;
     case CARD_STORM:            _storm_card(power); break;

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1330,7 +1330,7 @@ static void _summon_bee(int power)
 {
     const int power_level = _get_power_level(power);
     const monster_type flytypes = MONS_KILLER_BEE;
-    const int how_many = 2 + random2(3) + ((power_level * 2) + 1) * 3;
+    const int how_many = 1 + random2((power_level + 1) * 3);
 
     for (int i = 0; i < how_many; ++i)
         _friendly(flytypes, 5 - power_level);

--- a/crawl-ref/source/decks.h
+++ b/crawl-ref/source/decks.h
@@ -39,7 +39,7 @@ enum card_type
     CARD_ELIXIR,              // restoration of hp and mp
     CARD_SUMMON_DEMON,        // dual demons
     CARD_SUMMON_WEAPON,       // a dance partner
-    CARD_SUMMON_BEE,          // swarms of bee
+    CARD_SUMMON_BEE,          // swarm of bees
     CARD_WILD_MAGIC,          // miscasts for everybody
     CARD_STAIRS,              // moves stairs around
     CARD_WRATH,               // random godly wrath

--- a/crawl-ref/source/decks.h
+++ b/crawl-ref/source/decks.h
@@ -39,7 +39,7 @@ enum card_type
     CARD_ELIXIR,              // restoration of hp and mp
     CARD_SUMMON_DEMON,        // dual demons
     CARD_SUMMON_WEAPON,       // a dance partner
-    CARD_SUMMON_FLYING,       // swarms from the swamp
+    CARD_SUMMON_BEE,          // swarms of bee
     CARD_WILD_MAGIC,          // miscasts for everybody
     CARD_STAIRS,              // moves stairs around
     CARD_WRATH,               // random godly wrath


### PR DESCRIPTION
This card had a complicated function. There are many different types of monsters that appear on this card, but there was no reason to do so.  And some of the summoned monsters appeared hostile. The name was also not intuitive, making it difficult for users to understand what the card was doing. The user had too many considerations to make this card useful.

So I'm going to simply trim this card.
The basic feature of this card is that it summons many monsters. Therefore, I want to emphasize this characteristic clearly. Now this card summons a very large swarm of bees. In addition, I will change the name to swarms to make it easier to understand what this card is summoning.

If this change is not enough for cards to be useful, I think we can mix one or two queen bees.