### PR TITLE
additional guarded unrand vaults

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -7619,7 +7619,100 @@ HHH.....FFF
    .EEE.
 ENDMAP
 
+NAME:   hellmonk_guarded_unrand_seven_league_boots
+TAGS:   transparent no_monster_gen
+DEPTH:  D:10-, Lair, Depths
+WEIGHT: 3
+SUBST:  D = FFW, H : IF, I : cx
+NSUBST: F = 1:J / 1:J. / 1:9 / 9=0.. / *:.
+FTILE:  E = floor_ice
+COLOUR: E = white
+FTILE:  .08Jd = floor_grass
+KITEM:  d = seven-league_boots no_pickup
+KMONS:  d = guardian serpent
+: if you.branch() == "Depths" then
+KMONS:  J = vampire knight
+: elseif you.branch() == "Lair" then
+KMONS:  J = boulder beetle
+: else
+KMONS:  J = phantasmal warrior
+: end
+MAP
+        xxxxxxxxx
+     xxxxWWEEEWWxxxx
+   xxxWDDWWWWWWWWWWxxx
+  xxWWWDHDWWWWWWWWWWWxx
+ xxWWWDFFFDWWWWDDFFDDWxx
+ xWWDDHFFHFDWWDFFIFFFHFx
+xxWWWDFHFFDWWWDFFIFFFFFxx
+xWWWWDFHFDWWIWWWDFIFFFFFx
+@WWWDFFHDWWIIWWWDFIFFFFdx
+xWWWWDIDWWWWWWWDDDHFFFFFx
+xxWWWDIFFDWWWWDDFHDFFDDxx
+ xWWDIFFFDWWWWDFFHFDDWWx
+ xxWWDIFFDWWDWDFHFFDWWxx
+  xxWWDDDWWWWWWDFDDWWxx
+   xxxWWDWWWWWWWDWWxxx
+     xxxxWEEEEEWxxxx
+        xxxxxxxxx
+ENDMAP
 
+NAME:   hellmonk_guarded_unrand_zhor
+TAGS:   transparent no_monster_gen
+DEPTH:  D:7-12, Lair:1-3
+WEIGHT: 5
+ITEM:   skin_of_zhor no_pickup, box of beasts
+MONS:   rime drake
+NSUBST: d = 1:d / *:1
+KFEAT: ~ = closed_clear_door
+SUBST:  1 = 1.., e = e..
+: if you.branch() == "Lair" then
+MONS:   torpor snail
+: else
+SUBST:  2 = 1
+: end
+MAP
+            nnnn
+           nndenn
+          nn1.nn
+         nn.1nn
+    nnnnnn..nn
+   nnd.nn.1nn
+    nn..1.nn
+     nn22nn
+    nn..nn
+   nn1..1nn
+  nn..nn..nn
+ nn...11...nn
+nn~nnnnnnn~nnn
+  @       @
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_vitality_bloodlust
+TAGS:   transparent
+DEPTH:  D:7-11
+WEIGHT: 2
+ITEM:   amulet_of_vitality no_pickup / necklace_of_bloodlust no_pickup
+MONS:   deep troll
+COLOUR: x. = lightred
+NSUBST: 1 = 2:1 / *:.
+TILE:   x = wall_pebble_red
+FTILE:  .d1 = floor_pebble_lightred
+MAP
+    @
+   x.x
+  xx.xx
+ xx...xx
+xx.....xx
+x.......x
+x..1.1..x
+x.......x
+x1.....1x
+x...1...x
+xx1...1xx
+ xx.d.xx
+  xxxxx
+ENDMAP
 
 ###################################################################
 #

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -7481,20 +7481,20 @@ TILE:   F = wall_ice
 TILE:   H = wall_marble
 SUBST:  F : x, H : c
 MAP
-         DDbEE
-        DDEdDEE
-       DDE...DEEE
-        DDD2EEE
-          D.E
-        EEE.DDD
-      EEE1...1DDD
-     EEG..D.E..GDD
-      EEE.....DDD
-        EE...DD
-         EE.DD
-          D.E
-         ED.ED
-          D@E
+    DDbEE
+   DDEdDEE
+  DDE...DEEE
+   DDD2EEE
+     D.E
+   EEE.DDD
+ EEE1...1DDD
+EEG..D.E..GDD
+ EEE.....DDD
+   EE...DD
+    EE.DD
+     D.E
+    ED.ED
+     D@E
 ENDMAP
 
 NAME:   hellmonk_guarded_unrand_vines
