### PR TITLE
Adjustment magic staff's Acc and Dam

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -587,7 +587,7 @@ static const weapon_def Weapon_prop[] =
 
     // Staves
     // WPN_STAFF is for weapon stats for magical staves only.
-    { WPN_STAFF,             "staff",               5,  5, 12,
+    { WPN_STAFF,             "staff",               10,  0, 18,
         SK_STAVES,       SIZE_LITTLE, SIZE_MEDIUM, MI_NONE,
         DAMV_CRUSHING, 0, 0, 15, {} },
     { WPN_QUARTERSTAFF,      "quarterstaff",        10, 3, 13,


### PR DESCRIPTION
Lower hit rates and increase damage so that hybrid jobs can use magic staff more useful. Instead, I will make the basic attack very slow and significantly increase the required skill level from 12 to 18 in order to limit magic users from easily gaining melee capabilities.

p.s - I wanted to revise the damage formula a little, but this work seems a little sensitive and tricky, so I'm putting it on hold. If anyone is interested, please help me. :)