### PR TITLE
Fixes two unrelated bugs concerning Phantom Mirror and the monster

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -3263,10 +3263,10 @@ monster* cast_phantom_mirror(monster* mons, monster* targ, int hp_perc, int summ
         return nullptr;
 
     // Unentangle the real monster.
-    if (mons->is_constricted())
-        mons->stop_being_constricted();
+    if (targ->is_constricted())
+        targ->stop_being_constricted();
 
-    mons_clear_trapping_net(mons);
+    mons_clear_trapping_net(targ);
 
     // Don't leak the real one with the targeting interface.
     if (you.prev_targ == mons->mindex())

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -308,6 +308,14 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
     // The monster copy constructor doesn't copy constriction, so no need to
     // worry about that.
 
+    // We do need to worry about the enchantments associated with direct constriction, though.
+
+    if (mons->has_ench(ENCH_VILE_CLUTCH))
+        mons->del_ench(ENCH_VILE_CLUTCH);
+
+    if (mons->has_ench(ENCH_GRASPING_ROOTS))
+        mons->del_ench(ENCH_GRASPING_ROOTS);
+
     // Don't copy death triggers - phantom royal jellies should not open the
     // Slime vaults on death.
     if (mons->props.exists(MONSTER_DIES_LUA_KEY))


### PR DESCRIPTION
version of Phantom mirror.

Bug 1 is simple: When a monster casts phantom mirror on another monster,
the casting monster is unentangled/unconstricted. This behaviour is unintended,
as clearly, the monster being copied should be freed instead.

Bug 2 is more subtle: When a monster is copied, its constriction status is
not copied (as intended). However, the enchantment applied by BVC to indicate
direct constriction IS copied. This results (in tiles) in a graphical bug, where
the monster has the BVC icon, but can move around and act as normal.