### PR TITLE
Add "flight" to the stash search prefix for armour "of flying".

### DIFF
--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -83,6 +83,9 @@ function ch_stash_search_annotate_item(it)
       end
       annot = annot .. "} "
     else
+      if it.ego_type_terse == "Fly" then
+        annot = annot .. "{flight} "
+      end
       annot = annot .. "{" .. it.ego_type_terse .. "} "
     end
   end


### PR DESCRIPTION
Searching for "fly" returned any equipment which gives flight, but not potions, and searching for "flight" returned potions and artefacts, but not boots of flying (as "find" searches artefact descriptions, but not ego item ones).

This change means that a search for "flight" finds everything. Searches for "fly" are unchanged.