### PR TITLE
fix: don't force picking up of newly IDd equipment

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -953,13 +953,11 @@ static bool _id_floor_item(item_def &item)
         if (fully_identified(item))
             return false;
 
-        // autopickup hack for previously-unknown items
-        if (item_needs_autopickup(item))
-            item.props[NEEDS_AUTOPICKUP_KEY] = true;
-        identify_item(item);
-        // but skip ones that we discover to be useless
-        if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
-            item.props.erase(NEEDS_AUTOPICKUP_KEY);
+        // Same logic as wands here, may be viable to merge the two cases.
+        bool should_pickup = item_needs_autopickup(item);
+        set_ident_type(item, true);
+        if (!should_pickup)
+            set_item_autopickup(item, AP_FORCE_OFF);
         return true;
     }
 


### PR DESCRIPTION
This just re-uses the logic that was being used for wands, which also avoids the edge-case where if you floor-id something without using autopickup triggering (like when AP is disabled) then it was possible to have the item ID'd, marked as don't-pickup in `\`, and still picked up due to NEEDS_AUTOPICKUP_KEY set in its props.

The old code that led to this logic seems to imply there was an intentional hack for "previously-unknown items", but in testing, I found no unexpected behavior with the new version.

I also chose _not_ to merge the repeated code, as I unsure that it's too significant of an issue, and I have frankly no clue what the difference between the `if (fully_identified(item)) return false` and `get_ident_type(item) → return false` bits is in each of the branches.