### PR TITLE
Improve Makhleb's Major Destruction

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2557,12 +2557,11 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
             beam.origin_spell = SPELL_NO_SPELL; // let zapping reset this
             zap_type ztype =
                 random_choose(ZAP_BOLT_OF_FIRE,
-                              ZAP_FIREBALL,
                               ZAP_LIGHTNING_BOLT,
                               ZAP_STICKY_FLAME,
                               ZAP_IRON_SHOT,
                               ZAP_BOLT_OF_DRAINING,
-                              ZAP_ORB_OF_ELECTRICITY);
+                              ZAP_CORROSIVE_BOLT);
             zapping(ztype, power, beam);
         }
         break;


### PR DESCRIPTION
Throw out the fireball and orb, they cause problems and shouldn't
be using the same targeter as a bunch of bolts. Very Random spells
can be fun, but not when you're paying HP, piety, and a turn.

Add an acid bolt instead.

Not fixed: iron shot and sticky flame are also not bolts.

But at least those don't blow up in your face!