### PR TITLE
AppImage support

### DIFF
--- a/crawl-ref/.gitignore
+++ b/crawl-ref/.gitignore
@@ -249,3 +249,14 @@ icon.png
 
 # generated files for catch2-tests
 /source/catch2-tests/*.d
+
+# generated files for appimage
+/source/Dungeon_Crawl-*.AppImage
+/source/appimage/.DirIcon
+/source/appimage/AppRun
+/source/appimage/crawl.desktop
+/source/appimage/stone_soup_icon.svg
+/source/appimage/usr/bin
+/source/appimage/usr/data
+/source/appimage/usr/lib
+/source/appimage/usr/share/icons

--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -7,6 +7,7 @@
   * [Ubuntu / Debian](#ubuntu--debian)
   * [Fedora](#fedora)
   * [Other Linux / Unix](#other-linux--unix)
+  * [AppImage](#appimage)
   * [macOS](#macOS)
   * [Windows](#windows)
     * [MSYS2 (Recommended)](#msys2-recommended)
@@ -127,6 +128,31 @@ Dependencies](#packaged-dependencies) above):
 * libpng (tiles builds only)
 
 Then follow [the above compilation steps](#compiling).
+
+## AppImage
+
+When building for Linux targets, you can easily create an AppImage with the
+help of the `linuxdeploy` tool.
+
+1. [Download the linuxdeploy AppImage](
+   https://github.com/linuxdeploy/linuxdeploy/releases)
+
+2. Make it executable.
+
+    ```sh
+    chmod +x /path/to/linuxdeploy.AppImage
+    ```
+
+3. Follow [the above compilation steps](#compiling) and, when running `make`,
+   include the `appimage` target and the path to `linuxdeploy` in the
+   `LINUXDEPLOY` parameter.
+    
+    ```sh
+    # console build
+    make LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage
+    # tiles build
+    make TILES=y LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage
+    ```
 
 ## macOS
 

--- a/crawl-ref/docs/develop/release/appimage.md
+++ b/crawl-ref/docs/develop/release/appimage.md
@@ -1,0 +1,84 @@
+# AppImage
+
+## Contents
+
+* [Introduction](#introduction)
+* [Creating an AppImage](#creating-an-appimage)
+* [How does it work?](#how-does-it-work)
+
+## Introduction
+
+AppImage is a format for distributing portable software on Linux without needing
+superuser permissions to install the application. It tries also to allow Linux
+distribution-agnostic binary software deployment for application developers,
+also called upstream packaging.
+
+AppImages are very simple to use, just two steps required:
+
+1. Make it executable
+2. Run
+
+This can be done either with the command line or a GUI. It features some other
+uses like mounting or desktop integration. You can browse the [AppImage
+documentation](https://docs.appimage.org/) for more details.
+
+## Creating an AppImage
+
+When building Crawl for Linux targets, you can easily create an AppImage with
+the help of the `linuxdeploy` tool.
+
+1. [Download the linuxdeploy AppImage](
+   https://github.com/linuxdeploy/linuxdeploy/releases)
+
+2. Make it executable.
+
+    ```sh
+    chmod +x /path/to/linuxdeploy.AppImage
+    ```
+
+3. Follow the usual Linux compilation procedure and, when running `make`,
+   include the `appimage` target and the path to `linuxdeploy` in the
+   `LINUXDEPLOY` parameter.
+
+    ```sh
+    # console build
+    make LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage
+    # tiles build
+    make TILES=y LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage
+    ```
+
+## How does it work?
+
+Running
+
+    ```sh
+    make LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage
+    ```
+
+is roughly equivalent to
+
+    ```sh
+    make prefix=appimage/usr DATADIR=data/ install
+    /path/to/linuxdeploy.AppImage --appdir appimage --output appimage
+    ```
+
+1. First, a normal Linux build is performed.
+
+2. Crawl is installed under the `appimage/usr` directory. This path already
+   contains some files required by `linuxdeploy`, like the AppStream metadata
+   and a desktop entry.
+
+3. Then `linuxdeploy` reads the contents of the `appimage` directory and
+   completes the basic AppDir structure.
+
+4. The dependencies for `appimage/usr/bin/crawl` are copied  to
+   `appimage/usr/bin/lib`.
+
+5. The AppDir root directory is completed with some resource files copied or
+   symlinked.
+
+6. The AppStream metadata is validated.
+
+7. Finally, the `appimage` directory is packaged into a Squashfs filesystem.
+   The resulting file name is `Dungeon_Crawl-<version>-<arch>.AppImage`.
+

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -63,6 +63,7 @@
 #    WEBDIR        -- place to hold the Webtiles client data. Can be either
 #                     relative to prefix or absolute.
 #
+#    LINUXDEPLOY   -- path to linuxdeploy tool, required for AppImage builds
 #    ANDROID       -- perform an Android build (see docs/develop/android.txt)
 #    TOUCH_UI      -- enable UI behaviour more compatible with touch-screens
 #
@@ -102,9 +103,9 @@ MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
 .SUFFIXES:       # ... so zap the suffix list to neutralize most predifined rules, too
 
 .PHONY: all test install clean clean-contrib clean-rltiles clean-android \
-        clean-catch2 clean-plug-and-play-tests \
-		clean-coverage clean-coverage-full \
-        distclean debug debug-lite profile package-source source \
+        clean-appimage clean-catch2 clean-plug-and-play-tests \
+        clean-coverage clean-coverage-full \
+        appimage distclean debug debug-lite profile package-source source \
         build-windows package-windows-installer docs greet api api-dev android FORCE \
         monster catch2-tests plug-and-play-tests \
         crawl-universal crawl-arm64-apple-macos11 crawl-x86_64-apple-macos10.7 clean-mac
@@ -605,6 +606,13 @@ ifndef NO_PKGCONFIG
 ifeq ($(shell which $(PKGCONFIG) 2> /dev/null),)
 NO_PKGCONFIG = YesPlease
 endif
+endif
+
+ifdef LINUXDEPLOY
+  prefix=appimage/usr
+  DESTDIR=
+  DATADIR=data/
+  export VERSION = $(SRC_VERSION)
 endif
 
 ifdef ANDROID
@@ -1578,7 +1586,7 @@ ifeq ($(USE_DGAMELAUNCH),)
 endif
 
 clean: clean-rltiles clean-webserver clean-android clean-monster clean-catch2 \
-       clean-plug-and-play-tests clean-coverage-full clean-mac
+       clean-plug-and-play-tests clean-coverage-full clean-mac clean-appimage
 	+$(MAKE) -C $(UTIL) clean
 	$(RM) $(GAME) $(GAME).exe $(GENERATED_FILES) $(EXTRA_OBJECTS) libw32c.o\
 	    libunix.o $(ALL_OBJECTS) $(ALL_OBJECTS:.o=.d) *.ixx  \
@@ -1891,6 +1899,29 @@ package-source: package-tarball-deps package-zipball-deps package-tarball-nodeps
 removeold:
 	if [ -f ../../$(SRC_PKG_TAR) ]; then $(RM) ../../$(SRC_PKG_TAR); fi
 	if [ -f ../../$(SRC_PKG_ZIP) ]; then $(RM) ../../$(SRC_PKG_ZIP); fi
+
+#############################################################################
+# Linux AppImage
+#
+
+appimage: install
+ifeq ($(LINUXDEPLOY),)
+	@echo Please define LINUXDEPLOY path to use this build.
+	@exit 1
+endif
+	$(LINUXDEPLOY) --appdir appimage --desktop-file appimage/usr/share/applications/crawl.desktop \
+                       --icon-file dat/tiles/stone_soup_icon.svg --output appimage
+
+clean-appimage:
+	$(RM) Dungeon_Crawl-*.AppImage
+	$(RM) appimage/.DirIcon
+	$(RM) appimage/AppRun
+	$(RM) appimage/crawl.desktop
+	$(RM) appimage/stone_soup_icon.svg
+	$(RM) -r appimage/usr/bin
+	$(RM) -r appimage/usr/data
+	$(RM) -r appimage/usr/lib
+	$(RM) -r appimage/usr/share/icons
 
 #############################################################################
 # Building the unified Windows package.

--- a/crawl-ref/source/appimage/usr/share/applications/crawl.desktop
+++ b/crawl-ref/source/appimage/usr/share/applications/crawl.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Dungeon Crawl
+Exec=crawl
+Icon=stone_soup_icon
+Categories=Game;AdventureGame;

--- a/crawl-ref/source/appimage/usr/share/metainfo/crawl.appdata.xml
+++ b/crawl-ref/source/appimage/usr/share/metainfo/crawl.appdata.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>crawl.develz.org</id>
+  <project_license>GPL-2.0+</project_license>
+  <metadata_license>GPL-2.0+</metadata_license>
+  <name>Dungeon Crawl</name>
+  <summary>
+    An open source roguelike adventure through dungeons filled with dangerous
+    monsters in a quest to find the mystifyingly fabulous Orb of Zot.
+  </summary>
+  <description>
+    <p>
+      Crawl is a fun game in the grand tradition of similar games like Rogue,
+      Hack and Moria. The objective is to travel deep into a subterranean cave
+      complex and retrieve the Orb of Zot, guarded by many horrible and hideous
+      creatures.
+
+      If you have never played Crawl (or a similar game) before, select the
+      tutorial from the starting menu. The tutorial explains the interface in
+      five easy lessons. Once you're familiar with the controls, you may want to
+      play a few games using hints mode.
+    </p>
+  </description>
+  <launchable type="desktop-id">crawl.desktop</launchable>
+  <url type="homepage">https://crawl.develz.org</url>
+</component>


### PR DESCRIPTION
Closes: https://github.com/crawl/crawl/issues/1256

I added a new target and a new parameter to the Makefile, with the objective of building Crawl AppImages in an easy way.

It requires linuxdeploy: https://github.com/linuxdeploy/linuxdeploy/releases
It is also distributed as an AppImage, just need to download and make it executable.

Console build
`make LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage`
Tiles build
`make TILES=y LINUXDEPLOY=/path/to/linuxdeploy.AppImage appimage`

More exhaustive documentation is available at `docs/develop/release/appimage.md`

Please tell me if you need any changes for an easier integration with GitHub Actions.