### PR TITLE
fix: allow unrand air enhancer stacking

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1621,11 +1621,11 @@ int player_spec_air()
     // Staves
     sa += you.wearing(EQ_STAFF, STAFF_AIR);
 
-    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF)
-        || player_equip_unrand(UNRAND_AIR))
-    {
+    if (player_equip_unrand(UNRAND_ELEMENTAL_STAFF))
         sa++;
-    }
+
+    if (player_equip_unrand(UNRAND_AIR))
+        sa++;
 
     return sa;
 }


### PR DESCRIPTION
e08c5e17fd added an air enhancer to the amulet of the air, but unlike the
rest of the spell enhancers in the game, it didn't permit stacking this
with the elemental staff. This looks to me like an oversight rather than a
balance issue, (especially given that you could still stack the amulet with
a vanilla staff of air), so here's a fix.