### PR TITLE
New spell: Scorch (L2 Fire)

### DIFF
--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -484,7 +484,7 @@ static const vector<spell_type> spellbook_templates[] =
 },
 
 { // Book of Scorching
-    SPELL_FOXFIRE,
+    SPELL_SCORCH,
     SPELL_FIREBALL,
     SPELL_SUMMON_CACTUS,
 },

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1184,6 +1184,11 @@ Scattershot spell
 Blasts a cone-shaped area in front of the caster with metallic fragments. Its
 damage is strongly reduced by armour.
 %%%%
+Scorch spell
+
+Scorches a random foe. Those injured by this have their resistance to fire
+burned away for a short time.
+%%%%
 Seal Doors spell
 
 Imparts seals on nearby doors and stairs, preventing those not allied with

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1401,7 +1401,8 @@ bool vehumet_supports_spell(spell_type spell)
         || spell == SPELL_FROZEN_RAMPARTS
         || spell == SPELL_MAXWELLS_COUPLING
         || spell == SPELL_NOXIOUS_BOG
-        || spell == SPELL_POISONOUS_VAPOURS)
+        || spell == SPELL_POISONOUS_VAPOURS
+        || spell == SPELL_SCORCH)
     {
         return true;
     }

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -130,13 +130,13 @@ static const map<job_type, job_def> job_data =
 
 { JOB_CINDER_ACOLYTE, {
     "CA", "Cinder Acolyte",
-    7, 5, 0,
+    6, 6, 0,
     { SP_HILL_ORC, SP_BASE_DRACONIAN, SP_OGRE, SP_DJINNI, SP_GNOLL },
-    { SPELL_FOXFIRE },
+    { SPELL_SCORCH },
     { "robe" },
     WCHOICE_PLAIN,
     { { SK_FIGHTING, 3 }, { SK_WEAPON, 3 },
-      { SK_FIRE_MAGIC, 1 }, {SK_SPELLCASTING, 1} },
+      { SK_FIRE_MAGIC, 3 }, {SK_SPELLCASTING, 1} },
 } },
 
 { JOB_CONJURER, {
@@ -208,6 +208,7 @@ static const map<job_type, job_def> job_data =
       SP_DJINNI, },
     {
         SPELL_FOXFIRE,
+        SPELL_SCORCH,
         SPELL_CONJURE_FLAME,
         SPELL_INNER_FLAME,
         SPELL_STICKY_FLAME,

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -515,6 +515,7 @@ LUAFN(debug_check_moncasts)
         SPELL_MANIFOLD_ASSAULT,
         SPELL_STORM_FORM,
         SPELL_SUMMON_CACTUS,
+        SPELL_SCORCH,
     };
 
     for (int s = SPELL_FIRST_SPELL; s < NUM_SPELLS; s++)

--- a/crawl-ref/source/spell-type.h
+++ b/crawl-ref/source/spell-type.h
@@ -518,5 +518,6 @@ enum spell_type : int
     SPELL_SUMMON_CACTUS,
     SPELL_STOKE_FLAMES,
     SPELL_SERACFALL,
+    SPELL_SCORCH,
     NUM_SPELLS
 };

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1299,8 +1299,6 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     case SPELL_DISCHARGE: // not entirely accurate...maybe should highlight
                           // all potentially affected monsters?
         return make_unique<targeter_maybe_radius>(&you, LOS_NO_TRANS, 1, 0, 1);
-    case SPELL_DAZZLING_FLASH:
-        return make_unique<targeter_maybe_radius>(&you, LOS_SOLID_SEE, range);
     case SPELL_CHAIN_LIGHTNING:
         return make_unique<targeter_chain_lightning>();
     case SPELL_MAXWELLS_COUPLING:
@@ -1309,6 +1307,7 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
         return make_unique<targeter_ramparts>(&you);
     case SPELL_DISPERSAL:
     case SPELL_DISJUNCTION:
