### PR TITLE
Add Archmagi as a randart property

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -252,10 +252,8 @@ bool actor::faith(bool calc_unid, bool items) const
 
 int actor::archmagi(bool calc_unid, bool items) const
 {
-    if (!items)
-        return 0;
-
-    return wearing_ego(EQ_ALL_ARMOUR, SPARM_ARCHMAGI, calc_unid);
+    return items && (wearing_ego(EQ_ALL_ARMOUR, SPARM_ARCHMAGI, calc_unid)
+                     || scan_artefacts(ARTP_ARCHMAGI, calc_unid));
 }
 
 /**

--- a/crawl-ref/source/artefact-prop-type.h
+++ b/crawl-ref/source/artefact-prop-type.h
@@ -67,5 +67,6 @@ enum artefact_prop_type
     ARTP_SHIELDING,
     ARTP_HARM,
     ARTP_RAMPAGING,
+    ARTP_ARCHMAGI,
     ARTP_NUM_PROPERTIES
 };

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -587,6 +587,8 @@ static bool _artp_can_go_on_item(artefact_prop_type prop, const item_def &item,
             return item_class != OBJ_ARMOUR
                    && (item_class != OBJ_JEWELLERY
                        || jewellery_is_amulet(item));
+        case ARTP_ARCHMAGI:
+            return item.is_type(OBJ_ARMOUR, ARM_ROBE);
         default:
             return true;
     }
@@ -726,6 +728,8 @@ static const artefact_prop_data artp_data[] =
     { "Harm", ARTP_VAL_BOOL, 25, // ARTP_HARM,
         []() {return 1;}, nullptr, 0, 0},
     { "Rampage", ARTP_VAL_BOOL, 25, // ARTP_RAMPAGING,
+        []() {return 1;}, nullptr, 0, 0},
+    { "Archmagi", ARTP_VAL_BOOL, 25, // ARTP_ARCHMAGI,
         []() {return 1;}, nullptr, 0, 0},
 };
 COMPILE_CHECK(ARRAYSZ(artp_data) == ARTP_NUM_PROPERTIES);
@@ -1510,7 +1514,8 @@ static bool _randart_is_conflicting(const item_def &item,
     // see also _artp_can_go_on_item
 
     if (proprt[ARTP_PREVENT_SPELLCASTING]
-        && proprt[ARTP_INTELLIGENCE] > 0 || proprt[ARTP_MAGICAL_POWER] > 0)
+        && proprt[ARTP_INTELLIGENCE] > 0 || proprt[ARTP_MAGICAL_POWER] > 0
+        || proprt[ARTP_ARCHMAGI])
     {
         return true;
     }

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -351,6 +351,7 @@ static vector<string> _randart_propnames(const item_def& item,
         { ARTP_STEALTH,               prop_note::symbolic },
         { ARTP_CLARITY,               prop_note::plain },
         { ARTP_RMSL,                  prop_note::plain },
+        { ARTP_ARCHMAGI,              prop_note::plain },
     };
 
     const unrandart_entry *entry = nullptr;
@@ -585,6 +586,7 @@ static string _randart_descrip(const item_def &item)
         { ARTP_HARM, "It increases damage dealt and taken.", false},
         { ARTP_RAMPAGING, "It bestows one free step when moving towards enemies.",
           false},
+        { ARTP_ARCHMAGI, "It increases the power of your magical spells.", false},
     };
 
     // Give a short description of the base type, for base types with no

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2509,7 +2509,7 @@ static vector<formatted_string> _get_overview_resistances(
     const int no_cast = you.no_cast(calc_unid);
     if (no_cast)
         out += _resist_composer("NoCast", cwidth, 1, 1, false);
-    
+
     cols.add_formatted(1, out, false);
 
     _print_overview_screen_equip(cols, equip_chars, sw);

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2479,6 +2479,10 @@ static vector<formatted_string> _get_overview_resistances(
                             player_equip_unrand(UNRAND_SEVEN_LEAGUE_BOOTS))
            + "\n";
 
+    const int archmagi = you.archmagi(calc_unid);
+    if (archmagi)
+        out += _resist_composer("Archmagi", cwidth, archmagi) + "\n";
+
     const int rclar = you.clarity(calc_unid);
     const int stasis = you.stasis();
     // TODO: what about different levels of anger/berserkitis?
@@ -2505,7 +2509,7 @@ static vector<formatted_string> _get_overview_resistances(
     const int no_cast = you.no_cast(calc_unid);
     if (no_cast)
         out += _resist_composer("NoCast", cwidth, 1, 1, false);
-
+    
     cols.add_formatted(1, out, false);
 
     _print_overview_screen_equip(cols, equip_chars, sw);

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -290,7 +290,7 @@ static void _equip_artefact_effect(item_def &item, bool *show_msgs, bool unmeld,
         else
             mpr("You feel powerful.");
     }
-    
+
     if (proprt[ARTP_HP])
         _calc_hp_artefact();
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -283,6 +283,14 @@ static void _equip_artefact_effect(item_def &item, bool *show_msgs, bool unmeld,
     if (proprt[ARTP_RAMPAGING] && msg && !unmeld)
         mpr("You feel ready to rampage towards enemies.");
 
+    if (proprt[ARTP_ARCHMAGI] && msg && !unmeld)
+    {
+        if (!you.skill(SK_SPELLCASTING))
+            mpr("You feel strangely lacking in power.");
+        else
+            mpr("You feel powerful.");
+    }
+    
     if (proprt[ARTP_HP])
         _calc_hp_artefact();
 
@@ -348,6 +356,9 @@ static void _unequip_artefact_effect(item_def &item,
 
     if (proprt[ARTP_RAMPAGING] && !you.rampaging() && msg && !meld)
         mpr("You no longer feel able to rampage towards enemies.");
+
+    if (proprt[ARTP_ARCHMAGI] && msg && !meld)
+        mpr("You feel strangely numb.");
 
     if (proprt[ARTP_DRAIN] && !meld)
         drain_player(150, true, true);

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -1521,6 +1521,7 @@ static void _debug_rap_stats(FILE *ostat)
         "ARTP_SHIELDING",
         "ARTP_HARM",
         "ARTP_RAMPAGING",
+        "ARTP_ARCHMAGI",
     };
     COMPILE_CHECK(ARRAYSZ(rap_names) == ARTP_NUM_PROPERTIES);
 


### PR DESCRIPTION
This adds Archmagi as a randart property and enables it to generate on
robes only (for now). Also added are equip/unequip messages, same as for
the Archmagi ego, and an indicator in the character overview screen.