### PR TITLE
Split _gift_sif_kiku_gift() into a function for each god.

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1506,33 +1506,32 @@ static bool _give_sif_gift(bool forced)
     if (you.has_mutation(MUT_INNATE_CASTER))
         return false;
 
-    bool success = false;
     // Break early if giving a gift now means it would be lost.
     if (feat_eliminates_items(env.grid(you.pos())))
         return false;
 
-    if (forced || you.piety >= piety_breakpoint(4) && random2(you.piety) > 100
-                && coinflip())
+    if (!forced && (you.piety < piety_breakpoint(4)
+                    || random2(you.piety) < 101 || coinflip()))
     {
-        // Sif Muna special: Keep quiet if acquirement fails
-        // because the player already has seen all spells.
-        int item_index = acquirement_create_item(OBJ_BOOKS, you.religion,
-                                                 true, you.pos());
-        success = (item_index != NON_ITEM);
+        return false;
     }
 
-    if (success)
-    {
-        simple_god_message(" grants you a gift!");
-        // included in default force_more_message
+    // Sif Muna special: Keep quiet if acquirement fails
+    // because the player already has seen all spells.
+    int item_index = acquirement_create_item(OBJ_BOOKS, you.religion,
+                                             true, you.pos());
+    if (item_index == NON_ITEM)
+        return false;
 
-        you.num_current_gifts[you.religion]++;
-        you.num_total_gifts[you.religion]++;
-        _inc_gift_timeout(40 + random2avg(19, 2));
-        take_note(Note(NOTE_GOD_GIFT, you.religion));
-    }
+    simple_god_message(" grants you a gift!");
+    // included in default force_more_message
 
-    return success;
+    you.num_current_gifts[you.religion]++;
+    you.num_total_gifts[you.religion]++;
+    _inc_gift_timeout(40 + random2avg(19, 2));
+    take_note(Note(NOTE_GOD_GIFT, you.religion));
+
+    return true;
 }
 
 static bool _give_kiku_gift()

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1534,7 +1534,7 @@ static bool _give_sif_gift(bool forced)
     return true;
 }
 
-static bool _give_kiku_gift()
+static bool _give_kiku_gift(bool forced)
 {
     // Smokeless fire and books don't get along.
     if (you.has_mutation(MUT_INNATE_CASTER))
@@ -1547,9 +1547,9 @@ static bool _give_kiku_gift()
     const bool first_gift = !you.num_total_gifts[you.religion];
 
     // Kikubaaqudgha gives two Necromancy books in a quick succession.
-    if (you.piety < piety_breakpoint(0)
-        || !first_gift && you.piety < piety_breakpoint(2)
-        || you.num_total_gifts[you.religion] > 1)
+    if (!forced && (you.piety < piety_breakpoint(0)
+                    || !first_gift && you.piety < piety_breakpoint(2)
+                    || you.num_total_gifts[you.religion] > 1))
     {
         return false;
     }
@@ -2083,7 +2083,7 @@ bool do_god_gift(bool forced)
             break;
 
         case GOD_KIKUBAAQUDGHA:
-            success = _give_kiku_gift();
+            success = _give_kiku_gift(forced);
             break;
 
         case GOD_SIF_MUNA:


### PR DESCRIPTION
Split _gift_sif_kiku_gift() into _give_sif_gift() and _give_kiku_gift(), and rearrange each a bit.

In addition:

The "get a god gift" wizard command now works for Kikubaaqudgha.

The game doesn't crash if Kikubaaqudgha tries to create a spellbook when there are too many items on the level.