### PR TITLE
Add spell menu option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -53,15 +53,15 @@ The contents of this text are:
 3-g     Command Enhancements.
                 auto_switch, easy_unequip, equip_unequip, jewellery_prompt,
                 easy_confirm, simple_targeting, allow_self_target,
-                easy_quit_item_prompts, ability_menu, easy_floor_use,
-                sort_menus, spell_slot, item_slot, ability_slot,
-                autofight_stop, autofight_warning, autofight_throw,
-                autofight_throw_nomove, autofight_fire_stop, autofight_caught,
-                autofight_wait, autofight_prompt_range, automagic_enable,
-                automagic_slot, automagic_fight, automagic_stop,
-                fail_severity_to_confirm, easy_door, warn_hatches,
-                enable_recast_spell, confirm_action, regex_search,
-                autopickup_search, bad_item_prompt
+                easy_quit_item_prompts, ability_menu, spell_menu,
+                easy_floor_use, sort_menus, spell_slot, item_slot,
+                ability_slot, autofight_stop, autofight_warning,
+                autofight_throw, autofight_throw_nomove, autofight_fire_stop,
+                autofight_caught, autofight_wait, autofight_prompt_range,
+                automagic_enable, automagic_slot, automagic_fight,
+                automagic_stop, fail_severity_to_confirm, easy_door,
+                warn_hatches, enable_recast_spell, confirm_action,
+                regex_search, autopickup_search, bad_item_prompt
 3-h     Message and Display Improvements.
                 hp_warning, mp_warning, hp_colour, mp_colour, stat_colour,
                 status_caption_colour, enemy_hp_colour, clear_messages,
@@ -1063,6 +1063,13 @@ easy_quit_item_prompts = true
 ability_menu = true
         Always show the full-screen 'a'bility menu. If false, 'a' prompts
         in the message area, and the menu can be seen with '?' or '*'.
+
+        Setting this option to false has no effect in Android tiles builds.
+
+spell_menu = false
+        If set to true, the full-screen spell selection menu will always be
+        shown when using 'z'. If false, 'z' prompts in the message area, and
+        the menu can be seen with '?' or '*'.
 
         Setting this option to false has no effect in Android tiles builds.
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -212,6 +212,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(show_player_species), false),
         new BoolGameOption(SIMPLE_NAME(use_modifier_prefix_keys), true),
         new BoolGameOption(SIMPLE_NAME(ability_menu), true),
+        new BoolGameOption(SIMPLE_NAME(spell_menu), false),
         new BoolGameOption(SIMPLE_NAME(easy_floor_use), true),
         new BoolGameOption(SIMPLE_NAME(bad_item_prompt), true),
         new BoolGameOption(SIMPLE_NAME(dos_use_background_intensity), true),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -420,6 +420,7 @@ public:
     int         pickup_menu_limit;  // Over this number of items, menu for
                                     // pickup
     bool        ability_menu;       // 'a'bility starts with a full-screen menu
+    bool        spell_menu;         // 'z' starts with a full-screen menu
     bool        easy_floor_use;     // , selects the floor item if there's 1
     bool        bad_item_prompt;    // Confirm before using a bad consumable
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -784,7 +784,7 @@ bool cast_a_spell(bool check_range, spell_type spell, dist *_target)
 
             keyin = 0;
 #else
-            if (keyin == 0)
+            if (keyin == 0 && !Options.spell_menu)
             {
                 if (you.spell_no == 1)
                 {
@@ -828,7 +828,7 @@ bool cast_a_spell(bool check_range, spell_type spell, dist *_target)
                 keyin = get_ch();
             }
 
-            if (keyin == '?' || keyin == '*')
+            if (keyin == '?' || keyin == '*' || Options.spell_menu)
             {
                 keyin = list_spells(true, false);
                 if (!keyin)


### PR DESCRIPTION
Add the option to show full-screen spell selection menu when using 'z', as it's done for abilities.
The spell menu option is set to false, by default.
Resolves #2113.