### PR TITLE
Remove archer monsters hidden bonus damage

### DIFF
--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -349,11 +349,6 @@ int ranged_attack::calc_mon_to_hit_base()
 int ranged_attack::apply_damage_modifiers(int damage)
 {
     ASSERT(attacker->is_monster());
-    if (attacker->as_monster()->is_archer())
-    {
-        const int bonus = attacker->get_hit_dice() * 4 / 3;
-        damage += random2avg(bonus, 2);
-    }
     return damage;
 }
 


### PR DESCRIPTION
This commit removes the HD * 4/3 bonus damage from monsters with the archer tag. This bonus, besides being hidden, lacks an analogous bonus in melee monsters (those with the fighter tag). The end result of this is rather unintuitive from the player's perspective, since when the player uses ranged weapons, they usually hit for a little bit less than their melee counterparts, and this is dramatically different from monsters (a merfolk javelineer, for example, hits for a little bit more than an impaler with a +9 demon trident).

Monsters more heavily impacted by this were buffed recently with the change to attack speed.