### PR TITLE
add `monster.flags`

### DIFF
--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -428,8 +428,27 @@ LUAFN(moninf_get_is)
     return 1;
 }
 
+/*** Get the monster's flags.
+ * Returns all flags set for the moster, as a list of flag names.
+ * @treturn array
+ * @function flags
+ */
+LUAFN(moninf_get_flags)
+{
+    MONINF(ls, 1, mi);
+    lua_newtable(ls);
+    int index = 0;
+    for (std::map<string,int>::iterator it = mi_flags.begin(); it != mi_flags.end(); ++it)
+        if (mi->is(it->second))
+        {
+            lua_pushstring(ls, it->first.c_str());
+            lua_rawseti(ls, -2, ++index);
+        }
+    return 1;
+}
+
 /*** Get the monster's spells.
- * Returns a the monster's spellbook. The spellbook is given
+ * Returns the monster's spellbook. The spellbook is given
  * as a list of spell names.
  * @treturn array
  * @function spells
@@ -706,6 +725,7 @@ static const struct luaL_reg moninf_lib[] =
     MIREG(colour),
     MIREG(mname),
     MIREG(is),
+    MIREG(flags),
     MIREG(is_safe),
     MIREG(is_firewood),
     MIREG(stabbability),


### PR DESCRIPTION
Adds a `flags` function to the Lua `monster_info` object, which returns the list of flags set for the monster.

This is considerably easier and less buggy to use than the is function, which requires one to know in advance the names of all the possible flags that can be used. The flag list for monsters changes constantly as the game evolves. Because the is function raises an error if it is used to check a flag that no longer exists, it is extremely hard to keep Lua helper scripts functional, if they use monster flags via the is function.

It's also nice to simply get all the active flags at once, rather than having to query each possible flag against the is function to see if it's set.

@rawlins this PR supersedes https://github.com/crawl/crawl/pull/1897, which I'll close.  You'd asked to recreate as a branch and cherry-pick the commits, but my forked repo was just too messy, so I've re-forked it and just made a new, clean PR.  Will stick to single-branch PRs from now on.