### PR TITLE
refactor and a fix: wearing/taking off armour

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -498,6 +498,8 @@ string no_selectables_message(int item_selector)
     case OSEL_UNCURSED_WORN_JEWELLERY:
         return "You aren't wearing any piece of uncursed jewellery.";
 #endif
+    case OSEL_WORN_ARMOUR:
+        return "You aren't wearing any pieces of armour.";
     case OSEL_BRANDABLE_WEAPON:
         return "You aren't carrying any weapons that can be branded.";
     case OSEL_ENCHANTABLE_WEAPON:

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1254,8 +1254,7 @@ bool wear_armour(int item)
     if (to_wear->pos == ITEM_IN_INVENTORY && item_is_worn(to_wear->link))
     {
         if (Options.equip_unequip)
-            // TODO: huh? Why are we inverting the return value?
-            return !takeoff_armour(to_wear->link);
+            return takeoff_armour(to_wear->link);
         else
         {
             mpr("You're already wearing that object!");
@@ -1302,23 +1301,45 @@ bool wear_armour(int item)
     int item_slot = _get_item_slot_maybe_with_move(*to_wear);
 
     start_delay<EquipOnDelay>(ARMOUR_EQUIP_DELAY - (swapping ? 0 : 1),
-                               you.inv[item_slot]);
+                              you.inv[item_slot]);
+
+    return true;
+}
+
+static bool _can_generically_takeoff_armour()
+{
+    if (you.berserk())
+    {
+        canned_msg(MSG_TOO_BERSERK);
+        return false;
+    }
+
+    if (you.has_mutation(MUT_NO_ARMOUR))
+    {
+        mprf("You can't remove your %s, sorry.",
+             species::skin_name(you.species).c_str());
+        return false;
+    }
+
+    if (!form_can_wear())
+    {
+        mpr("You can't wear or remove anything in your present form.");
+        return false;
+    }
 
     return true;
 }
 
 static bool _can_takeoff_armour(int item)
 {
+    if (!_can_generically_takeoff_armour())
+        return false;
+
     item_def& invitem = you.inv[item];
+
     if (invitem.base_type != OBJ_ARMOUR)
     {
-        mpr("You aren't wearing that!");
-        return false;
-    }
-
-    if (you.berserk())
-    {
-        canned_msg(MSG_TOO_BERSERK);
+        mpr("You couldn't even wear that if you tried!");
         return false;
     }
 
@@ -1345,13 +1366,24 @@ static bool _can_takeoff_armour(int item)
     return true;
 }
 
-// TODO: It would be nice if this were made consistent with wear_armour,
-// wield_weapon, puton_ring, etc. in terms of taking a default value of -1,
-// which has the effect of prompting for an item to take off.
-//
-/// noask suppresses the "stat zero" prompt.
+/**
+ * Takes off a given piece of armour.
+ * @param item The item to remove. If -1, the player will be prompted.
+ * @param noask Whether to prompt if removing the item would cause stat-zero.
+ * @return True if the item was removed.
+ */
 bool takeoff_armour(int item, bool noask)
 {
+    // We want to check non-item depedent stuff before prompting for the actual item
+    if (!_can_generically_takeoff_armour())
+        return false;
+
+    if (item == -1
+        && !armour_prompt("Take off which item?", &item, OPER_TAKEOFF))
+    {
+        return false;
+    }
+
     if (!_can_takeoff_armour(item))
         return false;
 
@@ -1369,7 +1401,6 @@ bool takeoff_armour(int item, bool noask)
     }
 
     you.turn_is_over = true;
-
     start_delay<EquipOffDelay>(ARMOUR_EQUIP_DELAY - 1, invitem);
 
     return true;
@@ -1629,7 +1660,7 @@ static bool _safe_to_remove_or_wear(const item_def &item, const item_def
 static bool _safe_to_remove_or_wear(const item_def &item, bool remove,
                                     bool quiet)
 {
-    return _safe_to_remove_or_wear(item, 0, remove, quiet);
+    return _safe_to_remove_or_wear(item, nullptr, remove, quiet);
 }
 
 // Checks whether removing an item would cause flight to end and the
@@ -1924,6 +1955,12 @@ static bool _can_puton_amulet(const item_def &item)
     return true;
 }
 
