### PR TITLE
Improve ratskin cloak behavior and unmark it as evil

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1036,7 +1036,7 @@ STR:      -1
 INT:      -1
 DEX:      1
 LIFE:     1
-BOOL:     poison, evil
+BOOL:     poison
 DESCRIP:  When the wearer is hurt, rats may emerge from it to assist them.
 
 NAME:     shield of the Gong

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2713,14 +2713,6 @@ bool is_dangerous_item(const item_def &item, bool temp)
         return item.sub_type == MISC_TIN_OF_TREMORSTONES;
 
     case OBJ_ARMOUR:
-        if (you.allies_forbidden()
-            && is_unrandom_artefact(item, UNRAND_RATSKIN_CLOAK))
-        {
-            // some people don't like being randomly attacked by rats.
-            // weird but what can you do.
-            return true;
-        }
-
         // Tilting at windmills can be dangerous.
         return get_armour_ego_type(item) == SPARM_RAMPAGING;
 

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -538,7 +538,10 @@ static void _maybe_spawn_rats(int dam, kill_method_type death_type)
     if (!x_chance_in_y(capped_dam, you.hp_max))
         return;
 
-    monster_type mon = coinflip() ? MONS_HELL_RAT : MONS_RIVER_RAT;
+    monster_type mon;
+    mon = is_good_god(you.religion)
+          ? MONS_RIVER_RAT
+          : coinflip() ? MONS_HELL_RAT : MONS_RIVER_RAT;
 
     mgen_data mg(mon, BEH_FRIENDLY, you.pos(), MHITYOU);
     mg.flags |= MG_FORCE_BEH; // don't mention how much it hates you before it appears

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -546,12 +546,9 @@ static void _maybe_spawn_rats(int dam, kill_method_type death_type)
         if (!god_hates_monster(rat) && one_chance_in(++seen))
             mon = rat;
 
+    // If there's no valid creatures to pull from (e.g., follower of Oka), bail out.
     if (!seen)
-    {
-        // No valid creatures to pull from (e.g., follower of Oka), bail out.
-        mpr("Your cloak shudders, but is subdued by a divine force.");
         return;
-    }
 
     mgen_data mg(mon, BEH_FRIENDLY, you.pos(), MHITYOU);
     mg.flags |= MG_FORCE_BEH; // don't mention how much it hates you before it appears
@@ -559,7 +556,8 @@ static void _maybe_spawn_rats(int dam, kill_method_type death_type)
     {
         m->add_ench(mon_enchant(ENCH_FAKE_ABJURATION, 3));
         mprf("%s scurries out from under your cloak.", m->name(DESC_A).c_str());
-        // We should return early in the case of no_love or no_allies, so this is more a sanity check.
+        // We should return early in the case of no_love or no_allies,
+        // so this is more a sanity check.
         check_lovelessness(*m);
     }
 }


### PR DESCRIPTION
- ~~Add plain rats to its spawn list~~
  - Undid this on advice from PleasingFungus, as plain rats are effectively useless
- If you follow a good god, don't spawn hell rats
- Since it now can't spawn evil allies if you follow a good god, unmark it as evil