### PR TITLE
Vampires are not (pure) lifeless undead

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1468,7 +1468,7 @@ bool player_kiku_res_torment()
 int player_res_poison(bool calc_unid, bool temp, bool items)
 {
     if (you.is_nonliving(temp)
-        || you.is_lifeless_undead(temp || you.undead_state() == US_SEMI_UNDEAD) // XX: ugly, can this be cleaned up?
+        || you.is_lifeless_undead(temp)
         || temp && get_form()->res_pois() == 3
         || items && player_equip_unrand(UNRAND_OLGREB)
         || temp && you.duration[DUR_DIVINE_STAMINA])
@@ -7006,7 +7006,7 @@ bool player::is_lifeless_undead(bool temp) const
     if (temp && undead_state() == US_SEMI_UNDEAD)
         return !you.vampire_alive;
     else
-        return undead_state(temp) != US_ALIVE;
+        return undead_state(temp) == US_UNDEAD;
 }
 
 bool player::can_polymorph() const


### PR DESCRIPTION
Closes https://github.com/crawl/crawl/issues/2017

I have been looking into that issue and I think you should consider not returning true for is_lifeless_undead(false) when playing as a vampire. These are the (probably undesired) side effects I found:

- Rage and lignification potions are tagged as useless.
- Wanderers can't receive such potions.
- Poison ring tagged as useless while bloddless and other poison related side effects.
- Kikubaaqudgha does not grant Sublimation of Blood.

Also, it may render unnecessary a hack in player_res_poison.