### PR TITLE
Improve the plural of "<name>'s ghost", and the spelling of wilful.

### DIFF
--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -785,7 +785,7 @@ skilled in archery.
 centaur warrior
 
 A muscular centaur, veteran of numerous battles, armed with well-made weapons
-and able to use them skillfully.
+and able to use them skilful.
 %%%%
 chaos spawn
 

--- a/crawl-ref/source/english.cc
+++ b/crawl-ref/source/english.cc
@@ -163,6 +163,10 @@ string pluralise(const string &name, const char * const qualifiers[],
         // Tzitzimitl -> Tzitzimimeh (correct Nahuatl pluralisation)
         return name.substr(0, name.length() - 2) + "meh";
     }
+    // "<name>'s ghost" -> "ghosts called <name>".
+    pos = name.find("'s ghost");
+    if (string::npos != pos)
+            return string(name, 0, pos).insert(0, "ghosts called ");
 
     return name + "s";
 }

--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1745,7 +1745,7 @@ static const mutation_def mut_data[] =
   "demonic willpower",
 
   {"You punish those that try to bend your will. (Will+)", "", ""},
-  {"You feel willful.", "", ""},
+  {"You feel wilful.", "", ""},
   {"", "", ""},
 },
 

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1308,7 +1308,7 @@ static int _train(skill_type exsk, int &max_exp, bool simu)
         {
             mprf("You have finished your manual of %s and %stoss it away.",
                  skill_name(exsk),
-                 exsk == SK_THROWING ? "skillfully " : "");
+                 exsk == SK_THROWING ? "skilfully " : "");
         }
     }
 


### PR DESCRIPTION
1. Pluralise ghosts with the same name as "2 ghosts called <name>". I came across two identical ghosts in a vault, and thought that "2 <name>'s ghosts" wasn't very good English.

Two other possible approaches to this issue are:
a. Only merge the names of identically named ghosts if they are being merged at "genus" level (at which point the names disappear).
b. Only allow each name to be used for a ghost once in a game.

2.  Change "willful" to "wilful", and "skillful" to "skilful", as the longer version is a US spelling.