### PR TITLE
A couple small barding cleanups

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -120,7 +120,7 @@ M filtered_vector_select(vector<pair<M, int>> weights, function<bool(M)> filter)
  * For most races, even odds for all armour slots when acquiring, or 50-50
  * split between body armour/aux armour when getting god gifts.
  *
- * Nagas get a high extra chance for bardings, especially if they haven't
+ * Nagas and Palentongas get a high extra chance for bardings, especially if they haven't
  * seen any yet.
  *
  * Guaranteed to be wearable, in principle.

--- a/crawl-ref/source/species.cc
+++ b/crawl-ref/source/species.cc
@@ -275,7 +275,7 @@ namespace species
 
     bool wears_barding(species_type species)
     {
-        return bool(get_species_def(species).flags & SPF_SMALL_TORSO);
+        return bool(get_species_def(species).flags & SPF_BARDING);
     }
 
     bool has_claws(species_type species)


### PR DESCRIPTION
I was reading some Palentonga code to try to be less bad as them and
came across two things that looked like reasonable cleanups.

* Comment in acquire.cc suggests only nagas have increased chance to
  acquire a barding but I think it applies to palentongas too since it's
based off you.wear_barding().
* wears_barding() checks the SPF_SMALL_TORSO flag instead of SPF_BARDING
which works because they both apply to the same species but I assume is
just coincidental.

Tested out trying to wear bardings and acquire a bunch on
nagas/palentongas and humans as a control and I don't think I broke anything.