### PR TITLE
Add annotations for distracted monsters.

### DIFF
--- a/crawl-ref/source/mon-info-flag-name.h
+++ b/crawl-ref/source/mon-info-flag-name.h
@@ -84,6 +84,8 @@ static const vector<monster_info_flag_name> monster_info_flag_names = {
     { MB_SLEEPING, "asleep", "asleep", "asleep"},
     { MB_UNAWARE, "unaware", "unaware", "unaware"},
     { MB_BLIND, "blind", "blind", "blind"},
+    { MB_DISTRACTED_ONLY, "distracted", "not watching you", "distracted"},
+    { MB_CANT_SEE_YOU, "can't see you", "can't see you", "can't see you"},
     { MB_INFESTATION, "infested", "infested", "infested"},
     // Debuffs
     { MB_DUMB, "stupefied", "stupefied", "stupefied"},

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -19,6 +19,7 @@
 #include "coordit.h"
 #include "english.h"
 #include "env.h"
+#include "fight.h"
 #include "ghost.h"
 #include "god-passive.h" // passive_t::neutral_slimes
 #include "item-prop.h"
@@ -655,6 +656,15 @@ monster_info::monster_info(const monster* m, int milev)
         monster_info_flags flag = ench_to_mb(*m, entry.first);
         if (flag != NUM_MB_FLAGS)
             mb.set(flag);
+    }
+
+    if (!m->friendly())
+    {
+        const stab_type st = find_stab_type(&you, *m, false);
+        if (st == STAB_INVISIBLE && !mb[MB_BLIND])
+            mb.set(MB_CANT_SEE_YOU);
+        else if (st == STAB_DISTRACTED && !mb[MB_UNAWARE] && !mb[MB_WANDERING])
+            mb.set(MB_DISTRACTED_ONLY);
     }
 
     if (type == MONS_SILENT_SPECTRE)

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -207,6 +207,8 @@ enum monster_info_flags
     MB_RES_DROWN,
     MB_ANGUISH,
     MB_CLARITY,
+    MB_DISTRACTED_ONLY,
+    MB_CANT_SEE_YOU,
     NUM_MB_FLAGS
 };
 


### PR DESCRIPTION
Most of the reasons for a monster_info having MB_DISTRACTED give a description when the monster is selected on the level map, but not all.

This creates two flags to fill in the gap.
- Monsters which you can see, but which can't see you because of invisibility, are described as "can't see you" in the examine surroundings command and monster list summary.
- Monsters which are distracted (possibly because they are attacking a summoned monster rather than you) ar described as "not watching you" or as "distracted".