### PR TITLE
Add tile_number_ratio_pixels option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -109,7 +109,7 @@ The contents of this text are:
                 tile_map_pixels, tile_viewport_scale, tile_map_scale,
                 tile_cell_pixels, tile_filter_scaling, tile_force_overlay,
                 tile_overlay_col, tile_overlay_alpha_percent, tile_full_screen,
-                tile_single_column_menus, tile_font_crt_file,
+                tile_single_column_menus, tile_number_ratio_pixels, tile_font_crt_file,
                 tile_font_stat_file, tile_font_msg_file, tile_font_tip_file,
                 tile_font_lbl_file, tile_font_crt_family,
                 tile_font_stat_family, tile_font_msg_family,
@@ -2126,6 +2126,10 @@ tile_single_column_menus = true
         insufficient space to show all items in a single column. This option
         is only available on local tiles; all menus on console and on WebTiles
         always list items in a single column, as if this option were enabled.
+
+tile_number_ratio_pixels = 32
+        Font ratio for numbers which overlap icons (items quantity, spell level, etc.),
+        32 means no changes, lesser values will increase font size.
 
 tile_font_crt_file  = VeraMono.ttf
 tile_font_stat_file = VeraMono.ttf

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -395,6 +395,7 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(SIMPLE_NAME(tile_font_tip_file), MONOSPACED_FONT),
         new StringGameOption(SIMPLE_NAME(tile_font_lbl_file), PROPORTIONAL_FONT),
         new BoolGameOption(SIMPLE_NAME(tile_single_column_menus), true),
+        new IntGameOption(SIMPLE_NAME(tile_number_ratio_pixels), 32, 0, INT_MAX),
 #endif
 #ifdef USE_TILE_WEB
         new BoolGameOption(SIMPLE_NAME(tile_realtime_anim), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -543,6 +543,7 @@ public:
     string      tile_font_lbl_file;
     string      tile_font_tip_file;
     bool        tile_single_column_menus;
+    int         tile_number_ratio_pixels;
 #endif
 #ifdef USE_TILE_WEB
     string      tile_font_crt_family;

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -185,9 +185,9 @@ void DungeonCellBuffer::add_icons_tile(int tileidx, int x, int y)
 }
 
 void DungeonCellBuffer::add_icons_tile(int tileidx, int x, int y,
-                                       int ox, int oy)
+                                       int ox, int oy, int tile_ratio_px)
 {
-    m_buf_icons.add(tileidx, x, y, ox, oy, false);
+    m_buf_icons.add(tileidx, x, y, ox, oy, false, tile_ratio_px, tile_ratio_px, tile_ratio_px);
 }
 
 void DungeonCellBuffer::clear()

--- a/crawl-ref/source/tiledgnbuf.h
+++ b/crawl-ref/source/tiledgnbuf.h
@@ -30,7 +30,7 @@ public:
     void add_skill_tile(int tileidx, int x, int y);
     void add_command_tile(int tileidx, int x, int y);
     void add_icons_tile(int tileidx, int x, int y);
-    void add_icons_tile(int tileidx, int x, int y, int ox, int oy);
+    void add_icons_tile(int tileidx, int x, int y, int ox, int oy, int tile_ratio_px = 32);
 
     void clear();
     void draw();

--- a/crawl-ref/source/tilereg-grid.cc
+++ b/crawl-ref/source/tilereg-grid.cc
@@ -2,6 +2,7 @@
 
 #ifdef USE_TILE_LOCAL
 
+#include "options.h"
 #include "tilereg-grid.h"
 
 #include "format.h"
@@ -126,7 +127,7 @@ int GridRegion::add_quad_char(char c, int x, int y,
     ASSERT_RANGE(num, 0, 9 + 1);
     tileidx_t idx = TILEI_NUM0 + num;
 
-    m_buf.add_icons_tile(idx, x, y, ofs_x, ofs_y);
+    m_buf.add_icons_tile(idx, x, y, ofs_x, ofs_y, Options.tile_number_ratio_pixels);
     return tile_icons_info(idx).width;
 }
 


### PR DESCRIPTION
It's hard to read icon numbers for some people on retina displays,
so the option was added to customize font size for them.

tile_number_ratio_pixels = 28, for example:
<img width="374" alt="Screen Shot 2021-09-19 at 07 05 07" src="https://user-images.githubusercontent.com/11316827/133915060-9fcd0651-f17c-4fa8-8c7b-8b6379fda465.png">
.