### PR TITLE
Increase the piety cost of Rising Flame

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -647,7 +647,7 @@ static vector<ability_def> &_get_ability_list()
         { ABIL_IGNIS_FOXFIRE, "Foxfire Swarm",
             0, 0, 9, {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_RISING_FLAME, "Rising Flame",
-            0, 0, 96, {fail_basis::invo}, abflag::none },
+            0, 0, 0, {fail_basis::invo}, abflag::none },
 
         { ABIL_STOP_RECALL, "Stop Recall", 0, 0, 0, {fail_basis::invo}, abflag::none },
         { ABIL_RENOUNCE_RELIGION, "Renounce Religion",
@@ -1392,6 +1392,7 @@ static bool _can_blinkbolt(bool quiet)
 
 static bool _can_rising_flame(bool quiet)
 {
+    ASSERT(can_do_capstone_ability(GOD_IGNIS));
     if (you.duration[DUR_RISING_FLAME])
     {
         if (!quiet)
@@ -3267,6 +3268,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target)
         mpr("You begin to rise into the air.");
         // slightly faster than teleport
         you.set_duration(DUR_RISING_FLAME, 2 + random2(3));
+        you.one_time_ability_used.set(GOD_IGNIS);
         return spret::success;
 
     case ABIL_RENOUNCE_RELIGION:

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -642,10 +642,10 @@ static vector<ability_def> &_get_ability_list()
 
         // Ignis
         { ABIL_IGNIS_SEA_OF_FIRE, "Sea of Fire",
-            0, 0, 6, /*avg 15 uses from 150 to <30 piety*/
+            0, 0, 12, /*avg 15 uses from 150 to <30 piety*/
             {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_FOXFIRE, "Foxfire Swarm",
-            0, 0, 9, {fail_basis::invo}, abflag::quiet_fail },
+            0, 0, 18, {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_RISING_FLAME, "Rising Flame",
             0, 0, 0, {fail_basis::invo}, abflag::none },
 

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -642,10 +642,10 @@ static vector<ability_def> &_get_ability_list()
 
         // Ignis
         { ABIL_IGNIS_SEA_OF_FIRE, "Sea of Fire",
-            0, 0, 12, /*avg 15 uses from 150 to <30 piety*/
+            0, 0, 8, /*avg 12 uses from 150 to <30 piety*/
             {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_FOXFIRE, "Foxfire Swarm",
-            0, 0, 18, {fail_basis::invo}, abflag::quiet_fail },
+            0, 0, 12, {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_RISING_FLAME, "Rising Flame",
             0, 0, 0, {fail_basis::invo}, abflag::none },
 

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -647,7 +647,7 @@ static vector<ability_def> &_get_ability_list()
         { ABIL_IGNIS_FOXFIRE, "Foxfire Swarm",
             0, 0, 9, {fail_basis::invo}, abflag::quiet_fail },
         { ABIL_IGNIS_RISING_FLAME, "Rising Flame",
-            0, 0, 24, {fail_basis::invo}, abflag::none },
+            0, 0, 96, {fail_basis::invo}, abflag::none },
 
         { ABIL_STOP_RECALL, "Stop Recall", 0, 0, 0, {fail_basis::invo}, abflag::none },
         { ABIL_RENOUNCE_RELIGION, "Renounce Religion",

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -830,7 +830,8 @@ out, burst into raging flames.
 Rising Flame ability
 
 Sends you floating upward and, after a short delay for Ignis to gather enough
-power, blasts you through the ceiling and into the level above.
+power, blasts you through the ceiling and into the level above. This ability 
+may only be used once.
 %%%%
 Hop ability
 

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -830,7 +830,7 @@ out, burst into raging flames.
 Rising Flame ability
 
 Sends you floating upward and, after a short delay for Ignis to gather enough
-power, blasts you through the ceiling and into the level above. This ability 
+power, blasts you through the ceiling and into the level above. This ability
 may only be used once.
 %%%%
 Hop ability

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -105,7 +105,9 @@ static bool _player_sacrificed_arcana();
  */
 bool can_do_capstone_ability(god_type god)
 {
-   return in_good_standing(god, 5) && !you.one_time_ability_used[god];
+    // Worshippers of Ignis can use their capstone with any amount of piety
+    int pbreak = (god == GOD_IGNIS) ? -1 : 5;
+    return in_good_standing(god, pbreak) && !you.one_time_ability_used[god];
 }
 
 static const char *_god_blessing_description(god_type god)

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -398,7 +398,7 @@ const vector<god_power> god_powers[NUM_GODS] =
     {
         { 1, ABIL_IGNIS_SEA_OF_FIRE, "fill your surroundings with clouds of flame" },
         { 1, ABIL_IGNIS_FOXFIRE, "call a swarm of foxfires against your foes" },
-        { 2, ABIL_IGNIS_RISING_FLAME, "rocket upward and away" },
+        { 7, ABIL_IGNIS_RISING_FLAME, "rocket upward and away" },
     },
 };
 


### PR DESCRIPTION
Cinder Acolyte has proven to be an incredibly strong start. In
particular, the Rising Flame power changes the game in ways that
make the entire early and mid-game into a foregone conclusion for
any experienced reasonably-high-win-rate player. While strong
starts such as Berserker already exist, these are all still
susceptible to losing if one makes the various mistakes that
players make in an average game of Crawl. Rising Flame, however,
removes all consequences for mistakes.

At starting Ignis Piety, the player gets four uses of Rising
Flame. When they activate it, they are shafted upwards after a
delay of 2+random2(3) turns (an entire turn faster than a
teleport scroll!). This ability is probably the most powerful
escape ability in the entire game and is simply too strong to be
available from the start of the game in such a large quantity. A
"get out of jail free card" for a player's worst mistakes is a
cool idea, but it should only be available one time, similar to
Tso or Kiku's capstone abilities.

As such, this PR increases the piety cost of Rising Flame by four
times.