### PR TITLE
fix: click + key modifier detection in tiles

### DIFF
--- a/crawl-ref/source/windowmanager-sdl.cc
+++ b/crawl-ref/source/windowmanager-sdl.cc
@@ -646,28 +646,9 @@ unsigned int SDLWrapper::get_ticks() const
     return SDL_GetTicks();
 }
 
-tiles_key_mod SDLWrapper::get_mod_state() const
+unsigned char SDLWrapper::get_mod_state() const
 {
-    SDL_Keymod mod = SDL_GetModState();
-
-    switch (mod)
-    {
-    case KMOD_LSHIFT:
-    case KMOD_RSHIFT:
-        return TILES_MOD_SHIFT;
-        break;
-    case KMOD_LCTRL:
-    case KMOD_RCTRL:
-        return TILES_MOD_CTRL;
-        break;
-    case KMOD_LALT:
-    case KMOD_RALT:
-        return TILES_MOD_ALT;
-        break;
-    case KMOD_NONE:
-    default:
-        return TILES_MOD_NONE;
-    }
+    return _kmod_to_mod(SDL_GetModState());
 }
 
 void SDLWrapper::set_mod_state(tiles_key_mod mod)
@@ -828,7 +809,7 @@ int SDLWrapper::send_textinput(wm_event *event)
         // this is relevant only for ctrl-- and ctrl-= bindings at the moment,
         // and I'm somewhat nervous about blocking genuine text entry via the alt
         // key, so for the moment this only blacklists text events with ctrl held
-        bool nontext_modifier_held = wm->get_mod_state() == TILES_MOD_CTRL;
+        bool nontext_modifier_held = wm->get_mod_state() & TILES_MOD_CTRL;
 
         bool should_suppress = prev_keycode && _key_suppresses_textinput(prev_keycode) == wc;
         if (nontext_modifier_held || should_suppress)

--- a/crawl-ref/source/windowmanager-sdl.h
+++ b/crawl-ref/source/windowmanager-sdl.h
@@ -28,7 +28,7 @@ public:
 #ifdef TARGET_OS_WINDOWS
     virtual void set_window_placement(coord_def *m_windowsz);
 #endif
-    virtual tiles_key_mod get_mod_state() const override;
+    virtual unsigned char get_mod_state() const override;
     virtual void set_mod_state(tiles_key_mod mod) override;
     virtual void set_mouse_cursor(mouse_cursor_type id) override;
     virtual unsigned short get_mouse_state(int *x, int *y) const override;

--- a/crawl-ref/source/windowmanager.h
+++ b/crawl-ref/source/windowmanager.h
@@ -150,7 +150,7 @@ public:
     // Environment state functions
     virtual void set_window_title(const char *title) = 0;
     virtual bool set_window_icon(const char* icon_name) = 0;
-    virtual tiles_key_mod get_mod_state() const = 0;
+    virtual unsigned char get_mod_state() const = 0;
     virtual void set_mod_state(tiles_key_mod mod) = 0;
     virtual void set_mouse_cursor(mouse_cursor_type id) = 0;
     virtual unsigned short get_mouse_state(int *x, int *y) const = 0;


### PR DESCRIPTION
Fixes #898

The issue was caused because `SDL_GetModState` returns an OR'd combination of the modifier keys, but `SDLWrapper::get_mod_state` was comparing against the exact values of the flags.