### PR TITLE
move scroll of noise from bad item to dangerous item

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2610,8 +2610,6 @@ bool is_bad_item(const item_def &item)
         case SCR_CURSE_JEWELLERY:
             return !have_passive(passive_t::want_curses);
 #endif
-        case SCR_NOISE:
-            return true;
         default:
             return false;
         }
@@ -2683,6 +2681,8 @@ bool is_dangerous_item(const item_def &item, bool temp)
                    || !temp && you.species == SP_VAMPIRE;
         case SCR_HOLY_WORD:
             return you.undead_or_demonic();
+        case SCR_NOISE:
+            return true;
         default:
             return false;
         }


### PR DESCRIPTION
Scroll of noise is not a completely bad item. It's a dangerous item because it will wake sleeping monsters and attract them to you, but assuming you want monsters coming to you, that can be a positive effect. That's a similar usage to a potion of attraction, which is already classified as a dangerous item.