### PR TITLE
Fix Dj's hair on the species selection menu

### DIFF
--- a/crawl-ref/source/rltiles/dc-gui.txt
+++ b/crawl-ref/source/rltiles/dc-gui.txt
@@ -342,6 +342,7 @@ base/octopode1 SP_RECOMMENDED_OCTOPODE
 %start
 %compose base/djinni_f
 %compose body/animal_skin
+%compose hair/part2_red
 %finish SP_RECOMMENDED_DJINNI
 %syn LAST_RECOMMENDED_SPECIES
 


### PR DESCRIPTION
The newgame doll was missing red hair, which is the default according
to `tilepick-p.cc:tilep_race_default()`.