### PR TITLE
Implement CMD_REVEAL_OPTIONS on GNU/Linux

### DIFF
--- a/crawl-ref/source/command-type.h
+++ b/crawl-ref/source/command-type.h
@@ -156,7 +156,7 @@ enum command_type
 
     CMD_SHOW_CHARACTER_DUMP,
     CMD_GAME_MENU,
-#ifdef TARGET_OS_MACOSX
+#if defined TARGET_OS_MACOSX || defined TARGET_OS_LINUX
     CMD_REVEAL_OPTIONS,
 #endif
     CMD_LUA_CONSOLE,

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1964,6 +1964,10 @@ public:
         add_entry(new CmdMenuEntry("Show options file in finder",
             MEL_ITEM, 'O', CMD_REVEAL_OPTIONS));
 #endif
+#ifdef TARGET_OS_LINUX
+        add_entry(new CmdMenuEntry("Show options file in a file manager",
+            MEL_ITEM, 'O', CMD_REVEAL_OPTIONS));
+#endif
         add_entry(new CmdMenuEntry("", MEL_SUBTITLE));
         add_entry(new CmdMenuEntry(
                             "Quit and <lightred>abandon character</lightred>",
@@ -2245,6 +2249,12 @@ void process_command(command_type cmd, command_type prev_cmd)
         // TODO: add a way of triggering this from the main menu
         system(make_stringf("/usr/bin/open -R '%s'",
                                             Options.filename.c_str()).c_str());
+        break;
+#endif
+#ifdef TARGET_OS_LINUX
+    case CMD_REVEAL_OPTIONS:
+        system(make_stringf("xdg-open '%s'",
+                      get_parent_directory(Options.filename).c_str()).c_str());
         break;
 #endif
     case CMD_SHOW_CHARACTER_DUMP:


### PR DESCRIPTION
I have implemented CMD_REVEAL_OPTIONS on GNU/Linux in the same fashion as Mac, but there are two details where I'm not sure if I'm getting the expected behaviour. Can you confirm please?

First, if there's not custom configuration in the user's home, the global configuration is shown instead.

Second, there's no icon in the menu option.
![imagen](https://user-images.githubusercontent.com/9676118/152878473-b2160f27-e7a2-4bb4-b256-7215946d2b02.png)