### PR TITLE
FEAT: Mark identify scrolls as useless once everything is identified.

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -1963,10 +1963,11 @@ void check_if_everything_is_identified(void)
     for (const auto t : types)
     {
         ASSERT(item_type_has_ids(t));
+        int unidentified = 0;
 
         for (const auto s : all_item_subtypes(t))
         {
-            if (!item_type_known(t, s))
+            if (!item_type_known(t, s) && unidentified++)
             {
                 _is_everything_identified = false;
                 return;

--- a/crawl-ref/source/item-name.h
+++ b/crawl-ref/source/item-name.h
@@ -137,6 +137,7 @@ const char* armour_ego_name(const item_def& item, bool terse);
 const char* missile_brand_name(const item_def& item, mbn_type t);
 
 bool item_type_has_ids(object_class_type base_type);
+void check_if_everything_is_identified(void);
 bool get_ident_type(const item_def &item);
 bool get_ident_type(object_class_type basetype, int subtype);
 bool set_ident_type(item_def &item, bool identify);

--- a/crawl-ref/source/item-name.h
+++ b/crawl-ref/source/item-name.h
@@ -16,6 +16,7 @@ using std::vector;
 
 #define CORPSE_NAME_KEY      "corpse_name_key"
 #define CORPSE_NAME_TYPE_KEY "corpse_name_type_key"
+#define IDENTIFIED_ALL_KEY   "identified_all_key"
 
 struct item_kind
 {
@@ -137,11 +138,12 @@ const char* armour_ego_name(const item_def& item, bool terse);
 const char* missile_brand_name(const item_def& item, mbn_type t);
 
 bool item_type_has_ids(object_class_type base_type);
-void check_if_everything_is_identified(void);
+void check_if_everything_is_identified();
 bool get_ident_type(const item_def &item);
 bool get_ident_type(object_class_type basetype, int subtype);
-bool set_ident_type(item_def &item, bool identify);
-bool set_ident_type(object_class_type basetype, int subtype, bool identify);
+bool set_ident_type(item_def &item, bool identify, bool check_last=true);
+bool set_ident_type(object_class_type basetype, int subtype, bool identify,
+                    bool check_last=true);
 
 string item_prefix(const item_def &item, bool temp = true);
 string menu_colour_item_name(const item_def &item,

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4671,7 +4671,7 @@ static void _identify_last_item(item_def &item)
         item.props[NEEDS_AUTOPICKUP_KEY] = true;
     }
 
-    set_ident_type(item, true);
+    set_ident_type(item, true, false);
 
     if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
         item.props.erase(NEEDS_AUTOPICKUP_KEY);

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -363,6 +363,7 @@ static void _post_init(bool newc)
     update_vision_range();
     init_exclusion_los();
     ash_check_bondage();
+    check_if_everything_is_identified();
 
     trackers_init_new_level();
 

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -62,6 +62,7 @@
  #include "windowmanager.h"
 #endif
 #include "ui.h"
+#include "version.h"
 
 using namespace ui;
 
@@ -363,7 +364,8 @@ static void _post_init(bool newc)
     update_vision_range();
     init_exclusion_los();
     ash_check_bondage();
-    check_if_everything_is_identified();
+    if (you.prev_save_version != Version::Long)
+        check_if_everything_is_identified();
 
     trackers_init_new_level();
 


### PR DESCRIPTION
Create a "have identified all potions and scrolls" variable. Scrolls of identify are treated as useless if it is set. It's updated on game load, and also whenever set_ident_type() changes something.