### PR TITLE
Prevent stabs when berserk

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1735,7 +1735,7 @@ int attack::player_stab(int damage)
 void attack::player_stab_check()
 {
     // XXX: move into find_stab_type?
-    if (you.duration[DUR_CLUMSY] || you.confused())
+    if (you.duration[DUR_CLUMSY] || you.confused() || you.berserk())
     {
         stab_attempt = false;
         stab_bonus = 0;


### PR DESCRIPTION
Berserk prevents most actions, it ought also prevent attacking in "just the right spot."