### PR TITLE
Give berserk players a chance to break down the door

### DIFF
--- a/crawl-ref/docs/develop/levels/advanced.txt
+++ b/crawl-ref/docs/develop/levels/advanced.txt
@@ -734,6 +734,9 @@ dungeon cell which they are on:
 * door_berserk_verb_open: Replace the verb used for opening the door while
       berserk. Should include "%s%s", as it is printed as a formatted string.
 
+* door_berserk_verb_break: Replace the verb used for breaking the door while
+      berserk. Also requires "%s%s" as it is printed as a formatted string.
+
 * door_berserk_adjective: Replaces the adjective "with a bang" when the player
       is not silenced while opening a door.
 

--- a/crawl-ref/source/dat/defaults/runrest_messages.txt
+++ b/crawl-ref/source/dat/defaults/runrest_messages.txt
@@ -26,6 +26,7 @@ stop += A sourceless malevolence
 stop += A sentinel's mark forms upon you\.
 stop += it creaks loudly
 stop += flies open with a bang
+stop += breaks down with a bang
 
 ## Zot is coming!
 stop += You have lingered too long

--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -1041,6 +1041,7 @@ COLOUR:     W = green
 : lua_marker('+', props_marker {
 :           door_description_noun="fleshy orifice",
 :           door_berserk_verb_open="You part the %s%s",
+:           door_berserk_verb_break="You sever the %s%s",
 :           door_berserk_adjective="with a squelch!",
 :           door_berserk_verb_close="You squeeze the %s%s closed",
 :           door_noisy_verb_open="You part the %s%s with a squelch!",

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7799,9 +7799,12 @@ void player_open_door(coord_def doorpos)
     }
 
     const int skill = 8 + you.skill_rdiv(SK_STEALTH, 4, 3);
+    const bool broken = you.berserk() && one_chance_in(5);
 
-    string berserk_open = env.markers.property_at(doorpos, MAT_ANY,
-                                                  "door_berserk_verb_open");
+    string berserk_open = broken ? env.markers.property_at(doorpos, MAT_ANY,
+                                                           "door_berserk_verb_break")
+                                 : env.markers.property_at(doorpos, MAT_ANY,
+                                                           "door_berserk_verb_open");
     string berserk_adjective = env.markers.property_at(doorpos, MAT_ANY,
                                                        "door_berserk_adjective");
     string door_open_creak = env.markers.property_at(doorpos, MAT_ANY,
@@ -7822,7 +7825,8 @@ void player_open_door(coord_def doorpos)
                 mprf(berserk_open.c_str(), adj, noun);
             }
             else
-                mprf("The %s%s flies open!", adj, noun);
+                mprf("The %s%s %s!", adj, noun,
+                     broken ? "breaks down" : "flies open");
         }
         else
         {
@@ -7835,7 +7839,8 @@ void player_open_door(coord_def doorpos)
                 mprf(MSGCH_SOUND, berserk_open.c_str(), adj, noun);
             }
             else
-                mprf(MSGCH_SOUND, "The %s%s flies open with a bang!", adj, noun);
+                mprf(MSGCH_SOUND, "The %s%s %s with a bang!", adj, noun,
+                     broken ? "breaks down" : "flies open");
             noisy(15, you.pos());
         }
     }
@@ -7876,7 +7881,10 @@ void player_open_door(coord_def doorpos)
     {
         if (cell_is_runed(dc))
             explored_tracked_feature(env.grid(dc));
-        dgn_open_door(dc);
+        if (broken)
+          dgn_break_door(dc);
+        else
+          dgn_open_door(dc);
         set_terrain_changed(dc);
         dungeon_events.fire_position_event(DET_DOOR_OPENED, dc);
 


### PR DESCRIPTION
Let the player get in on the door breaking action. Gives a 20% chance to break down the door when berserk. Adds Lua marker property door_berserk_verb_break to customize the verbiage.