### PR TITLE
Fix: don't list walljump twice while silenced

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3943,7 +3943,11 @@ vector<ability_type> get_god_abilities(bool ignore_silence, bool ignore_piety,
     }
 
     if (!ignore_silence && silenced(you.pos()))
+    {
+        if (you_worship(GOD_WU_JIAN) && piety_rank() >= 2)
+            abilities.push_back(ABIL_WU_JIAN_WALLJUMP);
         return abilities;
+    }
 
     // Remaining abilities are unusable if silenced.
     if (you_worship(GOD_NEMELEX_XOBEH))

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -36,6 +36,7 @@
 #include "god-abil.h"
 #include "god-companions.h"
 #include "god-conduct.h"
+#include "god-passive.h"
 #include "hints.h"
 #include "invent.h"
 #include "item-prop.h"

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3944,7 +3944,7 @@ vector<ability_type> get_god_abilities(bool ignore_silence, bool ignore_piety,
 
     if (!ignore_silence && silenced(you.pos()))
     {
-        if (you_worship(GOD_WU_JIAN) && piety_rank() >= 2)
+        if (have_passive(passive_t::wu_jian_wall_jump))
             abilities.push_back(ABIL_WU_JIAN_WALLJUMP);
         return abilities;
     }

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3941,11 +3941,10 @@ vector<ability_type> get_god_abilities(bool ignore_silence, bool ignore_piety,
             abilities.push_back(static_cast<ability_type>(anc_type));
         }
     }
-    if (silenced(you.pos()) && you_worship(GOD_WU_JIAN) && piety_rank() >= 2)
-        abilities.push_back(ABIL_WU_JIAN_WALLJUMP);
 
     if (!ignore_silence && silenced(you.pos()))
         return abilities;
+
     // Remaining abilities are unusable if silenced.
     if (you_worship(GOD_NEMELEX_XOBEH))
     {


### PR DESCRIPTION
This specifically affected the "Abilities" section of the sidebar, but I'm not sure where else. It seems likely that this is legacy code from when walljump was more of a pseudo-ability, but since whether something can be used while silenced is determined by the failure basis (e.g., if it's an invocation), there's no need for this check to exist in get_god_abilities anymore.

Closes #2120.