### PR TITLE
Remove book ID

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5908,9 +5908,10 @@ static bool _valid_item_for_shop(int item_index, shop_type shop_type_,
     if (item.base_type == OBJ_GOLD)
         return false;
 
-    // Don't place missiles in general antique shops...
+    // Don't place missiles or books in general antique shops...
     if (shop_type_ == SHOP_GENERAL_ANTIQUE
-            && item.base_type == OBJ_MISSILES)
+            && (item.base_type == OBJ_MISSILES
+                || item.base_type == OBJ_BOOKS))
     {
         // ...unless they're specified by the item spec.
         return !spec.items.empty();

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -967,33 +967,6 @@ static string misc_type_name(int type)
     }
 }
 
-static bool _book_visually_special(uint32_t s)
-{
-    return s & 128; // one in ten books; c.f. item_colour()
-}
-
-static const char* book_secondary_string(uint32_t s)
-{
-    if (!_book_visually_special(s))
-        return "";
-
-    static const char* const secondary_strings[] = {
-        "", "chunky ", "thick ", "thin ", "wide ", "glowing ",
-        "dog-eared ", "oblong ", "runed ", "", "", ""
-    };
-    return secondary_strings[(s / NDSC_BOOK_PRI) % ARRAYSZ(secondary_strings)];
-}
-
-static const char* book_primary_string(uint32_t p)
-{
-    static const char* const primary_strings[] = {
-        "paperback", "hardcover", "leatherbound", "metal-bound", "papyrus",
-    };
-    COMPILE_CHECK(NDSC_BOOK_PRI == ARRAYSZ(primary_strings));
-
-    return primary_strings[p % ARRAYSZ(primary_strings)];
-}
-
 static const char* _book_type_name(int booktype)
 {
     switch (static_cast<book_type>(booktype))
@@ -1746,18 +1719,10 @@ string item_def::name_aux(description_level_type desc, bool terse, bool ident,
         if (is_random_artefact(*this) && !dbname && !basename)
         {
             buff << get_artefact_name(*this, ident);
-            if (!know_type)
-                buff << "book";
             break;
         }
         if (basename)
             buff << (item_typ == BOOK_MANUAL ? "manual" : "book");
-        else if (!know_type)
-        {
-            buff << book_secondary_string(rnd)
-                 << book_primary_string(rnd) << " "
-                 << (item_typ == BOOK_MANUAL ? "manual" : "book");
-        }
         else
             buff << sub_type_string(*this, !dbname);
         break;
@@ -1901,23 +1866,19 @@ bool item_type_known(const item_def& item)
     if (item_ident(item, ISFLAG_KNOW_TYPE))
         return true;
 
+    switch (item.base_type)
+    {
+    case OBJ_MISCELLANY:
+    case OBJ_MISSILES:
+    case OBJ_BOOKS:
+        return true;
+    default:
+        break;
+    }
+
     // Artefacts have different descriptions from other items,
     // so we can't use general item knowledge for them.
     if (is_artefact(item))
-        return false;
-
-    if (item.base_type == OBJ_MISSILES)
-        return true;
-
-    if (item.base_type == OBJ_MISCELLANY)
-        return true;
-
-#if TAG_MAJOR_VERSION == 34
-    if (item.is_type(OBJ_BOOKS, BOOK_BUGGY_DESTRUCTION))
-        return true;
-#endif
-
-    if (item.is_type(OBJ_BOOKS, BOOK_MANUAL))
         return false;
 
     if (!item_type_has_ids(item.base_type))
@@ -3079,12 +3040,11 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         }
 
     case OBJ_BOOKS:
-        // this might be wrong if we ever add more item ID back
         if (you.has_mutation(MUT_INNATE_CASTER) && item.sub_type != BOOK_MANUAL)
             return true;
-        if (!ident && !item_type_known(item))
+        if (item.sub_type == NUM_BOOKS)
             return false;
-        if ((ident || item_type_known(item)) && item.sub_type != BOOK_MANUAL)
+        if (item.sub_type != BOOK_MANUAL)
         {
             // Spellbooks are useless if all spells are either in the library
             // already or are uncastable.

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -1877,7 +1877,6 @@ bool item_type_has_ids(object_class_type base_type)
     COMPILE_CHECK(NUM_SCROLLS    < MAX_SUBTYPES);
     COMPILE_CHECK(NUM_JEWELLERY  < MAX_SUBTYPES);
     COMPILE_CHECK(NUM_POTIONS    < MAX_SUBTYPES);
-    COMPILE_CHECK(NUM_BOOKS      < MAX_SUBTYPES);
     COMPILE_CHECK(NUM_STAVES     < MAX_SUBTYPES);
     COMPILE_CHECK(NUM_MISCELLANY < MAX_SUBTYPES);
 #if TAG_MAJOR_VERSION == 34
@@ -1887,7 +1886,7 @@ bool item_type_has_ids(object_class_type base_type)
 
     return base_type == OBJ_WANDS || base_type == OBJ_SCROLLS
         || base_type == OBJ_JEWELLERY || base_type == OBJ_POTIONS
-        || base_type == OBJ_STAVES || base_type == OBJ_BOOKS;
+        || base_type == OBJ_STAVES;
 }
 
 bool item_brand_known(const item_def& item)

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -996,7 +996,7 @@ void unset_ident_flags(item_def &item, iflags_t flags)
 }
 
 // Returns the mask of interesting identify bits for this item
