### PR TITLE
fix: disable miscast-created allies when allies are forbidden

### DIFF
--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -634,6 +634,14 @@ void miscast_effect(actor& target, actor* source, miscast_source_info mc_info,
     if (school == spschool::random)
         school = spschools_type::exponent(random2(SPSCHOOL_LAST_EXPONENT + 1));
 
+    // Don't summon friendly nameless horrors if they would always turn hostile.
+    if (source && source->is_player()
+        && school == spschool::summoning
+        && you.allies_forbidden())
+    {
+        return;
+    }
+
     miscast_datum effect =  miscast_effects.find(school)->second;
 
     int dam = div_rand_round(roll_dice(level, fail + level), MISCAST_DIVISOR);


### PR DESCRIPTION
As a followup to cf4520f7, this commit blocks nameless horrors from
Spellbinder under Okawaru or Sac Love.