### PR TITLE
Remove a redundant "your" from a message.

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -551,7 +551,7 @@ static void _equip_weapon_effect(item_def& item, bool showMsgs, bool unmeld)
                     break;
 
                 case SPWPN_SPECTRAL:
-                    mprf("You feel a bond with your %s.", item_name.c_str());
+                    mprf("You feel a bond with %s.", item_name.c_str());
                     break;
 
                 default:


### PR DESCRIPTION
The item_name variable in _equip_weapon_effect() uses DESC_YOUR, so doesn't need "your" to be added later.