### PR TITLE
Check to make sure that the user wants to put on an amulet of faith.

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1662,6 +1662,13 @@ bool needs_handle_warning(const item_def &item, operation_types oper,
     {
         return true;
     }
+    
+    if (oper == OPER_PUTON
+        && item.is_type(OBJ_JEWELLERY, AMU_FAITH)
+        && faith_has_penalty())
+    {
+        return true;
+    }
 
     if (needs_notele_warning(item, oper))
         return true;


### PR DESCRIPTION
Trying to remove an amulet of faith (while worshipping a deity that cares about it) would trigger a confirmation to confirm your choice.
But there wasn't any confirmation like that for when you tried to put it on.

So I added a bit of code to a function so the game would ask the player if they were sure they wanted to wear an amulet of faith.