### PR TITLE
Adjusting the power cost of Fedhas

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -507,13 +507,13 @@ static vector<ability_def> &_get_ability_list()
 
         // Fedhas
         { ABIL_FEDHAS_WALL_OF_BRIARS, "Wall of Briars",
-            3, 0, 2, {fail_basis::invo, 30, 6, 20}, abflag::none},
+            4, 0, 1, {fail_basis::invo, 30, 6, 20}, abflag::none},
         { ABIL_FEDHAS_GROW_BALLISTOMYCETE, "Grow Ballistomycete",
-            4, 0, 4, {fail_basis::invo, 60, 4, 25}, abflag::none },
+            6, 0, 3, {fail_basis::invo, 60, 4, 25}, abflag::none },
         { ABIL_FEDHAS_OVERGROW, "Overgrow",
-            8, 0, 12, {fail_basis::invo, 70, 5, 20}, abflag::none},
+            12, 0, 10, {fail_basis::invo, 70, 5, 20}, abflag::none},
         { ABIL_FEDHAS_GROW_OKLOB, "Grow Oklob",
-            6, 0, 6, {fail_basis::invo, 80, 4, 25}, abflag::none },
+            8, 0, 4, {fail_basis::invo, 80, 4, 25}, abflag::none },
 
         // Cheibriados
         { ABIL_CHEIBRIADOS_TIME_BEND, "Bend Time",


### PR DESCRIPTION
Fedhas' plants are very powerful and the piety cost of them seems reasonable. However, in actual battles, due to restrictions on plants being unable to move, players had to summon plants again or bring their enemies to the place where they were. Also, Fedhas didn't give the player useful passive even if there were no plants, so the player had to  pay a lot of fee for every battle to get God's help.

So I'm going to lower the cost of the piety a little bit. However, the abuse of power is also not desired, so MP costs are increased in return. Instead of being able to summon plants more often, players will now have difficulty using power several times in a single battle(Lack of MP).