### PR TITLE
Prompt user when trying to enter ziggurat portal.

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -514,6 +514,7 @@ bool prompt_dangerous_portal(dungeon_feature_type ftype)
     switch (ftype)
     {
     case DNGN_ENTER_PANDEMONIUM:
+    case DNGN_ENTER_ZIGGURAT:
     case DNGN_ENTER_ABYSS:
         return yesno("If you enter this portal you might not be able to return "
                      "immediately. Continue?", false, 'n');


### PR DESCRIPTION
Ziggurats are very dangerous. The portal you enter through is disabled when you enter.  They are also more dangerous than Pandemonium or the abyss, which already had a prompt to enter.

Thus, I believe it would be a good idea to prompt the user to prevent them from accidentally entering a ziggurat.