### PR TITLE
Display potion/scroll rarity on the item knowledge screen

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1949,25 +1949,25 @@ static string _describe_lignify_ac()
                         treeform_ac);
 }
 
-static string _describe_item_rarity(const item_def &item)
+string describe_item_rarity(const item_def &item)
 {
     item_rarity_type rarity = consumable_rarity(item);
 
     switch (rarity)
     {
     case RARITY_VERY_RARE:
-        return "very rarely";
+        return "very rare";
     case RARITY_RARE:
-        return "rarely";
+        return "rare";
     case RARITY_UNCOMMON:
-        return "uncommonly";
+        return "uncommon";
     case RARITY_COMMON:
-        return "commonly";
+        return "common";
     case RARITY_VERY_COMMON:
-        return "very commonly";
+        return "very common";
     case RARITY_NONE:
     default:
-        return "buggily";
+        return "buggy";
     }
 }
 
@@ -2269,9 +2269,9 @@ string get_item_description(const item_def &item, bool verbose,
                         description << "\n\nDrinking this now will have no effect.";
                 }
             }
-            description << "\n\nIt is found "
-                        << _describe_item_rarity(item)
-                        << " compared to other types of potion.";
+            description << "\n\nIt is "
+                        << article_a(describe_item_rarity(item))
+                        << " potion.";
         }
         break;
 
@@ -2293,9 +2293,9 @@ string get_item_description(const item_def &item, bool verbose,
     case OBJ_SCROLLS:
         if (item_type_known(item))
         {
-            description << "\n\nIt is found "
-                        << _describe_item_rarity(item)
-                        << " compared to other types of scroll.";
+            description << "\n\nIt is "
+                        << article_a(describe_item_rarity(item))
+                        << " scroll.";
         }
         break;
 

--- a/crawl-ref/source/describe.h
+++ b/crawl-ref/source/describe.h
@@ -57,6 +57,7 @@ command_type describe_item_popup(const item_def &item,
                                  function<void (string&)> fixup_desc = nullptr,
                                  bool do_actions = false);
 bool describe_item(item_def &item, function<void (string&)> fixup_desc = nullptr);
+string describe_item_rarity(const item_def &item);
 void get_item_desc(const item_def &item, describe_info &inf);
 void inscribe_item(item_def &item);
 void target_item(item_def &item);

--- a/crawl-ref/source/known-items.cc
+++ b/crawl-ref/source/known-items.cc
@@ -6,6 +6,7 @@
 #include "AppHdr.h"
 
 #include "decks.h"
+#include "describe.h"
 #include "english.h"
 #include "invent.h"
 #include "item-prop.h"
@@ -140,6 +141,12 @@ public:
         {
             name = pluralise(item->name(DESC_DBNAME));
         }
+        else if (item->base_type == OBJ_SCROLLS
+                 || item->base_type == OBJ_POTIONS)
+        {
+            name = pluralise(item->name(DESC_DBNAME))
+                   + " (" + describe_item_rarity(*item) + ")";
+        }
         else
         {
             name = item->name(DESC_PLAIN, false, true, false, false,
@@ -207,11 +214,17 @@ public:
 
     virtual string get_text(const bool = false) const override
     {
+        if (item->base_type == OBJ_SCROLLS || item->base_type == OBJ_POTIONS)
+        {
+            return " " + item->name(DESC_PLAIN, false, true, false)
+                   + " (" + describe_item_rarity(*item) + ")";
+        }
+
         description_level_type desctype =
             item->base_type == OBJ_WANDS ? DESC_DBNAME : DESC_PLAIN;
 
-        return string(" ") + item->name(desctype, false, true, false, false,
-                                        ISFLAG_KNOW_PLUSES);
+        return " " + item->name(desctype, false, true, false, false,
+                                ISFLAG_KNOW_PLUSES);
     }
 };
 


### PR DESCRIPTION
This PR adds information about relative generation weights to the `\` screen. It'll look like this:

![unided_consumables](https://user-images.githubusercontent.com/3328424/147383803-531705f6-8694-4c86-8f64-44068c5f06d0.png)

Also, it replaces strings like `It is found rarely compared to other types of scroll.`
with a more succinct `It is a rare scroll.` in item descriptions.

