### PR TITLE
Corrects the description of Tin of Tremorstones

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1050,7 +1050,7 @@ disturbed. Tremorstones usually land slightly off-target, and the user is
 always at risk of being hit. However, armour is extremely effective at
 repelling the lightweight fragments of rock from a tremorstone's explosion, so
 a well-armoured wielder has little to fear. Evocations skill increases the
-number and power of the elementals' explosions.
+number of explosions.
 %%%%
 trident
 


### PR DESCRIPTION
The description states that the power scales with your evocations skill.
This does not appear to be the case based on the following:

1. Since https://github.com/crawl/crawl/commit/6f112fb28d0ec403ccb98850db96906d9a5dba3a the damage dice are `dicedef_calculator<6, 6, 0, 1>`, which multiplies the power by 0 when calculating the damage.
2. No other interpretations of 'power' such as the range or radius appear to change based on my reading of the code.

I've done my best to test this in wizard mode and to read and understand the source, however, I am not deeply familiar with crawl or its source code, so please review the above carefully.

It looks like many items (E.G. Wand of Iceblast) show damage stats in the description. Since this is now fixed, should we add that for this item? Ditto the number of explosions?