### PR TITLE
Update package name for DejaVu font on Ubuntu

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -79,7 +79,7 @@ libsqlite3-dev libz-dev pkg-config python3-yaml binutils-gold python-is-python3
 
 # Dependencies for tiles builds
 sudo apt install libsdl2-image-dev libsdl2-mixer-dev libsdl2-dev \
-libfreetype6-dev libpng-dev ttf-dejavu-core advancecomp pngcrush
+libfreetype6-dev libpng-dev fonts-dejavu advancecomp pngcrush
 ```
 
 Then follow [the above compilation steps](#compiling).


### PR DESCRIPTION
It's been unavailable under the old name for awhile now