### PR TITLE
Remove a compiler warning.

### DIFF
--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -225,7 +225,7 @@ static void _genus_factoring(map<const string, details> &types,
 
     genera.erase(genus);
 
-    const monster *mon;
+    const monster *mon = nullptr;
 
     auto it = types.begin();
     do
@@ -243,6 +243,7 @@ static void _genus_factoring(map<const string, details> &types,
         mon = it->second.mon;
         types.erase(it++);
     } while (it != types.end());
+    ASSERT(mon); // There is a match as genera contains the monsters in types.
 
     const auto name = mons_type_name(genus, DESC_PLAIN);
     types[name] = {mon, name, num, true};


### PR DESCRIPTION
In _genus_factoring(), mon is set in a loop. This is always set as "types" and "genera" are set in  _count_monster_types(), which builds them both from the sme list of monsters. This is not apparent to a code coverage tool, so set it to nullptr.

I noticed that a github code coverage check failed here for something unrelated, so I thought I should fix it.