### PR TITLE
Add tile_grid_pixels option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -109,7 +109,7 @@ The contents of this text are:
                 tile_map_pixels, tile_viewport_scale, tile_map_scale,
                 tile_cell_pixels, tile_filter_scaling, tile_force_overlay,
                 tile_overlay_col, tile_overlay_alpha_percent, tile_full_screen,
-                tile_single_column_menus, tile_font_crt_file,
+                tile_single_column_menus, tile_grid_pixels, tile_font_crt_file,
                 tile_font_stat_file, tile_font_msg_file, tile_font_tip_file,
                 tile_font_lbl_file, tile_font_crt_family,
                 tile_font_stat_family, tile_font_msg_family,
@@ -2129,6 +2129,11 @@ tile_single_column_menus = true
         insufficient space to show all items in a single column. This option
         is only available on local tiles; all menus on console and on WebTiles
         always list items in a single column, as if this option were enabled.
+
+tile_grid_pixels = 32
+        The width and height of tiles in the status view, in
+        (logical) pixels.
+        
 
 tile_font_crt_file  = VeraMono.ttf
 tile_font_stat_file = VeraMono.ttf

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -395,6 +395,7 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(SIMPLE_NAME(tile_font_tip_file), MONOSPACED_FONT),
         new StringGameOption(SIMPLE_NAME(tile_font_lbl_file), PROPORTIONAL_FONT),
         new BoolGameOption(SIMPLE_NAME(tile_single_column_menus), true),
+        new IntGameOption(SIMPLE_NAME(tile_grid_pixels), 32, 1, INT_MAX),
 #endif
 #ifdef USE_TILE_WEB
         new BoolGameOption(SIMPLE_NAME(tile_realtime_anim), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -568,6 +568,7 @@ public:
     int         tile_window_ratio;
     maybe_bool  tile_use_small_layout;
 #endif
+    int         tile_grid_pixels;
     int         tile_cell_pixels;
     int         tile_viewport_scale;
     int         tile_map_scale;

--- a/crawl-ref/source/tilereg-tab.cc
+++ b/crawl-ref/source/tilereg-tab.cc
@@ -2,6 +2,7 @@
 
 #ifdef USE_TILE_LOCAL
 
+#include "options.h"
 #include "tilereg-tab.h"
 
 #include "command-type.h"
@@ -346,8 +347,9 @@ int TabbedRegion::get_mouseover_tab(wm_mouse_event &event) const
         // x = ... only works because we have offset all the way over to the right and
         //         it's just the margin (ox) that's visible
         x = ((sx+ox)-event.px)*32/dx;
-        y = y*32/dy;
     }
+
+    y = y*32/dy;
 
     if (x < 0 || x > ox || y < 0 || y > wy)
         return -1;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -360,7 +360,8 @@ bool TilesFramework::initialise()
         return false;
 
     const auto font = tiles.is_using_small_layout() ? m_crt_font : m_lbl_font;
-    m_init = TileRegionInit(m_image, font, TILE_X, TILE_Y);
+    m_init = TileRegionInit(m_image, font, Options.tile_grid_pixels,
+                            Options.tile_grid_pixels);
     m_region_tile = new DungeonRegion(m_init);
     m_region_tab  = new TabbedRegion(m_init);
     m_region_inv  = new InventoryRegion(m_init);


### PR DESCRIPTION
The option allows to resize inventory and spells icons.
It works in the same way as tile_cell_pixels for the dungeon tiles

Screenshot was made with the next options:
tile_cell_pixels = 40
tile_grid_pixels = 40
<img width="355" alt="Screen Shot 2021-09-20 at 02 58 46" src="https://user-images.githubusercontent.com/11316827/133947435-413fb5ee-dc43-42ea-9920-eaacd2c0b8cd.png">
.