### PR TITLE
Rest before autoexplore when regenerating due to gods

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3928,7 +3928,7 @@ int get_real_mp(bool include_items)
     return enp;
 }
 
-/// Does the player currently regenerate hp? Used for resting.
+/// Does the player currently regenerate hp through non-god means?
 bool player_regenerates_hp()
 {
     if (you.has_mutation(MUT_NO_REGENERATION) || regeneration_is_inhibited())
@@ -5315,7 +5315,9 @@ bool player::is_banished() const
 bool player::is_sufficiently_rested() const
 {
     // Only return false if resting will actually help.
-    return (!player_regenerates_hp()
+    // We check whether either we regenerate HP in general, or whether 
+    // we are regenerating right now.
+    return ((player_regen() == 0 && !player_regenerates_hp())
                 || _should_stop_resting(hp, hp_max))
         && (!player_regenerates_mp()
                 || _should_stop_resting(magic_points, max_magic_points))

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5315,7 +5315,7 @@ bool player::is_banished() const
 bool player::is_sufficiently_rested() const
 {
     // Only return false if resting will actually help.
-    // We check whether either we regenerate HP in general, or whether 
+    // We check whether either we regenerate HP in general, or whether
     // we are regenerating right now.
     return ((player_regen() == 0 && !player_regenerates_hp())
                 || _should_stop_resting(hp, hp_max))


### PR DESCRIPTION
The decision on whether the character was rested was looking at only the ability to regenerate through mundane means, so for example a Deep Dwarf of Jiyva would never rest. With this change we also check the actual regeneration rate, which takes into account divine regeneration.