### PR TITLE
Lower Absolute Zero's range to 3

### DIFF
--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3324,7 +3324,7 @@ static const struct spell_desc spelldata[] =
     spflag::no_ghost,
     9,
     200,
-    5, 5,
+    3, 3,
     9, 40,  // 40 noise at 0 spellpower
     TILEG_ICE_STORM,
 },


### PR DESCRIPTION
This spell has a penalty of randomly selecting the target, but because of its long range, the player was able to offset the penalty by simply using the spell several times. Thus, the Pandemonium lord turned into an ice pillar upon encountering the player. So, to curb brainless play, I'm trying to reduce the range of this spell to 3.