### PR TITLE
Remove -Wiz from blade hand form

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -147,8 +147,7 @@ Blade Hands spell
                "Causes long, scythe-shaped blades to grow from the " ..
                "caster's " .. hands .. ", increasing melee damage " ..
                "significantly.\n\nWhile transformed, equipped weapons, " ..
-               "shields, and gloves are melded, and casting spells " ..
-               "becomes somewhat more difficult."
+               "shields, and gloves are melded."
 
     if hands == "paws" then
         return description .. " In addition, the clacking of blades " ..

--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -89,7 +89,7 @@ static const form_entry formdata[] =
     "",
     EQF_HANDS, MR_NO_FLAGS,
     FormDuration(10, PS_SINGLE, 100), 0, 0, SIZE_CHARACTER, 10,
-    0, 0, 0, true, 20, true, 22,
+    0, 0, 0, true, 0, true, 22,
     SPWPN_NORMAL, RED, "", { "hit", "slash", "slice", "shred" },
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true,
     "", 0, "", "", "", "",


### PR DESCRIPTION
Blade hand is now level 6 spell and has become much harder to find. You can only find it from a book of Transfiguration which contains statue form and dragon form. Blade hand is now not decent as before when it was level 5 and in a book of Changes, and not attractive compared to statue form which gives you a good deal of AC and resistance and makes you free from ER from body armour so that you can cast spells easily(and still you can wear shields!). Therefore, I suggest Blade hand form should have no -wiz penalty. It already requires a lot of exp and stats to stabilize. I want to make blade hand attractive as the same level spell: statue form.