### PR TITLE
Simplified Divine Vigour

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -453,7 +453,7 @@ static vector<ability_def> &_get_ability_list()
         { ABIL_ELYVILON_HEAL_SELF, "Heal Self",
             2, 0, 3, {fail_basis::invo, 40, 5, 20}, abflag::none },
         { ABIL_ELYVILON_DIVINE_VIGOUR, "Divine Vigour",
-            0, 0, 6, {fail_basis::invo, 80, 4, 25}, abflag::none },
+            0, 0, 4, {fail_basis::invo, 80, 4, 25}, abflag::none },
 
         // Lugonu
         { ABIL_LUGONU_ABYSS_EXIT, "Depart the Abyss",

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1327,7 +1327,7 @@ bool elyvilon_divine_vigour()
         mprf("%s grants you divine vigour.",
              god_name(GOD_ELYVILON).c_str());
 
-        const int vigour_amt = 1 + you.skill_rdiv(SK_INVOCATIONS, 1, 3);
+        const int vigour_amt = 30;
         const int old_hp_max = you.hp_max;
         const int old_mp_max = you.max_magic_points;
         you.attribute[ATTR_DIVINE_VIGOUR] = vigour_amt;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3764,7 +3764,7 @@ int get_real_hp(bool trans, bool drained)
 
     // Mutations that increase HP by a percentage
     hitp *= 100 + (you.get_mutation_level(MUT_ROBUST) * 10)
-                + (you.attribute[ATTR_DIVINE_VIGOUR] * 5)
+                + (you.attribute[ATTR_DIVINE_VIGOUR])
                 + (you.get_mutation_level(MUT_RUGGED_BROWN_SCALES) ?
                    you.get_mutation_level(MUT_RUGGED_BROWN_SCALES) * 2 + 1 : 0)
                 - (you.get_mutation_level(MUT_FRAIL) * 10)
@@ -3820,7 +3820,7 @@ int get_real_mp(bool include_items)
 
     // Analogous to ROBUST/FRAIL
     enp *= 100 + (you.get_mutation_level(MUT_HIGH_MAGIC) * 10)
-               + (you.attribute[ATTR_DIVINE_VIGOUR] * 5)
+               + (you.attribute[ATTR_DIVINE_VIGOUR])
                - (you.get_mutation_level(MUT_LOW_MAGIC) * 10);
     enp /= 100 * scale;
 //    enp = stepdown_value(enp, 9, 18, 45, 100)


### PR DESCRIPTION
The effectiveness and duration of Divine Vigour become stronger in proportion to the Invocation skill level. However, the usefulness of this power fluctuates excessively depending on the skill level. It's also annoying to guess how much the effect increases depending on the skill level. Therefore, I would like to simplify this power like Heroism.
I plan to fix the effect of this force to 'MaxHP/MaxMP 30% increase' and lower the cost slightly.