### PR TITLE
Issue #1800: Make Scarf of shadows not affect the lenght of bounced spells. Also slight buff to player Kobolds, their spells bounce back one space further.

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -843,7 +843,7 @@ void bolt::bounce()
     bolt boltcopy = *this;
     if (bounces == 1)
         {
-        extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,true)-range;
+        extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,(int)you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER))-range;
 
         if  (you.get_mutation_level(MUT_NIGHTSTALKER)==3)
         {

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -842,19 +842,8 @@ void bolt::bounce()
     //Also small buff to kobolds making it easier for them to multizap opponents
     bolt boltcopy = *this;
     if (bounces == 1)
-        {
         extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,(int)you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER))-range;
-
-        if  (you.get_mutation_level(MUT_NIGHTSTALKER)==3)
-        {
-                extra_range_used -= 1;//Makes it easier for kobolds to multizap opponents, (first zap is one cheaper),
-                                      //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
-        }
-
-        //Prevent bounced bolts from going outside of a radius of you.current_vision
-        extra_range_used += max(0.0,(ray.pos().x+ray.r.dir.x*(range-extra_range_used)-you.pos().x)-you.current_vision);
-        extra_range_used += max(0.0,(ray.pos().y+ray.r.dir.y*(range-extra_range_used)-you.pos().y)-you.current_vision);
-        }
+    
     ASSERT(!cell_is_solid(ray.pos()));
 }
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -850,8 +850,11 @@ void bolt::bounce()
                 extra_range_used -= 1;//Makes it easier for kobolds to multizap opponents, (first zap is one cheaper),
                                       //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
         }
-        }
 
+        //Prevent bounced bolts from going outside of a radius of you.current_vision
+        extra_range_used += max(0.0,(ray.pos().x+ray.r.dir.x*(range-extra_range_used)-you.pos().x)-you.current_vision);
+        extra_range_used += max(0.0,(ray.pos().y+ray.r.dir.y*(range-extra_range_used)-you.pos().y)-you.current_vision);
+        }
     ASSERT(!cell_is_solid(ray.pos()));
 }
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -837,19 +837,19 @@ void bolt::bounce()
         rg(*ai - ray.pos()) = cell_is_solid(*ai);
     ray.bounce(rg);
     extra_range_used += 2;
- 
+
     //Keep lenght of bounced Spells constant despite reduced los (scarf of shadows,Robe of Night)
     //Also small buff to Kolbolds making it easier for them to multizap opponents
     bolt boltcopy = *this;
     if (bounces == 1)
-    	{
-    	extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,true)-range;
-    	
-    	if  (you.species==SP_KOBOLD)
-		extra_range_used -= 1;//Makes it easier for Kobolds to multizap opponents, (first zap is one cheaper), 
-				      //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
-    	}
- 
+        {
+        extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,true)-range;
+
+        if  (you.species==SP_KOBOLD)
+                extra_range_used -= 1;//Makes it easier for Kobolds to multizap opponents, (first zap is one cheaper),
+                                      //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
+        }
+
     ASSERT(!cell_is_solid(ray.pos()));
 }
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -842,9 +842,11 @@ void bolt::bounce()
     //Also small buff to kobolds making it easier for them to multizap opponents
     bolt boltcopy = *this;
     if (bounces == 1)
+    {
         extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,(int)you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER))-range;
-    
+
     ASSERT(!cell_is_solid(ray.pos()));
+    }
 }
 
 void bolt::fake_flavour()

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -837,7 +837,19 @@ void bolt::bounce()
         rg(*ai - ray.pos()) = cell_is_solid(*ai);
     ray.bounce(rg);
     extra_range_used += 2;
-
+ 
+    //Keep lenght of bounced Spells constant despite reduced los (scarf of shadows,Robe of Night)
+    //Also small buff to Kolbolds making it easier for them to multizap opponents
+    bolt boltcopy = *this;
+    if (bounces == 1)
+    	{
+    	extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,true)-range;
+    	
+    	if  (you.species==SP_KOBOLD)
+		extra_range_used -= 1;//Makes it easier for Kobolds to multizap opponents, (first zap is one cheaper), 
+				      //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
+    	}
+ 
     ASSERT(!cell_is_solid(ray.pos()));
 }
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -838,16 +838,18 @@ void bolt::bounce()
     ray.bounce(rg);
     extra_range_used += 2;
 
