### PR TITLE
Remove dpeg_arrival_tiny_a

### DIFF
--- a/crawl-ref/source/dat/des/arrival/simple.des
+++ b/crawl-ref/source/dat/des/arrival/simple.des
@@ -383,13 +383,6 @@ x......x.....x.
 ENDMAP
 
 ##############################################################################
-NAME:   dpeg_arrival_tiny_a
-TAGS:   arrival transparent
-ORIENT: float
-MAP
-{
-ENDMAP
-
 NAME:   dpeg_arrival_tiny_b
 TAGS:   arrival transparent
 WEIGHT: 2


### PR DESCRIPTION
As the guideline for creating arrival vaults,  they should have multiple entry points, escape hatches, or enough space to permit tactics. dpeg_arrival_tiny_a doesn't have any of those and sometimes makes one-way corridor, which can be a certain death trap.

![image](https://user-images.githubusercontent.com/65288602/138826014-06f980a4-41cd-467f-a0ef-af375223bd0d.png)

![image](https://user-images.githubusercontent.com/65288602/138826157-4dddacd3-7957-4b49-a3f3-03c88c36dfae.png)
(from !log vepmir ghmo won)