### PR TITLE
Fix: remove sleepwalking, refactor duplicate methods

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -336,7 +336,6 @@ public:
     virtual int  dragon_level() const;
 
     virtual bool paralysed() const = 0;
-    virtual bool cannot_move() const = 0;
     virtual bool cannot_act() const = 0;
     virtual bool confused() const = 0;
     virtual bool caught() const = 0;
@@ -373,8 +372,7 @@ public:
 
     virtual bool incapacitated() const
     {
-        return cannot_move()
-            || asleep()
+        return cannot_act()
             || confused()
             || caught();
     }

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -1843,7 +1843,7 @@ static bool _curare_hits_monster(actor *agent, monster* mons, int levels)
 
     if (mons->alive())
     {
-        if (!mons->cannot_move())
+        if (!mons->cannot_act())
         {
             simple_monster_message(*mons, mons->has_ench(ENCH_SLOW)
                                          ? " seems to be slow for longer."

--- a/crawl-ref/source/behold.cc
+++ b/crawl-ref/source/behold.cc
@@ -258,7 +258,7 @@ bool player::possible_beholder(const monster* mon) const
             && !silenced(pos())
             && !mon->is_silenced()
             && !mon->confused()
-            && !mon->asleep() && !mon->cannot_move()
+            && !mon->asleep() && !mon->cannot_act()
             && !mon->berserk_or_insane()
             && !mons_is_fleeing(*mon)
             && !is_sanctuary(pos())

--- a/crawl-ref/source/fearmonger.cc
+++ b/crawl-ref/source/fearmonger.cc
@@ -174,7 +174,7 @@ bool player::_possible_fearmonger(const monster* mon) const
         && !silenced(pos()) && !silenced(mon->pos())
         && see_cell(mon->pos()) && mon->see_cell(pos())
         && !mon->submerged() && !mon->confused()
-        && !mon->asleep() && !mon->cannot_move()
+        && !mon->asleep() && !mon->cannot_act()
         && !mon->wont_attack() && !mon->pacified()
         && !mon->berserk_or_insane()
         && !mons_is_fleeing(*mon)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -2039,7 +2039,7 @@ static int _slouch_damage(monster *mon)
 static bool _slouchable(coord_def where)
 {
     monster* mon = monster_at(where);
-    if (mon == nullptr || mon->is_stationary() || mon->cannot_move()
+    if (mon == nullptr || mon->is_stationary() || mon->cannot_act()
         || mons_is_projectile(mon->type)
         || mon->asleep() && !mons_is_confused(*mon))
     {

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3262,7 +3262,7 @@ bool melee_attack::do_knockback(bool trample)
     if (defender->is_stationary())
         return false; // don't even print a message
 
-    if (attacker->cannot_move())
+    if (attacker->cannot_act())
         return false;
 
     const int size_diff =

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1949,7 +1949,7 @@ void handle_monster_move(monster* mons)
             return;
         }
 
-        if (mons->cannot_move() || !_monster_move(mons))
+        if (mons->cannot_act() || !_monster_move(mons))
             mons->speed_increment -= non_move_energy;
     }
     you.update_beholder(mons);
@@ -2690,10 +2690,10 @@ static bool _mons_can_displace(const monster* mpusher,
     // elbow past them, and the wake-up check happens downstream.
     // Monsters caught in a net also can't be pushed past.
     if (mons_is_confused(*mpusher) || mons_is_confused(*mpushee)
-        || mpusher->cannot_move() || mpusher->is_stationary()
+        || mpusher->cannot_act() || mpusher->is_stationary()
         || mpusher->is_constricted() || mpushee->is_constricted()
         || (!_same_tentacle_parts(mpusher, mpushee)
-           && (mpushee->cannot_move() || mpushee->is_stationary()))
+           && (mpushee->cannot_act() || mpushee->is_stationary()))
         || mpusher->asleep() || mpushee->caught())
     {
         return false;

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -2022,7 +2022,7 @@ static bool _battle_cry(const monster& chief, bool check_only = false)
         // no buffing confused/paralysed mons
         if (mons->berserk_or_insane()
             || mons->confused()
-            || mons->cannot_move())
+            || mons->cannot_act())
         {
             continue;
         }

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1376,7 +1376,7 @@ static void _fire_kill_conducts(monster &mons, killer_type killer,
         did_kill_conduct(DID_KILL_PLANT, mons);
 
     // Cheibriados hates fast monsters.
-    if (cheibriados_thinks_mons_is_fast(mons) && !mons.cannot_move())
+    if (cheibriados_thinks_mons_is_fast(mons) && !mons.cannot_act())
         did_kill_conduct(DID_KILL_FAST, mons);
 }
 

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -377,6 +377,7 @@ struct monster_info : public monster_info_base
 
     // These should be kept in sync with the actor equivalents
     // (Maybe unify somehow?)
+    // Note: actor version is now actor::cannot_act.
     bool cannot_move() const;
     bool airborne() const;
     bool ground_level() const;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3011,11 +3011,6 @@ bool monster::cannot_act() const
     return paralysed() || petrified();
 }
 
-bool monster::cannot_move() const
-{
-    return cannot_act();
-}
-
 bool monster::asleep() const
 {
     return behaviour == BEH_SLEEP;

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -422,7 +422,6 @@ public:
     bool is_skeletal() const override;
     bool is_spiny() const;
     bool paralysed() const override;
-    bool cannot_move() const override;
     bool cannot_act() const override;
     bool confused() const override;
     bool confused_by_you() const;

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -915,8 +915,8 @@ static void _print_stats_ev(int x, int y)
 {
     CGOTOXY(x+4, y, GOTO_STAT);
     textcolour(you.duration[DUR_PETRIFYING]
-               || you.cannot_move() ? RED
-                                    : _boosted_ev() ? LIGHTBLUE
+               || you.cannot_act() ? RED
+                                   : _boosted_ev() ? LIGHTBLUE
                                                     : HUD_VALUE_COLOUR);
     CPRINTF("%2d ", you.evasion());
 

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -777,9 +777,8 @@ static void _decrement_durations()
     dec_elixir_player(delay);
     dec_frozen_ramparts(delay);
 
-    if (!you.cannot_move()
-        && !you.confused()
-        && !you.asleep())
+    if (!you.cannot_act()
+        && !you.confused())
     {
         extract_manticore_spikes(
             make_stringf("You %s the barbed spikes from your body.",

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -400,7 +400,7 @@ bool swap_check(monster* mons, coord_def &loc, bool quiet)
         return false;
     }
 
-    if (mons->is_stationary() || mons->asleep() || mons->cannot_move())
+    if (mons->is_stationary() || mons->asleep() || mons->cannot_act())
     {
         if (!quiet)
             simple_monster_message(*mons, " cannot move out of your way!");
@@ -2041,7 +2041,7 @@ static int _player_evasion(ev_ignore_type evit)
 {
     const int size_factor = _player_evasion_size_factor();
     // Size is all that matters when paralysed or at 0 dex.
-    if ((you.cannot_move() || you.duration[DUR_CLUMSY]
+    if ((you.cannot_act() || you.duration[DUR_CLUMSY]
             || you.form == transformation::tree)
         && !(evit & ev_ignore::helpless))
     {
@@ -5251,7 +5251,7 @@ bool player::cannot_speak() const
     if (silenced(pos()))
         return true;
 
-    if (cannot_move()) // we allow talking during sleep ;)
+    if (paralysed() || petrified()) // we allow talking during sleep ;)
         return true;
 
     // No transform that prevents the player from speaking yet.
@@ -5376,7 +5376,7 @@ bool player::paralysed() const
     return duration[DUR_PARALYSIS];
 }
 
-bool player::cannot_move() const
+bool player::cannot_act() const
 {
     return asleep() || paralysed() || petrified();
 }
@@ -7128,12 +7128,6 @@ bool player::asleep() const
 {
     return duration[DUR_SLEEP];
 }
-
-bool player::cannot_act() const
-{
-    return asleep() || cannot_move();
-}
-
 
 bool player::can_feel_fear(bool include_unknown) const
 {

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5378,7 +5378,7 @@ bool player::paralysed() const
 
 bool player::cannot_move() const
 {
-    return paralysed() || petrified();
+    return asleep() || paralysed() || petrified();
 }
 
 bool player::confused() const

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -792,7 +792,6 @@ public:
     bool is_dragonkind() const override;
 
     bool paralysed() const override;
-    bool cannot_move() const override;
     bool cannot_act() const override;
     bool confused() const override;
     bool caught() const override;

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -118,7 +118,7 @@ void monster_consider_shouting(monster &mon)
  */
 bool monster_attempt_shout(monster &mon)
 {
-    if (mon.cannot_move() || mon.asleep() || mon.has_ench(ENCH_DUMB))
+    if (mon.cannot_act() || mon.asleep() || mon.has_ench(ENCH_DUMB))
         return false;
 
     const shout_type shout = mons_shouts(mon.type, false);


### PR DESCRIPTION
Being asleep wasn't considered a condition in being unable to move, which led to issues like not having your evasion reduced while asleep.

I investigated this after causative mentioned it in #crawl.