### PR TITLE
lower Necromutation to level 7

### DIFF
--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -955,7 +955,7 @@ static const struct spell_desc spelldata[] =
     SPELL_NECROMUTATION, "Necromutation",
     spschool::transmutation | spschool::necromancy,
     spflag::helpful | spflag::chaotic,
-    8,
+    7,
     200,
     -1, -1,
     6, 0,


### PR DESCRIPTION
Main reason:
1. This spell has many advantages, but at the same time, it has many dangerous disadvantages.

2. In addition, you must train Transmutation deeply to use this spell, but after using it, you will not be able to use multiple Transmutation spell. For this reason, I thought about excluding Transmutation from this magical school, but I decided to put this idea on hold because it seemed a little extreme.

3. Transmutation and Necromancy are schools that are deeply related to hybrid jobs. The Statue Form and Dragon Form do not wear armor, so hybrid players can access them in mid-game, but Necromutation is too high spell level for them to use. To allow trainees to use this spell at the right moment, you need to mitigate the difficulty of using it to their level.

Based on these reasons, I'm going to lower this spell level by one. (I wanted to give lich form a 'Sturdy Frame 1' for hybrid players, but this would be too much, right?)