### PR TITLE
Metric apts

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -569,7 +569,7 @@ Dodging or Stealth. See Appendix `3. List of Skills`_ for a detailed
 description of all skills present in Crawl. The ease with which a character
 learns a skill depends solely on species. These aptitudes are displayed when
 viewing your skills, and a full table can be viewed in aptitudes.txt (also from
-the help screen during play via '?%').
+the help screen during play via '?%'). Aptitudes generally range from 0 to 10.
 
 You can see your character's skills by pressing the 'm' key; the higher the
 level of a skill, the better you are at it. All characters start with a few
@@ -1470,7 +1470,7 @@ the species.
           which allow them to make extra attacks.
 
 .. note:: Humans are a useful reference point when considering other species:
-          they have 0 for almost all aptitudes; have no special abilities,
+          they have 5 for almost all aptitudes; have no special abilities,
           weakness, or constraints against using certain types of equipment;
           move normally; and gain experience and willpower at a "typical"
           rate. However, you will see that they are categorized as an

--- a/crawl-ref/docs/template/apt-tmpl-wide.txt
+++ b/crawl-ref/docs/template/apt-tmpl-wide.txt
@@ -9,24 +9,24 @@ two other ways:
 - Look at which combinations of species and background are recommended.
 
  --  no aptitude (cannot learn this skill at all)
- -5  abysmal aptitude
- -4  terrible aptitude (learning half as fast as at 0 aptitude)
- -3  very poor aptitude
- -2  poor aptitude
- -1  slightly disfavoured aptitude
-  0  standard aptitude
- +1  slightly favoured aptitude
- +2  strong aptitude
- +3  very strong aptitude
- +4  outstanding aptitude (learning twice as fast as at 0 aptitude)
- +5  exceptional aptitude
+  0  abysmal aptitude
+  1  terrible aptitude (learning half as fast as at 5 aptitude)
+  2  very poor aptitude
+  3  poor aptitude
+  4  slightly disfavoured aptitude
+  5  standard aptitude
+  6  slightly favoured aptitude
+  7  strong aptitude
+  8  very strong aptitude
+  9  outstanding aptitude (learning twice as fast as at 5 aptitude)
+ 10  exceptional aptitude
 
 There are four special values: HP, MP, Experience and Willpower:
 - The HP value indicates the percentage of hit points gained per experience
   level, 100% being the Human standard.
 - The MP value indicates a fixed additive modifier to magic points.
 - The Experience value indicates how much experience has to be earned in
-  order to gain a new experience level, +1 being the Human standard. These
+  order to gain a new experience level, 6 being the Human standard. These
   values use the same scale as the skill aptitudes.
 - The Willpower value indicates resistance to many magical effects per
   experience level, +3 being the Human standard.

--- a/crawl-ref/docs/template/apt-tmpl.txt
+++ b/crawl-ref/docs/template/apt-tmpl.txt
@@ -9,27 +9,27 @@ two other ways:
 - Look at which combinations of species and background are recommended.
 
  --  no aptitude (cannot learn this skill at all)
- -5  abysmal aptitude
- -4  terrible aptitude (learning half as fast as at 0 aptitude)
- -3  very poor aptitude
- -2  poor aptitude
- -1  slightly disfavoured aptitude
-  0  standard aptitude
- +1  slightly favoured aptitude
- +2  strong aptitude
- +3  very strong aptitude
- +4  outstanding aptitude (learning twice as fast as at 0 aptitude)
- +5  exceptional aptitude
+  0  abysmal aptitude
+  1  terrible aptitude (learning half as fast as at 5 aptitude)
+  2  very poor aptitude
+  3  poor aptitude
+  4  slightly disfavoured aptitude
+  5  standard aptitude
+  6  slightly favoured aptitude
+  7  strong aptitude
+  8  very strong aptitude
+  9  outstanding aptitude (learning twice as fast as at 5 aptitude)
+ 10  exceptional aptitude
 
 There are four special values: HP, MP, Experience and Willpower:
 - The HP value indicates the percentage of hit points gained per experience
   level, 100% being the Human standard.
 - The MP value indicates a fixed additive modifier to magic points.
 - The Experience value indicates how much experience has to be earned in
-  order to gain a new experience level, +1 being the Human standard. These
+  order to gain a new experience level, 6 being the Human standard. These
   values use the same scale as the skill aptitudes.
 - The Willpower value indicates resistance to many magical effects per
-  experience level, +3 being the Human standard.
+  experience level, 3 being the Human standard.
 
 The abbreviations used for the skills are:
 

--- a/crawl-ref/source/playable.cc
+++ b/crawl-ref/source/playable.cc
@@ -99,7 +99,7 @@ static JsonNode *_species_apts(species_type sp)
         const skill_type sk(static_cast<skill_type>(i));
         const int apt(species_apt(sk, sp));
         if (apt != UNUSABLE_SKILL)
