### PR TITLE
feat: add option autopickup_decide_on_sight

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -25,8 +25,8 @@ The contents of this text are:
 3-  Interface.
 3-a     Dropping and Picking up.
                 autopickup, autopickup_exceptions, default_autopickup,
-                pickup_thrown, assign_item_slot, pickup_menu_limit,
-                drop_filter
+                autopickup_decide_on_sight, pickup_thrown, assign_item_slot,
+                pickup_menu_limit, drop_filter
 3-b     Passive Sightings (detected and remembered entities).
                 detected_monster_colour, detected_item_colour,
                 remembered_monster_colour
@@ -562,6 +562,13 @@ autopickup_exceptions ^= <pickup-regex, >don't-pickup-regex, ...
 default_autopickup = true
         When set to false, the game starts with autopickup turned off.
         You can still toggle autopickup in-game with Ctrl-A.
+
+autopickup_decide_on_sight = true
+        When set to true, equipment on the ground will be marked to be picked
+        up as soon as you spot them, regardless of autopickup settings
+        changing after the equipment is spotted. When set to false, changing
+        the autopickup settings will not cause the newly-discovered equipment
+        to remain marked for pickup.
 
 pickup_thrown = true
         pickup_thrown = true causes autopickup to pick up thrown/fired

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -182,6 +182,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(allow_extended_colours), true),
         new BoolGameOption(SIMPLE_NAME(regex_search), false),
         new BoolGameOption(SIMPLE_NAME(autopickup_search), false),
+        new BoolGameOption(SIMPLE_NAME(autopickup_decide_on_sight), true),
         new BoolGameOption(SIMPLE_NAME(show_newturn_mark), true),
         new BoolGameOption(SIMPLE_NAME(show_game_time), true),
         new BoolGameOption(SIMPLE_NAME(equip_bar), false),

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -965,13 +965,11 @@ static bool _id_floor_item(item_def &item)
         if (fully_identified(item))
             return false;
 
-        // autopickup hack for previously-unknown items
-        if (item_needs_autopickup(item))
-            item.props[NEEDS_AUTOPICKUP_KEY] = true;
-        identify_item(item);
-        // but skip ones that we discover to be useless
-        if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
-            item.props.erase(NEEDS_AUTOPICKUP_KEY);
+        // Same logic as wands here, may be viable to merge the two cases.
+        bool should_pickup = item_needs_autopickup(item);
+        set_ident_type(item, true);
+        if (!should_pickup)
+            set_item_autopickup(item, AP_FORCE_OFF);
         return true;
     }
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -965,28 +965,14 @@ static bool _id_floor_item(item_def &item)
         if (fully_identified(item))
             return false;
 
-        // This is a weird option—basically, some people might want to change
-        // autopickup settings as soon as they spot an item but still expect
-        // to pick up the item, which is what the true case is for. Other
-        // people may want to disable autopickup for the item as soon as it's
-        // floor ID'd, which is what the second case is for.
-        if (Options.autopickup_decide_on_sight)
-        {
-            // autopickup hack for previously-unknown items
-            if (item_needs_autopickup(item))
-                item.props[NEEDS_AUTOPICKUP_KEY] = true;
-            identify_item(item);
-            // but skip ones that we discover to be useless
-            if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
-                item.props.erase(NEEDS_AUTOPICKUP_KEY);
-        }
-        else
-        {
-            bool should_pickup = item_needs_autopickup(item);
-            set_ident_type(item, true);
-            if (!should_pickup)
-                set_item_autopickup(item, AP_FORCE_OFF);
-        }
+        // Some people may want to change autopickup settings as soon as
+        // they spot an item but still expect to pick up the item
+        if (item_needs_autopickup(item) && Options.autopickup_decide_on_sight)
+            item.props[NEEDS_AUTOPICKUP_KEY] = true;
+        identify_item(item);
+        // but skip ones that we discover to be useless
+        if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
+            item.props.erase(NEEDS_AUTOPICKUP_KEY);
         return true;
     }
 

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -965,11 +965,28 @@ static bool _id_floor_item(item_def &item)
         if (fully_identified(item))
             return false;
 
-        // Same logic as wands here, may be viable to merge the two cases.
-        bool should_pickup = item_needs_autopickup(item);
-        set_ident_type(item, true);
-        if (!should_pickup)
-            set_item_autopickup(item, AP_FORCE_OFF);
+        // This is a weird option—basically, some people might want to change
+        // autopickup settings as soon as they spot an item but still expect
+        // to pick up the item, which is what the true case is for. Other
+        // people may want to disable autopickup for the item as soon as it's
+        // floor ID'd, which is what the second case is for.
+        if (Options.autopickup_decide_on_sight)
+        {
+            // autopickup hack for previously-unknown items
+            if (item_needs_autopickup(item))
+                item.props[NEEDS_AUTOPICKUP_KEY] = true;
+            identify_item(item);
+            // but skip ones that we discover to be useless
+            if (item.props.exists(NEEDS_AUTOPICKUP_KEY) && is_useless_item(item))
+                item.props.erase(NEEDS_AUTOPICKUP_KEY);
+        }
+        else
+        {
+            bool should_pickup = item_needs_autopickup(item);
+            set_ident_type(item, true);
+            if (!should_pickup)
+                set_item_autopickup(item, AP_FORCE_OFF);
+        }
         return true;
     }
 

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -496,6 +496,8 @@ public:
     bool        regex_search; // whether to default to regex search for ^F
     bool        autopickup_search; // whether to annotate stash items with
                                    // autopickup status
+    bool        autopickup_decide_on_sight; // Mark an item for pickup when you
+                                            // first spot it
 
     lang_t              language;         // Translation to use.
     const char*         lang_name;        // Database name of the language.


### PR DESCRIPTION
This is a second take at #2245, which was reverted in 87f88a2 as it turns out some people [rely](https://xkcd.com/1172/) on the behavior I thought I was fixing (understandably so, funny comics aside).

I would appreciate any feedback on the option naming and it's description in options_guide.txt since I'm not confident I'm explaining it well—although to be fair, I think this is an unintuitive (and possibly niche?) option to begin with.