### PR TITLE
Re-Add potions of cure mutation

### DIFF
--- a/crawl-ref/source/dat/des/variable/float.des
+++ b/crawl-ref/source/dat/des/variable/float.des
@@ -4689,8 +4689,8 @@ TAGS:   no_monster_gen no_trap_gen no_tele_into
 DEPTH:  D:4-, Lair
 ORIENT: float
 KMASK:  -'DE12 = no_item_gen
-# Cancellation placed only for mutagenic clouds.
-ITEM:   potion of resistance ident:type, potion of cancellation ident:type q:2
+# Cure Mutation placed only for mutagenic clouds.
+ITEM:   potion of resistance ident:type, potion of cure mutation ident:type q:2
 # Replaces a gold pile in late Dungeon
 : item(dgn.good_aux_armour)
 # Monsters appropriate for the cloud type must be defined in order of

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -872,6 +872,11 @@ A potion which mutates the drinker, removing several mutations then
 granting a few random mutations, which are likely (but not guaranteed) to be
 beneficial.
 %%%%
+potion of cure mutation
+
+A potion which removes several mutations from the drinker. A favorite of those who
+wander the infinite planes of the abyss.
+%%%%
 potion of resistance
 
 A potion which grants temporary resistance to a variety of harmful effects:

--- a/crawl-ref/source/dat/dlua/dungeon.lua
+++ b/crawl-ref/source/dat/dlua/dungeon.lua
@@ -699,14 +699,15 @@ dgn.loot_scrolls = [[
 dgn.loot_potions = [[
     w:15  potion of haste /
     w:15  potion of heal wounds /
-    w:10  potion of might /
-    w:10  potion of invisibility /
-    w:10  potion of magic /
-    w:10  potion of mutation /
+    w:11  potion of might /
+    w:11  potion of invisibility /
+    w:11  potion of magic /
+    w:11  potion of mutation /
     w:8   potion of cancellation /
+    w:5   potion of cure mutation /
     w:5   potion of brilliance /
     w:5   potion of resistance /
-    w:2   potion of experience
+    w:3   potion of experience
     ]]
 
 -- Some definitions for all types of auxiliary armour.

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -672,6 +672,7 @@ const char* potion_type_name(int potiontype)
     case POT_MAGIC:             return "magic";
     case POT_BERSERK_RAGE:      return "berserk rage";
     case POT_MUTATION:          return "mutation";
+	case POT_CURE_MUTATION:     return "cure mutation";
     case POT_RESISTANCE:        return "resistance";
     case POT_LIGNIFY:           return "lignification";
 

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -2143,6 +2143,7 @@ static map<potion_type, item_rarity_type> _potion_rarity = {
     { POT_MIGHT,        RARITY_UNCOMMON },
     { POT_BRILLIANCE,   RARITY_UNCOMMON },
     { POT_MUTATION,     RARITY_UNCOMMON },
+	{ POT_CURE_MUTATION,RARITY_RARE },
     { POT_INVISIBILITY, RARITY_RARE },
     { POT_RESISTANCE,   RARITY_RARE },
     { POT_MAGIC,        RARITY_RARE },

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -765,6 +765,55 @@ public:
     }
 };
 
+const int MIN_REMOVED = 3;
+const int MAX_REMOVED = 4;
+
+class PotionCureMutation : public PotionEffect
+{
+private:
+    PotionCureMutation() : PotionEffect(POT_CURE_MUTATION) { }
+    DISALLOW_COPY_AND_ASSIGN(PotionCureMutation);
+public:
+    static const PotionCureMutation &instance()
+    {
+        static PotionCureMutation inst; return inst;
+    }
+
+    bool can_quaff(string *reason = nullptr) const override
+    {
+        if (!_can_mutate(reason))
+            return false;
+
+        return true;
+    }
+
+    bool effect(bool = true, int = 40, bool = true) const override
+    {
+        mpr("It has a very clean taste.");
+        bool mutated = false;
+        int remove_mutations = random_range(MIN_REMOVED, MAX_REMOVED);
+
+        // Remove mutations.
+        for (int i = 0; i < remove_mutations; i++)
+            mutated |= delete_mutation(RANDOM_MUTATION, "potion of cure mutation", false);
+
+        learned_something_new(HINT_YOU_MUTATED);
+        return mutated;
+    }
+
+
+    bool quaff(bool was_known) const override
+    {
+        if (was_known && !check_known_quaff())
+            return false;
+
+        string msg = "Really drink that potion of cure mutation";
+        msg += you.rmut_from_item() ? " while resistant to mutation?" : "?";
+
+        effect();
+    }
+};
+
 class PotionDegeneration : public PotionEffect
 {
 private:

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -461,6 +461,10 @@ unsigned int item_value(item_def item, bool ident)
             case POT_MUTATION:
                 valued += 80;
                 break;
+			
+			case POT_CURE_MUTATION:
+                valued += 200;
+                break;
 
             case POT_BERSERK_RAGE:
             case POT_HEAL_WOUNDS:


### PR DESCRIPTION
There are some edge cases in the game where a player will be heavily mutated or just needs to remove a certain very bad mutation, and can quaff multiple potions of mutations and roll unluckily, still keeping the one mutation they wanted to remove and even adding further undesirable mutations. Re-adding potion of cure mutation as a low weight potion would fix this, and also make extended more desirable without fear of losing from a plethora of debilitating mutations.