### PR TITLE
Reduce Makhleb's heal-on-kill

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1870,7 +1870,7 @@ item_def* monster_die(monster& mons, killer_type killer,
 
                 if (have_passive(passive_t::restore_hp))
                 {
-                    hp_heal = random2avg(you.skill_rdiv(SK_INVOCATIONS, 2), 2)
+                    hp_heal = random2avg(you.skill_rdiv(SK_INVOCATIONS, 3, 2), 2)
                         + random2(mons.get_experience_level());
                 }
                 if (you.species == SP_GHOUL

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1870,7 +1870,7 @@ item_def* monster_die(monster& mons, killer_type killer,
 
                 if (have_passive(passive_t::restore_hp))
                 {
-                    hp_heal = mons.get_experience_level()
+                    hp_heal = random2avg(you.skill_rdiv(SK_INVOCATIONS, 2), 2)
                         + random2(mons.get_experience_level());
                 }
                 if (you.species == SP_GHOUL


### PR DESCRIPTION
The recent introduction of Djinni draws further attention to an ongoing DCSS problem, where Makh is a good choice for any character, and is a better "healing" god than Elyvilon. Part of the problem is getting a bunch of free healing regardless of piety earned or invocations investment.

Instead of healing for (roughly) the monster's HD * 1.5, now heal for (roughly) invocation skill + monster's HD * 0.5. 
(`(random2avg(foo * 2) ~= foo`_, right?)_

This is intended to help with: 

1. the highly visible runaway Dj/DD games, 
2. and also with the less-talked-about problem where Makh is a really strong choice any character, not just Dj/DD though they are the poster children.
3. It also incentivizes training Invocations, which could help makh's active abilities become less of a sideshow.