### PR TITLE
Show turn counts and real game times in lobby

### DIFF
--- a/crawl-ref/source/webserver/process_handler.py
+++ b/crawl-ref/source/webserver/process_handler.py
@@ -508,7 +508,7 @@ class CrawlProcessHandlerBase(object):
             self.process.send_signal(subprocess.signal.SIGABRT)
             self.kill_timeout = None
 
-    interesting_info = ("xl", "char", "place", "god", "title")
+    interesting_info = ("xl", "char", "place", "turn", "dur", "god", "title")
     def set_where_info(self, newwhere):
         interesting = False
         for key in CrawlProcessHandlerBase.interesting_info:

--- a/crawl-ref/source/webserver/static/scripts/client.js
+++ b/crawl-ref/source/webserver/static/scripts/client.js
@@ -1099,6 +1099,13 @@ function (exports, $, key_conversion, chat, comm) {
         set("xl", data.xl);
         set("char", data.char);
         set("place", data.place);
+        if (data.turn && data.dur)
+        {
+            set("turn", data.turn);
+            set("dur", format_duration(parseInt(data.dur)));
+
+            new_list.removeClass("no_game_times");
+        }
         set("god", data.god || "");
         set("title", data.title);
         set("idle_time", format_idle_time(data.idle_time));
@@ -1179,6 +1186,29 @@ function (exports, $, key_conversion, chat, comm) {
         return "<a href='#watch-" + data.username + "'></a>";
     }
 
+    function format_duration(seconds)
+    {
+        var elem = $("<span></span>");
+        if (seconds == 0)
+        {
+            elem.text("");
+        }
+        else if (seconds < 60)
+        {
+            elem.text(seconds + "s");
+        }
+        else if (seconds < (60 * 60))
+        {
+            elem.text(Math.floor(seconds / 60) + "m");
+        }
+        else
+        {
+            elem.text(Math.floor(seconds / (60 * 60)) + "h " +
+                (Math.floor(seconds / 60) % 60) + "m");
+        }
+        return elem;
+    }
+
     function format_idle_time(seconds)
     {
         var elem = $("<span></span>");
@@ -1188,15 +1218,15 @@ function (exports, $, key_conversion, chat, comm) {
         }
         else if (seconds < 120)
         {
-            elem.text(seconds + " s");
+            elem.text(seconds + "s");
         }
         else if (seconds < (60 * 60))
         {
-            elem.text(Math.round(seconds / 60) + " min");
+            elem.text(Math.round(seconds / 60) + "m");
         }
         else
         {
-            elem.text(Math.round(seconds / (60 * 60)) + " h");
+            elem.text(Math.round(seconds / (60 * 60)) + "h");
         }
         return elem;
     }

--- a/crawl-ref/source/webserver/static/style.css
+++ b/crawl-ref/source/webserver/static/style.css
@@ -99,6 +99,15 @@ body {
 #player_list th.place {
     width: 3em;
 }
+#player_list th.turn {
+    width: 3em;
+}
+#player_list th.dur {
+    width: 4em;
+}
+#player_list.no_game_times .turn, #player_list.no_game_times .dur {
+    display: none;
+}
 
 #player_list th.idle_time {
     width: 3em;

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -200,7 +200,7 @@
         <span>
           Games currently running:
         </span>
-        <table id="player_list">
+        <table id="player_list" class="no_game_times">
           <thead>
             <tr>
               <th class="username">User</th>
@@ -208,6 +208,8 @@
               <th class="xl">XL</th>
               <th class="char">Char</th>
               <th class="place">Place</th>
+              <th class="turn">Turn</th>
+              <th class="dur">Time</th>
               <th class="god">God</th>
               <th class="idle_time">Idle</th>
               <th class="spectator_count">Specs</th>
@@ -225,6 +227,8 @@
               <td class="xl"></td>
               <td class="char"></td>
               <td class="place"></td>
+              <td class="turn"></td>
+              <td class="dur"></td>
               <td class="god"></td>
               <td class="idle_time"></td>
               <td class="spectator_count"></td>


### PR DESCRIPTION
This lets spectators find potentially interesting games to view, i.e. from a speedrunning perspective.

`webserver/process_handler.py`:
* Treat the turn count and duration (real game time) as "interesting info" in the wherefile.

`webserver/static/scripts/client.js`:
* Show the new turn count and duration fields.
* While at it, rationalise the units shown for idle times ("min" -> "m", and drop the spaces).

`webserver/static/style.css`, `webserver/templates/client.html`:
* Add new fields.

Note that previous versions of the commit made the real time display increase automatically on the lobby's client side, similar to the idle time. However, this ignored the effect of `IDLE_TIME_CLAMP`; it's not valid to assume that real time is always ticking (instead, it stops after the game is idle for `IDLE_TIME_CLAMP` seconds). In practice only updating the time displays on new wherefile keeps it update to date enough.