### PR TITLE
fix: add support for Haiku

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -801,10 +801,6 @@ ifneq ($(SRC_BRANCH),$(filter master release stone_soup-%, $(SRC_BRANCH)))
 endif
 endif
 
-ifdef HAIKU_HYBRID_SECONDARY
-DEFINES_L += -DHAIKU_HYBRID_SECONDARY="\"$(HAIKU_HYBRID_SECONDARY)\""
-endif
-
 #
 # Figure out the build settings for this type of build
 #

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -382,7 +382,9 @@ ifdef WIN32
 EXTRA_OBJECTS += icon.o
 else
 ifndef ANDROID
+ifneq ($(uname_S),Haiku)
 EXTRA_LIBS += -pthread
+endif
 endif
 endif
 
@@ -797,6 +799,10 @@ SRC_BRANCH    := $(shell git rev-parse --abbrev-ref HEAD || echo release)
 ifneq ($(SRC_BRANCH),$(filter master release stone_soup-%, $(SRC_BRANCH)))
   DEFINES_L += -DEXPERIMENTAL_BRANCH="\"$(SRC_BRANCH)\""
 endif
+endif
+
+ifdef HAIKU_HYBRID_SECONDARY
+DEFINES_L += -DHAIKU_HYBRID_SECONDARY="\"$(HAIKU_HYBRID_SECONDARY)\""
 endif
 
 #

--- a/crawl-ref/source/crash.cc
+++ b/crawl-ref/source/crash.cc
@@ -10,7 +10,9 @@
 #if defined(UNIX)
 #include <unistd.h>
 #include <sys/param.h>
+#ifndef __HAIKU__
         #define BACKTRACE_SUPPORTED
+#endif
 #endif
 
 #ifdef USE_UNIX_SIGNALS

--- a/crawl-ref/source/endianness.h
+++ b/crawl-ref/source/endianness.h
@@ -18,6 +18,10 @@
 # endif
 #endif
 
+#ifdef __HAIKU__
+#include <endian.h>
+#endif
+
 #ifndef htole32
  #if BYTE_ORDER == LITTLE_ENDIAN
   #define htole32(x) (x)

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -422,19 +422,11 @@ string canonicalise_file_separator(const string &path)
 static vector<string> _get_base_dirs()
 {
 #ifdef __HAIKU__
-    char data_path[B_PATH_NAME_LENGTH];
-    char docs_path[B_PATH_NAME_LENGTH];
-
+    char path[B_PATH_NAME_LENGTH];
     find_path(B_APP_IMAGE_SYMBOL,
             B_FIND_PATH_DATA_DIRECTORY,
             "crawl/",
-            data_path,
-            B_PATH_NAME_LENGTH);
-
-    find_path(B_APP_IMAGE_SYMBOL,
-            B_FIND_PATH_DOCUMENTATION_DIRECTORY,
-            "packages/crawl",
-            docs_path,
+            path,
             B_PATH_NAME_LENGTH);
 #endif
     const string rawbases[] =
@@ -453,12 +445,7 @@ static vector<string> _get_base_dirs()
         "/sdcard/Android/data/org.develz.crawl/files/",
 #endif
 #ifdef __HAIKU__
-        std::string(data_path),
-#ifdef HAIKU_HYBRID_SECONDARY
-        std::string(docs_path) + "_" + HAIKU_HYBRID_SECONDARY + FILE_SEPARATOR,
-#else
-        std::string(docs_path) + FILE_SEPARATOR,
-#endif
+        std::string(path),
 #endif
     };
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -95,6 +95,10 @@ extern char **NXArgv;
 #include <unistd.h>
 #endif
 
+#ifdef __HAIKU__
+#include <FindDirectory.h>
+#endif
+
 const string game_options::interrupt_prefix = "interrupt_";
 system_environment SysEnv;
 
@@ -4016,6 +4020,20 @@ void get_system_environment()
     {
         SysEnv.crawl_dir
             = _user_home_subpath("Library/Application Support/" CRAWL);
+    }
+#endif
+
+#ifdef __HAIKU__
+    if (SysEnv.crawl_dir.empty())
+    {
+        char path[B_PATH_NAME_LENGTH];
+        find_directory(B_USER_SETTINGS_DIRECTORY,
+                        0,
+                        false,
+                        path,
+                        B_PATH_NAME_LENGTH);
+
+        SysEnv.crawl_dir = catpath(std::string(path), "/crawl");
     }
 #endif
 


### PR DESCRIPTION
This patch is currently being used in the official Haiku package repo (https://github.com/haikuports/haikuports/pull/6114, https://github.com/haikuports/haikuports/pull/6118)

[This patch](https://github.com/Crestwave/haikuports/blob/65ca2d9c37210996f9f7f91b3cbdb339f12b79cb/games-roguelike/crawl/patches/crawl-0.27.0.patchset) can alternatively be used if it's too messy splitting the documentation from the data directory