### PR TITLE
Adjust ru sacrifices and piety gain.

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4710,7 +4710,7 @@ void ru_reset_sacrifice_timer(bool clear_timer, bool faith_penalty)
 
     // raise the delay if there's an active sacrifice, and more so the more
     // often you pass on a sacrifice and the more piety you have.
-    const int base_delay = 80;
+    const int base_delay = 90;
     int delay = you.props[RU_SACRIFICE_DELAY_KEY].get_int();
     int added_delay;
     if (clear_timer)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4043,7 +4043,7 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
                                        you.skill_rdiv(SK_SPELLCASTING, 1, 2));
             }
             else if (mut == MUT_WEAK_WILLED)
-                piety_gain += 28;
+                piety_gain += 38;
             else
                 piety_gain += 2 + _get_stat_piety(STAT_INT, 6);
             break;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3857,9 +3857,16 @@ static bool _player_sacrificed_arcana()
  */
 static bool _sacrifice_is_possible(sacrifice_def &sacrifice)
 {
+    
+    // This mutation has 3 ranks and can be taken multiple times
+    if (sacrifice.mutation == MUT_UNSKILLED)
+    {
+        if (you.get_mutation_level(sacrifice.mutation) == 3)
+            return false;
+    }
     // for sacrifices other than health, essence, and arcana there is a
     // deterministic mapping between the sacrifice_def and a mutation_type.
-    if (sacrifice.mutation != MUT_NON_MUTATION
+    else if (sacrifice.mutation != MUT_NON_MUTATION
         && (you.get_mutation_level(sacrifice.mutation)
             || !_sac_mut_maybe_valid(sacrifice.mutation)))
     {
@@ -4072,6 +4079,10 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
         case ABIL_RU_SACRIFICE_ARTIFICE:
             if (you.get_mutation_level(MUT_NO_LOVE))
                 piety_gain -= 10; // You've already lost some value here
+            break;
+        case ABIL_RU_SACRIFICE_SKILL:
+            // give a small bonus if sacrifice skill is taken multiple times
+            piety_gain += 7 * you.get_mutation_level(mut);
             break;
         case ABIL_RU_SACRIFICE_NIMBLENESS:
             if (you.get_mutation_level(MUT_NO_ARMOUR_SKILL))

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4079,6 +4079,17 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
             else if (species_apt(SK_ARMOUR) == UNUSABLE_SKILL)
                 piety_gain += 28; // this sacrifice is worse for these races
             break;
+        // words and drink cut off a lot of options if taken together
+        case ABIL_RU_SACRIFICE_DRINK:
+            if (you.get_mutation_level(MUT_READ_SAFETY))
+                piety_gain += 10;
+            break;
+        case ABIL_RU_SACRIFICE_WORDS:
+            if (you.get_mutation_level(MUT_DRINK_SAFETY))
+                piety_gain += 10;
+            else if (you.get_mutation_level(MUT_NO_DRINK)) 
+                piety_gain += 15; // extra bad for mummies
+            break;
         case ABIL_RU_SACRIFICE_DURABILITY:
             if (you.get_mutation_level(MUT_NO_DODGING))
                 piety_gain += 20;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3858,8 +3858,9 @@ static bool _player_sacrificed_arcana()
 static bool _sacrifice_is_possible(sacrifice_def &sacrifice)
 {
     
-    // This mutation has 3 ranks and can be taken multiple times
-    if (sacrifice.mutation == MUT_UNSKILLED)
+    // These mutations have 3 ranks and can be taken multiple times
+    if (sacrifice.mutation == MUT_UNSKILLED
+        || sacrifice.mutation == MUT_INEXPERIENCED)
     {
         if (you.get_mutation_level(sacrifice.mutation) == 3)
             return false;
@@ -4120,18 +4121,18 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
             break;
         case ABIL_RU_SACRIFICE_EXPERIENCE:
             if (you.get_mutation_level(MUT_COWARDICE))
-                piety_gain += 15;
+                piety_gain += 12;
             // Ds are highly likely to miss at least one mutation. This isn't
             // absolutely certain, but it's very likely and they should still
             // get a bonus for the risk. Could check the exact mutation
             // schedule, but this seems too leaky.
-            // Dj are guaranteed to lose their last spell, which is pretty sad too.
+            // Dj are guaranteed to lose a spell each time, which is pretty sad too.
             if (you.species == SP_DEMONSPAWN || you.species == SP_DJINNI)
-                piety_gain += 20;
+                piety_gain += 16;
             break;
         case ABIL_RU_SACRIFICE_COURAGE:
-            if (you.get_mutation_level(MUT_INEXPERIENCED))
-                piety_gain += 15;
+            piety_gain += 12 * you.get_mutation_level(MUT_INEXPERIENCED);
+            break;
 
         default:
             break;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4053,7 +4053,8 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
             else if (mut == MUT_WEAK_WILLED)
                 piety_gain += 38;
             else
-                piety_gain += 2 + _get_stat_piety(STAT_INT, 6);
+                piety_gain += 2 + _get_stat_piety(STAT_INT, 6)
+                                + you.skill_rdiv(SK_SPELLCASTING, 1, 2);
             break;
         case ABIL_RU_SACRIFICE_PURITY:
             if (mut == MUT_WEAK || mut == MUT_DOPEY || mut == MUT_CLUMSY)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4040,8 +4040,7 @@ int get_sacrifice_piety(ability_type sac, bool include_skill)
             if (mut == MUT_LOW_MAGIC)
             {
                 piety_gain += 10 + max(you.skill_rdiv(SK_INVOCATIONS, 1, 2),
-                                       max( you.skill_rdiv(SK_SPELLCASTING, 1, 2),
-                                            you.skill_rdiv(SK_EVOCATIONS, 1, 2)));
+                                       you.skill_rdiv(SK_SPELLCASTING, 1, 2));
             }
             else if (mut == MUT_WEAK_WILLED)
                 piety_gain += 28;

--- a/crawl-ref/source/sacrifice-data.h
+++ b/crawl-ref/source/sacrifice-data.h
@@ -101,7 +101,7 @@ static const sacrifice_def sac_data[] =
   "sacrifice your ability to be loved",
   "sacrificed love",
 
-  35,
+  40,
   SK_SUMMONINGS,
   nullptr,
   nullptr,
@@ -151,7 +151,7 @@ static const sacrifice_def sac_data[] =
   "sacrifice one of your ",
   "sacrificed a hand",
 
-  65,
+  60,
   SK_SHIELDS,
   nullptr,
   nullptr,
@@ -191,7 +191,7 @@ static const sacrifice_def sac_data[] =
   "sacrifice your resistance to extreme temperatures",
   "sacrificed resistance",
 
-  60,
+  50,
   SK_NONE,
   nullptr,
   nullptr,

--- a/crawl-ref/source/sacrifice-data.h
+++ b/crawl-ref/source/sacrifice-data.h
@@ -161,7 +161,7 @@ static const sacrifice_def sac_data[] =
   "sacrifice your experiences",
   "sacrificed experience",
 
-  50,
+  40,
   SK_NONE,
   nullptr,
   []() { return you.experience_level > RU_SAC_XP_LEVELS; }

--- a/crawl-ref/source/sacrifice-data.h
+++ b/crawl-ref/source/sacrifice-data.h
@@ -171,7 +171,7 @@ static const sacrifice_def sac_data[] =
   "sacrifice your skill",
   "sacrificed skill",
 
-  40,
+  30,
   SK_NONE,
   nullptr,
   nullptr,


### PR DESCRIPTION
Nerfs a couple of the higher piety sacrifice values and buffs a few that seem undervalued. Allows multiple levels of sacrifice skill or sacrifice experience to be taken, something allowed by the mutation but formerly prohibited elsewhere. Increases the sacrifice timer by 12.5%, to make Ru's piety curve a little bit slower.