### PR TITLE
fix: make Trog tantrum if orb of energy is used

### DIFF
--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -307,7 +307,8 @@ bool is_hasty_item(const item_def& item, bool calc_unid)
 bool is_wizardly_item(const item_def& item, bool calc_unid)
 {
     if ((calc_unid || item_brand_known(item))
-        && get_weapon_brand(item) == SPWPN_PAIN)
+        && (get_weapon_brand(item) == SPWPN_PAIN
+           || get_armour_ego_type(item) == SPARM_ENERGY))
     {
         return true;
     }


### PR DESCRIPTION
An orb of energy is primarily used for enhancing spellcasting, so it
makes sense that it should be considered a wizardly item and thus that
Trog should frown upon its use.
