### PR TITLE
Qaz's power cost adjustment

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -595,11 +595,11 @@ static vector<ability_def> &_get_ability_list()
 
         // Qazlal
         { ABIL_QAZLAL_UPHEAVAL, "Upheaval",
-            4, 0, 3, {fail_basis::invo, 40, 5, 20}, abflag::none },
+            2, 0, 2, {fail_basis::invo, 40, 5, 20}, abflag::none },
         { ABIL_QAZLAL_ELEMENTAL_FORCE, "Elemental Force",
-            6, 0, 6, {fail_basis::invo, 60, 5, 20}, abflag::none },
+            5, 0, 5, {fail_basis::invo, 60, 5, 20}, abflag::none },
         { ABIL_QAZLAL_DISASTER_AREA, "Disaster Area",
-            7, 0, 10, {fail_basis::invo, 70, 4, 25}, abflag::none },
+            8, 0, 8, {fail_basis::invo, 70, 4, 25}, abflag::none },
 
         // Uskayaw
         { ABIL_USKAYAW_STOMP, "Stomp",


### PR DESCRIPTION
In early games, the risk is greater than the benefits of worshiping Qaz. His signature characteristic, the unstoppable noise, is a fatal disqualification, but the powers given are too expensive to overcome the ordeal and require long training to be strong. So, I have somewhat eased the cost of power. I hope the players will be able to overcome the hostile environment more actively.