### PR TITLE
RST manual: escape the vertical bar key for layer toggle

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -2497,7 +2497,7 @@ Ctrl-A
   Toggle autopickup. Note that encounters with invisible monsters always turns
   autopickup off. You need to switch it on with Ctrl-A afterwards.
 
-|
+\|
   Toggle various display layers and overlays. (Console only)
 
 \`


### PR DESCRIPTION
The RST version of the manual needs the | character escaped by a backslash for it to be displayed properly.