### PR TITLE
Ignis scorched temple vault & two small fixes

### DIFF
--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -4131,3 +4131,52 @@ ccQ..gh.hg..Lcc
   ccP.O.N.Mcc
    ccccccccc
 ENDMAP
+
+# 12 gods
+# plus 7 Ignis altars
+NAME:   pdpol_scorched_temple
+TAGS:   no_cloud_gen temple_variable temple_altars_12
+PLACE:  Temple
+ORIENT: encompass
+WEIGHT: 2
+KFEAT:  I = altar_ignis
+MARKER:  D = lua:fog_machine { cloud_type = "grey smoke", \
+             pow_max = 3, delay_min = 10, delay_max = 30, \
+             start_clouds = 0, size = 1, excl_rad = -1 }
+SUBST: A = AAAAG
+KPROP:  D = no_tele_into
+: set_feature_name("stone_arch", "broken pillar")
+SUBST: ^ = ^^.
+KFEAT: ^ = web
+SUBST: D = l
+SUBST:  " = -..
+SUBST:  ' =  LL--.
+SUBST:  L =  ll-
+COLOUR: - = brown
+TILE:   A = dngn_crumbled_column
+RTILE:  x = wall_volcanic
+FTILE:  GBIA^+. = floor_rough_red
+FTILE:  - = floor_rough_brown
+MAP
+xxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxBxxxxx
+xxxxxxxxxxxxxB...Bxxx
+xxxxxxxxxxxx.......xx
+xxxxx..^xxxG.......Gx
+xxxxA.I.Axxx.......xx
+xxx^."'"..xxxB...Bx+x
+xx.I"'L'"I.xxxxBxxx.x
+xA.""'L'"".Axxxxxx.xx
+x^.""'L'""..xxxxx.xxx
+x^I""LDL""I.+....{xxx
+x..""'L'""..xxxxx.xxx
+xA.""'L'"".Axxxxxx.xx
+xx.I""L""I.xxxxBxxx.x
+xxx.."'".^xxxB...Bx+x
+xxxxA.I.Axxx.......xx
+xxxxx^^.xxxG.......Gx
+xxxxxxxxxxxx.......xx
+xxxxxxxxxxxxxB...Bxxx
+xxxxxxxxxxxxxxxBxxxxx
+xxxxxxxxxxxxxxxxxxxxx
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -3835,17 +3835,17 @@ c...............c
 ccccccccccccccccc
 ENDMAP
 
-# 17, 18 gods
+# 16, 17 gods
 NAME:   minmay_temple_bridge_d
-TAGS:   no_cloud_gen temple_variable temple_altars_17 temple_altars_18
+TAGS:   no_cloud_gen temple_variable temple_altars_16 temple_altars_17
 PLACE:  Temple
 ORIENT: encompass
 WEIGHT: 2
 SUBST:  A : TUV
-: local altar_count = get_altar_count(_G, 18)
-: if altar_count == "17" then
+: local altar_count = get_altar_count(_G, 17)
+: if altar_count == "16" then
 SUBST:  C = .
-: elseif altar_count == "18" then
+: elseif altar_count == "17" then
 SUBST:  C = B
 : end
 MAP

--- a/crawl-ref/source/dat/dlua/lm_fog.lua
+++ b/crawl-ref/source/dat/dlua/lm_fog.lua
@@ -33,7 +33,7 @@
 -- pow_max: The maximum power of each cloud; must be provided.
 -- pow_rolls: The number of rolls of [pow_min, pow_max], with the average
 --     value uses; increasing the values makes the average value more likely
---     and extreme values less likely. Defaults to 1.
+--     and extreme values less likely. Defaults to 3.
 -- delay, delay_min and delay_max: The delay between laying down one cloud
 --     and the next.  10 is equal to normal-speed player turn. Either
 --     delay or delay_max and delay_min must be provided. Providing just


### PR DESCRIPTION
This PR comprises 3 commits. The first is a rare temple vault for Ignis in the vein of those for Lucy/Jiyva that there have been impassioned arguments made in discord for and against. The other two are small cleanups to things I was looking at while working on this that could be totally wrong and would be more than happy for someone to let me know I have no idea what I'm doing.
 
The Ignis vault is based predominantly on volcano features. I am hoping to somehow imply the "dying" aspect of Ignis with the size/shape of the lava pool and definitely looking for suggestions on how to make that read better.

As for the two fixes, I think the comment documenting usage of fog machines just has the wrong default value specified for `pow_rolls` based on https://github.com/crawl/crawl/blob/3d4abc6862629c0cc18f666097ec6b1ddd03e039/crawl-ref/source/dat/dlua/lm_fog.lua#L101.

Aside from that, when I was looking through `temple.des` I happened to be referencing `minmay_temple_bridge_d` a bunch since I was cribbing it's style heavily and all, and I became convinced that there either could never be 18 altars in that vault as written or I can't count/read. Either is possible. Thanks for your time!