### PR TITLE
Fix what happens when you try to read a spellbook.

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1110,10 +1110,6 @@ bool item_is_selected(const item_def &i, int selector)
     case OSEL_WIELD:
         return item_is_wieldable(i);
 
-    case OBJ_SCROLLS:
-        return itype == OBJ_SCROLLS
-               || (itype == OBJ_BOOKS && i.sub_type != BOOK_MANUAL);
-
     case OSEL_EVOKABLE:
         // assumes valid link...would break with evoking from floor?
         return item_is_evokable(i, true) && item_is_evokable(i, true, false);//evoke_check(i.link, true);


### PR DESCRIPTION
Make the game give a "You aren't carrying any scrolls." message if you try to read() when you have no scrolls in your inventory or on the floor, but there is a spellbook on the floor.

The game had given an inventory prompt with no items on it instead.

The first bit of item_is_selected() dealt with reading scrolls, so the case I've deleted was only used for spellbooks. A restriction in use_an_item() means that you couldn't select a spellbok at the "read which item" prompt it gave you, even if you selected "show all".

