### PR TITLE
Forbid time unfreeze during exploration

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1111,13 +1111,22 @@ static void _input()
         end_wait_spells();
         handle_delay();
 
+        // Some delays set you.turn_is_over.
+
+#ifdef WIZARD
+        if (you.props.exists(FREEZE_TIME_KEY))
+            you.turn_is_over = false;
+#endif
+
         // Some delays reset you.time_taken.
         if (you.time_taken || you.turn_is_over)
         {
             if (you.berserk())
                 _do_berserk_no_combat_penalty();
             _uncurl();
-            world_reacts();
+
+            if (you.turn_is_over)
+                world_reacts();
         }
 
         if (!you_are_delayed())

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -60,6 +60,7 @@
 #include "unicode.h"
 #include "unwind.h"
 #include "view.h"
+#include "wiz-you.h"
 
 enum IntertravelDestination
 {
@@ -1031,6 +1032,8 @@ static command_type _get_non_move_command()
 // Don't call travel() if you.running >= 0.
 command_type travel()
 {
+    mprf("travel");
+
     int holdx, holdy;
     int *move_x = &holdx;
     int *move_y = &holdy;
@@ -1064,8 +1067,21 @@ command_type travel()
 
     if (you.running.is_explore())
     {
-        if (Options.explore_auto_rest && !you.is_sufficiently_rested())
+        mprf("you.running.is_explore()");
+
+        bool time_is_frozen = false;
+
+#ifdef WIZARD
+        if (you.props.exists(FREEZE_TIME_KEY))
+            time_is_frozen = true;
+#endif
+
+        if (Options.explore_auto_rest
+            && !you.is_sufficiently_rested()
+            && !time_is_frozen){
+            mprf("rest");
             return CMD_WAIT;
+        }
 
         // Exploring.
         if (env.grid(you.pos()) == DNGN_ENTER_SHOP

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1032,8 +1032,6 @@ static command_type _get_non_move_command()
 // Don't call travel() if you.running >= 0.
 command_type travel()
 {
-    mprf("travel");
-
     int holdx, holdy;
     int *move_x = &holdx;
     int *move_y = &holdy;
@@ -1067,8 +1065,6 @@ command_type travel()
 
     if (you.running.is_explore())
     {
-        mprf("you.running.is_explore()");
-
         bool time_is_frozen = false;
 
 #ifdef WIZARD
@@ -1078,10 +1074,8 @@ command_type travel()
 
         if (Options.explore_auto_rest
             && !you.is_sufficiently_rested()
-            && !time_is_frozen){
-            mprf("rest");
+            && !time_is_frozen)
             return CMD_WAIT;
-        }
 
         // Exploring.
         if (env.grid(you.pos()) == DNGN_ENTER_SHOP


### PR DESCRIPTION
The world shouldn't react when the time is frozen. Resolves #2205.