### PR TITLE
Solve lost soul crash

### DIFF
--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -766,7 +766,8 @@ bool lost_soul_revive(monster& mons, killer_type killer)
             }
         }
 
-        monster_die(**mi, KILL_MISC, -1, true);
+        if (mi->alive())
+            monster_die(**mi, KILL_MISC, -1, true);
 
         return true;
     }


### PR DESCRIPTION
A lost soul may revive a mage who summoned it. It dies while the mage is dying, as one of this mage's enchantments. It shouldn't die again, at the end of the revival.
Resolves #1695.