### PR TITLE
Fix some issues with "stat zero" warnings.

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -596,7 +596,7 @@ void JewelleryOnDelay::finish()
 #ifdef USE_SOUND
     parse_sound(WEAR_JEWELLERY_SOUND);
 #endif
-    puton_ring(jewellery, false, false);
+    puton_ring(jewellery, false, false, true);
 }
 
 void EquipOnDelay::finish()

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1944,16 +1944,14 @@ static bool _puton_amulet(item_def &item,
     }
 
     item_def *old_amu = you.slot_item(EQ_AMULET, true);
-    if (old_amu)
-    {
-        // Remove the previous one.
-        if (!remove_ring(old_amu->link, true))
-            return false;
 
-        // Check for stat loss.
-        if (!_safe_to_remove_or_wear(item, false))
-            return false;
-    }
+    // Check for stat loss.
+    if (!_safe_to_remove_or_wear(item, old_amu, false))
+        return false;
+
+    // Remove the previous one.
+    if (old_amu && !remove_ring(old_amu->link, true, true))
+        return false;
 
     // puton_ring already confirmed there's room for it
     int item_slot = _get_item_slot_maybe_with_move(item);
@@ -2125,7 +2123,9 @@ bool puton_ring(int slot, bool allow_prompt, bool check_for_inscriptions)
 
 // Remove the ring/amulet at given inventory slot (or, if slot is -1, prompt
 // for which piece of jewellery to remove)
-bool remove_ring(int slot, bool announce)
+//
+// noask suppresses the "stat zero" prompt.
+bool remove_ring(int slot, bool announce, bool noask)
 {
     equipment_type hand_used = EQ_NONE;
     bool has_jewellery = false;
@@ -2237,7 +2237,7 @@ bool remove_ring(int slot, bool announce)
 
     const int removed_ring_slot = you.equip[hand_used];
     item_def &invitem = you.inv[removed_ring_slot];
-    if (!_safe_to_remove_or_wear(invitem, true))
+    if (!noask && !_safe_to_remove_or_wear(invitem, true))
         return false;
 
     // Remove the ring.

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1257,6 +1257,10 @@ bool wear_armour(int item)
 
     bool swapping = false;
     const equipment_type slot = get_armour_slot(*to_wear);
+
+    if (!_safe_to_remove_or_wear(*to_wear, you.slot_item(slot), false))
+        return false;
+
     if ((slot == EQ_CLOAK
            || slot == EQ_HELMET
            || slot == EQ_GLOVES
@@ -1265,18 +1269,12 @@ bool wear_armour(int item)
            || slot == EQ_BODY_ARMOUR)
         && you.equip[slot] != -1)
     {
-        if (!takeoff_armour(you.equip[slot]))
+        if (!takeoff_armour(you.equip[slot], true))
             return false;
         swapping = true;
     }
 
     you.turn_is_over = true;
-
-    // TODO: It would be nice if we checked this before taking off the item
-    // currently in the slot. But doing so is not quite trivial. Also applies
-    // to jewellery.
-    if (!_safe_to_remove_or_wear(*to_wear, false))
-        return false;
 
     // If it's on the ground, pick it up. Once it's picked up, there should be
     // no aborting
@@ -1330,7 +1328,9 @@ static bool _can_takeoff_armour(int item)
 // TODO: It would be nice if this were made consistent with wear_armour,
 // wield_weapon, puton_ring, etc. in terms of taking a default value of -1,
 // which has the effect of prompting for an item to take off.
-bool takeoff_armour(int item)
+//
+/// noask suppresses the "stat zero" prompt.
+bool takeoff_armour(int item, bool noask)
 {
     if (!_can_takeoff_armour(item))
         return false;
@@ -1339,7 +1339,7 @@ bool takeoff_armour(int item)
 
     // It's possible to take this thing off, but if it would drop a stat
     // below 0, we should get confirmation.
-    if (!_safe_to_remove_or_wear(invitem, true))
+    if (!noask && !_safe_to_remove_or_wear(invitem, true))
         return false;
 
     const equipment_type slot = get_armour_slot(invitem);

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -19,7 +19,7 @@ bool use_an_item(item_def *&target, int item_type, operation_types oper,
 
 bool armour_prompt(const string & mesg, int *index, operation_types oper);
 
-bool takeoff_armour(int index);
+bool takeoff_armour(int index, bool noask = false);
 
 void drink(item_def* potion = nullptr);
 

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -38,7 +38,7 @@ string cannot_read_item_reason(const item_def *item);
 bool scroll_has_targeter(scroll_type which_scroll);
 void read(item_def* scroll = nullptr, dist *target=nullptr);
 
-bool remove_ring(int slot = -1, bool announce = false);
+bool remove_ring(int slot = -1, bool announce = false, bool noask = false);
 
 bool wear_armour(int slot = -1);
 

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -28,10 +28,10 @@ bool god_hates_brand(const int brand);
 bool safe_to_remove(const item_def &item, bool quiet = false);
 
 bool puton_ring(int slot = -1, bool allow_prompt = true,
-                bool check_for_inscriptions = true);
+                bool check_for_inscriptions = true, bool noask = false);
 
 bool puton_ring(item_def &to_puton, bool allow_prompt = true,
-                bool check_for_inscriptions = true);
+                bool check_for_inscriptions = true, bool noask = false);
 
 bool scroll_hostile_check(scroll_type which_scroll);
 string cannot_read_item_reason(const item_def *item);


### PR DESCRIPTION
Make it so that:

1. A warning is generated if equipping an item reduces a stat below 1.
2. A warning is generated if removing at item (possibly as part of the same action as equipping a different one) reduces a stat below 1 at any point.
3. A warning is not generated if no stat will be reduced below 1 when equipping or removing items.
4. If a warning is generated and the player decides not to proceed, no in-game action takes place. There was a TODO for this.

The existing code didn't do any of these things reliably.