-    //Keep lenght of bounced Spells constant despite reduced los (scarf of shadows,Robe of Night)
-    //Also small buff to Kolbolds making it easier for them to multizap opponents
+    //Keep length of bounced spells constant despite reduced los (scarf of shadows,Robe of Night)
+    //Also small buff to kobolds making it easier for them to multizap opponents
     bolt boltcopy = *this;
     if (bounces == 1)
         {
         extra_range_used -= spell_range(boltcopy.origin_spell, boltcopy.ench_power,true,true)-range;
 
-        if  (you.species==SP_KOBOLD)
-                extra_range_used -= 1;//Makes it easier for Kobolds to multizap opponents, (first zap is one cheaper),
+        if  (you.get_mutation_level(MUT_NIGHTSTALKER)==3)
+        {
+                extra_range_used -= 1;//Makes it easier for kobolds to multizap opponents, (first zap is one cheaper),
                                       //Spells with range>=los now get reflected back an even number of tiles this also looks cleaner
+        }
         }
 
     ASSERT(!cell_is_solid(ray.pos()));

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3318,7 +3318,7 @@ static void _get_spell_description(const spell_type spell,
         if (spell == SPELL_CALL_DOWN_LIGHTNING)
             description += stringize_glyph(mons_char(mon_owner->type)) + "..---->";
         else
-            description += range_string(range, range, mons_char(mon_owner->type));
+            description += range_string(range, range, range, mons_char(mon_owner->type));
         description += "\n";
 
         // only display this if the player exists (not in the main menu)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2715,11 +2715,13 @@ string spell_power_string(spell_type spell)
         return make_stringf("%d%%", percent);
 }
 
-int calc_spell_range(spell_type spell, int power, bool allow_bonus)
+int calc_spell_range(spell_type spell, int power, bool allow_bonus, int range_cap)
 {
+    if (range_cap == -1)
+        range_cap = you.current_vision;
     if (power == 0)
         power = calc_spell_power(spell, true, false, false);
-    const int range = spell_range(spell, power, allow_bonus);
+    const int range = spell_range(spell, power, allow_bonus, range_cap);
 
     return range;
 }
@@ -2738,9 +2740,10 @@ string spell_range_string(spell_type spell)
 
     const int cap      = spell_power_cap(spell);
     const int range    = calc_spell_range(spell, 0);
-    const int maxrange = spell_range(spell, cap);
+    const int range_normal_vision = calc_spell_range(spell, 0,true,you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER));
+    const int maxrange = spell_range(spell, cap,true,you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER));
 
-    return range_string(range, maxrange, '@');
+    return range_string(range, range_normal_vision, maxrange, '@');
 }
 
 /**
@@ -2755,13 +2758,13 @@ string spell_range_string(spell_type spell)
  *                      Usually @ for the player.
  * @return              See above.
  */
-string range_string(int range, int maxrange, char32_t caster_char)
+string range_string(int range, int range_normal_vision, int maxrange, char32_t caster_char)
 {
     if (range <= 0)
         return "N/A";
 
     return stringize_glyph(caster_char) + string(range - 1, '-')
-           + string(">") + string(maxrange - range, '.');
+           + string(">") +string(range_normal_vision - range, '~')+string(maxrange - range_normal_vision, '.');
 }
 
 string spell_schools_string(spell_type spell)

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -99,7 +99,7 @@ int stepdown_spellpower(int power, int scale = 1);
 int calc_spell_power(spell_type spell, bool apply_intel,
                      bool fail_rate_chk = false, bool cap_power = true,
                      int scale = 1);
-int calc_spell_range(spell_type spell, int power = 0, bool allow_bonus = true);
+int calc_spell_range(spell_type spell, int power = 0, bool allow_bonus = true, int range_cap = -1);
 
 bool cast_a_spell(bool check_range, spell_type spell = SPELL_NO_SPELL, dist *_target = nullptr);
 
@@ -135,7 +135,7 @@ string spell_power_string(spell_type spell);
 string spell_damage_string(spell_type spell, bool evoked = false);
 int spell_acc(spell_type spell);
 string spell_range_string(spell_type spell);
