### PR TITLE
Add forest attitude

### DIFF
--- a/crawl-ref/source/attitude-change.cc
+++ b/crawl-ref/source/attitude-change.cc
@@ -62,6 +62,9 @@ void mons_att_changed(monster* mon)
         remove_companion(mon);
     }
 
+    if (mon->has_ench(ENCH_AWAKEN_FOREST))
+        mon->del_ench(ENCH_AWAKEN_FOREST);
+
     mon->remove_summons(true);
 }
 

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3215,8 +3215,11 @@ string feature_description_at(const coord_def& where, bool covering,
 
     if (covering && you.see_cell(where))
     {
-        if (feat_is_tree(grid) && env.forest_awoken_until)
+        if (feat_is_tree(grid) && env.forest_awoken_until){
             covering_description += ", awoken";
+            covering_description += env.forest_is_hostile ? " (hostile)" :
+                                                            " (friendly)";
+        }
 
         if (is_icecovered(where))
             covering_description = ", covered with ice";

--- a/crawl-ref/source/env.h
+++ b/crawl-ref/source/env.h
@@ -95,6 +95,7 @@ struct crawl_environment
     coord_def orb_pos;
     int sanctuary_time;
     int forest_awoken_until;
+    bool forest_is_hostile;
     int density;
     int absdepth0;
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -6184,6 +6184,8 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
         // Actually, it's a boolean marker... save for a sanity check.
         env.forest_awoken_until = you.elapsed_time + duration;
 
+        env.forest_is_hostile = !mons->friendly();
+
         // You may be unable to see the monster, but notice an affected tree.
         forest_message(mons->pos(), "The forest starts to sway and rumble!");
         return;


### PR DESCRIPTION
Set awoken forest's attitude, to inform the player whether it's friendly or hostile. Resolves #2015.