### PR TITLE
Allow upward stone stairs to be used for LRD

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1188,6 +1188,9 @@ static const map<dungeon_feature_type, feature_frag> fraggable_terrain = {
     { DNGN_ORCISH_IDOL, { "rock", "stone idol" } },
     { DNGN_GRANITE_STATUE, { "rock", "statue" } },
     { DNGN_PETRIFIED_TREE, { "rock", "petrified wood" } },
+    { DNGN_STONE_STAIRS_UP_I, { "rock", "stone staircase leading up" } },
+    { DNGN_STONE_STAIRS_UP_II, { "rock", "stone staircase leading up" } },
+    { DNGN_STONE_STAIRS_UP_III, { "rock", "stone staircase leading up" } },
     // Stone arches and doors
     { DNGN_OPEN_DOOR, { "rock", "stone door frame" } },
     { DNGN_OPEN_CLEAR_DOOR, { "rock", "stone door frame" } },


### PR DESCRIPTION
Tested: 
![image](https://user-images.githubusercontent.com/62170514/149863829-b05da978-3b41-41fb-a86d-f5e9bdc5e7b7.png)

Swamp can be a difficult place in which to find any valid LRD targets.
For those who play in tiles mode, it can be confusing that up-stairs
aren't targets for LRD; it's clearly a stone structure and is described
as such as well. 
![image](https://user-images.githubusercontent.com/62170514/149864170-214e6511-dc83-4099-a205-578b1dda5825.png)

Down stairs on the other hand, are a hole in the floor. 
![image](https://user-images.githubusercontent.com/62170514/149864203-059feca6-210d-41c0-98e4-1871a1c0ed97.png) Also, they're more friendly to stair-dancing, because that tends to be safe, cleared territory, so of the two, upstairs are the more interesting as a last-ditch LRD spot. One needs a lot of AC to sit on a stairwell and blow it up!

Floated this idea in IRC but I thought it might get more thoughts and comments if I do it up as a PR. Thanks for lookin!