### PR TITLE
Add the most nicolae demonic rune vault possible

### DIFF
--- a/crawl-ref/source/dat/des/branches/pan.des
+++ b/crawl-ref/source/dat/des/branches/pan.des
@@ -2521,6 +2521,106 @@ cc..B..B..cc
    cccccc
 ENDMAP
 
+################################################################################
+# A Pandemonium lord with a mercantile bent has set up a bazaar in Pandemonium.
+# There are three mostly-usual stores, but the center store is where the Pan
+# lord keeps their most special merchandise: the demonic rune of Zot. 
+# If you already have the demonic rune, it's got a zigfig for you.
+NAME:    nicolae_pan_bazaar_rune
+TAGS:    patrolling transparent no_item_gen
+WEIGHT:  5
+ORIENT:  float
+{{
+  local shoplord = string.gsub(crawl.make_name(), " ", "_")
+  local shops = { "Zone", "Stash", "Warehouse", "Hoard", "Trove", "Cache",
+                  "Depot", "Stock", "Depository", "Bin", "Store", "Supply",
+                  "Sales", "Hole", "Deals", "Outlet", "Market", "Inventory" }
+  local shopsuffix = shops[ crawl.random2(#shops) + 1 ]
+  kmons("Z = pandemonium lord name:" .. shoplord)
+  if you.have_rune("demonic") or is_validating() then
+    kfeat("Z = general shop name:" .. shoplord .. " type:Rarities suffix:"
+               .. shopsuffix .. " count:1 ; figurine of a ziggurat")
+  else
+    kfeat("Z = general shop name:" .. shoplord .. " type:Demonic_Rune suffix:"
+               .. shopsuffix .. " count:1 ; demonic rune of Zot")
+  end
+  kfeat("SH = general shop name:" .. shoplord)
+  kfeat("J = scroll shop name:" .. shoplord .. " type:Exquisite" ..
+        " suffix:Manuscripts ; " .. string.gsub(dgn.good_scrolls, "/", "|"))
+  kfeat("K = distillery shop name:" .. shoplord .. " type:Quality" ..
+        " suffix:Elixirs ; " .. string.gsub(dgn.loot_potions, "/", "|"))
+  kfeat("L = general shop name:" .. shoplord .. " type:Fine" ..
+        " suffix:Accessories ; any misc | any wand w:15")
+  kfeat("M = jewellery shop name:" .. shoplord)
+  kfeat("N = book shop name:" .. shoplord)
+  kfeat("O = antiques shop name:" .. shoplord .. " type:Forgotten" ..
+        " suffix:Relics ; any weapon randart | any armour randart | " ..
+        " any jewellery randart")
+}}
+# 2/3 chance of nothing, 4/15 chance of gold, 1/15 chance of a lot of gold
+KITEM:   S-_ = $ w:4 / $ good_item w:1 / nothing w:10
+# Fountains just get a 1/6 chance of a regular stack of gold
+KITEM:   TUY = $ / nothing w:50
+# 2/3 chance of nothing, 2/9 chance of any demon, 1/9 chance of a guest.
+# Guests are demon summoning monsters from other branches, who are here to
+# commune with demons, make deals, or just browse the pandemonic bazaar.
+KMONS:   S-_ = deep elf demonologist / kobold demonologist / mummy priest / \
+               orc high priest / orc sorcerer / dread lich w:5 / \
+               any demon w:110 / nothing w:495
+KMONS:   YPQR = greater demon w:80 / demonspawn black sun / \
+                demonspawn blood saint / demonspawn corrupter / \
+                demonspawn warmonger / nothing w:20
+KFEAT:   _ = altar_gozag
+KFEAT:   P = exit_pandemonium
+KFEAT:   QR = transit_pandemonium
+KFEAT:   Y = Y
+SHUFFLE: Pp/Qq/Rr, S_, TU
+SUBST:   p = +, qr = c
+NSUBST:  D = + / x, E = + / x, F = + / x
+: if crawl.x_chance_in_y( 2, 3 ) then
+NSUBST:  S = H / J / K
+SHUFFLE: HJKLMNO
+: end
+FTILE:   HJKLMNOPQRSTUYZcx-+_. = floor_limestone
+# This vault has a special announcement to provide a heads-up that this rune
+# is not obtained in the usual way. It uses yellow text to evoke Gozag's gold
+# related messages, as well the messages from arriving in the four unique
+# lords' levels.
+epilogue {{
+if not you.have_rune("demonic") then
+    crawl.mpr("A powerful Pandemonium lord resides here.", "warning")
+    crawl.mpr("<yellow>It is willing to " ..
+              "make a deal for the demonic rune of Zot.</yellow>")
+end
+}}
+MAP
+        xxDxx
+       xx...xx
+       D.....D
+      xx.....xx
+  xxDxx...U...xxDxx
+ xx...---...---...xx
+ x....-_-...-S-....x
+xx....---...---....xx
+x...T...ccccc...T...x
+xx.....cc...cc.....xx
+ F.....r..P..q.....E
+ xx---ccY...Ycc---xx
+  x-S-c...Z...c-_-x
+ xx---ccQ...Rcc---xx
+ F.....c..Y..c.....E
+xx.....cc...cc.....xx
+x...U...ccpcc...U...x
+xx....---...---....xx
+ F....-_-...-S-....E
+ xx...---...---...xx
+  xxFxx...T...xxExx
+      xx.....xx
+       F.....E
+       xx...xx
+        xxxxx
+ENDMAP
+
 #############################################################################
 # Pandemonium lesser demon vaults: (announced) rune serial vaults
 #############################################################################

--- a/crawl-ref/source/dat/des/branches/pan.des
+++ b/crawl-ref/source/dat/des/branches/pan.des
@@ -2524,8 +2524,9 @@ ENDMAP
 ################################################################################
 # A Pandemonium lord with a mercantile bent has set up a bazaar in Pandemonium.
 # There are three mostly-usual stores, but the center store is where the Pan
-# lord keeps their most special merchandise: the demonic rune of Zot. 
-# If you already have the demonic rune, it's got a zigfig for you.
+# lord keeps their most special merchandise: the demonic rune of Zot.
+# If you already have the demonic rune, it's got a selection of randarts for
+# you instead.
 NAME:    nicolae_pan_bazaar_rune
 TAGS:    patrolling transparent no_item_gen
 WEIGHT:  5
@@ -2539,12 +2540,14 @@ ORIENT:  float
   kmons("Z = pandemonium lord name:" .. shoplord)
   if you.have_rune("demonic") or is_validating() then
     kfeat("Z = general shop name:" .. shoplord .. " type:Rarities suffix:"
-               .. shopsuffix .. " count:1 ; figurine of a ziggurat")
+               .. shopsuffix .. " ; any weapon randart | any armour randart | "
+               .. "any jewellery randart | any randbook")
   else
     kfeat("Z = general shop name:" .. shoplord .. " type:Demonic_Rune suffix:"
                .. shopsuffix .. " count:1 ; demonic rune of Zot")
   end
-  kfeat("SH = general shop name:" .. shoplord)
+  kfeat("H = general shop name:" .. shoplord .. " type:Assorted" ..
+        " suffix:Sundries ; any | any good_item | star_item")
   kfeat("J = scroll shop name:" .. shoplord .. " type:Exquisite" ..
         " suffix:Manuscripts ; " .. string.gsub(dgn.good_scrolls, "/", "|"))
   kfeat("K = distillery shop name:" .. shoplord .. " type:Quality" ..
@@ -2553,23 +2556,31 @@ ORIENT:  float
         " suffix:Accessories ; any misc | any wand w:15")
   kfeat("M = jewellery shop name:" .. shoplord)
   kfeat("N = book shop name:" .. shoplord)
-  kfeat("O = antiques shop name:" .. shoplord .. " type:Forgotten" ..
-        " suffix:Relics ; any weapon randart | any armour randart | " ..
-        " any jewellery randart")
+  kfeat("O = general shop name:" .. shoplord .. " type:Superb" ..
+        " suffix:Hardware ; any weapon good_item | any armour good_item")
+  kfeat("S = general shop name:" .. shoplord .. " type:Infernal " ..
+        "suffix:Boutique ; any weapon good_item ego:draining | " ..
+        "any weapon good_item ego:pain | any weapon good_item ego:chaos | " ..
+        "any weapon good_item ego:vampirism | demon blade good_item | " ..
+        "demon trident good_item | demon whip good_item | " ..
+        "staff of death w:3 | scroll of torment q:2 w:5 | " ..
+        "scroll of torment q:3 w:5 | randbook disc:necromancy")
 }}
 # 2/3 chance of nothing, 4/15 chance of gold, 1/15 chance of a lot of gold