-// (e.g., scrolls don't have know-cursedness).
+// (e.g., missiles don't have know-type).
 static iflags_t _full_ident_mask(const item_def& item)
 {
     // KNOW_PROPERTIES is only relevant for artefacts, handled later.
@@ -1008,21 +1008,13 @@ static iflags_t _full_ident_mask(const item_def& item)
     case OBJ_ORBS:
     case OBJ_RUNES:
     case OBJ_GOLD:
+    case OBJ_BOOKS:
 #if TAG_MAJOR_VERSION == 34
     case OBJ_FOOD:
     case OBJ_RODS:
 #endif
         flagset = 0;
         break;
-    case OBJ_BOOKS:
-#if TAG_MAJOR_VERSION == 34
-        if (item.sub_type == BOOK_BUGGY_DESTRUCTION)
-        {
-            flagset = 0;
-            break;
-        }
-        // Intentional fall-through.
-#endif
     case OBJ_SCROLLS:
     case OBJ_POTIONS:
     case OBJ_WANDS:

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -969,17 +969,8 @@ void identify_item(item_def& item)
 static bool _id_floor_item(item_def &item)
 {
     if (item.base_type == OBJ_BOOKS)
-    {
-        if (fully_identified(item))
-            return false;
-
-        // fix autopickup for previously-unknown books (hack)
-        if (item_needs_autopickup(item))
-            item.props["needs_autopickup"] = true;
-        set_ident_flags(item, ISFLAG_IDENT_MASK);
         return true;
-    }
-    else if (item.base_type == OBJ_WANDS)
+    if (item.base_type == OBJ_WANDS)
     {
         if (!get_ident_type(item))
         {
@@ -2914,10 +2905,10 @@ static int _autopickup_subtype(const item_def &item)
     case OBJ_STAVES:
         return item_type_known(item) ? item.sub_type : max_type;
     case OBJ_BOOKS:
-        if (item.sub_type == BOOK_MANUAL || item_type_known(item))
+        if (item.sub_type == BOOK_MANUAL)
             return item.sub_type;
         else
-            return max_type;
+            return 0;
 #if TAG_MAJOR_VERSION == 34
     case OBJ_RODS:
 #endif
@@ -4562,10 +4553,7 @@ item_def get_item_known_info(const item_def& item)
         ii.subtype_rnd = item.subtype_rnd;
         break;
     case OBJ_BOOKS:
-        if (item_type_known(item) || !item_is_spellbook(item))
-            ii.sub_type = item.sub_type;
-        else
-            ii.sub_type = NUM_BOOKS;
+        ii.sub_type = item.sub_type;
         ii.subtype_rnd = item.subtype_rnd;
         if (item.sub_type == BOOK_MANUAL && item_type_known(item))
             ii.skill = item.skill; // manual skill
@@ -4608,7 +4596,7 @@ item_def get_item_known_info(const item_def& item)
         ARTEFACT_APPEAR_KEY, KNOWN_PROPS_KEY, CORPSE_NAME_KEY,
         CORPSE_NAME_TYPE_KEY, "item_tile", "item_tile_name",
         "worn_tile", "worn_tile_name", "needs_autopickup",
-        FORCED_ITEM_COLOUR_KEY,
+        FORCED_ITEM_COLOUR_KEY, SPELL_LIST_KEY,
     };
     for (const char *prop : copy_props)
         if (item.props.exists(prop))

--- a/crawl-ref/source/known-items.cc
+++ b/crawl-ref/source/known-items.cc
@@ -287,9 +287,6 @@ void check_item_knowledge(bool unknown_items)
             if (i == OBJ_JEWELLERY && j >= NUM_RINGS && j < AMU_FIRST_AMULET)
                 continue;
 
-            if (i == OBJ_BOOKS && (j > MAX_FIXED_BOOK || !unknown_items))
-                continue;
-
             if (you.type_ids[i][j] != unknown_items) // logical xor
                 _add_fake_item(i, j, selected_items, items, !unknown_items);
             else
@@ -347,7 +344,6 @@ void check_item_knowledge(bool unknown_items)
         {
             { OBJ_BOOKS, BOOK_MANUAL },
             { OBJ_GOLD, 1 },
-            { OBJ_BOOKS, NUM_BOOKS },
             { OBJ_RUNES, NUM_RUNE_TYPES },
         };
         for (auto e : misc_list)

--- a/crawl-ref/source/known-items.cc
+++ b/crawl-ref/source/known-items.cc
@@ -122,6 +122,8 @@ public:
 #endif
         else if (item->is_type(OBJ_BOOKS, BOOK_MANUAL))
             name = "manuals";
+        else if (item->is_type(OBJ_BOOKS, 0))
+            name = "spellbooks";
         else if (item->base_type == OBJ_GOLD)
         {
             name = lowercase_string(item_class_name(item->base_type));
@@ -344,6 +346,7 @@ void check_item_knowledge(bool unknown_items)
         {
             { OBJ_BOOKS, BOOK_MANUAL },
             { OBJ_GOLD, 1 },
+            { OBJ_BOOKS, 0 },
             { OBJ_RUNES, NUM_RUNE_TYPES },
         };
         for (auto e : misc_list)

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -260,6 +260,7 @@ enum tag_minor_version
     TAG_MINOR_COMPRESS_BADMUTS,    // Reduce some mutations to 2 levels
     TAG_MINOR_NEW_TREES,           // New tree types
     TAG_MINOR_DISEASE,             // Turn disease into a normal duration
+    TAG_MINOR_BOOK_UNID,           // Remove book ID.
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1


### PR DESCRIPTION
Books being unknown had almost no impact on the game. They were a
little fun in antique shops, but that was fairly rare and not worth
keeping the feature given the limitations it presents (max 60 book
types), let's scrap it.

I strongly suspect there are some subtle nasty bugs here, so if someone wants to glance over it, I'd appreciate that.