+    case SPELL_DAZZLING_FLASH:
         return make_unique<targeter_maybe_radius>(&you, LOS_SOLID_SEE, range);
 
     // at player's position only but not a selfench; most transmut spells go here:
@@ -1389,6 +1388,8 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
         return make_unique<targeter_multiposition>(&you, _find_blink_targets(&you));
     case SPELL_MANIFOLD_ASSAULT:
         return make_unique<targeter_multiposition>(&you, _simple_find_all_hostiles(&you));
+    case SPELL_SCORCH:
+        return make_unique<targeter_multiposition>(&you, find_near_hostiles(range));
     case SPELL_DRAGON_CALL: // this is just convenience: you can start the spell with no enemies in sight
         return make_unique<targeter_multifireball>(&you, _simple_find_all_hostiles(&you));
     case SPELL_NOXIOUS_BOG:
@@ -2154,6 +2155,9 @@ static spret _do_cast(spell_type spell, int powc, const dist& spd,
     case SPELL_SHATTER:
         return cast_shatter(powc, fail);
 
+    case SPELL_SCORCH:
+        return cast_scorch(powc, fail);
+
     case SPELL_IRRADIATE:
         return cast_irradiate(powc, &you, fail);
 
@@ -2684,6 +2688,8 @@ static dice_def _spell_damage(spell_type spell, bool evoked)
             return irradiate_damage(power, false);
         case SPELL_SHATTER:
             return shatter_damage(power);
+        case SPELL_SCORCH:
+            return scorch_damage(power, false);
         case SPELL_BATTLESPHERE:
             return battlesphere_damage(power);
         case SPELL_FROZEN_RAMPARTS:

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -52,6 +52,7 @@
 #include "stringutil.h"
 #include "target.h"
 #include "terrain.h"
+ #include "tilepick.h"
 #include "transform.h"
 #include "unicode.h"
 #include "viewchar.h"
@@ -1689,6 +1690,111 @@ void shillelagh(actor *wielder, coord_def where, int pow)
 
     if ((you.pos() - wielder->pos()).rdist() <= 1 && in_bounds(you.pos()))
         _shatter_player(pow, wielder, true);
+}
+
+dice_def scorch_damage(int pow, bool random)
+{
+    const int max_dam = 10 + (random ? div_rand_round(pow, 5) : pow / 5);
+    return calc_dice(2, max_dam);
+}
+
+static void _animate_scorch(coord_def p)
+{
+    if (!(Options.use_animations & UA_BEAM))
+        return;
+
+#ifdef USE_TILE
+        view_add_tile_overlay(p, tileidx_zap(RED));
+#endif
+#ifndef USE_TILE_LOCAL
+        view_add_glyph_overlay(p, {dchar_glyph(DCHAR_FIRED_ZAP),
+                                   static_cast<unsigned short>(RED)});
+#endif
+
+    viewwindow(false);
+    update_screen();
+    scaled_delay(50);
+}
+
+spret cast_scorch(int pow, bool fail)
+{
+    fail_check();
+
+    const int range = spell_range(SPELL_SCORCH, pow);
+    monster *targ = nullptr;
+    int seen = 0;
+    for (radius_iterator ri(you.pos(), range, C_SQUARE, LOS_NO_TRANS); ri; ++ri)
+    {
+        monster *mons = monster_at(*ri);
+        if (!mons
+            || mons->wont_attack()
+            || !_act_worth_targeting(you, *mons))
+        {
+            continue;
+        }
+        ++seen;
+        if (one_chance_in(seen))
+            targ = mons;
+    }
+    if (!targ)
+    {
+        canned_msg(MSG_NOTHING_HAPPENS);
+        return spret::success;
+    }
+
+    const int base_dam = scorch_damage(pow, true).roll();
+    const int post_ac_dam = max(0, targ->apply_ac(base_dam));
+
+    mprf("Flames lash %s%s.", targ->name(DESC_THE).c_str(),
+         post_ac_dam ? "" : " but do no damage");
+    const coord_def p = targ->pos();
+    noisy(spell_effect_noise(SPELL_SCORCH), p);
+
+    bolt beam;
+    beam.flavour = BEAM_FIRE;
+    const int damage = mons_adjust_flavoured(targ, beam, post_ac_dam);
+    _player_hurt_monster(*targ, damage, beam.flavour);
+
+    if (!targ->alive())
+    {
+        _animate_scorch(p);
+        return spret::success;
+    }
+
+    you.pet_target = targ->mindex();
+
+    if (damage > 0 && !targ->has_ench(ENCH_FIRE_VULN))
+    {
+        if (you.can_see(*targ))
+        {
+            mprf("%s fire resistance burns away.",
+                 targ->name(DESC_ITS).c_str());
+        }
+        const int dur = 3 + div_rand_round(damage, 3);
+        targ->add_ench(mon_enchant(ENCH_FIRE_VULN, 1, &you,
+                                   dur * BASELINE_DELAY));
+
+    }
+    _animate_scorch(targ->pos());
+    return spret::success;
+}
+
+/// Mimics Scorch's target selection.
+vector<coord_def> find_near_hostiles(int range)
+{
+    vector<coord_def> hostiles;
+    for (radius_iterator ri(you.pos(), range, C_SQUARE, LOS_NO_TRANS); ri; ++ri)
+    {
+        monster *mons = monster_at(*ri);
+        if (mons
+            && !mons->wont_attack()
+            && _act_worth_targeting(you, *mons)
+            && you.can_see(*mons))
+        {
+            hostiles.push_back(*ri);
+        }
+    }
+    return hostiles;
 }
 
 dice_def irradiate_damage(int pow, bool random)

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -80,6 +80,9 @@ dice_def glaciate_damage(int pow, int eff_range);
 spret cast_glaciate(actor *caster, int pow, coord_def aim,
                          bool fail = false);
 
