### PR TITLE
Buff Ko's apt and adjust recommended jobs

### DIFF
--- a/crawl-ref/source/dat/species/kobold.yaml
+++ b/crawl-ref/source/dat/species/kobold.yaml
@@ -15,7 +15,7 @@ aptitudes:
   maces_and_flails: -1
   polearms: -2
   staves: -1
-  crossbows: 2
+  crossbows: 4
   throwing: 1
   armour: -2
   dodging: 2
@@ -33,7 +33,7 @@ mutations:
   1:
     MUT_NIGHTSTALKER: 3
 recommended_jobs:
-  - JOB_HUNTER
+  - JOB_BRIGAND
   - JOB_BERSERKER
   - JOB_ARCANE_MARKSMAN
   - JOB_ENCHANTER


### PR DESCRIPTION
Xbow is very difficult to utilise in comparson to bow and it's even worse for Kobold with reduced los. I suggested giving better xbow apt to several other species and nerfing Kobold's but PF doesn't think it is the right way. Instead, Buff Ko's xbow apt by 2(+2 to +4). Kobold with reduced los has difficulty with using ranged weapons, especally when it has 1.0 mindelay, so I think it's still balanced.

Also, AM is enough for Ko's recommended job about ranged weapons. Therefore, remove Hu from it and add Br in it.