### PR TITLE
Add `you.known_items` Lua function

### DIFF
--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -807,6 +807,36 @@ static int l_you_abil_table(lua_State *ls)
 }
 
 
+/*** Known items.
+ * @treturn table The list of identifiable item subtypes you know.
+ * @function known_items
+ */
+static int you_known_items(lua_State *ls)
+{
+    lua_newtable(ls);
+    int index = 0;
+    for (int ii = 0; ii < NUM_OBJECT_CLASSES; ii++)
+    {
+        object_class_type basetype = (object_class_type)ii;
+        if (!item_type_has_ids(basetype))
+            continue;
+        for (const auto subtype : all_item_subtypes(basetype))
+        {
+            if (basetype == OBJ_JEWELLERY && subtype >= NUM_RINGS && subtype < AMU_FIRST_AMULET)
+                continue;
+            if (you.type_ids[basetype][subtype] ) {
+                item_def it = item_def();
+                it.base_type = basetype;
+                it.sub_type  = subtype;
+                lua_pushstring(ls, it.name(DESC_PLAIN, true).c_str());
+                lua_rawseti(ls, -2, ++index);
+            }
+        }
+    }
+    return 1;
+}
+
+
 /*** Activate an ability by name, supplying a target where relevant. If the
  * ability is not targeted, the target is ignored. An invalid target will
  * open interactive targeting.
@@ -1217,6 +1247,7 @@ static const struct luaL_reg you_clib[] =
     { "abilities"   , l_you_abils },
     { "ability_letters", l_you_abil_letters },
     { "ability_table", l_you_abil_table },
+    { "known_items" , you_known_items },
     { "name"        , you_name },
     { "race"        , you_race },
     { "hand"        , you_hand },

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -808,7 +808,7 @@ static int l_you_abil_table(lua_State *ls)
 
 
 /*** Known items.
- * @treturn table The list of identifiable item subtypes you know.
+ * @treturn table The list of identifiable items you know.
  * @function known_items
  */
 static int you_known_items(lua_State *ls)
@@ -824,7 +824,7 @@ static int you_known_items(lua_State *ls)
         {
             if (basetype == OBJ_JEWELLERY && subtype >= NUM_RINGS && subtype < AMU_FIRST_AMULET)
                 continue;
-            if (you.type_ids[basetype][subtype] ) {
+            if (you.type_ids[basetype][subtype]) {
                 item_def it = item_def();
                 it.base_type = basetype;
                 it.sub_type  = subtype;


### PR DESCRIPTION
This exposes the list of known, identifiable subtypes to Lua.  It's the same list as given by the `\` "display known objects" command, minus the unknowns.  Without this, it's impossible to know (within Lua), that one has already seen a particular kind of potion or scroll.