### PR TITLE
Travel trail fixes (#2081)

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -529,10 +529,17 @@ void moveto_location_effects(dungeon_feature_type old_feat,
     if (stepped)
         _moveto_maybe_repel_stairs();
 
+    bool was_running = you.running;
+
     update_monsters_in_view();
     maybe_update_stashes();
     if (check_for_interesting_features() && you.running.is_explore())
         stop_running();
+
+    // If travel was interrupted, we need to add the last step
+    // to the travel trail.
+    if (was_running && !you.running)
+        env.travel_trail.push_back(you.pos());
 }
 
 // Use this function whenever the player enters (or lands and thus re-enters)

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1128,7 +1128,7 @@ command_type travel()
                 if (lev && lev->needs_stop(newpos))
                 {
                     explore_stopped_pos = newpos;
-                    stop_running();
+                    stop_running(false);
                     return direction_to_command(*move_x, *move_y);
                 }
             }


### PR DESCRIPTION
This PR fixes two travel trail-related bugs reported in #2081. These visual bugs happen because some events stop travel and clear delays *a bit* earlier than before.