### PR TITLE
Don't highlight spells Vehumet offers if you've read a book about them.

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -365,7 +365,7 @@ void EquipOffDelay::start()
 
 void MemoriseDelay::start()
 {
-    if (vehumet_is_offering(spell))
+    if (vehumet_is_offering(spell, true))
     {
         string message = make_stringf(" grants you knowledge of %s.",
             spell_title(spell));

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1200,9 +1200,12 @@ static bool _jiyva_mutate()
     return to_give == 0 || deleted;
 }
 
-bool vehumet_is_offering(spell_type spell)
+// Is Vehumet offering this? With "only" only return true if this is the only
+// reason the player can learn the spell now.
+bool vehumet_is_offering(spell_type spell, bool only)
 {
-    return you.vehumet_gifts.count(spell);
+    return you.vehumet_gifts.count(spell)
+           && !(only && you.spell_library[spell]);
 }
 
 void vehumet_accept_gift(spell_type spell)

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -128,7 +128,7 @@ bool is_fellow_slime(const monster& mon);
 bool is_follower(const monster& mon);
 
 // Vehumet gift interface.
-bool vehumet_is_offering(spell_type spell);
+bool vehumet_is_offering(spell_type spell, bool only = false);
 void vehumet_accept_gift(spell_type spell);
 
 mgen_data hepliaklqana_ancestor_gen_data();

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -436,8 +436,8 @@ static bool _sort_mem_spells(const sortable_spell &a, const sortable_spell &b)
         return mem_a;
 
     // List the Vehumet gifts at the very top.
-    const bool offering_a = vehumet_is_offering(a.spell);
-    const bool offering_b = vehumet_is_offering(b.spell);
+    const bool offering_a = vehumet_is_offering(a.spell, true);
+    const bool offering_b = vehumet_is_offering(b.spell, true);
     if (offering_a != offering_b)
         return offering_a;
 
@@ -636,7 +636,7 @@ private:
 
     colour_t entry_colour(const sortable_spell& entry)
     {
-        if (vehumet_is_offering(entry.spell))
+        if (vehumet_is_offering(entry.spell, true))
             return LIGHTBLUE;
         else
         {

--- a/crawl-ref/source/tilereg-mem.cc
+++ b/crawl-ref/source/tilereg-mem.cc
@@ -154,7 +154,7 @@ void MemoriseRegion::update()
             desc.flag |= TILEI_FLAG_INVALID;
         }
 
-        if (vehumet_is_offering(spell))
+        if (vehumet_is_offering(spell, true))
             desc.flag |= TILEI_FLAG_EQUIP;
 
         m_items.push_back(desc);


### PR DESCRIPTION
This changes the meaning of "blue spell at the top of the list" from "spell Vehumet is offering you" to "spell which is only available because Vehumet is offering it to you". Vehumet can withdraw the offer, but you cannot lose the book.

This change doesn't affect the religion screen.

This change means that:

1. The memorise spell list is in order of difficulty except when there's a spell on it which Vehumet is providing. It's easier to look through the list when the spells are in order of difficulty.

2. The game shows the player which spells are only available because Vehumet is offering them. Until the last set of spells, this gives the player a motive to learn (say) LRD now as it may be useful later on. As things stand, someone using the default options has no easy way to check if a "blue" spell is one of these or not.