### PR TITLE
Rework the static discharge formulas

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2736,6 +2736,16 @@ string spell_damage_string(spell_type spell, bool evoked)
             return desc_cloud_damage(CLOUD_FIRE, false);
         case SPELL_FREEZING_CLOUD:
             return desc_cloud_damage(CLOUD_COLD, false);
+        case SPELL_DISCHARGE:
+        {
+            int max = discharge_max_damage(_spell_power(spell, evoked));
+            return make_stringf("%d-%d/arc", FLAT_DISCHARGE_ARC_DAMAGE, max);
+        }
+        case SPELL_AIRSTRIKE:
+        {
+            int max = airstrike_base_max_damage(_spell_power(spell, evoked));
+            return make_stringf("0-%d+", max);
+        }
         default:
             break;
     }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2432,16 +2432,15 @@ spret cast_ignition(const actor *agent, int pow, bool fail)
 }
 
 static int _discharge_monsters(const coord_def &where, int pow,
-                               const actor &agent)
+                               const actor &agent, int remaining)
 {
     actor* victim = actor_at(where);
 
     if (!victim || !victim->alive())
         return 0;
 
-    int damage = (&agent == victim) ? 1 + random2(3 + pow / 15)
-                                    : 3 + random2(5 + pow / 10
-                                                  + (random2(pow) / 10));
+    int damage = (&agent == victim) ? 1 + random2(2 + div_rand_round(pow,15))
+                                    : 3 + random2(4 + div_rand_round(pow,8));
 
     bolt beam;
     beam.flavour    = BEAM_ELECTRICITY; // used for mons_adjust_flavoured
@@ -2461,7 +2460,7 @@ static int _discharge_monsters(const coord_def &where, int pow,
 
     if (victim->is_player())
     {
-        damage = 1 + random2(3 + pow / 15);
+        damage = 1 + random2(2 + div_rand_round(pow,15));
         dprf("You: static discharge damage: %d", damage);
         damage = check_your_resists(damage, BEAM_ELECTRICITY,
                                     "static discharge");
@@ -2500,13 +2499,12 @@ static int _discharge_monsters(const coord_def &where, int pow,
             mons->hurt(agent.as_monster(), damage);
     }
 
-    // Recursion to give us chain-lightning -- bwr
-    // Low power slight chance added for low power characters -- bwr
-    if ((pow >= 10 && !one_chance_in(4)) || (pow >= 3 && one_chance_in(10)))
+    // Recursion to give us chain-lightning
+    if (remaining > 0)
     {
-        pow /= random_range(2, 3);
-        damage += apply_random_around_square([pow, &agent] (coord_def where2) {
-            return _discharge_monsters(where2, pow, agent);
+        damage += apply_random_around_square([pow, &agent, remaining]
+                                            (coord_def where2) {
+            return _discharge_monsters(where2, pow, agent, remaining -1);
         }, where, true, 1);
     }
     else if (damage > 0)
@@ -2560,10 +2558,11 @@ spret cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
 
     fail_check();
 
-    const int num_targs = 1 + random2(random_range(1, 3) + pow / 20);
+    const int num_targs = 1 + random2(2 + div_rand_round(pow,20));
     const int dam =
         apply_random_around_square([pow, &agent] (coord_def target) {
-            return _discharge_monsters(target, pow, agent);
+            return _discharge_monsters(target, pow, agent,
+                        1 + random2(2 + div_rand_round(pow, 20)));
         }, agent.pos(), true, num_targs);
 
     dprf("Arcs: %d Damage: %d", num_targs, dam);

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -13,6 +13,8 @@ struct dice_def;
 class dist;
 
 const int DEFAULT_SHATTER_DICE = 3;
+const int FLAT_DISCHARGE_ARC_DAMAGE = 3;
+
 #define COUPLING_TIME_KEY "maxwells_charge_time"
 #define FLAME_WAVE_KEY "flame_waves"
 #define FLAME_WAVE_POWER_KEY "flame_wave_power"
@@ -39,6 +41,7 @@ spret cast_freeze(int pow, monster* mons, bool fail);
 dice_def freeze_damage(int pow);
 spret cast_airstrike(int pow, coord_def target, bool fail);
 int airstrike_space_around(coord_def target, bool count_invis);
+int airstrike_base_max_damage(int pow);
 spret cast_shatter(int pow, bool fail);
 dice_def shatter_damage(int pow, monster *mons = nullptr);
 int terrain_shatter_chance(coord_def where, const actor &agent);
@@ -54,6 +57,7 @@ spret cast_poisonous_vapours(int pow, const dist &beam, bool fail, bool test=fal
 bool safe_discharge(coord_def where, vector<const actor *> &exclude);
 spret cast_discharge(int pow, const actor &agent, bool fail = false,
                           bool prompt = true);
+int discharge_max_damage(int pow);
 dice_def base_fragmentation_damage(int pow);
 bool setup_fragmentation_beam(bolt &beam, int pow, const actor *caster,
                               const coord_def target, bool quiet,

--- a/crawl-ref/source/util/monster/monster-main.cc
+++ b/crawl-ref/source/util/monster/monster-main.cc
@@ -263,8 +263,9 @@ static string mi_calc_smiting_damage(monster* /*mons*/) { return "7-17"; }
 
 static string mi_calc_airstrike_damage(monster* mons)
 {
-    int pow = 12 * mons->get_experience_level();
-    return make_stringf("8-%d", 2 + ( 6 + pow ) / 7);
+    const int pow = mons_power_for_hd(SPELL_AIRSTRIKE, mons->get_hit_dice());
+    const int base = FLAT_AIRSTRIKE_DAMAGE + 3; // lol legacy
+    return make_stringf("%d-%d", base, airstrike_base_max_damage(pow));
 }
 
 static string mi_calc_glaciate_damage(monster* mons)


### PR DESCRIPTION
Primarily so that damage can be displayed in future. Don't rely on division by
power to recur, just caclulate the number of arcs to do upfront and do them at
full power. Additionally, random round all of the formulas to avoid messy power
breakpoints. New numbers give mostly similar damage at low power, I think.
At high power with a lot of targets things can get a bit wilder. If it's a
problem, can cap power at 50 instead of 100.

I didn't actually make a commit to display damage yet, will do that later probably.