### PR TITLE
Add a help option for the wizard mode create monster command.

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -312,3 +312,298 @@ set with <w>Ctrl-F</w>. If <w>Enter</w> is pressed at the prompt without enterin
 that will reset the filter to none.
 You can filter spells by name and by spell school.
 %%%%
+wiz-monster
+<h>Create specified monster</h>
+
+To create a monster with the default equipment for its species, simply enter
+the species name, such as <w>kobold</w> or <w>Yiuf</w>.
+
+A hydra can be given a specific number of heads by calling it an n<w>-headed</w>
+<w>hydra</w> (with a maximum of 20 heads):
+
+<w>four-headed hydra</w>
+
+To set the colour a (very) ugly thing takes when it is first created, use:
+
+<w>white very ugly thing</w>
+
+The valid colours are <w>brown</w>, <w>cyan</w>, <w>green</w>, <w>purple</w>, <w>red</w> and <w>white</w>.
+
+A mutant beast can be customized by prefacing it with a maturity level and/or
+hyphen-separated set of traits, as follows:
+
+<w>mature shock-weird mutant beast</w>
+
+The valid maturity levels are <w>larval</w>, <w>juvenile</w>, <w>mature</w>, <w>elder</w> and <w>primal</w>. The
+facets are <w>sting</w>, <w>bat</w>, <w>fire</w>, <w>weird</w>, <w>shock</w> and <w>ox</w>.
+
+A slime creature's size can be set to other than normal using the prefixes
+<w>large</w>, <w>very large</w>, <w>enormous</w> or <w>titanic</w>:
+
+<w>very large slime creature</w>
+
+If a monster is a member of a band, you can request that it be eligible for
+band members by adding the keyword <w>band</w> to the name. For instance:
+
+<w>orc warlord band</w>
+
+Specifying <w>band</w> doesn't force bands to be placed - it requests that the game
+use the normal chances of creating a band. A band will only be placed if there
+is space for it.
+
+A monster can be given specific items by following the monster name with a
+semi-colon and then with an item list. For example:
+
+<w>orc ; rapier | quick blade . chain mail | plate armour</w>
+
+will generate an orc wielding either a rapier or a quick blade and wearing
+either chain mail or plate armour. Randarts and ego items are only generated
+if they are explicitly requested. Note that any items that the monster was
+originally generated with will be removed and destroyed. This can be used to
+force a monster to have no items whatsoever:
+
+<w>orc; nothing</w>
+
+For further information, see <cyan>docs/develop/levels/syntax.txt</cyan>, section <cyan>ITEMS</cyan>.
+Any reference to a slash (<w>/</w>) should be replaced with a pipe (<w>|</w>) and any comma
+(<w>,</w>) with a full stop (<w>.</w>).
+
+The same syntax is also used to create a specific type of dancing weapon:
+
+<w>dancing weapon; rapier</w>
+
+Limitations: If a monster is given a random launcher, there is no way to force
+the ammo type to match the launcher type. As a special case, however, a
+launcher dancing weapon is always generated with some suitable ammunition.
+
+You can specify that a monster will always generate a corpse by using the tag
+<w>always_corpse</w>, or that it will never generate a corpse with <w>never_corpse</w>.
+
+By default, monsters are generated asleep. This is changed by prefixing the
+name with <w>generate_awake</w>.
+
+<w>generate_awake boulder beetle</w>
+
+A prefix of <w>patrolling</w> prevents it from walking out of sight of the the place
+where it was created.
+
+You can set the monster's god using the <w>god</w>: specifier as follows:
+
+<w>orc god:the_shining_one</w>
+
+If the monster is to be a gift of the specified god, this should be suffixed
+with <w>god_gift</w>:
+
+<w>orc god:the_shining_one god_gift</w>
+
+Note that the monster will not be considered a god gift unless <w>god_gift</w> is
+explicitly set.
+
+You can set the monster's faction by specifying <w>att</w>: one of:
+
+* <w>att:hostile</w> -- the default
+* <w>att:friendly</w> -- tame, will follow you
+* <w>att:neutral</w> -- hostile to both you and att:hostile monsters
+* <w>att:good_neutral</w> -- hostile to att:hostile
+* <w>att:fellow_slime</w> -- tame, won't follow you
+
+Monsters can be given colours that override their default colour:
+
+<w>col:darkgrey fungus</w>
+
+The colour <w>any</w> can be given, in which case a random colour will be chosen.
+
+You can override the displayed monster tile using the <w>tile</w>: specifier as
+follows:
+
+<w>rat tile:mons_giant_bat</w>
+
+In tiles version, this would create a monster that uses the "<cyan>mons_giant_bat</cyan>"
+tile, but is otherwise identical to a rat. In ASCII mode, this will do
+nothing.
+
+If you want to place a random monster suitable for the level the map is
+generated on, you can use
+
+<w>random</w>
+
+If you want to place a random monster suitable for some other place, you can
+use a place: tag in the monster spec:
+
+<w>place:Abyss</w>
+
+Using <w>place</w>: implies that you want a random monster. You can also request
+zombies from random monsters suitable for some other depth as (e.g.):
+
+<w>place:Elf:3 zombie</w>
+
+The available modifiers are <w>zombie</w>, <w>skeleton</w>, <w>simulacrum</w>, and <w>spectre</w>.
+
+<h>Overriding Monster Names</h>
+
+Individual monsters can be given names as follows:
+
+<w>kobold name:Durwent</w>
+
+This will cause the monster to appear as "<cyan>Durwent the kobold</cyan>". Spaces can be
+placed in the name by substituting them with the _ symbol. It is worth noting
+that "<cyan>the <<race></cyan>" will be appended to all names, which should be considered
+when coming up with them.
+
+There are three different modifiers that can be used on a name:
+<w>name_adjective</w>, <w>name_suffix and </w>name_replace. <w>name_adjective</w> makes the
+name act as an adjective. For example:
+
+<w>kobold name:ugly name_adjective</w>
+
+Will cause "<cyan>An ugly kobold</cyan>", "<cyan>The ugly kobold hits you</cyan>", and so on.
+
+<w>name_suffix</w> does the same, but after the monster's base name:
+
+<w>kobold name:wearing_mittens name_suffix</w>
+
+Will give "<cyan>A kobold wearing mittens</cyan>", "<cyan>The kobold wearing mittens hits you</cyan>",
+and so on.
+
+<w>name_replace</w> causes the base name to be replaced by given name, as if the
+monster was a unique:
+
+<w>kobold name:Durwent name_replace</w>
+
+Will result in "<cyan>Durwent</cyan>" rather than "<cyan>Durwent the Kobold</cyan>". The corpse will
+still be a "<cyan>kobold corpse of Durwent</cyan>".
+
+<w>name_species</w> uses the name for corpses as-is, without prefixing it with
+"<cyan>kobold</cyan> <cyan>corpse of X</cyan>" for <w>name_replace</w>. It also avoids the usual name tag
+that displays above unique and renamed monsters in local tiles.
+
+In combination with <w>name_replace</w> or <w>name_species</w>, there are two further tags
+that can be used when renaming monsters, but not giving them an actual "name":
+<w>name_descriptor</w>, and <w>name_definite</w>.
+
+For example:
+
+<w>kobold name:goblin name_replace</w>
+
+Will result in "<cyan>goblin hits you</cyan>". However, adding <w>name_descriptor</w> from the
+above flags will result in "<cyan>The goblin hits you</cyan>" and in the description of the
+monster, "<cyan>A goblin</cyan>".
+
+<w>kobold name:goblin name_replace name_descriptor</w>
+
+The <w>name_definite</w> flag ensures that it is never referred to as "<cyan>a</cyan>" or "<cyan>an</cyan>",
+but that the definite object is always used. Therefore, you will see "<cyan>The
+<cyan>goblin</cyan> <cyan>hits you</cyan>", as per above, but also "<cyan>The goblin</cyan>" in its description.
+Setting <w>name_definite</w> will automatically set the flag <w>name_descriptor</w>,
+therefore meaning that:
+
+<w>kobold name:goblin name_replace name_definite</w>
+
+is exactly the same as:
+
+<w>kobold name:goblin name_replace name_descriptor name_definite</w>
+
+<w>name_zombie</w> can be used to redefine already zombified monsters (including
+skeletons, simulacra and spectrals).
+
+Finally, <w>name_nocorpse</w> will cause the name to be completely ignored for
+corpses. For example:
+
+<w>wizard name:sad name_adjective name_nocorpse</w>
+
+will result in "<cyan>a sad wizard</cyan>" that leaves "<cyan>a wizard corpse</cyan>".
+
+For instances where space in definitions is limited, you can use abbreviated
+forms of these tags:
+
+* <w>name_suffix</w> -> <w>n_suf</w>
+* <w>name_adjective</w> -> <w>n_adj</w>
+* <w>name_replace</w> -> <w>n_rpl</w>
+* <w>name_species</w> -> <w>n_spe</w>
+* <w>name_descriptor</w> -> <w>n_des</w>
+* <w>name_definite</w> -> <w>n_the</w>
+* <w>name_zombie</w> -> <w>n_zom</w>
+* <w>name_nocorpse</w> -> <w>n_noc</w>
+
+<h>Overriding Monster Stats</h>
+
+Further monster customisation can be made by using <w>hd</w> and <w>hp</w>. These two tags
+allow you to completely overwrite the original hit dice and hit points of a
+monster:
+
+<w>kobold hd:20</w>
+
+Creates a kobold with a hit dice of 20. As its hp is randomised, based on its
+hit dice, this will also be re-rolled. Monsters with a specific hit point
+value will not have this value change.
+
+You can also have a specific value for hit points:
+
+<w>kobold hp:20</w>
+
+Creates a kobold with 20 hit points. This is also useful for monsters (such as
+statues) which come with non-randomised HP values.
+
+Monsters can be marked as summoned by using <w>dur</w> and <w>sum</w> tags. The <w>dur</w> tag
+accepts an integer between 1 and 6 inclusive. The <w>sum</w> tag accepts the name of
+a spell (parsed as per the <w>spells</w> tag, described below) or any of <w>clone</w>
+(Rakshasa), <w>animate</w> (from animate dead), <w>chaos</w> (made from pure chaos), <w>miscast</w>
+(summoned from by spell miscast effect), <w>zot</w> (summoned by a Zot trap), <w>wrath</w>
+(summoned by a god in an act of retribution), <w>aid</w> (summoned by a god in order
+to give aid).
+
+Of the spells, <w>shadow_creatures</w> has the most significant effect, in that
+monsters will dissipate into the shadows rather than disappear in a puff of
+smoke. Using non-summoning spells will also have no effect.
+
+Tagging a monster with <w>seen</w> will override the system and force that monster to
+be marked as already viewed; this means that it won't generate messages such
+as "<cyan>A kobold comes into view</cyan>".
+
+<h>Overriding Monster Spells</h>
+
+Monster spell sets can be overridden with a <w>spells</w>: tag, used as follows:
+
+*<w>goblin spells:throw_flame.50.wizard</w>
+*<w>ancient lich spells:symbol_of_torment.26.wizard; glaciate.51.wizard</w>
+
+(a list of spell slots, consisting of a spell name with spaces replaced with
+underscores, a frequency of casting and set of spell slot flags specified
+afterwards with <w>.</w>, with slots separated by <w>;</w>. There should be no spaces around
+the <w>;</w> or after the <w>spells</w>: prefix)
+
+Spell names must exactly match the names in <cyan>spl-data.h</cyan>, with spaces replaced
+by underscores. Spell frequencies are an (x in 200) chance that that spell
+will be cast. Spell flags include:
+
+* <w>natural</w>, <w>magical</w>, <w>demonic</w>, <w>wizard</w>, or <w>priest</w> - the manner in which this
+spell is being cast. Wizards and priests can be silenced and will trigger
+appropriate conducts (Trog will appreciate killing wizards, Beogh will
+appreciate killing priests). Magical, demonic, and wizard spells are subject
+to anti-magic effects. Natural spells do not generate noise.
+* <w>emergency</w> - the monster will only cast the spell when low on health.
+* <w>breath</w> - the spell is a breath weapon, and using it triggers a breath
+timeout during which the spell cannot be cast again.
+* <w>no_silent</w> - the spell cannot be used while silent, even if it is an ability
+type normally not subject to silence.
+* <w>instant</w> - the spell does not expend the monster's energy; they may take
+another action on the same turn.
+* <w>noisy</w> - forces the spell to make noise even if it is a natural ability.
+
+You may use <w>none</w> specify that a slot should be left empty. You can force a
+spell-less monster with:
+
+<w>orc wizard spells:none</w>
+
+<h>Setting enchantments</h>
+
+You may give a monster any number of enchantments. It may start hasted, blind,
+have permanent RMsl, etc. The syntax is <w>ench:<<name>:<<degree>:<<duration></w> or
+<w>perm_ench:<<name>:<<degree></w>. The <w><<degree></w> and <w><<duration></w> fields may be
+omitted.
+
+For example:
+
+* <w>orc perm_ench:blind perm_ench:mad</w>
+* <w>dream sheep ench:sticky_flame</w>
+* <w>stone giant dur:1 ench:berserk</w>

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -14,6 +14,7 @@
 #include "areas.h"
 #include "cloud.h"
 #include "colour.h"
