### PR TITLE
Simplify mon_to_hit_base, remove pointless distinction

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4075,7 +4075,7 @@ static void _describe_mons_to_hit(const monster_info& mi, ostringstream &result)
     const item_def* weapon = mi.inv[MSLOT_WEAPON].get();
     const bool melee = weapon == nullptr || !is_range_weapon(*weapon);
     const bool skilled = mons_class_flag(mi.type, melee ? M_FIGHTER : M_ARCHER);
-    const int base_to_hit = mon_to_hit_base(mi.hd, skilled, !melee);
+    const int base_to_hit = mon_to_hit_base(mi.hd, skilled);
     const int weapon_to_hit = weapon ? weapon->plus + property(*weapon, PWPN_HIT) : 0;
     const int total_base_hit = base_to_hit + weapon_to_hit;
 

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -105,19 +105,13 @@ int to_hit_pct(const monster_info& mi, attack &atk, bool melee)
  * Return the base to-hit bonus that a monster with the given HD gets.
  * @param hd               The hit dice (level) of the monster.
  * @param skilled    Does the monster have bonus to-hit from the fighter or archer flag?
- * @param ranged      Is this attack ranged or melee?
  *
  * @return         A base to-hit value, before equipment, statuses, etc.
  */
-int mon_to_hit_base(int hd, bool skilled, bool ranged)
+int mon_to_hit_base(int hd, bool skilled)
 {
-    if (ranged)
-    {
-        const int hd_mult = skilled ? 15 : 9;
-        return 18 + hd * hd_mult / 6;
-    }
-    const int hd_mult = skilled ? 25 : 15;
-    return 18 + hd * hd_mult / 10;
+    const int hd_mult = skilled ? 5 : 3;
+        return 18 + hd * hd_mult / 2;
 }
 
 int mon_shield_bypass(int hd)

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -58,7 +58,7 @@ void attack_cleave_targets(actor &attacker, list<actor*> &targets,
 
 class attack;
 int to_hit_pct(const monster_info& mi, attack &atk, bool melee);
-int mon_to_hit_base(int hd, bool skilled, bool ranged);
+int mon_to_hit_base(int hd, bool skilled);
 int mon_to_hit_pct(int to_land, int ev);
 int mon_shield_bypass(int hd);
 int mon_beat_sh_pct(int shield_bypass, int shield_class);

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3496,7 +3496,7 @@ int melee_attack::calc_mon_to_hit_base()
 {
     const bool fighter = attacker->is_monster()
                          && attacker->as_monster()->is_fighter();
-    return mon_to_hit_base(attacker->get_hit_dice(), fighter, false);
+    return mon_to_hit_base(attacker->get_hit_dice(), fighter);
 }
 
 /**

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -343,7 +343,7 @@ int ranged_attack::calc_base_unarmed_damage()
 int ranged_attack::calc_mon_to_hit_base()
 {
     ASSERT(attacker->is_monster());
-    return mon_to_hit_base(attacker->get_hit_dice(), attacker->as_monster()->is_archer(), true);
+    return mon_to_hit_base(attacker->get_hit_dice(), attacker->as_monster()->is_archer());
 }
 
 int ranged_attack::apply_damage_modifiers(int damage)


### PR DESCRIPTION
mon_to_hit_base asked if the attack was ranged or not. but this was pointless, since it always returned 18 + 2.5 * HD for skilled monsters or, 18 * 1.5 * HD for unskilled ones.

Removed this distinction, and simplified the magic numbers.