### PR TITLE
fix: phial should always engulf the center target

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2419,8 +2419,7 @@ void bolt::affect_endpoint()
         set<coord_def> splash_coords = create_feat_splash(pos(), is_player ? 2 : 1, num, dur);
         dprf(DIAG_BEAM, "Creating pool at %d,%d with %d tiles of water for %d auts.", pos().x, pos().y, num, dur);
 
-        // Waterlog anything at the center, even if a pool wasn't generated
-        // there
+        // Waterlog anything at the center, even if a pool wasn't generated there
         splash_coords.insert(pos());
 
         if (is_player)

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2078,12 +2078,12 @@ void fire_tracer(const monster* mons, bolt &pbolt, bool explode_only,
     pbolt.is_tracer = false;
 }
 
-vector<coord_def> create_feat_splash(coord_def center,
+set<coord_def> create_feat_splash(coord_def center,
                                 int radius,
                                 int number,
                                 int duration)
 {
-    vector<coord_def> splash_coords;
+    set<coord_def> splash_coords;
 
     for (distance_iterator di(center, true, false, radius); di && number > 0; ++di)
     {
@@ -2095,7 +2095,7 @@ vector<coord_def> create_feat_splash(coord_def center,
             int time = random_range(duration, duration * 3 / 2) - (di.radius() * 20);
             temp_change_terrain(*di, DNGN_SHALLOW_WATER, time,
                                 TERRAIN_CHANGE_FLOOD);
-            splash_coords.push_back(*di);
+            splash_coords.insert(*di);
         }
     }
 
@@ -2416,8 +2416,13 @@ void bolt::affect_endpoint()
         const int num = is_player ? div_rand_round(ench_power * 3, 20) + 3 + random2(7)
                                   : random_range(3, 12, 2);
         const int dur = div_rand_round(ench_power * 4, 3) + 66;
-        vector<coord_def> splash_coords = create_feat_splash(pos(), is_player ? 2 : 1, num, dur);
+        set<coord_def> splash_coords = create_feat_splash(pos(), is_player ? 2 : 1, num, dur);
         dprf(DIAG_BEAM, "Creating pool at %d,%d with %d tiles of water for %d auts.", pos().x, pos().y, num, dur);
+
+        // Waterlog anything at the center, even if a pool wasn't generated
+        // there
+        splash_coords.insert(pos());
+
         if (is_player)
         {
             for (const coord_def &coord : splash_coords)

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -345,7 +345,7 @@ spret zapping(zap_type ztype, int power, bolt &pbolt,
                    bool fail = false);
 bool player_tracer(zap_type ztype, int power, bolt &pbolt, int range = 0);
 
-vector<coord_def> create_feat_splash(coord_def center, int radius, int num, int dur);
+set<coord_def> create_feat_splash(coord_def center, int radius, int num, int dur);
 
 void init_zap_index();
 void clear_zap_info_on_exit();


### PR DESCRIPTION
Previously, if the phial of floods knocked a target back onto a non-floor or water feature like a staircase, then no flooding would generate at that location (fine) and consequently no waterlogging/engulfing (not fine).

Let's instead make create_feat_splash return a set of coordinates, and add back the center location before iterating over monsters to waterlog.

Closes #2331.