### PR TITLE
Display Irradiate damage in monster descriptions

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -385,6 +385,8 @@ static dice_def _spell_damage(spell_type spell, int hd)
             return waterstrike_damage(hd);
         case SPELL_IOOD:
             return iood_damage(pow, INFINITE_DISTANCE, false);
+        case SPELL_IRRADIATE:
+            return irradiate_damage(pow, false);
         case SPELL_GLACIATE:
             return glaciate_damage(pow, 3);
         case SPELL_CONJURE_BALL_LIGHTNING:

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1829,7 +1829,7 @@ dice_def irradiate_damage(int pow, bool random)
 {
     const int dice = 3;
     const int max_dam = 40 + (random ? div_rand_round(pow, 2) : pow / 2);
-    return calc_dice(dice, max_dam);
+    return calc_dice(dice, max_dam, random);
 }
 
 /**


### PR DESCRIPTION
There is an inconsistency with damage numbers. According to the monster utility, radroaches can do `3d25 / 3d26` damage with Irradiate. Monster descriptions show only one formula, though. Half of the time it will be `3d25`, and in other cases it will be `3d26`, even for the same radroach.

What would be the best way to address this?

For posterity:
> PleasingFungus: correct fix is to pass a random bool to the damage func and do false for the ingame monster damage desc
