### PR TITLE
arrival vaults

### DIFF
--- a/crawl-ref/source/dat/des/arrival/simple.des
+++ b/crawl-ref/source/dat/des/arrival/simple.des
@@ -2508,3 +2508,38 @@ tt.........tt
  tt.......tt
   ttt@@@ttt
 ENDMAP
+
+##############################################################
+NAME:    spicycebolla_xxxplode
+TAGS:    arrival transparent
+ORIENT:  float
+SUBST:   A : .A@
+SUBST:   @ = .@@@@
+SUBST:   X : tXXXX
+SHUFFLE: xX
+SUBST:   X:xX, X:.mw, x:xxvc, t:tttgw
+TILE:    t = dngn_tree_dead
+: set_feature_name("tree", "dead tree")
+MAP
+    X           X
+  txxXxx  A  xxXxx
+  @xxxXxx . xxXxxx@
+ xx.xxxXx . xXxxx.xx
+Xxxx.xxXxx.xxXxx.xxxX
+ Xxxx.xxXx.xXxx.xxxX
+ xXxxx.xXx.xXx.xxxXx
+ xxXXxx.xxXxx.xxXXxx
+  xxxXXx.x.x.xXXxxx
+    xxxxx.X.xxxxx
+ A..X..X.X{X.X..X..A
+    xxxxx.X.xxxxx
+  xxxXXx.x.x.xXXxxx
+ xxXXxx.xxXxx.xxXXxx
+ xXxxx.xXx.xXx.xxxXx
+ Xxxx.xxXx.xXxx.xxxX
+Xxxx.xxXxx.xxXxx.xxxX
+ xx.xxxXx . xXxxx.xx
+  @xxxXxx . xxXxxx@
+   xxXxx  A  xxXxx
+    X           X
+ENDMAP

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -173,31 +173,37 @@ ENDMAP
 
 ##############################################################################
 # Was evilmike_arrival_teleporters
+# Now with all new transporters!
 NAME:    evilmike_arrival_plus
 TAGS:    arrival
 ORIENT:  float
-SHUFFLE: GTVt1`
+SHUFFLE: GTVt1`, HIJK
 SUBST:   `=.
 SUBST:   X:Y. , Y:xx.
 MONS:    plant
+SUBST:   H = @, I = @
+MARKER:  J = lua:transp_loc("evilmike")
+MARKER:  K = lua:transp_dest_loc("evilmike")
 MAP
-       x+x
-      xx.xx
-      xY.Yx
-      xX.Xx
-      xX.Xx
-     xx...xx
- xxxxx..G..xxxxx
-xxYXX.......XXYxx
-+.....G.{.G.....+
-xxYXX.......XXYxx
- xxxxx..G..xxxxx
-     xx...xx
-      xX.Xx
-      xX.Xx
-      xY.Yx
-      xx.xx
-       x+x
+         H
+        x+x
+       xx.xx
+       xY.Yx
+       xX.Xx
+       xX.Xx
+      xx...xx
+  xxxxx..G..xxxxx
+ xxYXX.......XXYxx
+K+.....G.{.G.....+I
+ xxYXX.......XXYxx
+  xxxxx..G..xxxxx
+      xx...xx
+       xX.Xx
+       xX.Xx
+       xY.Yx
+       xx.xx
+        x+x
+         J
 ENDMAP
 
 ##############################################################

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -3591,3 +3591,41 @@ xxxxxxxppprrrrrr.._-x
            x--xxx--xx
            xxxxxxxxxx
 ENDMAP
+
+##############################################################################
+# most teleporter vaults are dangerous, especially for new players.
+# here's a no-stress scenario in which they can try out teleporters
+NAME:    spicycebolla_arrival_teleporter_tutorial
+TAGS:    arrival no_monster_gen no_pool_fixup
+ORIENT:  float
+FTILE:   .GAT}{EFJK : none:30 / floor_marble:5 / floor_pebble_blue
+COLOUR:  . : blue:5 / none
+SUBST:   A = wW, ? = W., G : .GAT
+SUBST:   ? = W:15 . w:5, ! = W.:20
+SUBST:   _ : .:40 W
+SUBST:   T : wwwwT
+KFEAT:   T = mangrove
+SHUFFLE: EJ/FK
+MARKER:  E = lua:transp_loc("tut_entry")
+MARKER:  F = lua:transp_dest_loc("tut_stairs")
+MARKER:  J = lua:transp_dest_loc("tut_entry")
+MARKER:  K = lua:transp_loc("tut_stairs")
+MAP
+ AA?@?AAA
+Awww_wwwwA
+wwww_wwwwwA
+wwAW_WAwwww
+wAW...WAwwA
+wW.J>K.WwwwA
+wAW.G.WAwwww
+wwAWWWAwwwwA
+AwwwwwwwwwwwA
+ AwwwwAWWWAww
+ wwwwAW.G.WAw
+ AwwwW.E{F.Ww
+  AwwAW...WAw
+  wwwwAW!WAww
+  Awww??!?www
+   AwwT?!TwwA
+    AAAT!@?A
+ENDMAP


### PR DESCRIPTION
Teleporters generally only show up in dangerous scenarios; this puts
a pair of teleporters into an arrival vault for people to play with.
These can also be used to juke gnolls and panlords, in times of need.

(Inspired by the "throwing tutorial" key holder vault in Brogue, which
shows up early and often in dungeon generation, helpiing the player
learn that items can be thrown to trigger traps from a distance.)