-KITEM:   S-_ = $ w:4 / $ good_item w:1 / nothing w:10
+KITEM:   HJKLMNOS-_ = $ w:4 / $ good_item w:1 / nothing w:10
 # Fountains just get a 1/6 chance of a regular stack of gold
 KITEM:   TUY = $ / nothing w:50
-# 2/3 chance of nothing, 2/9 chance of any demon, 1/9 chance of a guest.
+# Monsters in the outer promenade area: 1/9 chance of a guest, 1/9 chance of
+# a greater demon, 2/9 chance of any demon or demonspawn, 5/9 chance of nothing.
 # Guests are demon summoning monsters from other branches, who are here to
 # commune with demons, make deals, or just browse the pandemonic bazaar.
-KMONS:   S-_ = deep elf demonologist / kobold demonologist / mummy priest / \
-               orc high priest / orc sorcerer / dread lich w:5 / \
-               any demon w:110 / nothing w:495
-KMONS:   YPQR = greater demon w:80 / demonspawn black sun / \
-                demonspawn blood saint / demonspawn corrupter / \
-                demonspawn warmonger / nothing w:20
+KMONS:   HJKLMNOS-_ = deep elf demonologist / kobold demonologist / \
+           mummy priest / orc high priest / orc sorcerer / dread lich / \
+           greater demon w:60 / demonspawn warmonger w:2 / \
+           demonspawn black sun w:2 / demonspawn blood saint w:2 / \
+           demonspawn corrupter w:2 / any demon w:112 / nothing w:300
+KMONS:   YPQR = greater demon w:360 / demonspawn black sun / \
+           demonspawn blood saint / demonspawn corrupter / demonspawn warmonger
 KFEAT:   _ = altar_gozag
 KFEAT:   P = exit_pandemonium
 KFEAT:   QR = transit_pandemonium
