### PR TITLE
fix: display_bar should clamp negative values

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4501,22 +4501,26 @@ static void _describe_mons_to_hit(const monster_info& mi, ostringstream &result)
 }
 
 /**
- * Print a bar of +s and .s representing a given stat to a provided stream.
+ * Print a bar of +s representing a given stat to a provided stream.
  *
- * @param value[in]         The current value represented by the bar.
- * @param scale[in]         The value that each + and . represents.
+ * @param value[in]         The current value represented by the bar. Clamped
+ *                          to zero.
+ * @param scale[in]         The value that each + represents.
  * @param name              The name of the bar.
  * @param result[in,out]    The stringstream to append to.
- * @param base_value[in]    The 'base' value represented by the bar. If
- *                          INT_MAX, is ignored.
+ * @param base_value[in]    The 'base' value represented by the bar, clamped to
+ *                          zero. If INT_MAX, is ignored.
  */
 static void _print_bar(int value, int scale, string name,
                        ostringstream &result, int base_value)
 {
+    value = max(0, value);
+    base_value = max(0, base_value);
+
     if (base_value == INT_MAX)
         base_value = value;
 
-    if (name.size())
+    if (!name.empty())
         result << name << " ";
 
     const int display_max = value ? value : base_value;
@@ -4526,7 +4530,7 @@ static void _print_bar(int value, int scale, string name,
       result << "none (normally ";
 
     if (display_max == 0)
-        result <<  "none";
+        result << "none";
     else
     {
         for (int i = 0; i * scale < display_max; i++)
@@ -4542,13 +4546,11 @@ static void _print_bar(int value, int scale, string name,
 
 #ifdef DEBUG_DIAGNOSTICS
     if (!you.suppress_wizard)
+    {
         result << " (" << value << ")";
-#endif
-
-#ifdef DEBUG_DIAGNOSTICS
-    if (currently_disabled)
-        if (!you.suppress_wizard)
+        if (currently_disabled)
             result << " (base: " << base_value << ")";
+    }
 #endif
 }
 

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -96,7 +96,7 @@
 using namespace ui;
 
 static command_type _get_action(int key, vector<command_type> actions);
-static void _print_bar(int value, int scale, string name,
+static void _print_bar(int value, int scale, const string &name,
                        ostringstream &result, int base_value = INT_MAX);
 
 static void _describe_mons_to_hit(const monster_info& mi, ostringstream &result);
@@ -4511,7 +4511,7 @@ static void _describe_mons_to_hit(const monster_info& mi, ostringstream &result)
  * @param base_value[in]    The 'base' value represented by the bar, clamped to
  *                          zero. If INT_MAX, is ignored.
  */
-static void _print_bar(int value, int scale, string name,
+static void _print_bar(int value, int scale, const string &name,
                        ostringstream &result, int base_value)
 {
     value = max(0, value);


### PR DESCRIPTION
If a bar was displayed of something with a negative value (like with EV) then text such as "EV: none (normally )" could be displayed. This is a bit odd, so let's make cases like that display "EV: none" instead.

I'm unsure if this breaks anything, but a bit of testing didn't show anything unexpected. The function isn't used for much besides showing player accuracy in `_player_spell_stats` (which seems to only be called when accuracy isn't -1) as well as monster EV, will, and AC.

Before:
![image](https://user-images.githubusercontent.com/12972285/147511713-87bb3363-c529-493b-b4ea-399c5e6abc07.png)

After:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/12972285/147514544-3dc36a1c-fef9-4d61-a14c-2b84ffd3f7f8.png">