@@ -7515,6 +7515,112 @@ xx'....'''WW't'....'xx
   ..'xxxxd2'dxxxx'..
         xxxxxx
 ENDMAP
+
+NAME:   hellmonk_guarded_unrand_frostbite
+TAGS:   transparent no_monster_gen
+DEPTH:  D:7-12
+WEIGHT: 5
+ITEM:   frostbite no_pickup
+MONS:   white imp, freezing wraith
+TILE:   D = wall_ice
+FTILE:  . = floor_ice
+COLOUR: . = white
+SUBST:  D : x, 1 = 1., 2 = 2.
+NSUBST: d = 1:d / *:W
+NSUBST: E = 2:2 / *:.
+MAP
+          DDDDDD
+       DDDDE11EDDDD
+ DDDDDDD11......11DDDDDDD
+DDWE..................EWDD
+ DDD..1.2...DddD.2.1..DDD
+ DW...DD..DddDDW..DD...WD
+DDD2.DDD.1WDDDDW1.DDD.2DDD
+ DW...DD..WDDWWD..DD...WD
+ DDD......DWWD........DDD
+DDW....................WDD
+ DDDDDDD..........DDDDDDD
+       D++++++++++D
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_rift
+TAGS:   transparent
+DEPTH:  D:13-, Depths
+WEIGHT: 3
+ITEM:   rift no_pickup
+KFEAT:  t = demonic_tree
+MONS:   wizard, starcursed mass / tentacled starspawn
+NSUBST: D = 1:d / *:2
+SUBST:  c : ctttn, 1 = 1..
+SUBST:  E = xxxcvlWbtTG_....
+KFEAT:  t = demonic_tree
+KFEAT:  _ = altar_lugonu / enter_abyss
+MAP
+   c       c       c
+   c       c       c
+  ccc     ccc     ccc
+ ccDcc   ccDcc   ccDcc
+ccE.Ecc ccE.Ecc ccE.Ecc
+ c...c   c...c   c...c
+ c.1.c   c.1.c   c.1.c
+ c...c   c...c   c...c
+ c...c   c...c   c...c
+ c...c   cE.Ec   c...c
+ c..EcccccE.EcccccE..c
+ c..EEcccEE2EEcccEE..c
+ c1....1..._...1....1c
+ cc......EE.EE......cc
+  ccccccccE1Ecccccccc
+        ccE.Ecc
+         c...c
+         c...c
+         c...c
+         cE1Ec
+         c...c
+         c...c
+         c...c
+         cE.Ec
+         c...c
+         c...c
+         c...c
+         c@@@c
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_lears
+TAGS:   transparent
+DEPTH:  D:6-
+WEIGHT: 5
+ITEM:   lear's_hauberk no_pickup, hat plus:-2 ident:all
+ITEM:   helmet plus:-2 ident:all, chain mail plus:-2 ident:all
+ITEM:   pair of boots plus:-2 ident:all
+ITEM:   pair of gloves plus:-2 ident:all
+NSUBST: D = 1:d / 1:e / 1:f / 1:g / 1:h / 1:i
+SUBST:  E : xcv, F : xcv, H : xcv, G = G.., T : T...
+: if you.absdepth() < 8 then
+MONS:   troll
+: elseif you.absdepth() < 13 then
+MONS:   tengu warrior
+:else
+MONS:   minotaur
+: end
+MAP
+   .EEE.
+   .EDE.
+....E+E....
+FFF.....HHH
+FDF.G.G.HDH
+FF+..T..+HH
+....G1G....
+HH+..T..+FF
+HDH.G.G.FDF
+HHH.....FFF
+....E+E....
+   .EDE.
+   .EEE.
+ENDMAP
+
+
+
 ###################################################################
 #
 # <<9>> Pre-Lair vaults with monsters guarding a manual

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -7313,6 +7313,7 @@ NSUBST: ' = 1:2 / *:1
 MONS: efreet, hellion
 SUBST: K = c
 :end
+SUBST:  c : cv
 NSUBST: D = 1:2 / 1:1 / *:.
 MAP
            ccc    ccccccc
@@ -7381,6 +7382,139 @@ MAP
     ........
 ENDMAP
 
