### PR TITLE
Don't grant free piety to Jiyva worshippers

### DIFF
--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -794,7 +794,7 @@ static like_map divine_likes[] =
     // GOD_JIYVA,
     {
         { DID_EXPLORATION, {
-            "you explore the world", false,
+            "you explore the world outside of the Slime Pits", false,
             0, 0, 0, nullptr,
             [] (int &piety, int &/*denom*/, const monster* /*victim*/)
             {

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1070,7 +1070,8 @@ static update_flags player_view_update_at(const coord_def &gc)
     {
         if (!crawl_state.game_is_arena()
             && cell_triggers_conduct(gc)
-            && !player_in_branch(BRANCH_TEMPLE))
+            && !player_in_branch(BRANCH_TEMPLE)
+            && !(player_in_branch(BRANCH_SLIME) && you_worship(GOD_JIYVA)))
         {
             did_god_conduct(DID_EXPLORATION, 2500);
             const int density = env.density ? env.density : 2000;


### PR DESCRIPTION
Fully exploring the Slime Pits is a risk-free and tedious way of getting exploration piety under Jiyva. Let's not give players an incentive to do this.