### PR TITLE
Remove identification scrolls from troves

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -231,11 +231,11 @@ end
 function trove.good_scroll (e)
     e.item([[scroll of enchant weapon / scroll of brand weapon w:3 /
              scroll of enchant armour / scroll of immolation w:8 /
-             scroll of magic mapping w:5 / scroll of blinking /
+             scroll of magic mapping w:8 / scroll of blinking /
              scroll of silence w:2 / scroll of acquirement w:1 /
              scroll of teleportation w:20 / scroll of vulnerability w:2 /
              scroll of holy word w:8 / scroll of fog w:8 /
-             scroll of torment w:8]])
+             scroll of torment w:8 / scroll of summoning w:1 ]])
 end
 
 function trove.place_fog(e, type, strength)

--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -230,11 +230,12 @@ end
 -- scrolls with a low chance of silence, vulnerability or acquirement (lowest)
 function trove.good_scroll (e)
     e.item([[scroll of enchant weapon / scroll of brand weapon w:3 /
-             scroll of enchant armour / scroll of identify w:20 /
+             scroll of enchant armour / scroll of immolation w:8 /
              scroll of magic mapping w:5 / scroll of blinking /
              scroll of silence w:2 / scroll of acquirement w:1 /
              scroll of teleportation w:20 / scroll of vulnerability w:2 /
-             scroll of holy word w:8 / scroll of fog w:8]])
+             scroll of holy word w:8 / scroll of fog w:8 /
+             scroll of torment w:8]])
 end
 
 function trove.place_fog(e, type, strength)


### PR DESCRIPTION
In the past year, identification scrolls have become increasingly less
important as gear now is automatically identified, and never cursed.

By the time players get into a trove, they generally will have no
further use for scrolls of identify, so those should be removed from the
good_scroll table. In their place, we now have immolation scrolls, which
are a fun tool for safely fighting large armies, and torment scrolls,
so that these troves can be just as fun for demons/undead as they are
for other species. These two additions are equally as common as scrolls
of holy word.

(20 weight of identify has been replaced by 16 weight of new scrolls, so a mere 4 weight is now evenly distributed among the remaining scroll types, which have a combined weight of ~~95~~ 96. edit: seems that these probabilities previously totalled 100. we could increase some quantity, or slap in a curiously absent good scroll: summoning?) 