### PR TITLE
feat: allow checking if there is enough space for Malign Gateway

### DIFF
--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1152,13 +1152,16 @@ void create_malign_gateway(coord_def point, beh_type beh, string cause,
                      "and a portal to some otherworldly place is opened!");
 }
 
-spret cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
+spret cast_malign_gateway(actor * caster, int pow, god_type god,
+                          bool fail, bool test)
 {
     if (caster->is_player() && rude_stop_summoning_prompt())
         return spret::abort;
 
     coord_def point = find_gateway_location(caster);
     bool success = point != coord_def(0, 0);
+    if (test)
+        return success ? spret::success : spret::abort;
 
     bool is_player = caster->is_player();
 
@@ -1179,10 +1182,6 @@ spret cast_malign_gateway(actor * caster, int pow, god_type god, bool fail)
 
         return spret::success;
     }
-
-    // We don't care if monsters fail to cast it.
-    if (is_player)
-        mpr("A gateway cannot be opened in this cramped space!");
 
     return spret::abort;
 }

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -56,7 +56,8 @@ void create_malign_gateway(coord_def point, beh_type beh, string cause,
                            int pow, god_type god = GOD_NO_GOD,
                            bool is_player = false);
 spret cast_malign_gateway(actor* caster, int pow,
-                               god_type god = GOD_NO_GOD, bool fail = false);
+                          god_type god = GOD_NO_GOD, bool fail = false,
+                          bool test = false);
 coord_def find_gateway_location(actor* caster);
 spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail, bool test=false);
 spret cast_summon_guardian_golem(int pow, god_type god, bool fail);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1383,6 +1383,11 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
             return "the dungeon can only cope with one malign gateway"
                     " at a time.";
         }
+        if (temp && cast_malign_gateway(&you, 0, GOD_NO_GOD, false, true)
+                    == spret::abort)
+        {
+            return "you need more open space to create a gateway.";
+        }
         break;
 
     case SPELL_SUMMON_FOREST:


### PR DESCRIPTION
This commit disables the spell in the quiver and z/Z menu when there
is not enough space to open a gateway.