### PR TITLE
Removed dead code ranged_attack::calc_to_hit

### DIFF
--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -65,16 +65,6 @@ ranged_attack::ranged_attack(actor *attk, actor *defn, item_def *proj,
         wpn_skill = SK_THROWING;
 }
 
-// Duplicates describe.cc:_apply_defender_effects().
-int ranged_attack::calc_to_hit(bool random)
-{
-    int mhit = attack::calc_to_hit(random);
-    if (mhit == AUTOMATIC_HIT)
-        return AUTOMATIC_HIT;
-
-    return mhit;
-}
-
 int ranged_attack::post_roll_to_hit_modifiers(int mhit, bool random)
 {
     int modifiers = attack::post_roll_to_hit_modifiers(mhit, random);

--- a/crawl-ref/source/ranged-attack.h
+++ b/crawl-ref/source/ranged-attack.h
@@ -18,7 +18,6 @@ public:
 
     // Applies attack damage and other effects.
     bool attack();
-    int calc_to_hit(bool random) override;
     int post_roll_to_hit_modifiers(int mhit, bool random) override;
 
 private:


### PR DESCRIPTION
Removed dead code ranged_attack::calc_to_hit

This method calls the base and then returns the result.
This can be achieved by simply not overriding the base method.

I believe this was missed during editing because of the conditional in the method, however, since this conditional just returns the same result, it is obsolete.