### PR TITLE
Knife the Spriggan's Nerf, er...

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1757,7 +1757,8 @@ void attack::player_stab_check()
     // so upgrade the stab type for !stab and the Spriggan's Knife here
     if (using_weapon()
         && is_unrandom_artefact(*weapon, UNRAND_SPRIGGANS_KNIFE)
-        && st != STAB_NO_STAB)
+        && st != STAB_NO_STAB
+        && coinflip())
     {
         st = STAB_SLEEPING;
     }


### PR DESCRIPTION
Most monsters die in a single hit from the Spriggan's Knife; those that survive take massive damage and can be quickly dispatched with a couple more stabs. Stabs that result from netted/webbed/petrifying/invisible/confused often leave the target open for further stabbing, as the condition still applies. This is especially overpowered with irresistible status effects such as that from Line Pass.

To make this less of a guaranteed instant-kill, add a coinflip(). It may take a few tries before the target dies.