### PR TITLE
FIX Remove an erronous "the" from a message.

### DIFF
--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -618,9 +618,9 @@ void monster::remove_enchantment_effect(const mon_enchant &me, bool quiet)
                          : me.ench == ENCH_HEXED ? "hexed"
                                                  : "bribed");
 
-                mprf("You can %s detect the %s.",
+                mprf("You can %s detect %s.",
                      friendly() ? "once again" : "no longer",
-                     name(DESC_PLAIN, true).c_str());
+                     name(DESC_THE, true).c_str());
             }
 
             autotoggle_autopickup(friendly());


### PR DESCRIPTION
The player can see invisible monsters which are bribed, charmed or hexed. When the status is lost, the monster may suddenly vanish.

This changes the message this generates from "You can no longer detect the Sigmund." to "You can no longer detect Sigmund.". The "the" is retained for non-unique monsters.

monster::add_enchantment_effect() is unaffected by this. It inserts an adjective before the monster name, so the "the" is acceptable.