### PR TITLE
Have C-glyph altars use temple_god_list()

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5745,12 +5745,9 @@ static dungeon_feature_type _pick_an_altar()
                 god = GOD_MAKHLEB;
             break;
 
-        default: // Any god (with exceptions).
-            do
-            {
-                god = random_god();
-            }
-            while (god == GOD_LUGONU || god == GOD_BEOGH || god == GOD_JIYVA);
+        default: // Any temple-valid god
+            auto temple_gods = temple_god_list();
+            god = *random_iterator(temple_gods);
             break;
         }
     }


### PR DESCRIPTION
Previously there was a hardcoded list of gods that couldn't generate for C glyphs in dungeons. It turns out this was essentially equivalent to the list already used in temple_god_list(), so this removes that duplication. This also fixes an issue where an altar to Ignis could generate on a few Zot dungeon levels which used random altars.

I did go through and test this to make sure "bad" altars can't generate, and it seems to behave as expected for "hangedman_orp_of_zott", which was likely the vault causing Ignis altars to rarely appear in Zot.