### PR TITLE
Exclude hidden spells from the memorisation tab

### DIFF
--- a/crawl-ref/source/tilereg-mem.cc
+++ b/crawl-ref/source/tilereg-mem.cc
@@ -141,6 +141,9 @@ void MemoriseRegion::update()
     {
         const spell_type spell = spells[i];
 
+        if (you.hidden_spells.get(spell))
+            continue;
+
         InventoryTile desc;
         desc.tile     = tileidx_spell(spell);
         desc.idx      = (int) spell;


### PR DESCRIPTION
If a spell is hidden in the memorisation menu, I think it should not be listed in the memorisation tab either.