### PR TITLE
Make color tags render in MessageRegion

### DIFF
--- a/crawl-ref/source/tilereg-msg.cc
+++ b/crawl-ref/source/tilereg-msg.cc
@@ -67,12 +67,12 @@ void MessageRegion::render()
         coord_def min_pos(sx, sy);
         coord_def max_pos(ex, ey);
         // these hover strings never use the last line
-        string text = m_font->split(formatted_string::parse_string(m_alt_text),
-                ex-sx-2*ox, ey-sy-2*oy-m_font->char_height()).tostring();
+        formatted_string text = m_font->split(formatted_string::parse_string(m_alt_text),
+                ex-sx-2*ox, ey-sy-2*oy-m_font->char_height());
         if (ends_with(text, ".."))
-            text = text.substr(0, text.find_last_of('\n')) + "\n...";
+            text = text.substr_bytes(0, text.tostring().find_last_of('\n')) + "\n...";
 
-        m_font->render_string(sx + ox, sy + oy, formatted_string::parse_string(text, WHITE));
+        m_font->render_string(sx + ox, sy + oy, text);
         return;
     }
 

--- a/crawl-ref/source/tilereg-msg.cc
+++ b/crawl-ref/source/tilereg-msg.cc
@@ -67,12 +67,12 @@ void MessageRegion::render()
         coord_def min_pos(sx, sy);
         coord_def max_pos(ex, ey);
         // these hover strings never use the last line
-        string text = m_font->split(formatted_string(m_alt_text),
+        string text = m_font->split(formatted_string::parse_string(m_alt_text),
                 ex-sx-2*ox, ey-sy-2*oy-m_font->char_height()).tostring();
         if (ends_with(text, ".."))
             text = text.substr(0, text.find_last_of('\n')) + "\n...";
 
-        m_font->render_string(sx + ox, sy + oy, formatted_string(text, WHITE));
+        m_font->render_string(sx + ox, sy + oy, formatted_string::parse_string(text, WHITE));
         return;
     }
 


### PR DESCRIPTION
Previously, any color tags in a string such as `the <w>C</w> key` that was passed to a MessageRegion would be totally ignored, and printed verbatim to the message region. This fixes that by using `formatted_string::parse_string` instead of `formatted_string::formatted_string`. I’m unsure if this is the idiomatic way of getting a `formatted_string` instance that’s been parsed, but it does seem to work.

The other mild thing this makes me wonder is that text descriptions in the MessageRegion are white by default, so the rendered format string for the above example just looks like uncolored text. Would it be feasible to give something like a bold weight to any color tags inside a formatted string whose `init_color` is the same as the color tag’s? As an alternate solution, which I’m including in this PR, I’ve changed the color for these popups to the more “default” color of light gray. It seems okay to me and also works with what a lot of previous `<w>` usage in descriptions seems to expect.

I’ve also tested this fairly throughly across a good number of scenarios, but I would still appreciate a close review here—this is definitely an area that can be subject to annoying off-by-one type errors.

-----

Here’s a screenshot without the fix:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/12972285/146817247-66378793-4eaa-49e2-9dc2-7578802e1f21.png">


Here’s a screenshot with:
<img width="711" alt="image" src="https://user-images.githubusercontent.com/12972285/146822220-d41feeed-0461-4337-924a-479dcec53fb7.png">

