### PR TITLE
Triple the number of level 2 spell gifts that Veh can choose from

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -163,9 +163,9 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Maledictions
     SPELL_CORONA,
     SPELL_HIBERNATION,
+    SPELL_DAZZLING_FLASH,
     SPELL_CONFUSING_TOUCH,
     SPELL_TUKIMAS_DANCE,
-    SPELL_DAZZLING_FLASH,
 },
 
 {   // Book of Air

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1398,7 +1398,8 @@ bool vehumet_supports_spell(spell_type spell)
         || spell == SPELL_IGNITION
         || spell == SPELL_FROZEN_RAMPARTS
         || spell == SPELL_ABSOLUTE_ZERO
-        || spell == SPELL_NOXIOUS_BOG)
+        || spell == SPELL_NOXIOUS_BOG
+        || spell == SPELL_POISONOUS_VAPOURS)
     {
         return true;
     }

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -2101,7 +2101,7 @@ static const struct spell_desc spelldata[] =
     SPELL_DAZZLING_FLASH, "Dazzling Flash",
     spschool::conjuration | spschool::hexes,
     spflag::area | spflag::no_ghost,
-    3,
+    2,
     50,
     2, 3,
     0, 0,


### PR DESCRIPTION
When comparing the [array of gifts](https://gist.github.com/RojjaCebolla/86d9d532445426194319f912e5109000) chosen upon levelup for Veh and Djinn characters, I noticed two things: Dj has a tighter bound, guaranteeing at least one spell of each level. Veh has "clumpier" preferences which may have made sense in the past, but right now there are too few level 2 and level 7 options to support that table.

This PR aims to help with the situation by increasing the giftable options at level 2 from one spell (Searing Ray), to three spells (adding Poisonous Vapours and Dazzling PBAOE).  

Not addressed:
There just aren't many level 2 spells that deal damage, probably because many boring ones have been removed.  This is a bit of a hole that some creative person could fill!