### PR TITLE
Ammo's mulch rate and generation probability adjustment

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -662,15 +662,15 @@ struct missile_def
 static int Missile_index[NUM_MISSILES];
 static const missile_def Missile_prop[] =
 {
-    { MI_DART,          "dart",          0, 12, 2,  true  },
+    { MI_DART,          "dart",          0, 20, 2,  true  },
 #if TAG_MAJOR_VERSION == 34
     { MI_NEEDLE,        "needle",        0, 12, 2,  false },
 #endif
-    { MI_STONE,         "stone",         2, 8,  1,  true  },
-    { MI_ARROW,         "arrow",         0, 8,  2,  false },
-    { MI_BOLT,          "bolt",          0, 8,  2,  false },
-    { MI_LARGE_ROCK,    "large rock",   20, 25, 7,  true  },
-    { MI_SLING_BULLET,  "sling bullet",  4, 8,  5,  false },
+    { MI_STONE,         "stone",         2, 20,  1,  true  },
+    { MI_ARROW,         "arrow",         0, 20,  2,  false },
+    { MI_BOLT,          "bolt",          0, 20,  2,  false },
+    { MI_LARGE_ROCK,    "large rock",   20, 20, 7,  true  },
+    { MI_SLING_BULLET,  "sling bullet",  4, 20,  5,  false },
     { MI_JAVELIN,       "javelin",      10, 20, 8,  true  },
     { MI_THROWING_NET,  "throwing net",  0, 0,  30, true  },
     { MI_BOOMERANG,     "boomerang",     6, 20, 5,  true  },

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -629,12 +629,12 @@ static void _generate_missile_item(item_def& item, int force_type,
     else
     {
         item.sub_type =
-            random_choose_weighted(50, MI_STONE,
+            random_choose_weighted(20, MI_STONE,
                                    20, MI_ARROW,
-                                   12, MI_BOLT,
-                                   12, MI_SLING_BULLET,
-                                   10, MI_DART,
-                                   3,  MI_BOOMERANG,
+                                   20, MI_BOLT,
+                                   16, MI_SLING_BULLET,
+                                   16, MI_DART,
+                                   4,  MI_BOOMERANG,
                                    2,  MI_JAVELIN,
                                    1,  MI_THROWING_NET,
                                    1,  MI_LARGE_ROCK);

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -1022,7 +1022,7 @@ bool thrown_object_destroyed(item_def *item)
     const int mult = 2;
     int chance = base_chance * mult;
 
-    if (brand == SPMSL_CURARE)
+    if (brand == (SPMSL_CURARE)||(SPMSL_BLINDING)||(SPMSL_FRENZY))
         chance /= 2;
 
     dprf("mulch chance: %d in %d", mult, chance);

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -1022,7 +1022,7 @@ bool thrown_object_destroyed(item_def *item)
     const int mult = 2;
     int chance = base_chance * mult;
 
-    if (brand == (SPMSL_CURARE)||(SPMSL_BLINDING)||(SPMSL_FRENZY))
+    if (brand == SPMSL_CURARE || brand == SPMSL_BLINDING || brand == SPMSL_FRENZY)
         chance /= 2;
 
     dprf("mulch chance: %d in %d", mult, chance);


### PR DESCRIPTION
It's not important, but the mulch rate of ammo is hidden information. Since I don't think there's any real benefit to adjust the figures individually, I'd like to divide the rate ratio into three types.
General(Except for the exception, all)
Susceptible to destruction(special dart)
Very susceptible to destruction(net)

I think the supply and demand of bows and crossbows need to be smoother because they are main weapon. I think it is ideal that the amount of ammo is somewhat insufficient when the player does not have the help of god. In line with the developers' intention to turn throwing weapons into strategic resources, I'm will not touch javelin. However, I think the quantity of darts and boomerangs is somewhat insufficient to achieve the strategic goal. Of course, excessive use of special darts is not allowed, so I will apply two times the probability of destruction to them like curare.