### PR TITLE
Fix warning with OTR up + poison immune summons

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1345,8 +1345,7 @@ static void _BATTLE_unequip(item_def */*item*/, bool */*show_msgs*/)
 static void _BATTLE_world_reacts(item_def */*item*/)
 {
     if (!find_battlesphere(&you)
-        && there_are_monsters_nearby(true, true, false)
-        && rude_stop_summoning_reason().empty())
+        && there_are_monsters_nearby(true, true, false))
     {
         cast_battlesphere(&you, calc_spell_power(SPELL_BATTLESPHERE, true),
                           GOD_NO_GOD, false);

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4245,12 +4245,12 @@ void bolt::handle_stop_attack_prompt(monster* mon)
     {
         string verb = make_stringf("charm %s", mon->name(DESC_THE).c_str());
         monster_info mi = monster_info(mon);
+        bool has_rpois = get_resist(mi.resists(), MR_RES_POISON) > 0;
 
-        bool stop = get_resist(mi.resists(), MR_RES_POISON) <= 0
-                  ? rude_stop_summoning_prompt(verb)
-                  : stop_summoning_poison_immune_prompt(verb);
+        bool stop = has_rpois ? stop_summoning_poison_resistance_prompt(verb)
+                              : stop_summoning_prompt(verb);
 
-        if (stop) 
+        if (stop)
         {
             beam_cancelled = true;
             finish_beam();

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4250,7 +4250,8 @@ void bolt::handle_stop_attack_prompt(monster* mon)
                   ? rude_stop_summoning_prompt(verb)
                   : stop_summoning_poison_immune_prompt(verb);
 
-        if (stop) {
+        if (stop) 
+        {
             beam_cancelled = true;
             finish_beam();
             prompted = true;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4244,8 +4244,9 @@ void bolt::handle_stop_attack_prompt(monster* mon)
     else if (flavour == BEAM_CHARM)
     {
         string verb = make_stringf("charm %s", mon->name(DESC_THE).c_str());
+        monster_info mi = monster_info(mon);
 
-        bool stop = mon->res_poison() <= 0
+        bool stop = get_resist(mi.resists(), MR_RES_POISON) <= 0
                   ? rude_stop_summoning_prompt(verb)
                   : stop_summoning_poison_immune_prompt(verb);
 

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4244,8 +4244,12 @@ void bolt::handle_stop_attack_prompt(monster* mon)
     else if (flavour == BEAM_CHARM)
     {
         string verb = make_stringf("charm %s", mon->name(DESC_THE).c_str());
-        if (rude_stop_summoning_prompt(verb))
-        {
+
+        bool stop = mon->res_poison() <= 0
+                  ? rude_stop_summoning_prompt(verb)
+                  : stop_summoning_poison_immune_prompt(verb);
+
+        if (stop) {
             beam_cancelled = true;
             finish_beam();
             prompted = true;

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1165,11 +1165,8 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
     }
 }
 
-string rude_stop_summoning_reason()
+static string stop_summoning_poison_immune_reason()
 {
-    if (you.duration[DUR_TOXIC_RADIANCE])
-        return "toxic aura";
-
     if (you.duration[DUR_NOXIOUS_BOG])
         return "noxious bog";
 
@@ -1179,20 +1176,16 @@ string rude_stop_summoning_reason()
     return "";
 }
 
-/**
- * Does the player have a hostile duration up that would/could cause
- * a summon to be abjured? If so, prompt the player as to whether they
- * want to continue to create their summon. Note that this prompt is never a
- * penance prompt, because we don't cause penance when monsters enter line of
- * sight when OTR is active, regardless of how they entered LOS.
- *
- * @param verb    The verb to be used in the prompt. Defaults to "summon".
- * @return        True if the player wants to abort.
- */
-bool rude_stop_summoning_prompt(string verb)
+static string rude_stop_summoning_reason()
 {
-    string which = rude_stop_summoning_reason();
+    if (you.duration[DUR_TOXIC_RADIANCE])
+        return "toxic aura";
 
+    return stop_summoning_poison_immune_reason();
+}
+
+static bool stop_summoning_prompt(string verb, string which)
+{
     if (which.empty())
         return false;
 
@@ -1212,6 +1205,26 @@ bool rude_stop_summoning_prompt(string verb)
         canned_msg(MSG_OK);
         return true;
     }
+}
+
+/**
+ * Does the player have a hostile duration up that would/could cause
+ * a summon to be abjured? If so, prompt the player as to whether they
+ * want to continue to create their summon. Note that this prompt is never a
+ * penance prompt, because we don't cause penance when monsters enter line of
+ * sight when OTR is active, regardless of how they entered LOS.
+ *
+ * @param verb    The verb to be used in the prompt. Defaults to "summon".
+ * @return        True if the player wants to abort.
+ */
+bool rude_stop_summoning_prompt(string verb)
+{
+    return stop_summoning_prompt(verb, rude_stop_summoning_reason());
+}
+
+bool stop_summoning_poison_immune_prompt(string verb)
+{
+    return stop_summoning_prompt(verb, stop_summoning_poison_immune_reason());
 }
 
 bool can_reach_attack_between(coord_def source, coord_def target,

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -84,8 +84,8 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
                         bool *prompted = nullptr,
                         const monster *mons = nullptr);
 
-string rude_stop_summoning_reason();
 bool rude_stop_summoning_prompt(string verb = "summon");
+bool stop_summoning_poison_immune_prompt(string verb = "summon");
 
 bool can_reach_attack_between(coord_def source, coord_def target,
                               reach_type range);

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -84,8 +84,8 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
                         bool *prompted = nullptr,
                         const monster *mons = nullptr);
 
-bool rude_stop_summoning_prompt(string verb = "summon");
-bool stop_summoning_poison_immune_prompt(string verb = "summon");
+bool stop_summoning_prompt(string verb = "summon");
+bool stop_summoning_poison_resistance_prompt(string verb = "summon");
 
 bool can_reach_attack_between(coord_def source, coord_def target,
                               reach_type range);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -89,7 +89,7 @@ static mgen_data _pal_data(monster_type pal, int dur, god_type god,
 
 spret cast_summon_small_mammal(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -109,7 +109,7 @@ spret cast_summon_small_mammal(int pow, god_type god, bool fail)
 
 spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -134,7 +134,7 @@ spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 
 spret cast_summon_cactus(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -149,7 +149,7 @@ spret cast_summon_cactus(int pow, god_type god, bool fail)
 
 spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     const item_def *armour = you.slot_item(EQ_BODY_ARMOUR);
@@ -197,7 +197,7 @@ spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
 
 spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -217,7 +217,7 @@ spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 
 spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 {
-    if (caster->is_player() && rude_stop_summoning_prompt())
+    if (caster->is_player() && stop_summoning_prompt())
         return spret::abort;
 
     fail_check();
@@ -254,7 +254,7 @@ spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 
 spret cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
 {
-    if (caster->is_player() && stop_summoning_poison_immune_prompt())
+    if (caster->is_player() && stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -300,7 +300,7 @@ static monster_type _choose_dragon_type(int pow, god_type /*god*/, bool player)
 
 spret cast_dragon_call(int pow, bool fail)
 {
-    if (rude_stop_summoning_prompt("call dragons"))
+    if (stop_summoning_prompt("call dragons"))
         return spret::abort;
 
     fail_check();
@@ -496,7 +496,7 @@ spret cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
 
 spret cast_summon_mana_viper(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -841,7 +841,7 @@ spret cast_conjure_ball_lightning(int pow, god_type god, bool fail)
 
 spret cast_summon_lightning_spire(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -862,7 +862,7 @@ spret cast_summon_lightning_spire(int pow, god_type god, bool fail)
 
 spret cast_summon_guardian_golem(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -923,7 +923,7 @@ static map<monster_type, const char*> _imp_summon_messages = {
  */
 spret cast_call_imp(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -1024,7 +1024,7 @@ bool summon_demon_type(monster_type mon, int pow, god_type god,
 spret cast_summon_demon(int pow)
 {
     // Chaos spawn, orange demons and sixfirhies are not rPois
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_prompt())
         return spret::abort;
 
     mpr("You open a gate to Pandemonium!");
@@ -1037,7 +1037,7 @@ spret cast_summon_demon(int pow)
 
 spret summon_shadow_creatures()
 {
-    if (rude_stop_summoning_prompt("summon"))
+    if (stop_summoning_prompt("summon"))
         return spret::abort;
 
     mpr("Wisps of shadow whirl around you...");
@@ -1148,7 +1148,7 @@ void create_malign_gateway(coord_def point, beh_type beh, string cause,
 spret cast_malign_gateway(actor * caster, int pow, god_type god,
                           bool fail, bool test)
 {
-    if (caster->is_player() && stop_summoning_poison_immune_prompt())
+    if (caster->is_player() && stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     coord_def point = find_gateway_location(caster);
@@ -1181,7 +1181,7 @@ spret cast_malign_gateway(actor * caster, int pow, god_type god,
 
 spret cast_summon_horrible_things(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -1267,7 +1267,7 @@ spret cast_summon_forest(actor* caster, int pow, god_type god, bool fail, bool t
 
     if (success)
     {
-        if (rude_stop_summoning_prompt("summon a forest"))
+        if (stop_summoning_prompt("summon a forest"))
             return spret::abort;
 
         fail_check();
@@ -1696,7 +1696,7 @@ vector<coord_def> find_animatable_skeletons(coord_def c)
 
 spret cast_animate_skeleton(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     vector<coord_def> skeletons = find_animatable_skeletons(you.pos());
@@ -1742,7 +1742,7 @@ spret cast_animate_skeleton(int pow, god_type god, bool fail)
 
 spret cast_animate_dead(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -1780,7 +1780,7 @@ int find_simulacrable_corpse(coord_def c)
  */
 spret cast_simulacrum(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     int co = find_simulacrable_corpse(you.pos());
@@ -1846,7 +1846,7 @@ monster_type pick_random_wraith()
 
 spret cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     monster* m = monster_at(where);
@@ -2024,7 +2024,7 @@ void init_servitor(monster* servitor, actor* caster, int pow)
 
 spret cast_spellforged_servitor(int pow, god_type god, bool fail)
 {
-    if (stop_summoning_poison_immune_prompt())
+    if (stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -2067,7 +2067,7 @@ dice_def battlesphere_damage(int pow)
 
 spret cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
 {
-    if (agent->is_player() && stop_summoning_poison_immune_prompt())
+    if (agent->is_player() && stop_summoning_poison_resistance_prompt())
         return spret::abort;
 
     fail_check();
@@ -3102,7 +3102,7 @@ bool summon_spider(const actor &agent, coord_def pos, god_type god,
 
 spret summon_spiders(actor &agent, int pow, god_type god, bool fail)
 {
-    if (agent.is_player() && rude_stop_summoning_prompt())
+    if (agent.is_player() && stop_summoning_prompt())
         return spret::abort;
 
     fail_check();

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -149,7 +149,7 @@ spret cast_summon_cactus(int pow, god_type god, bool fail)
 
 spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     const item_def *armour = you.slot_item(EQ_BODY_ARMOUR);
@@ -197,7 +197,7 @@ spret cast_summon_armour_spirit(int pow, god_type god, bool fail)
 
 spret cast_summon_ice_beast(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -254,7 +254,7 @@ spret cast_monstrous_menagerie(actor* caster, int pow, god_type god, bool fail)
 
 spret cast_summon_hydra(actor *caster, int pow, god_type god, bool fail)
 {
-    if (caster->is_player() && rude_stop_summoning_prompt())
+    if (caster->is_player() && stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -496,7 +496,7 @@ spret cast_summon_dragon(actor *caster, int pow, god_type god, bool fail)
 
 spret cast_summon_mana_viper(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -841,7 +841,7 @@ spret cast_conjure_ball_lightning(int pow, god_type god, bool fail)
 
 spret cast_summon_lightning_spire(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -862,7 +862,7 @@ spret cast_summon_lightning_spire(int pow, god_type god, bool fail)
 
 spret cast_summon_guardian_golem(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -923,7 +923,7 @@ static map<monster_type, const char*> _imp_summon_messages = {
  */
 spret cast_call_imp(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -1148,7 +1148,7 @@ void create_malign_gateway(coord_def point, beh_type beh, string cause,
 spret cast_malign_gateway(actor * caster, int pow, god_type god,
                           bool fail, bool test)
 {
-    if (caster->is_player() && rude_stop_summoning_prompt())
+    if (caster->is_player() && stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     coord_def point = find_gateway_location(caster);
@@ -1181,7 +1181,7 @@ spret cast_malign_gateway(actor * caster, int pow, god_type god,
 
 spret cast_summon_horrible_things(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -1696,7 +1696,7 @@ vector<coord_def> find_animatable_skeletons(coord_def c)
 
 spret cast_animate_skeleton(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     vector<coord_def> skeletons = find_animatable_skeletons(you.pos());
@@ -1742,7 +1742,7 @@ spret cast_animate_skeleton(int pow, god_type god, bool fail)
 
 spret cast_animate_dead(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -1780,7 +1780,7 @@ int find_simulacrable_corpse(coord_def c)
  */
 spret cast_simulacrum(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     int co = find_simulacrable_corpse(you.pos());
@@ -1846,7 +1846,7 @@ monster_type pick_random_wraith()
 
 spret cast_haunt(int pow, const coord_def& where, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     monster* m = monster_at(where);
@@ -2024,7 +2024,7 @@ void init_servitor(monster* servitor, actor* caster, int pow)
 
 spret cast_spellforged_servitor(int pow, god_type god, bool fail)
 {
-    if (rude_stop_summoning_prompt())
+    if (stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();
@@ -2067,7 +2067,7 @@ dice_def battlesphere_damage(int pow)
 
 spret cast_battlesphere(actor* agent, int pow, god_type god, bool fail)
 {
-    if (agent->is_player() && rude_stop_summoning_prompt())
+    if (agent->is_player() && stop_summoning_poison_immune_prompt())
         return spret::abort;
 
     fail_check();


### PR DESCRIPTION
Fixes #2419

Previously we warned about summoning with OTR up, even for summons
with poison immune. Now another method is added to cover summons with
poison immune to remove pointless warning.