### PR TITLE
Record a few game milestones in morgue

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2084,6 +2084,8 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         {
             mpr("Your magical essence is drained by the effort!");
             rot_mp(1);
+            take_note(Note(NOTE_MESSAGE, 0, 0,
+                    "Lost one MP permanently [self-heal ability]"));
         }
         potionlike_effect(POT_HEAL_WOUNDS, 40);
         break;

--- a/crawl-ref/source/god-prayer.cc
+++ b/crawl-ref/source/god-prayer.cc
@@ -82,6 +82,8 @@ static bool _pray_ecumenical_altar()
             unwind_var<int> fakepoor(you.attribute[ATTR_GOLD_GENERATED], 0);
 
             god_type altar_god = _altar_identify_ecumenical_altar();
+            take_note(Note(NOTE_MESSAGE, 0, 0,
+                    "Prayed at the altar of an unknown god."));
             mprf(MSGCH_GOD, "%s accepts your prayer!",
                             god_name(altar_god).c_str());
             you.turn_is_over = true;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2818,6 +2818,8 @@ void level_change(bool skip_attribute_increase)
                                      "your demonic heritage exerts itself.");
                                 mark_milestone("monstrous", "discovered their "
                                                "monstrous ancestry!");
+                                take_note(Note(NOTE_MESSAGE, 0, 0,
+                                        "Discovered your monstrous ancestry."));
                             }
                             break;
                         }


### PR DESCRIPTION
These are three events that I've wished were recorded in the morgue file so that I later when reviewing the morgue I can accurately recall the details.

1. Record when praying at an ecumenical altar.  When the morgue only lists that the player became the worshiper of foo, this doesn't remind me whether I chose this god or got it randomly.
2. Record when a DD loses MP permanently.  I play DD poorly and will occasionally run out of MP from needing to heal too much.  I could do arithmetic to figure out how many MP I lost over the course of a game, but Crtl-F and letting it count for me is easier.
3. Record when a Ds is revealed as monstrous. This is mainly in-game, when I get a body slot before scales and I don't recall whether "I felt monstrous."  This is relevant for deciding whether to train UC and deciding whether to purchase aux armor pieces.

Overall, this is an instance of, "I wish Crawl did X" and then making the change myself!