### PR TITLE
WIP: add Mjölnir, a throwable returning melee weapon

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1455,6 +1455,16 @@ COLOUR:   ETC_ENCHANT
 INSCRIP:  Rampage+∞
 VALUE:    400
 
+# Mojo is what most Nethack players call it; easier than guessing at spelling.
+ENUM:     MOJO
+NAME:     Mjölnir
+OBJ:      OBJ_WEAPONS/WPN_MORNINGSTAR
+PLUS:     +9
+BRAND:    SPWPN_HOLY_WRATH
+COLOUR:   ETC_ELECTRICITY
+INSCRIP:  Thrown
+BOOL:     elec
+
 # This entry must always be last.
 ENUM:   DUMMY2
 NAME:   DUMMY UNRANDART 2

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1374,6 +1374,31 @@ static void _THERMIC_ENGINE_unequip(item_def *item, bool *show_msgs)
     item->plus = 2;
 }
 
+static void _MOJO_melee_effects(item_def* /*weapon*/, actor* attacker,
+                                actor* defender, bool mondied, int /*dam*/)
+{
+    /* in nethack, mojo does tremendous damage infrequently; we nod to that
+       here with a double-damage electrocution brand that happens half as
+       often as standard elec brand. */
+    if (defender->res_elec() >= 3 || mondied)
+        return;
+    if (one_chance_in(6))
+        {
+            int special_damage = 16 + random2(26);
+            const string punctuation =
+                    attack_strength_punctuation(special_damage);
+            mpr((defender->is_player())
+            ? make_stringf("You are electrocuted%s", punctuation.c_str())
+            : make_stringf("Lightning courses through %s%s",
+                            defender->name(DESC_THE).c_str(),
+                            punctuation.c_str()));
+            defender->hurt(attacker, special_damage, BEAM_ELECTRICITY);
+            if (defender->alive())
+                defender->expose_to_element(BEAM_ELECTRICITY, 2);
+        }
+
+}
+
 static void _THERMIC_ENGINE_melee_effects(item_def* weapon, actor* attacker,
                                    actor* defender, bool mondied, int dam)
 {

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -492,8 +492,10 @@ static bool _setup_missile_beam(const actor *agent, bolt &beam, item_def &item,
         }
     }
 
-    returning = item.base_type == OBJ_MISSILES
-                && item.sub_type == MI_BOOMERANG;
+    returning = (item.base_type == OBJ_MISSILES
+                && item.sub_type == MI_BOOMERANG)
+                || (item.base_type == OBJ_WEAPONS
+                && is_unrandom_artefact(*launcher, UNRAND_MOJO));
 
     if (item.base_type == OBJ_MISSILES
         && get_ammo_brand(item) == SPMSL_EXPLODING)


### PR DESCRIPTION
However you choose spell "Mjolnurr", it's the so-called "hammer of thor".

The main idea is that it's a melee weapon that also can be thrown, and
it has the returning property.  Advice greatly welcome as i tinker with this!

Due to the existence of Eos, an electric+holy mace might not be the most
exciting version of Mjlnr.  Perhaps it'd be better as a throwing dagger, or a
sharpened boomerang.  But what I'd like to try to code is a weapon that
can both be thrown and used in melee.  Potentially interesting is any
codepath in [throw.cc](https://github.com/crawl/crawl/blob/master/crawl-ref/source/throw.cc) that yields "toss away" or "but it does no damage".

With what I've coded so far, Crawl simply crashes when you throw Moljnir,
but i haven't given up yet!