### PR TITLE
Check for monsters, objects & features as soon as you move.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -534,6 +534,9 @@ void moveto_location_effects(dungeon_feature_type old_feat,
 
     if (stepped)
         _moveto_maybe_repel_stairs();
+
+    update_monsters_in_view();
+    check_for_interesting_features();
 }
 
 // Use this function whenever the player enters (or lands and thus re-enters)


### PR DESCRIPTION
The game previously only reported which monsters had "come into view" when a monster shouted or the player was ready to start a turn.

This interacted badly with ABIL_WU_JIAN_WALLJUMP (for one), as you move to a new location as part of the turn, and both you and the monster can act before the next "start of turn" rolls around.

Calling update_monsters_in_view() from moveto_location_effects() should make the "comes into view" message the first one you see for a monster. I also call check_for_interesting_features() so that nearby objects and features are announced at the same time.