+# this vault gives the item to a monster instead of placing it normally
+NAME:   hellmonk_guarded_unrand_dark_maul
+TAGS:   transparent no_monster_gen
+DEPTH:  D:8-12, Orc, Depths
+WEIGHT: 5
+MONS:   ogre ; dark maul
+: if you.branch() == "Depths" then
+MONS:   juggernaut / titan / iron giant w:5
+: elseif you.branch() == "orc" then
+MONS:   two-headed ogre / orc warlord / stone giant
+: else
+MONS:   two-headed ogre / orc knight
+: end
+SUBST: D = 2..
+MAP
+                    @@
+vvvvvvvvvvvvvvvvvvvv++v
+v.2+.....D......D..v..v
+v..+..v.........v..v..v
+v..v..v....D....v..v..v
+v..v..v...v.v...v..v..v
+v..v..v..D.1.D..v..v..v
+v..v..v...v.v...v..v..v
+v..v..v....D....v..v..v
+v..v..v.........v..+..v
+v..v..D......D.....+2.v
+v++vvvvvvvvvvvvvvvvvvvv
+ @@
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_gong
+TAGS:   transparent no_monster_gen
+DEPTH:  D:7-12
+WEIGHT: 5
+ITEM:   shield_of_the_gong no_pickup
+MONS:   vault sentinel
+KFEAT:  ^ = alarm trap
+SUBST:  ' = ^....
+MAP
+      ^@^
+     vv+vv
+   vvv^.^vvv
+  vv^'''''^vv
+  v^'''''''^v
+ vv'''vvv'''vv
+ v..'v...v'..v
+ v1.v..d..v.1v
+ v..'v...v'..v
+ vv'''vvv'''vv
+  v^'''''''^v
+  vv^'''''^vv
+   vvv^.^vvv
+     vv+vv
+      ^@^
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_night
+TAGS:   transparent no_monster_gen
+DEPTH:  D:7-12
+WEIGHT: 5
+ITEM:   robe_of_night no_pickup
+MONS:   dream sheep, shadow
+SUBST:  c : ccv
+SUBST:  1 = 1.
+FTILE:  .12d+ = floor_limestone
+COLOUR: .12d+ = yellow
+MAP
+    cccccc
+  ccc1...ccc
+ cc1.....2dcc
+ c.....ccccc
+cc..1ccc
+c1..cc
+c...c
+c.2.c
+c...c
+c1..cc
+cc..1ccc
+ c.....ccccc
+ cc1.......+@
+  ccc1...ccc
+    cccccc
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_gyre_and_gimble
+TAGS:   transparent no_monster_gen
+DEPTH:  D:6-10, Elf
+WEIGHT: 5
+ITEM:   gyre no_pickup
+: if you.branch() == "Elf" then
+MONS:   deep elf blademaster, deep elf blademaster
+: else
+MONS:   two-headed ogre, spriggan
+: end
+SUBST:  E : cv, D : FH
+TILE:   F = wall_ice
+TILE:   H = wall_marble
+SUBST:  F : x, H : c
+MAP
+         DDbEE
+        DDEdDEE
+       DDE...DEEE
+        DDD2EEE
+          D.E
+        EEE.DDD
+      EEE1...1DDD
+     EEG..D.E..GDD
+      EEE.....DDD
+        EE...DD
+         EE.DD
+          D.E
+         ED.ED
+          D@E
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_vines
+TAGS:   transparent ruin_lair
+DEPTH:  D:7-11, Lair:1-3
+WEIGHT: 5
+ITEM:   robe_of_vines no_pickup
+MONS:   plant, hydra
+NSUBST: d = 1:d / *:1
+SUBST:  ' = 1..
+MAP
+        xxxxxx
+  ..'xxxxd'2dxxxx'..
+ ''..'x'x'.....x'..''    
+xx'...''t'WW'''....'xx
+xx'....'''WW't'....'xx     
+ ''..'x.....'x'x'..''    
+  ..'xxxxd2'dxxxx'..
+        xxxxxx
+ENDMAP
 ###################################################################
 #
 # <<9>> Pre-Lair vaults with monsters guarding a manual

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -7229,6 +7229,158 @@ xx--xx''''x'''dxx--xx
   xxx@xx
 ENDMAP
 
