### PR TITLE
Change the HUD "heavily drained" message from "drained" to "drained!".

### DIFF
--- a/crawl-ref/source/mon-info-flag-name.h
+++ b/crawl-ref/source/mon-info-flag-name.h
@@ -118,7 +118,7 @@ static const vector<monster_info_flag_name> monster_info_flag_names = {
     { MB_SICK, "sick", "sick", "sick"},
     { MB_WEAK, "weak", "weak", "weak"},
     { MB_LIGHTLY_DRAINED, "drained", "lightly drained", "drained"},
-    { MB_HEAVILY_DRAINED, "drained", "heavily drained", "drained"},
+    { MB_HEAVILY_DRAINED, "drained!", "heavily drained", "drained!"},
     { MB_SAP_MAGIC, "magic-sapped", "magic-sapped", "magic-sapped"},
     { MB_GLOWING, "corona", "softly glowing", "coronas"},
     { MB_WATERLOGGED, "waterlogged", "waterlogged", "waterlogged"},


### PR DESCRIPTION
As things were, both light and heavy drain were displayed as "drained", meaning that you could be near "3 orcs (1 drained, 2 drained)". Changing one to "drained!" tells the player which is which.

The only other message which is used for more than one status is "clouds", and a type of monster can only be surrounded by one type of cloud.