### PR TITLE
fix: skip title on tiles integration tests

### DIFF
--- a/crawl-ref/source/test/stress/run
+++ b/crawl-ref/source/test/stress/run
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
-
-CRAWL=${CRAWL:-timeout 655 ./crawl -seed 1 -no-save -name test -wizard -no-throttle}
+CRAWL=${CRAWL:-timeout 655 ./crawl -seed 1 -no-save -name test -wizard -no-throttle -extra-opt-first "tile_skip_title=true"}
 
 run_one()
 {


### PR DESCRIPTION
This is a real minor point, but I figured it couldn't hurt. Previously, when running `make test` with `TILES=y`, you would have to manually press through the "Loading complete, press any key to start." message during the test/stress suite. This message can be skipped by either setting `tile_skip_title=true` or during a `./crawl -test` run. I added the tile_skip_title option for stress/run since that seemed like the best option.

I tested this with both tiles and non-tiles and all tests ran as expected in both modes. This shouldn't affect much since there's little reason to run tests with tiles, other than enjoying the pretty animations.