+/**
+ * Handles the case of putting on a ring where the ring was an amulet; called by puton_ring.
+ * @param item The amulet we're putting on.
+ * @param check_for_inscriptions Whether or not to prompt the player when there are side effects to wearing the amulet.
+ * @return True if the item was put on /or/ taken off.
+ */
 static bool _puton_amulet(item_def &item,
                           bool check_for_inscriptions)
 {
@@ -1931,9 +1968,7 @@ static bool _puton_amulet(item_def &item,
     {
         // "Putting on" an equipped item means taking it off.
         if (Options.equip_unequip)
-            // TODO: why invert the return value here? failing to remove
-            // an amulet is equivalent to successfully putting one on?
-            return !remove_ring(item.link);
+            return remove_ring(item.link);
         mpr("You're already wearing that amulet!");
         return false;
     }
@@ -1980,9 +2015,7 @@ static bool _puton_ring(item_def &item, bool prompt_slot,
             continue;
         // "Putting on" an equipped item means taking it off.
         if (Options.equip_unequip)
-            // TODO: why invert the return value here? failing to remove
-            // a ring is equivalent to successfully putting one on?
-            return !remove_ring(item.link);
+            return remove_ring(item.link);
         mpr("You're already wearing that ring!");
         return false;
     }
@@ -2078,7 +2111,14 @@ static bool _puton_ring(item_def &item, bool prompt_slot,
     return true;
 }
 
-// Put on a ring or amulet. (Most of the work is in _puton_item.)
+/**
+ * Try to put on or take off a ring or amulet. Most of the work is in _puton_item.
+ *
+ * @param allow_prompt If we prompt for a slot if we need to choose.
+ * @param noask Whether or not to prompt a warning when this action will cause
+ *              stat-zero effects.
+ * @return True if the item was put on /or/ taken off.
+ */
 bool puton_ring(item_def &to_puton, bool allow_prompt,
                 bool check_for_inscriptions, bool noask)
 {
@@ -2129,10 +2169,16 @@ bool puton_ring(int slot, bool allow_prompt, bool check_for_inscriptions,
                       noask);
 }
 
-// Remove the ring/amulet at given inventory slot (or, if slot is -1, prompt
-// for which piece of jewellery to remove)
-//
-// noask suppresses the "stat zero" prompt.
+/**
+ * Remove the ring or amulet at the given inventory slot, prompting
+ * if slot is -1 (default).
+ *
+ * @param slot The slot to remove the ring from, or -1 if the player should
+ *             be prompted.
+ * @param announce If the item name should be used in the "It's cursed" message
+ * @param noask Suppresses the "stat zero" prompt
+ * @returns true if the ring was removed
+ */
 bool remove_ring(int slot, bool announce, bool noask)
 {
     equipment_type hand_used = EQ_NONE;
@@ -2179,13 +2225,13 @@ bool remove_ring(int slot, bool announce, bool noask)
     if (hand_used == EQ_NONE)
     {
         const int equipn =
-            (slot == -1)? prompt_invent_item("Remove which piece of jewellery?",
-                                             menu_type::invlist,
-                                             OBJ_JEWELLERY,
-                                             OPER_REMOVE,
-                                             invprompt_flag::no_warning
-                                                | invprompt_flag::hide_known)
-                        : slot;
+            (slot == -1) ? prompt_invent_item("Remove which piece of jewellery?",
+                                              menu_type::invlist,
+                                              OBJ_JEWELLERY,
+                                              OPER_REMOVE,
+                                              invprompt_flag::no_warning
+                                                  | invprompt_flag::hide_known)
+                         : slot;
 
         if (prompt_failed(equipn))
             return false;

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -790,7 +790,7 @@ bool item_is_worn(int inv_slot)
 }
 
 /**
- * Prompt user for carried armour.
+ * Prompt user for carried armour. Will warn user if wearing/removing the armour is dangerous.
  *
  * @param mesg Title for the prompt
  * @param index[out] the inventory slot of the item chosen; not initialised
@@ -1393,12 +1393,6 @@ bool takeoff_armour(int item, bool noask)
     // below 0, we should get confirmation.
     if (!noask && !_safe_to_remove_or_wear(invitem, true))
         return false;
-
-    if (!check_warning_inscriptions(invitem, OPER_REMOVE))
-    {
-        canned_msg(MSG_OK);
-        return false;
-    }
 
     you.turn_is_over = true;
     start_delay<EquipOffDelay>(ARMOUR_EQUIP_DELAY - 1, invitem);

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -19,7 +19,7 @@ bool use_an_item(item_def *&target, int item_type, operation_types oper,
 
 bool armour_prompt(const string & mesg, int *index, operation_types oper);
 
-bool takeoff_armour(int index, bool noask = false);
+bool takeoff_armour(int index = -1, bool noask = false);
 
 void drink(item_def* potion = nullptr);
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1683,26 +1683,6 @@ static void _experience_check()
 #endif
 }
 
-static void _do_remove_armour()
-{
-    if (you.has_mutation(MUT_NO_ARMOUR))
-    {
-        mprf("You can't remove your %s, sorry.",
-                            species::skin_name(you.species).c_str());
-        return;
-    }
-
-    if (!form_can_wear())
-    {
-        mpr("You can't wear or remove anything in your present form.");
-        return;
-    }
-
-    int index = 0;
-    if (armour_prompt("Take off which item?", &index, OPER_TAKEOFF))
-        takeoff_armour(index);
-}
-
 static void _toggle_travel_speed()
 {
     you.travel_ally_pace = !you.travel_ally_pace;
@@ -2136,16 +2116,15 @@ void process_command(command_type cmd, command_type prev_cmd)
     case CMD_LOOK_AROUND:          do_look_around();         break;
     case CMD_QUAFF:                drink();                  break;
     case CMD_READ:                 read();                   break;
-    case CMD_REMOVE_ARMOUR:        _do_remove_armour();      break;
+    case CMD_REMOVE_ARMOUR:        takeoff_armour();         break;
     case CMD_REMOVE_JEWELLERY:     remove_ring();            break;
     case CMD_SHOUT:                issue_orders();           break;
     case CMD_THROW_ITEM_NO_QUIVER: throw_item_no_quiver();   break;
     case CMD_WEAPON_SWAP:          wield_weapon(true);       break;
     case CMD_WEAR_ARMOUR:          wear_armour();            break;
-    case CMD_WEAR_JEWELLERY:       puton_ring(-1);           break;
+    case CMD_WEAR_JEWELLERY:       puton_ring();             break;
     case CMD_WIELD_WEAPON:         wield_weapon(false);      break;
     case CMD_ZAP_WAND:             zap_wand();               break;
-
     case CMD_DROP:
         drop();
         break;


### PR DESCRIPTION
This refactors a good bit of the logic for taking off armour, as well as a few other things in the inventory wear/unwear section.

I also removed a few TODOs, clarified the semantics of the return values of the wear/unwear armour functions (they are not used anywhere anyway), and added a few doc comments for some of the less intuitive functions.

As a part of this, it fixes a tiles bug where clicking to equip items that were dangerous to put on would give you a prompt twice: this is seen in the changes in tile_item_use.
