### PR TITLE
hint mode: prevent temporary portals being misindentified as downstairs

### DIFF
--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -3673,6 +3673,8 @@ void hints_observe_cell(const coord_def& gc)
 {
     if (feat_is_escape_hatch(env.grid(gc)))
         learned_something_new(HINT_SEEN_ESCAPE_HATCH, gc);
+    else if (feat_is_portal_entrance(env.grid(gc)))
+        learned_something_new(HINT_SEEN_PORTAL, gc);
     else if (feat_is_branch_entrance(env.grid(gc)))
         learned_something_new(HINT_SEEN_BRANCH, gc);
     else if (is_feature('>', gc))
@@ -3687,8 +3689,6 @@ void hints_observe_cell(const coord_def& gc)
         learned_something_new(HINT_SEEN_DOOR, gc);
     else if (env.grid(gc) == DNGN_ENTER_SHOP)
         learned_something_new(HINT_SEEN_SHOP, gc);
-    else if (feat_is_portal_entrance(env.grid(gc)))
-        learned_something_new(HINT_SEEN_PORTAL, gc);
 
     const int it = you.visible_igrd(gc);
     if (it != NON_ITEM)


### PR DESCRIPTION
The call to is_feature('>', gc) will return true for a temporary portal because '>' is the command to use it, and it's not an altar. Not sure if that's the expected behaviour of that function or not, so didn't modify it. Instead, moved test for a portal entrance before that call so that portals are correctly identified in hints mode.