### PR TITLE
"okay, then" for negative responses to warn_hatches prompts, and a nearby indentation fix

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1449,7 +1449,7 @@ static bool _prompt_stairs(dungeon_feature_type ygrd, bool down, bool shaft)
             canned_msg(MSG_OK);
             return false;
         }
-      }
+    }
 
     // Escaping.
     if (!down && ygrd == DNGN_EXIT_DUNGEON && !player_has_orb())

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1468,9 +1468,22 @@ static bool _prompt_stairs(dungeon_feature_type ygrd, bool down, bool shaft)
     if (Options.warn_hatches)
     {
         if (feat_is_escape_hatch(ygrd))
-            return yesno("Really go through this one-way escape hatch?", true, 'n');
+        {
+            if (!yesno("Really go through this one-way escape hatch?", true, 'n'))
+            {
+                canned_msg(MSG_OK);
+                return false;
+            }
+        }
+
         if (down && shaft) // voluntary shaft usage
-            return yesno("Really dive through this shaft in the floor?", true, 'n');
+        {
+            if (!yesno("Really dive through this shaft in the floor?", true, 'n'))
+            {
+                canned_msg(MSG_OK);
+                return false;
+            }
+        }
     }
 
     return true;


### PR DESCRIPTION
Saying 'n' to the warn_hatches prompts currently has no feedback and leaves the question on the screen, which may cause the player to try to repeat their response.  Since 'n' is a movement key, this is potentially dangerous.