### PR TITLE
Add new option to hide the blood

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -73,11 +73,12 @@ The contents of this text are:
                 messages_at_top, msg_condense_repeats, msg_condense_short,
                 show_travel_trail, skill_focus, default_show_all_skills,
                 monster_list_colour, view_delay, use_animations,
-                darken_beyond_range, force_more_message, flash_screen_message,
-                cloud_status, always_show_zot, action_panel,
-                action_panel_filter, action_panel_show_unidentified,
-                action_panel_scale, action_panel_orientation,
-                action_panel_font_family, action_panel_font_size
+                darken_beyond_range, show_blood force_more_message,
+                flash_screen_message, cloud_status, always_show_zot,
+                action_panel, action_panel_filter,
+                action_panel_show_unidentified, action_panel_scale,
+                action_panel_orientation, action_panel_font_family,
+                action_panel_font_size
 3-i     Colours (messages and menus).
                 menu_colour, message_colour
 3-j     Quivers, firing, and ammo.
@@ -1623,6 +1624,11 @@ darken_beyond_range = true
         If set to true, everything beyond range when targeting will be
         coloured grey. Setting this to false will also disable the "range"
         category of the use_animations option.
+
+show_blood = true
+        Setting this option to false will hide blood splatters in the floor
+        and in the walls. In tiles, it will also replace the fresh corpse
+        tiles with their corresponding bone tiles.
 
 force_more_message += <regex>, <regex>
         (List option)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -227,6 +227,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(cloud_status), !is_tiles()),
         new BoolGameOption(SIMPLE_NAME(always_show_zot), false),
         new BoolGameOption(SIMPLE_NAME(darken_beyond_range), true),
+        new BoolGameOption(SIMPLE_NAME(show_blood), true),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs), false),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs_all), false),
         new BoolGameOption(SIMPLE_NAME(arena_list_eq), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -266,6 +266,7 @@ public:
     msg_colour_type channels[NUM_MESSAGE_CHANNELS];  // msg channel colouring
     use_animations_type use_animations; // which animations to show
     bool        darken_beyond_range; // whether to darken squares out of range
+    bool        show_blood; // wheather to show blood or not
 
     int         hp_warning;      // percentage hp for danger warning
     int         magic_point_warning;    // percentage mp for danger warning

--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -72,7 +72,7 @@ static unsigned short _cell_feat_show_colour(const map_cell& cell,
                 colour = LIGHTGREY; // 1/12
         }
     }
-    else if (cell.flags & MAP_BLOODY && !norecolour)
+    else if (cell.flags & MAP_BLOODY && !norecolour && Options.show_blood)
         colour = RED;
     else if (cell.flags & MAP_CORRODING && feat == DNGN_FLOOR)
         colour = LIGHTGREEN;

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -11,6 +11,7 @@
 #include "tiledoll.h"
 #include "tilemcache.h"
 #include "tilepick.h"
+#include "options.h"
 
 DungeonCellBuffer::DungeonCellBuffer(const ImageManager *im) :
     m_buf_floor(&im->m_textures[TEX_FLOOR]),
@@ -223,6 +224,9 @@ void DungeonCellBuffer::draw()
 void DungeonCellBuffer::add_blood_overlay(int x, int y, const packed_cell &cell,
                                           bool is_wall)
 {
+    if (!Options.show_blood)
+        return;
+
     if (cell.is_liquefied && !is_wall)
     {
         int offset = cell.flv.special % tile_dngn_count(TILE_LIQUEFACTION);

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2849,7 +2849,7 @@ tileidx_t tileidx_item(const item_def &item)
 #endif
 
     case OBJ_CORPSES:
-        if (item.sub_type == CORPSE_SKELETON)
+        if (!Options.show_blood || item.sub_type == CORPSE_SKELETON)
             return _tileidx_bone(item);
         else
             return _tileidx_corpse(item);

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1621,11 +1621,13 @@ void TilesFramework::_send_cell(const coord_def &gc,
             write_tileidx(next_pc.cloud);
         }
 
-        if (next_pc.is_bloody != current_pc.is_bloody)
-            json_write_bool("bloody", next_pc.is_bloody);
+        if (Options.show_blood) {
+            if (next_pc.is_bloody != current_pc.is_bloody)
+                json_write_bool("bloody", next_pc.is_bloody);
 
-        if (next_pc.old_blood != current_pc.old_blood)
-            json_write_bool("old_blood", next_pc.old_blood);
+            if (next_pc.old_blood != current_pc.old_blood)
+                json_write_bool("old_blood", next_pc.old_blood);
+        }
 
         if (next_pc.is_silenced != current_pc.is_silenced)
             json_write_bool("silenced", next_pc.is_silenced);


### PR DESCRIPTION
Add a new option show_blood to control if the blood splatters and
bloody corpses should be shown or not. The new option defaults to
true to maintain the previous behavior.