### PR TITLE
At game start, downgrade unusable scrolls to identification scrolls

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -148,6 +148,15 @@ item_def* newgame_make_item(object_class_type base,
             item.sub_type = ARM_ROBE;
     }
 
+    // If the character can't use a given scroll, hand out a replacement instead.
+    if (item.base_type == OBJ_SCROLLS) {
+        if (item.sub_type == SCR_HOLY_WORD && you.undead_or_demonic())
+            item.sub_type = SCR_IDENTIFY;
+        else if (item.sub_type == SCR_BLINKING || item.sub_type == SCR_TELEPORTATION)
+            if (you.stasis())
+                item.sub_type = SCR_IDENTIFY;
+    }
+
     // Make sure we didn't get a stack of shields or such nonsense.
     ASSERT(item.quantity == 1 || is_stackable_item(item));
 

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -152,6 +152,18 @@ item_def* newgame_make_item(object_class_type base,
     if (item.base_type == OBJ_SCROLLS && is_useless_item(item, false, true))
             item.sub_type = SCR_IDENTIFY;
 
+    // Hand out curing to replace unusable potions, or an ident scroll
+    if (item.base_type == OBJ_POTIONS && is_useless_item(item, false, true))
+    {
+        if (!you.has_mutation(MUT_NO_DRINK))
+            item.sub_type = POT_CURING;
+        else
+        {
+            item.base_type = OBJ_SCROLLS;
+            item.sub_type = SCR_IDENTIFY;
+        }
+    }
+
     // Make sure we didn't get a stack of shields or such nonsense.
     ASSERT(item.quantity == 1 || is_stackable_item(item));
 

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -149,13 +149,8 @@ item_def* newgame_make_item(object_class_type base,
     }
 
     // If the character can't use a given scroll, hand out a replacement instead.
-    if (item.base_type == OBJ_SCROLLS) {
-        if (item.sub_type == SCR_HOLY_WORD && you.undead_or_demonic())
+    if (item.base_type == OBJ_SCROLLS && is_useless_item(item, false, true))
             item.sub_type = SCR_IDENTIFY;
-        else if (item.sub_type == SCR_BLINKING || item.sub_type == SCR_TELEPORTATION)
-            if (you.stasis())
-                item.sub_type = SCR_IDENTIFY;
-    }
 
     // Make sure we didn't get a stack of shields or such nonsense.
     ASSERT(item.quantity == 1 || is_stackable_item(item));


### PR DESCRIPTION
I think this only affects Warpers and Wanderers at present, but may become more broadly applicable if player start inventories are changed in the future.