### PR TITLE
Storm Form should display weapon name as "Storm paws", "Storm tentacles" or "Storm fists" depending on species

### DIFF
--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -306,7 +306,7 @@ static const form_entry formdata[] =
     EQF_PHYSICAL, MR_RES_ELEC | MR_RES_PETRIFY,
     DEFAULT_DURATION, 0, 0, SIZE_CHARACTER, 10,
     10, 10, 0, true, 0, true, -1,
-    SPWPN_ELECTROCUTION, LIGHTCYAN, "Storm fists", { "hit", "buffet", "batter", "blast" },
+    SPWPN_ELECTROCUTION, LIGHTCYAN, "", { "hit", "buffet", "batter", "blast" },
     FC_ENABLE, FC_DEFAULT, FC_FORBID, false,
     "bellow", 0, "", "", "place yourself before", "air",
     { { "cleaving", "Your stormy fists strike out in all directions at once." },

--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -309,7 +309,7 @@ static const form_entry formdata[] =
     SPWPN_ELECTROCUTION, LIGHTCYAN, "", { "hit", "buffet", "batter", "blast" },
     FC_ENABLE, FC_DEFAULT, FC_FORBID, false,
     "bellow", 0, "", "", "place yourself before", "air",
-    { { "cleaving", "Your stormy fists strike out in all directions at once." },
+    { { "cleaving", "Your electrical attacks strike out in all directions at once." },
       { "", "You are incredibly evasive." }
     }
 }

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -999,7 +999,9 @@ public:
      */
     string get_uc_attack_name(string /*default_name*/) const override
     {
-        return "Storm " + storm_parts(true);
+        // there's special casing in base_hand_name to get "fists"
+        string hand = you.base_hand_name(true, true);
+        return make_stringf("Storm %s", hand.c_str());
     }
 };
 
@@ -1433,18 +1435,6 @@ string blade_parts(bool terse)
         str = "front " + str;
     else if (!terse && you.arm_count() > 2)
         str = "main " + str; // Op have four main tentacles
-
-    return str;
-}
-
-string storm_parts(bool)
-{
-    if (you.has_mutation(MUT_PAWS, false))
-        str = "paws";
-    else if (you.arm_count() > 2)
-        str = "tentacles"; // Op have four main tentacles
-    else
-        str = "fists";
 
     return str;
 }

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -993,6 +993,14 @@ public:
     }
 
     bool can_offhand_punch() const override { return true; }
+    
+    /**
+     * Get the name displayed in the UI for the form's unarmed-combat 'weapon'.
+     */
+    string get_uc_attack_name(string /*default_name*/) const override
+    {
+        return "Storm " + storm_parts(true);
+    }
 };
 
 #if TAG_MAJOR_VERSION == 34
@@ -1425,6 +1433,18 @@ string blade_parts(bool terse)
         str = "front " + str;
     else if (!terse && you.arm_count() > 2)
         str = "main " + str; // Op have four main tentacles
+
+    return str;
+}
+
+string storm_parts(bool)
+{
+    if (you.has_mutation(MUT_PAWS, false))
+        str = "paws";
+    else if (you.arm_count() > 2)
+        str = "tentacles"; // Op have four main tentacles
+    else
+        str = "fists";
 
     return str;
 }


### PR DESCRIPTION
Currently, this form always displays "Storm fists" no matter the active species, despite tiles showing that the player character's anatomy is maintained in this transformation.

To be consistent with Statue Form and Blade Hands, this minor change uses the same logic used in Statue Form to fix this.