### PR TITLE
Shift gyre and gimbal to be early-game

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1400,9 +1400,9 @@ DBRAND:  It occasionally heals its wielder for a portion of the damage dealt
 DESCRIP: Its wielder's spells cost health as well as magical power.
 
 ENUM:    GYRE
-NAME:    pair of quick blades "Gyre" and "Gimble"
-OBJ:     OBJ_WEAPONS/WPN_QUICK_BLADE
-TYPE:    pair of quick blades
+NAME:    pair of short swords "Gyre" and "Gimble"
+OBJ:     OBJ_WEAPONS/WPN_SHORT_SWORD
+TYPE:    pair of short swords
 COLOUR:  ETC_ENCHANT
 TILE:    urand_gyre
 TILE_EQ: gyre

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -1343,6 +1343,7 @@ static int _preferred_max_level(int unrand_index)
     case UNRAND_WOODCUTTERS_AXE:
     case UNRAND_MORG:
     case UNRAND_THROATCUTTER:
+    case UNRAND_GYRE:
         return 9;
     case UNRAND_DEVASTATOR:
     case UNRAND_RATSKIN_CLOAK:


### PR DESCRIPTION
The protection brand is particularly relevant when enemies may only be
swinging for 9 to 20 damage. In the same way, damage-dealing can be
less of a struggle for short blades when AC is lower.

In the late-game, most short blades that maintain relevance will be sporting different brands (or are rapiers). If one finds this weapon in Vaults, they're probably already wielding something else and unlikely to switch to Gyre.

Having this weapon crop up earlier will give players a chance to use it
during a time where it's not outclassed by as many other weapons.
Making the base item a short sword may help nudge people to look for
replacements. Also, there aren't any artifact short swords currently.