### PR TITLE
add travel funcs

### DIFF
--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -8,6 +8,7 @@
 #include "branch.h"
 #include "cluautil.h"
 #include "coord.h"
+#include "env.h"
 #include "player.h"
 #include "terrain.h"
 #include "travel.h"
@@ -161,6 +162,35 @@ LUAFN(l_set_waypoint)
     return 0;
 }
 
+/*** Clears the travel trail.
+ * Call crawl.redraw_screen afterward to see changes.
+ * @function clear_travel_trail
+ */
+static int l_clear_travel_trail(lua_State*)
+{
+    clear_travel_trail();
+    return 0;
+}
+
+/*** Set travel_trail on a cell
+ * Call crawl.redraw_screen afterward to see changes. 
+ * Uses player-centered coordinates.
+ * @tparam int x
+ * @tparam int y
+ * @function set_travel_trail
+ */
+LUAFN(l_set_travel_trail)
+{
+    coord_def s;
+    s.x = luaL_safe_checkint(ls, 1);
+    s.y = luaL_safe_checkint(ls, 2);
+    const coord_def p = player2grid(s);
+    if (!_in_map_bounds(p))
+        return luaL_error(ls, "Coordinates out of bounds: (%d, %d)", s.x, s.y);
+    env.travel_trail.push_back(p);
+    return 0;
+}
+
 static const struct luaL_reg travel_lib[] =
 {
     { "set_exclude", l_set_exclude },
@@ -171,6 +201,8 @@ static const struct luaL_reg travel_lib[] =
     { "find_deepest_explored", l_find_deepest_explored },
     { "waypoint_delta", l_waypoint_delta },
     { "set_waypoint", l_set_waypoint },
+    { "clear_travel_trail", l_clear_travel_trail },
+    { "set_travel_trail", l_set_travel_trail },    
 
     { nullptr, nullptr }
 };

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -202,7 +202,7 @@ static const struct luaL_reg travel_lib[] =
     { "waypoint_delta", l_waypoint_delta },
     { "set_waypoint", l_set_waypoint },
     { "clear_travel_trail", l_clear_travel_trail },
-    { "set_travel_trail", l_set_travel_trail },    
+    { "set_travel_trail", l_set_travel_trail },
 
     { nullptr, nullptr }
 };

--- a/crawl-ref/source/l-travel.cc
+++ b/crawl-ref/source/l-travel.cc
@@ -173,7 +173,7 @@ static int l_clear_travel_trail(lua_State*)
 }
 
 /*** Set travel_trail on a cell
- * Call crawl.redraw_screen afterward to see changes. 
+ * Call crawl.redraw_screen afterward to see changes.
  * Uses player-centered coordinates.
  * @tparam int x
  * @tparam int y


### PR DESCRIPTION
Adds `travel.clear_travel_trail` and `travel.set_travel_trail` functions, allowing clua control over the travel trail.  This purely visual feature enables generation of nice visualizations, without affecting gameplay.