### PR TITLE
Check negative energy resistance when casting vampiric drain

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5199,7 +5199,8 @@ bool ench_flavour_affects_monster(beam_type flavour, const monster* mon,
         break;
 
     case BEAM_VAMPIRIC_DRAINING:
-        rc = actor_is_susceptible_to_vampirism(*mon);
+        rc = actor_is_susceptible_to_vampirism(*mon)
+                && (mon->res_negative_energy(intrinsic_only) < 3);
         break;
 
     case BEAM_VIRULENCE:


### PR DESCRIPTION
The game doesn't warn the player when casting vampiric drain on natural monsters with immunity to negative energy.

I challenged Josephine to a vampiric drain duel, now all my familiy and friends are ashamed of me.