### PR TITLE
fix: acknowledge Storm Form in player-act.cc

### DIFF
--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -489,10 +489,16 @@ static string _hand_name_singular(bool temp)
     if (you.has_usable_tentacles())
         return "tentacle";
 
+    // Storm Form inactivates the paws mutation, but graphically, a Felid's electric body still maintains similar anatomy.
+    // In order to avoid defaulting to the "fist" check below, use this check instead.
+    if (temp && you.form == transformation::storm 
+        && you.species == SP_FELID)
+        return "paw";
+
     // For flavor reasons, use "fists" instead of "hands" in various places,
     // but if the creature does have a custom hand name, let the above code
     // preempt it.
-    if (temp && you.form == transformation::statue)
+    if (temp && you.form == (transformation::statue || transformation::storm))
         return "fist";
 
     // player has no usable claws, but has the mutation -- they are suppressed


### PR DESCRIPTION
A follow up to #2265. player-act.cc did not take into account the new 0.27 spell Storm Form in _hand_name_singular. This corrects this, and adds a correction to an edge case with felids that was encountered while testing.