### PR TITLE
Update special_room_magic_class

### DIFF
--- a/crawl-ref/source/dat/des/builder/rooms.des
+++ b/crawl-ref/source/dat/des/builder/rooms.des
@@ -6,7 +6,7 @@
 # box creation and placement code is off in mini_monsters.des.
 #
 # Current sets: Kobolds, Orcs, Bees, Undead, Slimes,
-# Mythological Zoo, Greater Demons.
+# Mythological Zoo, Spellcasters, Greater Demons.
 #
 
 lua {{
@@ -289,21 +289,22 @@ function sroom_magic_class(e)
     if e.is_validating() then return end
 
     local mons = {}
-    mons[1] = "wizard w:35"
-    mons[2] = "deep troll earth mage w:35"
-    mons[3] = "vampire knight w:35"
-    mons[4] = "ogre mage w:30"
-    mons[5] = "spriggan air mage w:25"
-    mons[6] = "deep elf annihilator w:15"
-    mons[7] = "deep elf sorcerer w:15"
-    mons[8] = "deep elf demonologist w:5"
-    mons[9] = "deep elf death mage w:5"
-    mons[10] = "deep elf elementalist w:5"
-    mons[11] = "vampire mage w:5"
+    mons[1] = "wizard w:8"
+    mons[2] = "ogre mage w:7"
+    mons[3] = "deep elf annihilator w:6"
+    mons[4] = "deep troll earth mage w:5"
+    mons[5] = "vampire knight w:5"
+    mons[6] = "spriggan air mage w:5"
+    mons[7] = "necromancer w:4"
+    mons[8] = "deep elf death mage w:3"
+    mons[9] = "deep elf sorcerer w:3"
+    mons[10] = "deep elf demonologist w:2"
+    mons[11] = "deep elf elementalist w:1"
+    mons[12] = "vampire mage w:1"
 
     local absdepth = you.absdepth()
     if absdepth == 27 then
-        mons[12] = "draconian annihilator w:5"
+        mons[13] = "draconian annihilator w:5"
         lord_mon = "draconian shifter / ancient lich / Jory w:1 / " ..
                    "Frederick w:1 / Boris w:1, draconian shifter / " ..
                    "ancient lich / dread lich"


### PR DESCRIPTION
Some adjustments to the magic classroom special room I submitted a while back.  Added necromancers to the monster set, and adjusted weights in general.  Vampire knights and deep troll earth mages get the biggest drop in weight, and deep elf sorcerers and deep elf death mages get the biggest increase.  Depths:5 draconian annihilators are more common now as well.  This should make the room generate a more varied monster set.  Boss monsters are untouched.