+#include "command.h"
 #include "dbg-util.h"
 #include "delay.h"
 #include "directn.h"
@@ -52,10 +53,16 @@
 void wizard_create_spec_monster_name()
 {
     char specs[1024];
-    mprf(MSGCH_PROMPT, "Enter monster name (or MONS spec): ");
+    mprf(MSGCH_PROMPT, "Enter monster name (or MONS spec) (? for help): ");
     if (cancellable_get_line_autohist(specs, sizeof specs) || !*specs)
     {
         canned_msg(MSG_OK);
+        return;
+    }
+
+    if (!strcmp(specs, "?"))
+    {
+        show_specific_help("wiz-monster");
         return;
     }
 


### PR DESCRIPTION
Entering ? as the monster name causes some help text to appear. This is
derived from the MONS section of docs/develop/levels/syntax.txt, but
with a few changes.

1. Use colour - yellow for headings, white for keywords which can be
entered as part of the command, and cyan for other things such as text
the game produces in response to a command, or file references.

2. Remove quotation marks from around keywords. I haven't done this with
cyan text, as this contains longer phrases which may be harder to
separate.

3. Don't give advice on how the command should be used (such as "use
this sparingly").

4. Rearrange the paragraphs a bit, and add a new opening paragraph.

5. Add lists of valid characteristics for mutant beasts and ugly things.

This change means that most of the information you need to create a monster is easily accessible from the create monster command, rather than being hidden away in a file you're told nothing about.

It does mean that sections of two files have much the same content in different formats. I don't know what the best way to handle this would be.