### PR TITLE
Further fix webtiles display of defense boosts

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -845,7 +845,7 @@ static bool _update_statuses(player_info& c)
             inf = status_info();
             if (!you.duration[status])
                 continue;
-            inf.short_text = "divine shield";
+            inf.short_text = "divinely shielded";
         }
         else if (status == DUR_ICEMAIL_DEPLETED)
         {
@@ -859,7 +859,7 @@ static bool _update_statuses(player_info& c)
             inf = status_info();
             if (!acrobat_boost_active())
                 continue;
-            inf.short_text = "acrobat";
+            inf.short_text = "acrobatic";
         }
         else if (!fill_status_info(status, inf)) // this will reset inf itself
             continue;

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -184,7 +184,7 @@ function ($, comm, enums, map_knowledge, messages, options, util) {
         else
             elem = inventory_item_desc(wielded);
 
-        if (player.has_status("corroded equipment"))
+        if (player.has_status("corroded"))
             elem.addClass("corroded_weapon");
 
         return elem;
@@ -236,7 +236,7 @@ function ($, comm, enums, map_knowledge, messages, options, util) {
             elem.addClass("degenerated_defense");
         else if (player.has_status(defense_boosters[type]))
             elem.addClass("boosted_defense");
-        else if (type == "ac" && player.has_status("corroded equipment"))
+        else if (type == "ac" && player.has_status("corroded"))
             elem.addClass("degenerated_defense");
         else if (type == "sh" && player.god == "Qazlal"
                  && player.piety_rank > 0)


### PR DESCRIPTION
After fc3203cb, defense boosts provided by the "acrobat and divine
shield are no longer coloured blue.

This is because unlike other boosts, these two are handled separately
in `tileweb.cc:_update_statuses()` and don't use `short_text` strings
from duration-data.h.

Fix this by updating `short_text`s in `_update_statuses()`. Also, fix
colouring of corroded AC and weapons on the HUD.

I checked all other defense boosts too and they are all coloured
correctly on WebTiles.