### PR TITLE
Mephitic Cloud --> Corpse Rot in Book of Vapours

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -135,7 +135,7 @@ static const vector<spell_type> spellbook_templates[] =
 
 {   // Book of Vapours
     SPELL_POISONOUS_VAPOURS,
-    SPELL_MEPHITIC_CLOUD,
+    SPELL_CORPSE_ROT,
     SPELL_FREEZING_CLOUD,
 },
 


### PR DESCRIPTION
All the spells that appear in only one book and are not available in starting libraries are all level 7 or higher, except for Corpse Rot.  At the same time, Mephitic Cloud is available from Turn 1 for two backgrounds, and also appears in three books.  Thus with Mephitic Cloud being so easily gained, and Corpse Rot as hard to find as end-game spells, and both having a theme of noxious fumes, put Corpse Rot into the Book of Vapours in place of Mephitic Cloud.