+spret cast_scorch(int pow, bool fail);
+dice_def scorch_damage(int pow, bool random);
+
 vector<coord_def> get_ignition_blast_sources(const actor *agent,
                                              bool tracer = false);
 spret cast_ignition(const actor *caster, int pow, bool fail);
@@ -112,3 +115,5 @@ void end_maxwells_coupling(bool quiet = false);
 
 spret cast_noxious_bog(int pow, bool fail);
 vector<coord_def> find_bog_locations(const coord_def &center, int pow);
+
+vector<coord_def> find_near_hostiles(int range);

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3496,6 +3496,17 @@ static const struct spell_desc spelldata[] =
 },
 
 {
+    SPELL_SCORCH, "Scorch",
+    spschool::fire,
+    spflag::no_ghost,
+    2,
+    50,
+    3, 3,
+    4, 8,
+    TILEG_ERROR,
+},
+
+{
     SPELL_NO_SPELL, "nonexistent spell",
     spschool::none,
     spflag::testing,

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1637,6 +1637,9 @@ bool spell_no_hostile_in_range(spell_type spell)
         }
         return true;
 
+    case SPELL_SCORCH:
+        return find_near_hostiles(range).empty();
+
     default:
         break;
     }


### PR DESCRIPTION
Scorch is a damage spell that strikes a random enemy in sight, dealing fire
damage to them and (if it beats AC & resists) applying Cerebov's rF- debuff
to them for a few turns. Currently, it does 2d5 damage at 0 power, scaling to
2d10 at 50 power.

Scorch is intended to provide additional variety to the Fire Elementalist
early game (reducing reliance on Foxfire) and to make Cinder Acolyte feel
more distinctive from FE by replacing its Foxfire entirely.

Open questions:
- Is the 'random targeting' gimmick actually fun, or should the player have
  a bit more control over what they bap?
- Would the spell feel more fun with a limit on range (& perhaps some
  compensatory buff)?
- Are the numbers reasonable?

TODOs:
- Add the spell to books properly.
- Add a message when spells become castable due to level up, if there isn't already such a message.