### PR TITLE
Fix: redraw tiles when breath ability gained

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2793,7 +2793,9 @@ void level_change(bool skip_attribute_increase)
                     // when we redraw the screen
                     _gain_and_note_hp_mp();
                     updated_maxhp = true;
-
+#ifdef USE_TILE_LOCAL
+                    tiles.layout_statcol();
+#endif
                     redraw_screen();
                     update_screen();
                 }


### PR DESCRIPTION
Before, until `TilesFramework::update_tabs()` was called, the tiles abilities pane would not appear when receiving your first ability by way of draconian breath. This amends that by calling `layout_statcol when Draconian maturity is reached.