-            json_append_member(apts, skill_name(sk), json_mknumber(apt));
+            json_append_member(apts, skill_name(sk), json_mknumber(apt + 5));
     }
     return apts;
 }

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -300,22 +300,21 @@ string SkillMenuEntry::get_prefix()
 
 void SkillMenuEntry::set_aptitude()
 {
-    string text = "<white>";
 
     const bool manual = you.skill_manual_points[m_sk] > 0;
     const int apt = species_apt(m_sk, you.species);
 
-    if (apt != 0)
-        text += make_stringf("%+d", apt);
-    else
-        text += make_stringf(" %d", apt);
+    const string color = apt < -2 ? "lightred"
+                        : apt > 2 ? "lightgreen"
+                        : "white";
 
-    text += "</white> ";
+    string text =
+        make_stringf("<%s>%2d</%s> ", color.c_str(), apt + 5, color.c_str());
 
     if (manual)
     {
         skm.set_flag(SKMF_MANUAL);
-        text += "<lightred>+4</lightred>";
+        text += "<lightblue>+4</lightblue>";
     }
 
     m_aptitude->set_text(text);
@@ -449,7 +448,7 @@ void SkillMenuEntry::set_cost()
     if (you.skills[m_sk] == MAX_SKILL_LEVEL)
         return;
     if (you.skill_manual_points[m_sk])
-        m_progress->set_fg_colour(LIGHTRED);
+        m_progress->set_fg_colour(LIGHTBLUE);
     else
         m_progress->set_fg_colour(CYAN);
 
@@ -577,7 +576,7 @@ string SkillMenuSwitch::get_help()
                "<cyan>cyan</cyan>";
         if (skm.is_set(SKMF_MANUAL))
         {
-            result += " (or <lightred>red</lightred> if enhanced by a "
+            result += " (or <lightblue>blue</lightblue> if enhanced by a "
                       "manual)";
         }
         result += ".\n";
@@ -1424,7 +1423,7 @@ void SkillMenu::set_default_help()
             text += "The species aptitude is in <white>white</white>. ";
 
         if (is_set(SKMF_MANUAL))
-            text += "Bonus from skill manuals is in <lightred>red</lightred>. ";
+            text += "Bonus from skill manuals is in <lightblue>blue</lightblue>. ";
     }
 
     m_help->set_text(text);

--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -157,7 +157,7 @@ sub aptitude_table
             }
             if ($abbr eq 'HP')
             {
-                $skill = $skill * 10;
+                $skill = $skill * 10 + 100;
                 $fmt = "%3d%%";
             }
             $line .= sprintf($fmt, $skill);

--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -137,6 +137,7 @@ sub aptitude_table
         for my $abbr (@skill_abbrevs)
         {
             my $skill = find_skill($sp, abbr_to_skill($abbr)) || 0;
+            $skill = $skill + 5 unless $skill == -99 || $abbr eq 'HP' || $abbr eq 'MP' || $abbr eq 'WL';
 
             my $pos = index($headers, " $abbr");
             die "Could not find $abbr in $headers?\n" if $pos == -1;
@@ -147,7 +148,7 @@ sub aptitude_table
                 $line .= " " x ($pos - length($line));
             }
 
-            my $fmt = "%+3d";
+            my $fmt = "%3d";
             $fmt = "%3d" if $skill == 0;
             if ($skill == -99)
             {
@@ -157,7 +158,7 @@ sub aptitude_table
             if ($abbr eq 'HP')
             {
                 $skill = $skill * 10;
-                $fmt = "%+3d%%";
+                $fmt = "%3d%%";
             }
             $line .= sprintf($fmt, $skill);
         }


### PR DESCRIPTION
Main commit message:

```
At the moment, this commit is intended to be up for discussion.

On the one hand, the positive/negative values for aptitudes provide an
easy and convenient shorthand for "good"/"bad", and also make it
relatively easy to do the math for what a particular apt will mean. On
the other hand, we have seen that this scheme often leads to players
overemphasizing the sign vs the actual numeric value; no amount of
documentation etc has led to players (especially newer ones) conceiving
of -1 is more "normal" as opposed to "terrible". For reference (sorry,
did not recalculate this for 0.27, but it hasn't changed that much): in
0.25, the overall mean aptitude was -0.35, with the worst species being
troll at -2.6 and the best species being barachi at +0.77.

This commit is a way I've found to solve some aspects of this problem
without majorly changing the underlying math: where previously
everything except Gn fell on a -5 to +5 range, it simply linearly
rescales aptitudes onto a 0 to 10 range for presentational purposes.
(Internally, nothing changes.)

I do think this makes the skill menu a bit harder to process quickly,
and I've accordingly done some recoloring to try to make good and bad
apts stand out more quickly. But, this still may be a net negative in UI
terms.
```