### PR TITLE
Allow detransforming over water if flying

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1370,7 +1370,8 @@ static bool _check_ability_possible(const ability_def& abil, bool quiet = false)
     // dangerous.)
     if (abil.ability == ABIL_END_TRANSFORMATION)
     {
-        if (feat_dangerous_for_form(transformation::none, env.grid(you.pos())))
+        if (feat_dangerous_for_form(transformation::none, env.grid(you.pos()))
+            && !you.duration[DUR_FLIGHT])
         {
             if (!quiet)
             {

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1474,7 +1474,7 @@ static bool _transformation_is_safe(transformation which_trans,
                                     dungeon_feature_type feat,
                                     string *fail_reason)
 {
-    if (!feat_dangerous_for_form(which_trans, feat))
+    if (!feat_dangerous_for_form(which_trans, feat) || you.duration[DUR_FLIGHT])
         return true;
 
     if (fail_reason)


### PR DESCRIPTION
Even if you're [de]transforming into a non-flyer over dangerous terrain,
that's okay if you're currently in flight form. Closes #1881.