@@ -2577,10 +2588,8 @@ KFEAT:   Y = Y
 SHUFFLE: Pp/Qq/Rr, S_, TU
 SUBST:   p = +, qr = c
 NSUBST:  D = + / x, E = + / x, F = + / x
-: if crawl.x_chance_in_y( 2, 3 ) then
 NSUBST:  S = H / J / K
-SHUFFLE: HJKLMNO
-: end
+SHUFFLE: HJKLMNOS
 FTILE:   HJKLMNOPQRSTUYZcx-+_. = floor_limestone
 # This vault has a special announcement to provide a heads-up that this rune
 # is not obtained in the usual way. It uses yellow text to evoke Gozag's gold


### PR DESCRIPTION
I have reached my apotheosis: I have put a rune in a shop.

Since the demonic rune repeats if you don't pick it up, I figured it
would be the best option for a rune shop. (The abyssal rune also
reappears if you don't pick it up, but the theme is easier to fit into
Pandemonium.) If you already have the rune, the shop instead places
randarts of various kinds.

Out of 25 generated shops, the stats on the price of a demonic rune:
Minimum: 3804
Maximum: 8647
Average: 6640.76
St Dev:  1412.1

The vault also places fat stacks of cash, three other shops, and
demon-summoning monsters from other branches as visitors. Enjoy!