### PR TITLE
update acquirement armor gen debugging with new egos

### DIFF
--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -875,11 +875,11 @@ static void _debug_acquirement_stats(FILE *ostat)
     int randbook_spells = 0;
 
     int subtype_quants[256];
-    int ego_quants[NUM_SPECIAL_WEAPONS];
+    int ego_quants[256];
 
     memset(subtype_quants, 0, sizeof(subtype_quants));
     memset(ego_quants, 0, sizeof(ego_quants));
-
+    
     for (int i = 0; i < num_itrs; ++i)
     {
         if (kbhit())
@@ -1144,7 +1144,9 @@ static void _debug_acquirement_stats(FILE *ostat)
         const char* names[] =
         {
             "normal",
+#if TAG_MAJOR_VERSION == 34
             "running",
+#endif
             "fire resistance",
             "cold resistance",
             "poison resistance",
@@ -1173,9 +1175,17 @@ static void _debug_acquirement_stats(FILE *ostat)
             "cloud immunity",
 #endif
             "harm",
+            "shadows",
             "rampaging",
             "infusion",
+            "light",
+            "rage",
+            "mayhem",
+            "guile",
+            "energy",
+            "debug_randart",
         };
+        COMPILE_CHECK(ARRAYSZ(names) == NUM_SPECIAL_ARMOURS);
 
         const int non_art = acq_calls - num_arts;
         for (int i = 0; i < NUM_SPECIAL_ARMOURS; ++i)


### PR DESCRIPTION
debug acquirement generation couldn't track new armor egos.  Also lacked compiler check to ensure they're in sync the way weapons did, and fixed a small bug where it assumes num weapon brands always > armor egos.
