### PR TITLE
Improve the UI when the user creates an ironbound beastmaster.

### DIFF
--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -315,8 +315,15 @@ namespace arena
                 if (!in_bounds(loc))
                     break;
 
-                const monster* mon = dgn_place_monster(spec,
-                                                       loc, false, true, false);
+                const monster* mon;
+                if (mons_class_requires_band(spec.type) && !spec.band)
+                {
+                    unwind_bool no(allow_bands, false);
+                    unwind_bool yes(spec.band, true);
+                    mon = dgn_place_monster(spec, loc, false, true, false);
+                }
+                else
+                    mon = dgn_place_monster(spec, loc, false, true, false);
                 if (!mon)
                 {
                     game_ended_with_error(

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -111,6 +111,13 @@ void wizard_create_spec_monster_name()
     if (mons_is_unique(type) && you.unique_creatures[type])
         you.unique_creatures.set(type, false);
 
+    if (mons_class_requires_band(type) && !mspec.band)
+    {
+        mprf(MSGCH_DIAGNOSTICS,
+             "That monster can only be created with a band.");
+        return;
+    }
+
     if (!dgn_place_monster(mspec, place, true, false))
     {
         mprf(MSGCH_DIAGNOSTICS, "Unable to place monster.");


### PR DESCRIPTION
In the arena, create a sole ironbound beastmaster if the user asks for one. This means that, if the user wants an ironbound beastmaster and two lindwurms, "ironbound beastmaster,2 lindwurm" will now request this, where it would previously have to have been "2 lindwurm,ironbound beastmaster band no_bands".

In wizard mode, print a relevant message if the player tries to make a sole ironbound beastmaster. The player can remove unwanted monsters later on if needed.

The addresses the issues I raised in #1869