### PR TITLE
add optional weapon argument to `target_weapon`

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4045,11 +4045,10 @@ static void _add_energy_to_string(int speed, int energy, string what,
  * @param result[in,out]    The stringstream to append to.
  */
 void describe_to_hit(const monster_info& mi, ostringstream &result,
-                     bool parenthesize)
+                     bool parenthesize, const item_def* weapon)
 {
     // TODO: don't do this if the player doesn't exist (main menu)
 
-    const item_def* weapon = you.weapon();
     if (weapon != nullptr && !is_weapon(*weapon))
         return; // breadwielding
 
@@ -4063,7 +4062,7 @@ void describe_to_hit(const monster_info& mi, ostringstream &result,
     else
     {
         // TODO: handle throwing to-hit somehow?
-        const int missile = quiver::find_action_from_launcher(you.weapon())->get_item();
+        const int missile = quiver::find_action_from_launcher(weapon)->get_item();
         if (missile < 0)
             return; // failure to launch
         ranged_attack attk(&you, nullptr, &you.inv[missile], is_pproj_active());

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4227,7 +4227,7 @@ static void _describe_monster_ac(const monster_info& mi, ostringstream &result)
 static void _describe_monster_ev(const monster_info& mi, ostringstream &result)
 {
     _print_bar(mi.ev, 5, "    EV:", result, mi.base_ev);
-    describe_to_hit(mi, result, true);
+    describe_to_hit(mi, result, true, you.weapon());
     result << "\n";
 }
 

--- a/crawl-ref/source/describe.h
+++ b/crawl-ref/source/describe.h
@@ -87,7 +87,7 @@ void describe_skill(skill_type skill);
 
 int hex_chance(const spell_type spell, const int hd);
 void describe_to_hit(const monster_info& mi, ostringstream &result,
-                     bool parenthesize = false);
+                     bool parenthesize = false, const item_def* weapon = nullptr);
 
 string get_command_description(const command_type cmd, bool terse);
 

--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -345,7 +345,7 @@ static int moninf_get_target_desc(lua_State *ls)
 static int moninf_get_target_weapon(lua_State *ls)
 {
     MONINF(ls, 1, mi);
-    item_def *item = lua_isnone(ls, 2) ? nullptr : *(item_def **) luaL_checkudata(ls, 2, ITEM_METATABLE);
+    item_def *item = (lua_isnone(ls, 2) || lua_isnil(ls, 2)) ? nullptr : *(item_def **) luaL_checkudata(ls, 2, ITEM_METATABLE);
     ostringstream result;
     describe_to_hit(*mi, result, false, item);
     lua_pushstring(ls, result.str().c_str());

--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -337,15 +337,17 @@ static int moninf_get_target_desc(lua_State *ls)
     return 1;
 }
 
-/*** Returns the string displayed if you target this monster with your current weapon.
+/*** Returns the string displayed if you target this monster with a weapon (or unarmed attack).
+ * @tparam[opt] weapon (item object) to use; omit for unarmed attack.
  * @treturn string (such as "about 18% to evade your dagger")
  * @function target_weapon
  */
 static int moninf_get_target_weapon(lua_State *ls)
 {
     MONINF(ls, 1, mi);
+    item_def *item = lua_isnone(ls, 2) ? nullptr : *(item_def **) luaL_checkudata(ls, 2, ITEM_METATABLE);
     ostringstream result;
-    describe_to_hit(*mi, result, false);
+    describe_to_hit(*mi, result, false, item);
     lua_pushstring(ls, result.str().c_str());
     return 1;
 }

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -54,7 +54,7 @@ static bool _items_similar(const item_def& a, const item_def& b,
 static vector<string> _desc_hit_chance(const monster_info &mi)
 {
     ostringstream result;
-    describe_to_hit(mi, result);
+    describe_to_hit(mi, result, false, you.weapon());
     string str = result.str();
     if (str.empty())
         return vector<string>{};


### PR DESCRIPTION
Adds an optional `weapon` argument to the Lua `monsterinfo.target_weapon` function.  If `weapon` is omitted, it shows the targeting description accompanying an unarmed attack.  If `weapon` is provided, it shows the targeting description for an attack with that weapon.

This changes usage of the function slightly (formerly, the function returned only the description for your current weapon), but the function is relatively new so this is hopefully not a very breaking change.