### PR TITLE
Prevent players getting stuck in a vault's teleport closets

### DIFF
--- a/crawl-ref/source/dat/des/altar/nemelex_the_gamble.des
+++ b/crawl-ref/source/dat/des/altar/nemelex_the_gamble.des
@@ -78,7 +78,7 @@ end
 
 NAME:   grunt_nemelex_the_gamble
 TAGS:   temple_overflow_nemelex_xobeh temple_overflow_1 no_trap_gen
-TAGS:   no_monster_gen no_item_gen
+TAGS:   no_monster_gen no_item_gen no_tele_into
 WEIGHT: 2
 ITEM:   unobtainable any, unobtainable superb_item
 {{


### PR DESCRIPTION
Issue was reported here: https://github.com/crawl/crawl/issues/2126
The vault is grunt_nemelex_the_gamble
It's a relatively small vault that heavily relies on triggers and has two closets for players to potentially get stuck in.
My proposed solution is just to add "no_tele_into" as a Tag. This will prevent any problems with unexpected teleports/shafts/hatches.