### PR TITLE
Remove "const" from the parameter to seen_item().

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -2748,7 +2748,7 @@ weapon_type name_nospace_to_weapon(string name_nospace)
     return WPN_UNKNOWN;
 }
 
-void seen_item(const item_def &item)
+void seen_item(item_def &item)
 {
     if (!is_artefact(item) && _is_affordable(item))
     {
@@ -2763,15 +2763,9 @@ void seen_item(const item_def &item)
 
     _maybe_note_found_unrand(item);
 
-    // major hack. Deconstify should be safe here, but it's still repulsive.
-    item_def& malleable_item = const_cast<item_def &>(item);
-
-    malleable_item.flags |= ISFLAG_SEEN;
+    item.flags |= ISFLAG_SEEN;
     if (item.base_type == OBJ_GOLD && !item.tithe_state)
-    {
-        malleable_item.plus = (you_worship(GOD_ZIN)) ? TS_FULL_TITHE
-                                                     : TS_NO_PIETY;
-    }
+        item.plus = (you_worship(GOD_ZIN)) ? TS_FULL_TITHE : TS_NO_PIETY;
 
     if (item_type_has_ids(item.base_type) && !is_artefact(item)
         && item_ident(item, ISFLAG_KNOW_TYPE)

--- a/crawl-ref/source/item-prop.h
+++ b/crawl-ref/source/item-prop.h
@@ -227,7 +227,7 @@ string item_base_name(object_class_type type, int sub_type);
 const char *weapon_base_name(weapon_type subtype) IMMUTABLE;
 weapon_type name_nospace_to_weapon(string name_nospace);
 
-void seen_item(const item_def &item);
+void seen_item(item_def &item);
 
 static inline bool is_weapon(const item_def &item)
 {

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -437,7 +437,7 @@ void Stash::_update_identification()
     }
 }
 
-void Stash::add_item(const item_def &item, bool add_to_front)
+void Stash::add_item(item_def &item, bool add_to_front)
 {
     if (_is_rottable(item))
         StashTrack.update_corpses();

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -64,7 +64,7 @@ public:
 private:
     void _update_corpses(int rot_time);
     void _update_identification();
-    void add_item(const item_def &item, bool add_to_front = false);
+    void add_item(item_def &item, bool add_to_front = false);
 
 private:
     bool visited;      // Is this correct to the best of our knowledge?


### PR DESCRIPTION
751e42844d described removing the const from a reference within seen_item() as a "major hack". 11 years later, fixing this involves removing the const from this function and one additional method, with no changes needed for stack_iterator.