### PR TITLE
Make mid-lategame more compact.

### DIFF
--- a/crawl-ref/source/branch-data.h
+++ b/crawl-ref/source/branch-data.h
@@ -57,7 +57,7 @@ const Branch branches[NUM_BRANCHES] =
       'K', {}, branch_noise::normal, DEFAULT_MON_DIE_SIZE },
 #endif
 
-    { BRANCH_LAIR, BRANCH_DUNGEON, 8, 11, 6, 10,
+    { BRANCH_LAIR, BRANCH_DUNGEON, 8, 11, 4, 10,
       brflag::none,
       DNGN_ENTER_LAIR, DNGN_EXIT_LAIR, NUM_FEATURES,
       "Lair", "the Lair of Beasts", "Lair",
@@ -65,7 +65,7 @@ const Branch branches[NUM_BRANCHES] =
       GREEN, BROWN,
       'L', {}, branch_noise::normal, DEFAULT_MON_DIE_SIZE },
 
-    { BRANCH_SWAMP, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SWAMP, BRANCH_LAIR, 1, 3, 3, 15,
       brflag::dangerous_end | brflag::spotty,
       DNGN_ENTER_SWAMP, DNGN_EXIT_SWAMP, NUM_FEATURES,
       "Swamp", "the Swamp", "Swamp",
@@ -73,7 +73,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, BROWN,
       'S', { RUNE_SWAMP }, branch_noise::loud, 8 },
 
-    { BRANCH_SHOALS, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SHOALS, BRANCH_LAIR, 1, 3, 3, 15,
       brflag::dangerous_end,
       DNGN_ENTER_SHOALS, DNGN_EXIT_SHOALS, NUM_FEATURES,
       "Shoals", "the Shoals", "Shoals",
@@ -81,7 +81,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, BROWN,
       'A', { RUNE_SHOALS }, branch_noise::loud, DEFAULT_MON_DIE_SIZE },
 
-    { BRANCH_SNAKE, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SNAKE, BRANCH_LAIR, 1, 3, 3, 15,
       brflag::dangerous_end,
       DNGN_ENTER_SNAKE, DNGN_EXIT_SNAKE, NUM_FEATURES,
       "Snake Pit", "the Snake Pit", "Snake",
@@ -89,7 +89,7 @@ const Branch branches[NUM_BRANCHES] =
       LIGHTGREEN, YELLOW,
       'P', { RUNE_SNAKE }, branch_noise::normal, DEFAULT_MON_DIE_SIZE },
 
-    { BRANCH_SPIDER, BRANCH_LAIR, 2, 4, 4, 15,
+    { BRANCH_SPIDER, BRANCH_LAIR, 1, 3, 3, 15,
       brflag::dangerous_end,
       DNGN_ENTER_SPIDER, DNGN_EXIT_SPIDER, NUM_FEATURES,
       "Spider Nest", "the Spider Nest", "Spider",
@@ -97,7 +97,7 @@ const Branch branches[NUM_BRANCHES] =
       BROWN, YELLOW,
       'N', { RUNE_SPIDER }, branch_noise::quiet, DEFAULT_MON_DIE_SIZE },
 
-    { BRANCH_SLIME, BRANCH_LAIR, 5, 6, 5, 17,
+    { BRANCH_SLIME, BRANCH_LAIR, 4, 4, 4, 17,
       brflag::no_items | brflag::dangerous_end | brflag::spotty,
       DNGN_ENTER_SLIME, DNGN_EXIT_SLIME, NUM_FEATURES,
       "Slime Pits", "the Pits of Slime", "Slime",
@@ -105,7 +105,7 @@ const Branch branches[NUM_BRANCHES] =
       GREEN, BROWN,
       'M', { RUNE_SLIME }, branch_noise::quiet, 7 },
 
-    { BRANCH_VAULTS, BRANCH_DUNGEON, 13, 14, 5, 19,
+    { BRANCH_VAULTS, BRANCH_DUNGEON, 13, 14, 4, 19,
       brflag::dangerous_end,
       DNGN_ENTER_VAULTS, DNGN_EXIT_VAULTS, NUM_FEATURES,
       "Vaults", "the Vaults", "Vaults",
@@ -114,7 +114,7 @@ const Branch branches[NUM_BRANCHES] =
       'V', { RUNE_VAULTS }, branch_noise::normal, 9 },
 #if TAG_MAJOR_VERSION == 34
 
-    { BRANCH_BLADE, BRANCH_VAULTS, 3, 4, 1, 21,
+    { BRANCH_BLADE, BRANCH_VAULTS, 2, 3, 1, 21,
       brflag::no_items,
       DNGN_ENTER_BLADE, DNGN_EXIT_BLADE, NUM_FEATURES,
       "Hall of Blades", "the Hall of Blades", "Blade",
@@ -123,7 +123,7 @@ const Branch branches[NUM_BRANCHES] =
       'B', {}, branch_noise::quiet, DEFAULT_MON_DIE_SIZE },
 #endif
 
-    { BRANCH_CRYPT, BRANCH_VAULTS, 2, 3, 3, 19,
+    { BRANCH_CRYPT, BRANCH_VAULTS, 1, 3, 3, 19,
       brflag::dangerous_end,
       DNGN_ENTER_CRYPT, DNGN_EXIT_CRYPT, NUM_FEATURES,
       "Crypt", "the Crypt", "Crypt",
@@ -140,7 +140,7 @@ const Branch branches[NUM_BRANCHES] =
       'W', { RUNE_TOMB }, branch_noise::quiet, DEFAULT_MON_DIE_SIZE },
 #if TAG_MAJOR_VERSION > 34
 
-    { BRANCH_DEPTHS, BRANCH_DUNGEON, 15, 15, 5, 22,
+    { BRANCH_DEPTHS, BRANCH_DUNGEON, 15, 15, 3, 22,
       brflag::none,
       DNGN_ENTER_DEPTHS, DNGN_EXIT_DEPTHS, NUM_FEATURES,
       "Depths", "the Depths", "Depths",
@@ -189,7 +189,7 @@ const Branch branches[NUM_BRANCHES] =
       MAGENTA, MAGENTA,
       'Y', { RUNE_TARTARUS }, branch_noise::normal, HELL_MON_DIE_SIZE },
 
-    { BRANCH_ZOT, BRANCH_DEPTHS, 5, 5, 5, 27,
+    { BRANCH_ZOT, BRANCH_DEPTHS, 3, 3, 5, 27,
       brflag::dangerous_end,
       DNGN_ENTER_ZOT, DNGN_EXIT_ZOT, NUM_FEATURES,
       "Zot", "the Realm of Zot", "Zot",
@@ -226,7 +226,7 @@ const Branch branches[NUM_BRANCHES] =
       'R', { RUNE_DEMONIC, RUNE_MNOLEG, RUNE_LOM_LOBON, RUNE_CEREBOV,
              RUNE_GLOORX_VLOQ }, branch_noise::normal, 8 },
 
-    { BRANCH_ZIGGURAT, BRANCH_DEPTHS, 1, 5, 27, 27,
+    { BRANCH_ZIGGURAT, BRANCH_DEPTHS, 1, 3, 27, 27,
       brflag::no_x_level_travel | brflag::no_items,
       DNGN_ENTER_ZIGGURAT, DNGN_EXIT_ZIGGURAT, DNGN_FLOOR,
       "Ziggurat", "a ziggurat", "Zig",

--- a/crawl-ref/source/dat/des/branches/abyss.des
+++ b/crawl-ref/source/dat/des/branches/abyss.des
@@ -23,9 +23,9 @@ end
 
 function abyss_entry(e, glyph)
   e.tags("extra luniq_enter_abyss chance_enter_abyss")
-  e.depth_chance("Depths:1-3", 3333)
-  e.depth_chance("Depths:4",   10000)
-  e.depth_chance("Depths:5-",  3333)
+  e.depth_chance("Depths:1", 3333)
+  e.depth_chance("Depths:2", 10000)
+  e.depth_chance("Depths:3", 3333)
 -- start TAG_MAJOR_VERSION == 34
   e.depth_chance("D:21-24", 3333)
   e.depth_chance("D:25",    10000)
@@ -37,7 +37,7 @@ end
 
 ###############################################################################
 # Abyss entries.
-# 1/3 chance to appear on Depths floors and guaranteed on Depths:4.
+# 1/3 chance to appear on Depths floors and guaranteed on Depths:2.
 ###############################################################################
 
 default-depth: Depths, D:21-

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_ghost.des
@@ -134,7 +134,7 @@ ENDMAP
 NAME:   gammafunk_vaults_ghost_necromancy
 TAGS:   vaults_orient_w allow_dup
 KMONS:  O = player ghost
-MONS:   simulacrum place:Vaults:5 / spectre place:Vaults:5, lich
+MONS:   simulacrum place:Vaults:3 / spectre place:Vaults:3, lich
 : ghost_good_loot(_G)
 SUBST:  fg = |*, h = *, i = %$, j = -
 NSUBST: 1 = 12 / 1, - = 3=1 / 6=1. / .

--- a/crawl-ref/source/dat/dlua/gauntlet.lua
+++ b/crawl-ref/source/dat/dlua/gauntlet.lua
@@ -407,7 +407,7 @@ tier1_gauntlet_arenas = {
   },
   {
     first  = {mons = "death scarab", min = 1, max = 1},
-    second = {mons = "spectre place:Lair:6", min = 1, max = 1},
+    second = {mons = "spectre place:Lair:4", min = 1, max = 1},
     liquid = "water",
     plant  = "withered",
   },
@@ -635,7 +635,7 @@ tier2_gauntlet_arenas = {
   },
   {
     second = {mons = "death scarab", min = 2, max = 2},
-    third  = {mons = "spectre place:Lair:6", min = 2, max = 4},
+    third  = {mons = "spectre place:Lair:4", min = 2, max = 4},
     liquid = "water",
     plant  = "withered",
   },

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1111,11 +1111,11 @@ static void _add_missing_branches()
         _ensure_entry(BRANCH_VAULTS);
     if (brentry[BRANCH_ZOT] == lc)
         _ensure_entry(BRANCH_ZOT);
-    if (lc == level_id(BRANCH_DEPTHS, 2) || lc == level_id(BRANCH_DUNGEON, 21))
+    if (lc == level_id(BRANCH_DEPTHS, 1) || lc == level_id(BRANCH_DUNGEON, 21))
         _ensure_entry(BRANCH_VESTIBULE);
     if (lc == level_id(BRANCH_DEPTHS, 3) || lc == level_id(BRANCH_DUNGEON, 24))
         _ensure_entry(BRANCH_PANDEMONIUM);
-    if (lc == level_id(BRANCH_DEPTHS, 4) || lc == level_id(BRANCH_DUNGEON, 25))
+    if (lc == level_id(BRANCH_DEPTHS, 2) || lc == level_id(BRANCH_DUNGEON, 25))
         _ensure_entry(BRANCH_ABYSS);
     if (player_in_branch(BRANCH_VESTIBULE))
     {


### PR DESCRIPTION
This PR removes 2 floors of lair, 1 floor of sbranch, 1 floor of vaults, 1 floor of slime, and 2 floors of depths with no compensation for xp or items. It does not change extended because that involves a larger overhaul, but somebody should get on that :^)

Think of this as a conversation starter pull request; I don't really expect it to get merged as-is. It may also be worth chopping late dungeon somewhat, bcrawl style, but I think late D tends to work better than 6 floor lair. I support merging the manman xp curve pr as a follow up to this one if approved.