### PR TITLE
Improve archer description

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3920,11 +3920,6 @@ static string _monster_attacks_description(const monster_info& mi)
         }
 
         int dam = attack.damage;
-        if (mons_class_flag(mi.type, M_ARCHER)
-            && info.weapon && is_range_weapon(*info.weapon))
-        {
-            dam += archer_bonus_damage(mi.hd);
-        }
 
         // Damage is listed in parentheses for attacks with a flavour
         // description, but not for plain attacks.
@@ -3955,6 +3950,12 @@ static string _monster_attacks_description(const monster_info& mi)
                                                   "; and ", "; ");
         _describe_mons_to_hit(mi, result);
         result << ".\n";
+    }
+
+    if (mons_class_flag(mi.type, M_ARCHER))
+    {
+        result << make_stringf("It can deal up to %d extra damage when attacking with ranged weaponry.\n",
+                                archer_bonus_damage(mi.hd));
     }
 
     if (mi.type == MONS_ROYAL_JELLY)


### PR DESCRIPTION
Improved the description given for for monsters bonus damage given in  619f226d55, the goal is to make it easier fot the player to understand what damage will be gone if they get the monster to stop attacking with ranged weaponry.