### PR TITLE
bugfix: lua moninf_get_flags must init flags

### DIFF
--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -493,6 +493,8 @@ LUAFN(moninf_get_is)
  */
 LUAFN(moninf_get_flags)
 {
+    if (mi_flags.empty())
+        _init_mi_flags();
     MONINF(ls, 1, mi);
     lua_newtable(ls);
     int index = 0;


### PR DESCRIPTION
As with `is`, the `flags` function needs to init `mi_flags`.  Currently the function will fail until flags are initialized, which you can workaround by calling `is` first with a string, but that's silly.