### PR TITLE
Remove Maud from montitle.txt.

### DIFF
--- a/crawl-ref/source/dat/database/montitle.txt
+++ b/crawl-ref/source/dat/database/montitle.txt
@@ -183,10 +183,6 @@ Margery title
 
 Margery the Dragonslayer
 %%%%
-Maud title
-
-Maud the Forgotten
-%%%%
 Maurice title
 
 Maurice the Thief


### PR DESCRIPTION
Maud has gone, and her ghost cannot use this title, so it's just clutter.