### PR TITLE
when felid has 2 lives, fix Experience Info to show actual died-now xp needed

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1653,10 +1653,10 @@ static void _experience_check()
         perc = (you.experience - exp_needed(xl)) * 100
              / (exp_needed(xl + 1) - exp_needed(xl));
         perc = (nl - xl) * 100 - perc;
-        mprf(you.lives < 2 ?
-             "You'll get an extra life in %d.%02d levels' worth of XP." :
-             "If you died right now, you'd get an extra life in %d.%02d levels' worth of XP.",
-             perc / 100, perc % 100);
+        you.lives < 2 ?
+             mprf("You'll get an extra life in %d.%02d levels' worth of XP.", perc / 100, perc % 100) :
+             mprf("If you died right now, you'd get an extra life in %d.%02d levels' worth of XP.",
+             (perc / 100) + 1 , perc % 100);
     }
 
     handle_real_time();


### PR DESCRIPTION
Currently, when a Felid has two lives, the related Experience Info message is off by one. E.g., at level 10 with 2 lives, it reads, "If you died right now, you'd get an extra life in 1 levels' worth of XP." If you died at that moment, however, you'd need to gain two levels to get another life.

This fixes the Experience Info to display the correct number of levels needed to gain another life following death when you currently have two lives.