### PR TITLE
Modify Grammar Sceptre of Torment

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -493,7 +493,7 @@ static void _LIGHTNING_SCALES_unequip(item_def */*item*/, bool *show_msgs)
 
 static void _TORMENT_equip(item_def */*item*/, bool *show_msgs, bool /*unmeld*/)
 {
-    _equip_mpr(show_msgs, "A terribly searing pain shoots up your arm!");
+    _equip_mpr(show_msgs, "A terrible, searing pain shoots up your arm!");
 }
 
 static void _TORMENT_melee_effects(item_def* /*weapon*/, actor* attacker,


### PR DESCRIPTION
Minor grammatical modification to the message when wielding the Sceptre of Torment.  "Terribly searing pain" (adverb modifying adjective describing noun) becomes "Terrible, searing pain" (compound adjective describing noun).  Both are correct, however, the former is a little awkward because it partially shifts the focus of the sentence from pain to searing.  The latter flows  better because the compound adjective shifts the focus of the introductory descriptions to pain.