### PR TITLE
Stop running when opening a door with shift + direction

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1103,8 +1103,6 @@ void move_player_action(coord_def move)
              || !you.running)
         && !attacking && feat_is_closed_door(env.grid(targ)))
     {
-        if (you.running == RMODE_START)
-            stop_running();
         open_door_action(move);
         move.reset();
         return;

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1103,7 +1103,8 @@ void move_player_action(coord_def move)
              || !you.running)
         && !attacking && feat_is_closed_door(env.grid(targ)))
     {
-        stop_running();
+        if (you.running == RMODE_START)
+            stop_running();
         open_door_action(move);
         move.reset();
         return;

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1103,6 +1103,7 @@ void move_player_action(coord_def move)
              || !you.running)
         && !attacking && feat_is_closed_door(env.grid(targ)))
     {
+        stop_running();
         open_door_action(move);
         move.reset();
         return;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7832,20 +7832,20 @@ void player_open_door(coord_def doorpos)
                     berserk_open += " " + berserk_adjective;
                 else
                     berserk_open += ".";
-                mprf(MSGCH_SOUND, berserk_open.c_str(), adj, noun);
+                mprf(berserk_open.c_str(), adj, noun);
             }
             else
-                mprf(MSGCH_SOUND, "The %s%s flies open with a bang!", adj, noun);
+                mprf("The %s%s flies open with a bang!", adj, noun);
             noisy(15, you.pos());
         }
     }
     else if (one_chance_in(skill) && !silenced(you.pos()))
     {
         if (!door_open_creak.empty())
-            mprf(MSGCH_SOUND, door_open_creak.c_str(), adj, noun);
+            mprf(door_open_creak.c_str(), adj, noun);
         else
         {
-            mprf(MSGCH_SOUND, "As you open the %s%s, it creaks loudly!",
+            mprf("As you open the %s%s, it creaks loudly!",
                  adj, noun);
         }
         noisy(10, you.pos());


### PR DESCRIPTION
Using shift + direction to open a door would continue running for another turn when the door creaked, the player would remain stationary if the door remained silent. Reported in issue #2346