-string range_string(int range, int maxrange, char32_t caster_char);
+string range_string(int range, int range_normal_vision, int maxrange, char32_t caster_char);
 string spell_schools_string(spell_type spell);
 string spell_failure_rate_string(spell_type spell);
 string spell_noise_string(spell_type spell, int chop_wiz_display_width = 0);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -985,10 +985,21 @@ int spell_power_cap(spell_type spell)
     }
 }
 
-int spell_range(spell_type spell, int pow, bool allow_bonus)
+int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
 {
     int minrange = _seekspell(spell)->min_range;
     int maxrange = _seekspell(spell)->max_range;
+    
+    if !(ignore_los)
+    int los_cap  = (int)you.current_vision;
+    else
+    	{ 
+    	if (you.species!=SP_KOBOLD)
+    		int los_cap  = (int)you.normal_vision;
+    	else
+    		int los_cap  = (int)you.normal_vision-3
+    }
+    
     ASSERT(maxrange >= minrange);
 
     // spells with no range have maxrange == minrange == -1
@@ -1007,15 +1018,15 @@ int spell_range(spell_type spell, int pow, bool allow_bonus)
     }
 
     if (minrange == maxrange)
-        return min(minrange, (int)you.current_vision);
+        return min(minrange, los_cap);
 
     const int powercap = spell_power_cap(spell);
 
     if (powercap <= pow)
-        return min(maxrange, (int)you.current_vision);
+        return min(maxrange, los_cap);
 
     // Round appropriately.
-    return min((int)you.current_vision,
+    return min(los_cap,
            (pow * (maxrange - minrange) + powercap / 2) / powercap + minrange);
 }
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -989,15 +989,13 @@ int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
 {
     int minrange = _seekspell(spell)->min_range;
     int maxrange = _seekspell(spell)->max_range;
-    
-    if !(ignore_los)
     int los_cap  = (int)you.current_vision;
-    else
+    if (ignore_los)
     	{ 
     	if (you.species!=SP_KOBOLD)
-    		int los_cap  = (int)you.normal_vision;
+    		los_cap  = (int)you.normal_vision;
     	else
-    		int los_cap  = (int)you.normal_vision-3
+    		los_cap  = (int)you.normal_vision-3;
     }
     
     ASSERT(maxrange >= minrange);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -990,6 +990,9 @@ int spell_range(spell_type spell, int pow, bool allow_bonus, int range_cap)
     int minrange = _seekspell(spell)->min_range;
     int maxrange = _seekspell(spell)->max_range;
 
+    if (range_cap == -1)
+        range_cap = you.current_vision;
+
     ASSERT(maxrange >= minrange);
 
     // spells with no range have maxrange == minrange == -1

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -991,12 +991,8 @@ int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
     int maxrange = _seekspell(spell)->max_range;
     int los_cap  = (int)you.current_vision;
     if (ignore_los)
-        {
-        if (you.species!=SP_KOBOLD)
-                los_cap  = (int)you.normal_vision;
-        else
-                los_cap  = (int)you.normal_vision-3;
-    }
+        los_cap  = (int)you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER);
+
 
     ASSERT(maxrange >= minrange);
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -985,14 +985,10 @@ int spell_power_cap(spell_type spell)
     }
 }
 
-int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
+int spell_range(spell_type spell, int pow, bool allow_bonus, int range_cap)
 {
     int minrange = _seekspell(spell)->min_range;
     int maxrange = _seekspell(spell)->max_range;
-    int los_cap  = (int)you.current_vision;
-    if (ignore_los)
-        los_cap  = (int)you.normal_vision-you.get_mutation_level(MUT_NIGHTSTALKER);
-
 
     ASSERT(maxrange >= minrange);
 
@@ -1012,15 +1008,15 @@ int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
     }
 
     if (minrange == maxrange)
-        return min(minrange, los_cap);
+        return min(minrange, range_cap);
 
     const int powercap = spell_power_cap(spell);
 
     if (powercap <= pow)
-        return min(maxrange, los_cap);
+        return min(maxrange, range_cap);
 
     // Round appropriately.
