### PR TITLE
Good lugonu

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -461,7 +461,7 @@ static vector<ability_def> &_get_ability_list()
             7, scaling_cost::fixed(5), 10, -1, {fail_basis::invo, 70, 4, 25},
             abflag::none },
         { ABIL_LUGONU_ABYSS_ENTER, "Enter the Abyss",
-            10, 0, 28, -1, {fail_basis::invo, 80, 4, 25}, abflag::pain },
+            2, 0, 28, -1, {fail_basis::invo, 80, 4, 25}, abflag::pain },
         { ABIL_LUGONU_BLESS_WEAPON, "Brand Weapon With Distortion",
             0, 0, 0, -1, {fail_basis::invo}, abflag::none },
 

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1959,7 +1959,7 @@ static bool _lugonu_warp_monster(monster& mon, int pow)
     if (coinflip())
         return false;
 
-    if (!mon.friendly())
+    if (!mon.friendly()&&!mon.neutral())
         behaviour_event(&mon, ME_ANNOY, &you);
 
     mon.hurt(&you, 1 + random2(pow / 6));


### PR DESCRIPTION
Bend space
The higher the power, the higher the probability of moving the surrounding objects together, and at the same time, the higher the damage. However, this effect also applies to neutral objects, so players can become hostile to them if they use this power to escape from the existence of abyss that emerged through 'corrupt'. The higher the power, the higher the probability of Blink, and the higher the likelihood of them antagonizing the player. This bizarre interaction should have been eliminated sooner. Now, even if a neutral monsters is damaged through bend space, it is no longer hostile to the player.

Enter the Abyss
I want to distinguish Enter the Abyss from Sanctuary more clearly. If 2 MP is too low, 3 or 4 would be fine.

I want to change Banish, but I'm holding it for a while. I'm thinking about whether it's better to change this decision to HD-based or to leave the decision as it is, but change it to a smite method.