### PR TITLE
Menu highlight option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -74,7 +74,7 @@ The contents of this text are:
                 show_travel_trail, skill_focus, default_show_all_skills,
                 monster_list_colour, view_delay, use_animations,
                 darken_beyond_range, force_more_message, flash_screen_message,
-                cloud_status, always_show_zot, action_panel,
+                cloud_status, always_show_zot, menu_highlight, action_panel,
                 action_panel_filter, action_panel_show_unidentified,
                 action_panel_scale, action_panel_orientation,
                 action_panel_font_family, action_panel_font_size
@@ -1648,6 +1648,16 @@ cloud_status = true
 always_show_zot = false
         Whether to show the "Zot" status light at all times, even when you've
         got plenty of time left.
+
+menu_highlight = (background | inverse | square)
+        Control how the console interface shows highlighted rows in some menus.
+        background = Use a grey background in place of the normal colour,
+                     black by default. (default)
+           inverse = Swap the foreground and background colours for the row.
+                     If the row has differently coloured sections, only the
+                     first colour is changed.
+            square = Display square brackets on the left side of the selected
+                     row.
 
 action_panel_show = true
         Whether to show or hide the action panel. This option is automatically

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -313,6 +313,10 @@ const vector<GameOption*> game_options::build_options_list()
              {"open", travel_open_doors_type::open},
              {"false", travel_open_doors_type::_false},
              {"true", travel_open_doors_type::_true}}),
+        new MultipleChoiceGameOption<string>(
+            SIMPLE_NAME(menu_highlight), "background",
+            {{"background", "background"}, {"inverse", "inverse"},
+             {"square", "square"}}), // matches _menu_highlight_funcs.
 
 #ifdef DGL_SIMPLE_MESSAGING
         new BoolGameOption(SIMPLE_NAME(messaging), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -285,6 +285,7 @@ public:
                                         // two autofight commands
     bool        cloud_status;     // Whether to show a cloud status light
     bool        always_show_zot;  // Whether to always show the Zot timer
+    string      menu_highlight;   // How to display a highlighted menu item.
 
 #ifdef USE_TILE_WEB
     vector<object_class_type> action_panel;   // types of items to show on the panel

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1199,7 +1199,6 @@ bool ShopMenu::process_key(int keyin)
             update_more();
         }
         return true;
-    case ' ':
     case CK_MOUSE_CLICK:
     case CK_ENTER:
         if (can_purchase)


### PR DESCRIPTION
I've made a couple of changes which I think would improve how the new menu layout works, particularly for console users. I've:

1. Created an option (menu_highlight) to control how a highlighted menu row is shown. I know this affects console, and doesn't affect local tiles, but I don't know how webtiles shows things.

"background" gives the selected row a grey background.
"inverse" switches the foreground and background colours.
"square" adds [ and ] to the selected row.

This does not affect the start menu, or any other menu which doesn't use the Menu class.

My idea here is that you can't control how third party clients display text, but there should be something here which looks reasonable on most systems.

2. Changed the shop menu so that space is "toggle selection for highlighted item" rather than "buy"; a synonym for  '.' rather than Enter.

There's nothing in the instructions to say what space should do, or say how to select an item except by letter, so this is closer to what I expected to happen when I first saw it.