### PR TITLE
Allow zoom in via ctrl-'+'

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2039,12 +2039,13 @@ tile_viewport_scale = 1.0
         A scale factor to apply to the dungeon view. The minimum value is 0.2
         and the maximum value is determined by resolution; zoom will be capped
         so that at a minimum, your line of sight is always visible. This can
-        also be adjusted in-game in local tiles with ctrl-'-' and ctrl-'='.
+        also be adjusted in-game in local tiles with ctrl-'-' and ctrl-'='
+        (or ctrl-'+' on some keyboards).
 
 tile_map_scale = 0.6
         A scale factor to apply to the dungeon view in map mode (X). This can
         also be adjusted in map mode in tiles with '{' and '}', as well as in
-        local tiles with ctrl-'-' and ctrl-'='.
+        local tiles with ctrl-'-' and ctrl-'=' (or ctrl-'+' on some keyboards).
 
 tile_cell_pixels = 32
         The width and height of tiles in the dungeon view at 1.0 scale, in

--- a/crawl-ref/source/cmd-keys.h
+++ b/crawl-ref/source/cmd-keys.h
@@ -383,8 +383,10 @@
 // no good webtiles keys available for the main view case, and browser zoom
 // already more or less accomplishes this.
 {'=' - SDLK_a + 1, CMD_ZOOM_IN},  // Believe it or not, this is how we map SDL
-{'-' - SDLK_a + 1, CMD_ZOOM_OUT}, // ctrl scancodes...
+{'+' - SDLK_a + 1, CMD_ZOOM_IN},  // ctrl scancodes...
+{'-' - SDLK_a + 1, CMD_ZOOM_OUT},
 {'=' - SDLK_a + 1, CMD_MAP_ZOOM_IN},
+{'+' - SDLK_a + 1, CMD_MAP_ZOOM_IN},
 {'-' - SDLK_a + 1, CMD_MAP_ZOOM_OUT},
 #endif
 #ifdef USE_TILE


### PR DESCRIPTION
While testing the zoom for the next Android version, I found it's impossible to zoom in with my keyboard. Some European keyboards like Spanish or German require pressing shift-0 for the equals character, but ctrl-shift-0 doesn't work for zooming it and you get the reassign function instead.

This patch allows ctrl-'+' to be used for zooming in with the affected keyboards.