### PR TITLE
fix: really end engulf upon polymorph

### DIFF
--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1133,21 +1133,21 @@ bool monster::decay_enchantment(enchant_type en, bool decay_degree)
     return false;
 }
 
-bool monster::clear_far_engulf(bool)
+bool monster::clear_far_engulf(bool force)
 {
     if (you.duration[DUR_WATER_HOLD]
         && (mid_t) you.props[WATER_HOLDER_KEY].get_int() == mid)
     {
-        you.clear_far_engulf();
+        you.clear_far_engulf(force);
     }
 
     const mon_enchant& me = get_ench(ENCH_WATER_HOLD);
     if (me.ench == ENCH_NONE)
         return false;
     const bool nonadj = !me.agent() || !adjacent(me.agent()->pos(), pos());
-    if (nonadj)
+    if (nonadj || force)
         del_ench(ENCH_WATER_HOLD);
-    return nonadj;
+    return nonadj || force;
 }
 
 // Returns true if you resist the merfolk avatar's call.

--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -411,7 +411,7 @@ void change_monster_type(monster* mons, monster_type targetc)
     // evaporating and reforming justifies this behaviour.
     mons->stop_constricting_all();
     mons->stop_being_constricted();
-    mons->clear_far_engulf();
+    mons->clear_far_engulf(true);
 }
 
 // Is the new monster able to live in *any* habitat that the original


### PR DESCRIPTION
At present, the bug described in #1935 still occurs in trunk.
dd09596130 made an attempt to fix this, but clear_far_engulf()
only applies to non-adjacent monsters by default.

This commit forces the engulf removal upon monster polymorph,
hopefully fixing the bug.