### PR TITLE
Make the Wrath of Trog worthwhile

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -204,9 +204,8 @@ COLOUR:  ETC_BLOOD
 TILE:    spwpn_wrath_of_trog
 TILE_EQ: axe_trog
 VALUE:   800
-ANGRY:   5
-BASE_DELAY: -4
-BASE_DAM: +3
+ANGRY:   50
+BOOL:    rampage
 BRAND:   SPWPN_ANTIMAGIC
 
 NAME:    mace of Variability

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -204,7 +204,9 @@ COLOUR:  ETC_BLOOD
 TILE:    spwpn_wrath_of_trog
 TILE_EQ: axe_trog
 VALUE:   800
-ANGRY:   50
+ANGRY:   5
+BASE_DELAY: -4
+BASE_DAM: +3
 BRAND:   SPWPN_ANTIMAGIC
 
 NAME:    mace of Variability

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -16,10 +16,9 @@ Screaming Sword
 %%%%
 Wrath of Trog
 
-A bloodstained axe, forged by Trog himself to have exquisite sharpness and
-balance.  It was his favourite weapon, but was lost many centuries ago.
-It can induce a bloodthirsty berserker rage in warriors who use it in
-battle.
+A bloodstained axe that was the favourite weapon of the old god Trog, before it
+was lost. It induces a bloodthirsty berserker rage in warriors who use it in
+battle and enables them to dash towards their enemies.
 %%%%
 mace of Variability
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -16,8 +16,9 @@ Screaming Sword
 %%%%
 Wrath of Trog
 
-A bloodstained axe that was the favourite weapon of the old god Trog, before it
-was lost. It induces a bloodthirsty berserker rage in warriors who use it in
+A bloodstained axe, forged by Trog himself to have exquisite sharpness and
+balance.  It was his favourite weapon, but was lost many centuries ago.
+It can induce a bloodthirsty berserker rage in warriors who use it in
 battle.
 %%%%
 mace of Variability

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1619,6 +1619,15 @@ item_def* monster_die(monster& mons, killer_type killer,
             you.increase_duration(DUR_BERSERK, bonus);
             mpr("The necklace of Bloodlust glows a violent red.");
         }
+        else if (player_equip_unrand(UNRAND_TROG))
+        {
+            const int bonus = (2 + random2(4)) / 2;
+            you.increase_duration(DUR_BERSERK, bonus);
+            if (!random2(4))
+            {
+                mpr("Blood oozes out of your axe's blade.");
+            }
+        }
     }
 
     if (you.prev_targ == monster_killed)

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -57,6 +57,7 @@ my %field_type = (
     NOTELEP  => "bool",
     NO_UPGRADE => "bool",
     POISON   => "bool",
+    RAMPAGE  => "bool",
     RANDAPP  => "bool",
     RCORR    => "bool",
     REGEN    => "num",
@@ -537,7 +538,7 @@ my @art_order = (
     "BASE_DELAY", "HP", "CLARITY", "BASE_ACC", "BASE_DAM", "\n",
     "RMSL", "unused", "REGEN", "unused", "NO_UPGRADE", "RCORR", "\n",
     "RMUT", "unused", "CORRODE", "DRAIN", "SLOW", "FRAGILE", "\n",
-    "SH", "HARM", "\n",
+    "SH", "HARM", "RAMPAGE", "\n",
     "}",
 # end TAG_MAJOR_VERSION
 # start TAG_MAJOR_VERSION == 35


### PR DESCRIPTION
Wrath of Trog is very thematic with ANGRY: 50, but suicidally dangerous if you cannot manage the *Rage.  This is 5.55x more frequent than Berserkitis 3.  Other unrands with *Rage, besides have ANGRY of only 5, also have beneficial properties such as super-vampiricism, Slay+6, and berserking allies.  Wrath of Trog, though, is simply a +8 antimagic battleaxe.  This hardly compensates for berserking the wielder 10x as often.

This PR brings Wrath of Trog's ANGRY down to 5 and adds beneficial properties to it, to match the other *Rage unrands.  In keeping of the theme with this being Trog's favorite weapon, instead of giving it Troggish properties such as Regen+, Will++, or +Rage--things Trog wouldn't need himself from a weapon--just make it very powerful weapon with no properties other than the *Rage.  Trog's favorite weapon ought, after all, to be as good or better as the best gifts he used to give his followers!

This is accomplished by adding BASE_DAM: +3 and BASE_DELAY: -4 to its entry in art-data.txt, giving it the base damage of an executioner's axe with the base delay of a dire flail.  The enchantment is not changed.  Attached to the commit itself are five graphs comparing the new axe at skills 14, 20 and 26 to a +9 battleaxe of speed and to a +9 anti-magic executioner's axe, plus the fsim.csv.  The higher the target AC and EV, the better Wrath of Trog's relative performance.

The fsim settings were fsim_scale = fighting and fsim_rounds = 10000.  Wrath of Trog was changed in atr-data.txt to comment out the ANGRY line for fsim testing and to add BASE_DELAY = -4 and BASE_DAM = +3, then recompiling just in case.  Player stats were Strength 30 and Dex 20, wearing plate mail with Armour skill 20.  Target monsters were fungus (AC/EV of 0/0), tentacled monstrosity (5/5), wraith (10/10), orb guardian (13/13) and orb of fire (20/20).