-    return min(los_cap,
+    return min(range_cap,
            (pow * (maxrange - minrange) + powercap / 2) / powercap + minrange);
 }
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -991,13 +991,13 @@ int spell_range(spell_type spell, int pow, bool allow_bonus, bool ignore_los)
     int maxrange = _seekspell(spell)->max_range;
     int los_cap  = (int)you.current_vision;
     if (ignore_los)
-    	{ 
-    	if (you.species!=SP_KOBOLD)
-    		los_cap  = (int)you.normal_vision;
-    	else
-    		los_cap  = (int)you.normal_vision-3;
+        {
+        if (you.species!=SP_KOBOLD)
+                los_cap  = (int)you.normal_vision;
+        else
+                los_cap  = (int)you.normal_vision-3;
     }
-    
+
     ASSERT(maxrange >= minrange);
 
     // spells with no range have maxrange == minrange == -1

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -71,7 +71,7 @@ bool del_spell_from_memory(spell_type spell);
 int spell_mana(spell_type which_spell, bool real_spell = true);
 int spell_difficulty(spell_type which_spell);
 int spell_power_cap(spell_type spell);
-int spell_range(spell_type spell, int pow, bool allow_bonus = true, int range_cap = you.current_vision);
+int spell_range(spell_type spell, int pow, bool allow_bonus = true, int range_cap = -1);
 int spell_noise(spell_type spell);
 int spell_effect_noise(spell_type spell, bool random = true);
 

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -71,7 +71,7 @@ bool del_spell_from_memory(spell_type spell);
 int spell_mana(spell_type which_spell, bool real_spell = true);
 int spell_difficulty(spell_type which_spell);
 int spell_power_cap(spell_type spell);
-int spell_range(spell_type spell, int pow, bool allow_bonus = true);
+int spell_range(spell_type spell, int pow, bool allow_bonus = true, bool ignore_los = false); 
 int spell_noise(spell_type spell);
 int spell_effect_noise(spell_type spell, bool random = true);
 

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -71,7 +71,7 @@ bool del_spell_from_memory(spell_type spell);
 int spell_mana(spell_type which_spell, bool real_spell = true);
 int spell_difficulty(spell_type which_spell);
 int spell_power_cap(spell_type spell);
-int spell_range(spell_type spell, int pow, bool allow_bonus = true, bool ignore_los = false); 
+int spell_range(spell_type spell, int pow, bool allow_bonus = true, bool ignore_los = false);
 int spell_noise(spell_type spell);
 int spell_effect_noise(spell_type spell, bool random = true);
 

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -71,7 +71,7 @@ bool del_spell_from_memory(spell_type spell);
 int spell_mana(spell_type which_spell, bool real_spell = true);
 int spell_difficulty(spell_type which_spell);
 int spell_power_cap(spell_type spell);
-int spell_range(spell_type spell, int pow, bool allow_bonus = true, bool ignore_los = false);
+int spell_range(spell_type spell, int pow, bool allow_bonus = true, int range_cap = you.current_vision);
 int spell_noise(spell_type spell);
 int spell_effect_noise(spell_type spell, bool random = true);
 


### PR DESCRIPTION
This pull request addresses Issue #1800:

Los restrictions (like the Scarf of shadows) reduce the length of lighting bolts/shocks reflected at walls.
![image](https://user-images.githubusercontent.com/49498206/114088621-7e46be00-98b5-11eb-8e36-6ef4d632810e.png)

The code checks how long a bounced spell would have been if los had not been restricted and then increases the range of bounced the spell.  (Kobolds nightstalker mutation does not count as a los restriction)

This change does not allow player to affect tiles outside of the los-radius (unless you wear a scarf of shadows and the "Robe of Night" together then it is possible).

Additionally I also gave a slight buff to player kobolds, their spells bounce back one further. Since for kobolds all reflected spells(Shock,Lighting_Bolt,Fire_Ball,Starburst) have range 4 and this results in this:
![image](https://user-images.githubusercontent.com/49498206/114081070-69b1f800-98ac-11eb-9389-7a73c30de400.png)
rather than this:
![image](https://user-images.githubusercontent.com/49498206/114086296-bd274480-98b2-11eb-9a11-574097df28d7.png)
Also this change does not allow players to affect tiles outside of the los-radius (unless you wear a scarf of shadows and the "Robe of Night" together then it is possible).

I think it looks nicer and more symmetrical this way and I don't think it is very unbalancing.