+NAME:   hellmonk_guarded_unrand_starlight
+TAGS:   transparent
+DEPTH:  Depths
+WEIGHT: 5
+ITEM:   cloak of starlight no_pickup
+MONS:   wretched star, daeva / angel
+SHUFFLE: 12
+SUBST:  D = 12..
+MAP
+                @
+               v+v
+               v.v
+               v.v
+               v.v
+              vv.vv
+              v...v
+              v...v
+             vv...vv
+             v..1..v
+            vv.....vv
+           vv.......vv
+          vv....v....vv
+        vvv.v...v...v.vvv
+     vvvv....v.vDv.v....vvvv
+ vvvvv........vDvDv........vvvvv
+@+.......2..vvDvdvDvv..2.......+@
+ vvvvv........vDvDv........vvvvv
+     vvvv....v.vDv.v....vvvv
+        vvv.v...v...v.vvv
+          vv....v....vv
+           vv.......vv
+            vv.....vv
+             v..1..v
+             vv...vv
+              v...v
+              v...v
+              vv.vv
+               v.v
+               v.v
+               v.v
+               v+v
+                @
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_salamander
+TAGS:   transparent no_monster_gen
+DEPTH:  D:10-, Snake, !Snake:$, Depths
+WEIGHT: 5
+ITEM:   salamander_hide_armour no_pickup
+: if you.branch() == "Snake" then
+MONS:    salamander, salamander mystic, salamander tyrant
+: elseif you.branch() == "Depths" then
+MONS:    fire dragon, salamander tyrant, salamander tyrant
+: else
+MONS:   salamander, salamander mystic
+SUBST:  2 = 1, 3 = 2
+: end
+SUBST:  1 = 1.
+MAP
+vvvvvvvvvvvvvvvvv
+vGllllllllGvGllGv
+vl1..1....lvl..dv
+vl...Gv..1lvl.3.v
+vl...lv...lvl...v
+vl...lv...GlG...v
+vl...lv.1......2v
+vG...Gv....2....v
+vv+++vvvvvvvvvvvv
+  @@
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_damnation
+TAGS:   transparent no_monster_gen
+DEPTH:  D:13-, Elf
+WEIGHT: 3
+ITEM:   damnation no_pickup
+: if you.branch() == "Elf" then
+MONS: deep elf sorcerer / deep elf high priest, hellion
+KFEAT:  K = iron_grate
+NSUBST: ' = 1:2 / *:1 
+: else
+MONS: efreet, hellion
+SUBST: K = c
+:end
+NSUBST: D = 1:2 / 1:1 / *:.
+MAP
+           ccc    ccccccc
+ ccc       c'cccccccc..Dcc
+ c.cc      c.......D.....cc
+ c..cccccccc..ccKc..cKc...cc
+ c.c..c..c......c....c.....cc
+@+..c......1ccccKcdccKccc'.Dcc
+ c.c..c..c......c....c.....cc
+ c..cccccccc..ccKc..cKc...cc
+ c.cc      c.......D.....cc
+ ccc       c'cccccccc..Dcc
+           ccc    ccccccc
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_cigotuvi
+TAGS:   transparent no_monster_gen
+DEPTH:  D:9-14
+WEIGHT: 5
+ITEM:   cigotuvi's_embrace no_pickup
+MONS:   zombie / skeleton, hellwing
+SUBST:  1 = 1.
+KPROP:  D = no_tele_into
+: dgn.delayed_decay(_G, 'D', 'human corpse')
+MAP
+     @
+ccccc+ccccc
+ccc.....ccc
+cc.......cc
+c1.......1c
+c..nnnnn..c
+c.1nDDDn1.c
+c..nDDDn..c
+c1.nDDDn.1c
+c..nnnnn..c
+c1.1.2.1.1c
+cc.......cc
+ccc2.d.2ccc
+ccccccccccc
+ENDMAP
+
+NAME:   hellmonk_guarded_unrand_staff_of_battle
+TAGS:   transparent
+DEPTH:  D:8-13
+WEIGHT: 5
+ITEM:   staff_of_battle no_pickup
+MONS:   tengu conjurer
+NSUBST: E = 1:+ / *:b
+SUBST:  F = 1.
+MAP
+   ........
+  ...EEEEEE...
+ ..EEE....EEE..
+ .EE........EE.
+..E...bbbb...E..
+.EE..bbdFbb..EE.
+.E...b....b...E.
+.E.....bb.....E.
+.E.....bb.....E.
+.E...b....b...E.
+.EE..bbF1bb..EE.
+..E...bbbb...E..
+ .EE........EE.
+ ..EEE....EEE..
+  ...EEEEEE...
+    ........
+ENDMAP
+
 ###################################################################
 #
 # <<9>> Pre-Lair vaults with monsters guarding a manual


### PR DESCRIPTION
Total of 16 vaults, includes guarded unrand vaults for newer unrands like staff of battle, cigotuvi's embrace, and seven-league boots