### PR TITLE
Don't put Refrigeration users under penance for tracer checks

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -501,7 +501,7 @@ static int _los_spell_damage_monster(const actor* agent, monster &target,
     // Set conducts here. The monster needs to be alive when this is done, and
     // mons_adjust_flavoured() could kill it.
     god_conduct_trigger conducts[3];
-    if (YOU_KILL(beam.thrower))
+    if (actual && YOU_KILL(beam.thrower))
         set_attack_conducts(conducts, target, you.can_see(target));
 
     int hurted = actual ? beam.damage.roll()


### PR DESCRIPTION
After 73eefd5d, Ozocubu's Refrigeration users can get under penance for
opening the z? or Q menus or just for having the spell on the quiver.
It happens if they worship a god who cares about allies and if there
are allies nearby.

Fix this by skipping conducts when doing tracer checks.