### PR TITLE
Check for monsters, objects & features as soon as you move.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -527,6 +527,10 @@ void moveto_location_effects(dungeon_feature_type old_feat,
 
     if (stepped)
         _moveto_maybe_repel_stairs();
+
+    update_monsters_in_view();
+    if (check_for_interesting_features() && you.running.is_explore())
+        stop_running();
 }
 
 // Use this function whenever the player enters (or lands and thus re-enters)

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4986,7 +4986,7 @@ bool check_for_interesting_features()
     // Scan through the shadow map, compare it with the actual map, and if
     // there are any squares of the shadow map that have just been
     // discovered and contain an item, or have an interesting dungeon
-    // feature, stop exploring.
+    // feature, announce the discovery and return true.
     explore_discoveries discoveries;
     for (vision_iterator ri(you); ri; ++ri)
     {


### PR DESCRIPTION
Check for things after the player moves, rather than waiting for the start of the next turn.
This now uses check_for_interesting_features() in the same way _prep_input() already did, so explore stops if you find an item which autopickup wouldn't pick up.

Change a comment in check_for_interesting_features() so that it now says which the function does.