### PR TITLE
fix: moving staircases shouldn't be considered invisible

### DIFF
--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2320,8 +2320,8 @@ bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,
                 && feat_stair_direction(feat) != CMD_NO_CMD
                 && feat_stair_direction(stair_taken) != CMD_NO_CMD)
             {
-                string stair_str = feature_description_at(you.pos(), false,
-                                                          DESC_THE);
+                string stair_str = feature_description(feat, NUM_TRAPS, "",
+                                                       DESC_THE);
                 string verb = stair_climb_verb(feat);
 
                 if (coinflip()


### PR DESCRIPTION
When you climbed down a staircase while Xom was sliding them around, you could get the message " slides away from you right [...]". The stair was being described by feature_description_at which only uses the player map knowledge, which means the staircase would be DNGN_UNSEEN. This uses feature_description instead to get around that.