### PR TITLE
add item.description in Lua

### DIFF
--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -13,6 +13,7 @@
 #include "cluautil.h"
 #include "colour.h"
 #include "coord.h"
+#include "describe.h"
 #include "env.h"
 #include "invent.h"
 #include "item-prop.h"
@@ -964,6 +965,20 @@ IDEF(inscription)
     return 1;
 }
 
+/*** Item description string, as displayed in the game UI.
+ * @field description string
+ */
+IDEF(description)
+{
+    if (!item || !item->defined())
+        return 0;
+
+    lua_pushstring(ls, get_item_description(*item, true, false).c_str());
+
+    return 1;
+}
+
+
 // DLUA-only functions
 static int l_item_do_pluses(lua_State *ls)
 {
@@ -1615,6 +1630,7 @@ static ItemAccessor item_attrs[] =
     { "encumbrance",       l_item_encumbrance },
     { "is_in_shop",        l_item_is_in_shop },
     { "inscription",       l_item_inscription },
+    { "description",       l_item_description },
 
     // dlua only past this point
     { "pluses",            l_item_pluses },

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1520,8 +1520,6 @@ static void _mpr(string text, msg_channel_type channel, int param, bool nojoin,
     if (channel == MSGCH_GOD && param == 0)
         param = you.religion;
 
-    clua.callfn("c_message", "ss", text.c_str(), channel_to_str(channel).c_str());
-
     // Ugly hack.
     if (channel == MSGCH_DIAGNOSTICS || channel == MSGCH_ERROR)
         cap = false;

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1520,6 +1520,8 @@ static void _mpr(string text, msg_channel_type channel, int param, bool nojoin,
     if (channel == MSGCH_GOD && param == 0)
         param = you.religion;
 
+    clua.callfn("c_message", "ss", text.c_str(), channel_to_str(channel).c_str());
+
     // Ugly hack.
     if (channel == MSGCH_DIAGNOSTICS || channel == MSGCH_ERROR)
         cap = false;


### PR DESCRIPTION
Similar to the recently added `spells.describe` function, this adds the string `description` to the Lua `item` object.  The description is the same text one sees in the UI.  Helpful for players using scripts to evaluate relative item values for damage, noise, etc.
