### PR TITLE
Update typed-ast to 1.4.3

### DIFF
--- a/crawl-ref/source/webserver/requirements/dev.py3.txt
+++ b/crawl-ref/source/webserver/requirements/dev.py3.txt
@@ -43,7 +43,7 @@ testfixtures==6.14.0      # via flake8-isort
 toml==0.10.0              # via isort, tox
 tornado==6.0.4            # via -r requirements.in/base.txt
 tox==3.14.5               # via -r requirements.in/dev.txt
-typed-ast==1.4.1          # via mypy
+typed-ast==1.4.3          # via mypy
 typing-extensions==3.7.4.1  # via mypy
 virtualenv==20.0.13       # via tox
 wcwidth==0.1.9            # via pytest


### PR DESCRIPTION
This is required to run the server on Python 3.10+