### PR TITLE
add `travel.is_excluded` and include exclusions in test for `is_safe_square`

### DIFF
--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -47,7 +47,7 @@ LUAFN(l_set_exclude)
  * Uses player-centered coordinates
  * @tparam int x
  * @tparam int y
- * @function del_eclude
+ * @function del_exclude
  */
 LUAFN(l_del_exclude)
 {
@@ -59,6 +59,25 @@ LUAFN(l_del_exclude)
         return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
     del_exclude(p);
     return 0;
+}
+
+/*** Test for exclusion.
+ * Uses player-centered coordinates
+ * @tparam int x
+ * @tparam int y
+ * @treturn boolean
+ * @function is_excluded
+ */
+LUAFN(l_is_excluded)
+{
+    coord_def s;
+    s.x = luaL_safe_checkint(ls, 1);
+    s.y = luaL_safe_checkint(ls, 2);
+    const coord_def p = player2grid(s);
+    if (!_in_map_bounds(p))
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
+    PLUARET(boolean, is_excluded(p));
+    return 1;
 }
 
 /*** Can we get across this without swimming or flying?
@@ -146,6 +165,7 @@ static const struct luaL_reg travel_lib[] =
 {
     { "set_exclude", l_set_exclude },
     { "del_exclude", l_del_exclude },
+    { "is_excluded", l_is_excluded },
     { "feature_traversable", l_feature_is_traversable },
     { "feature_solid", l_feature_is_solid },
     { "find_deepest_explored", l_find_deepest_explored },

--- a/crawl-ref/source/l-view.cc
+++ b/crawl-ref/source/l-view.cc
@@ -99,6 +99,11 @@ LUAFN(view_is_safe_square)
         PLUARET(boolean, false);
         return 1;
     }
+    if (is_excluded(p))
+    {
+        PLUARET(boolean, false);
+        return 1;
+    }
     PLUARET(boolean, true);
     return 1;
 }


### PR DESCRIPTION
The `travel` module in Lua lets you set and remove exclusions, but not test for them.  This PR adds the `is_excluded` function to that module.  

It also adds a test for `is_excluded` in the function `view.is_safe_square`.  Currently `view.is_safe_square` returns false if a square has clouds or a trap or something known to be nasty, but not if the square is marked excluded.  However, a marked exclusion, whether by the player or the game, would seem to be an obvious indicator that the square is unsafe.  So even though you can (now) also test with `travel.is_excluded` yourself, it seems smartest to include that test also within `is_safe_square`.

(With the current implementation of `is_safe_square`, hitting TAB to autofight when a monster is within an excluded area, such as that surrounding an ice statue, can result in the question "Are you sure you want to move into that travel-excluded area?"  Which is annoying.  This PR would fix that.)