### PR TITLE
fix: let pieces from Xom's chessboard affect frenzied monsters

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -929,7 +929,7 @@ static bool _xoms_chessboard()
 
     for (monster_near_iterator mi(&you, LOS_NO_TRANS); mi; ++mi)
     {
-        if (mi->friendly() || mi->neutral())
+        if (mi->friendly() || mi->neutral() && !mi->has_ench(ENCH_INSANE))
             continue;
         if (mons_is_firewood(**mi))
             continue;


### PR DESCRIPTION
Continuing with the removal of restrictions on attacking frenzied monsters, let the pieces affect insane enemies.