### PR TITLE
Let the player create both Maggie and Margery in wizard mode.

### DIFF
--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -533,8 +533,7 @@ namespace arena
         for (int i = 0; i < MAX_MONSTERS; i++)
             to_respawn[i] = -1;
 
-        unwind_var< FixedBitVector<NUM_MONSTERS> >
-            uniq(you.unique_creatures);
+        unwind_var<unique_creature_list> uniq(you.unique_creatures);
 
         place_a = dgn_find_feature_marker(DNGN_STONE_STAIRS_UP_I);
         place_b = dgn_find_feature_marker(DNGN_STONE_STAIRS_DOWN_I);

--- a/crawl-ref/source/bitary.h
+++ b/crawl-ref/source/bitary.h
@@ -73,7 +73,7 @@ public:
         return get(i);
     }
 
-    inline void set(unsigned int i, bool value = true)
+    inline virtual void set(unsigned int i, bool value = true)
     {
 #ifdef ASSERTS
         if (i >= SIZE)

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -189,7 +189,7 @@ static void _mark_solid_squares();
 
 // A mask of vaults and vault-specific flags.
 vector<vault_placement> Temp_Vaults;
-static FixedBitVector<NUM_MONSTERS> temp_unique_creatures;
+static unique_creature_list temp_unique_creatures;
 static FixedVector<unique_item_status_type, MAX_UNRANDARTS> temp_unique_items;
 
 const map_bitmask *Vault_Placement_Mask = nullptr;
@@ -4933,29 +4933,10 @@ static void _dgn_give_mon_spec_items(mons_spec &mspec, monster *mon)
         _give_animated_weapon_ammo(*mon);
 }
 
-static bool _monster_type_is_already_spawned_unique(monster_type type)
-{
-    return mons_is_unique(type) && you.unique_creatures[type];
-}
-
-static bool _unique_conflicts_with_younger_or_older_version(monster_type type)
-{
-    if (type == MONS_MAGGIE
-       && _monster_type_is_already_spawned_unique(MONS_MARGERY))
-    {
-        return true;
-    }
-    else if (type == MONS_MARGERY
-       && _monster_type_is_already_spawned_unique(MONS_MAGGIE))
-        return true;
-
-    return false;
-}
-
 static bool _should_veto_unique(monster_type type)
 {
-    return _monster_type_is_already_spawned_unique(type)
-           || _unique_conflicts_with_younger_or_older_version(type);
+    // Already generated.
+    return mons_is_unique(type) && you.unique_creatures[type];
 }
 
 monster* dgn_place_monster(mons_spec &mspec, coord_def where,

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -283,7 +283,7 @@ LUAFN(debug_handle_monster_move)
     return 0;
 }
 
-static FixedBitVector<NUM_MONSTERS> saved_uniques;
+static unique_creature_list saved_uniques;
 
 LUAFN(debug_save_uniques)
 {
@@ -318,7 +318,7 @@ static bool _check_uniques()
 {
     bool ret = true;
 
-    FixedBitVector<NUM_MONSTERS> uniques_on_level;
+    unique_creature_list uniques_on_level;
     for (monster_iterator mi; mi; ++mi)
         if (mons_is_unique(mi->type))
             uniques_on_level.set(mi->type);

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -26,6 +26,7 @@
 #include "kills.h"
 #include "maybe-bool.h"
 #include "mon-holy-type.h"
+#include "monster-type.h"
 #include "mutation-type.h"
 #include "place-info.h"
 #include "quiver.h"
@@ -75,6 +76,21 @@ static const int FASTEST_PLAYER_MOVE_SPEED = 6;
 
 // Min delay for thrown projectiles.
 static const int FASTEST_PLAYER_THROWING_SPEED = 7;
+
+class unique_creature_list : public FixedBitVector<NUM_MONSTERS>
+{
+public:
+    inline void set(unsigned int i, bool value = true) override
+    {
+        if (i != MONS_MAGGIE && i != MONS_MARGERY)
+            FixedBitVector<NUM_MONSTERS>::set(i, value);
+        else
+        {
+            FixedBitVector<NUM_MONSTERS>::set(MONS_MARGERY, value);
+            FixedBitVector<NUM_MONSTERS>::set(MONS_MAGGIE, value);
+        }
+    }
+};
 
 class targeter;
 class Delay;
@@ -241,7 +257,7 @@ public:
 
     FixedArray<uint32_t, 6, MAX_SUBTYPES> item_description;
     FixedVector<unique_item_status_type, MAX_UNRANDARTS> unique_items;
-    FixedBitVector<NUM_MONSTERS> unique_creatures;
+    unique_creature_list unique_creatures;
 
     KillMaster kills;
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -4329,7 +4329,7 @@ static void _tag_read_you_dungeon(reader &th)
     {
         const bool created = unmarshallBoolean(th);
 
-        if (j < NUM_MONSTERS)
+        if (j < NUM_MONSTERS && created)
             you.unique_creatures.set(j, created);
     }
 


### PR DESCRIPTION
Wizard mode let you bypass the "has this unique been generated?" check, but not the "has the other unique been generated?" one.

Instead of the second check, this change has the game mark Maggie and Margery as having been created whenever either one is.

(Last copy closed in error.)

Addendum: I've solved this problem in this way because the code is simpler, and it works however a monster is created. As things stood, dgn_place_monster() used one function to avoid placing both Maggie and Margery, and I don't know what _builder_monsters() did.

I've used inheritance because it reduced the amount of code I need to write. I made FixedBitVector::set() virtual in case someone casts a uniques_on_level to one at some point. These could be changed easily enough.