### PR TITLE
Stop artefact amulets of faith from flashing on first worshipping Gozag.

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3561,7 +3561,8 @@ static void _god_welcome_handle_gear()
 {
     // Check for amulets of faith.
     item_def *amulet = you.slot_item(EQ_AMULET, false);
-    if (amulet && amulet->sub_type == AMU_FAITH && !is_useless_item(*amulet))
+    if (amulet && amulet->sub_type == AMU_FAITH
+        && ignore_faith_reason().empty())
     {
         mprf(MSGCH_GOD, "Your amulet flashes!");
         flash_view_delay(UA_PLAYER, god_colour(you.religion), 300);


### PR DESCRIPTION
FIX. The game checked ignore_faith_reason() when a non-demigod puts on an amulet of faith, and checked is_useless_item() when one committed to a god. These give different results for artefacts (which are never considered "useless").

It now checks ignore_faith_reason() in both cases, and there is no special message when a character wearing an amulet of faith worships Ashenzari, Gozag or Ignis.