### PR TITLE
Don't ever consider books evil

### DIFF
--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -159,8 +159,6 @@ bool is_evil_item(const item_def& item, bool calc_unid)
         return item.sub_type == SCR_TORMENT;
     case OBJ_STAVES:
         return item.sub_type == STAFF_DEATH;
-    case OBJ_BOOKS:
-        return _is_book_type(item, is_evil_spell);
     case OBJ_MISCELLANY:
         return item.sub_type == MISC_HORN_OF_GERYON;
     default:


### PR DESCRIPTION
Unfortunate from a flavour perspective, but in gameplay terms it's never
detrimental to read a book.  This allows autopickup to read books, even
if your current god forbids you from casting the spells contained
within.  It isn't the knowledge that's harmful, after all, but how you
use it!