### PR TITLE
Onboarding: set hp_colour to higher defaults

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1417,7 +1417,7 @@ mp_warning = 0
         channel when the player's magic points drop below this
         percentage of their maximum (use 0 to turn off these messages).
 
-hp_colour = 50:yellow, 25:red
+hp_colour = 70:yellow, 40:red
         (List option)
         hp_colour colours your Health appropriately in the status
         display. In the default setting, your health will appear in

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -306,7 +306,7 @@ const vector<GameOption*> game_options::build_options_list()
         new ListGameOption<text_pattern>(SIMPLE_NAME(auto_exclude)),
         new ListGameOption<text_pattern>(SIMPLE_NAME(explore_stop_pickup_ignore)),
         new ColourThresholdOption(hp_colour, {"hp_colour", "hp_color"},
-                                  "50:yellow, 25:red", _first_greater),
+                                  "70:yellow, 40:red", _first_greater),
         new ColourThresholdOption(mp_colour, {"mp_colour", "mp_color"},
                                   "50:yellow, 25:red", _first_greater),
         new ColourThresholdOption(stat_colour, {"stat_colour", "stat_color"},


### PR DESCRIPTION
This might subtly hint to newer players that things have
gone awry sooner.
Before: yellow at 50%, red at 25%.
Now: yellow at 70%, red at 40%.

With devteam approval, I'd also like to set other warnings a bit higher, like hp_warning, mp_warning, autofight_stop.