### PR TITLE
fix: further fix grammar for artefact bardings with Regen

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -859,8 +859,11 @@ static void _update_equipment_attunement_by_health()
                     item_slot_name(static_cast<equipment_type>(slot)) :
                     "armour");
 
-            if (slot == EQ_GLOVES || slot == EQ_BOOTS)
+            if (slot == EQ_BOOTS && arm.sub_type != ARM_BARDING
+                || slot == EQ_GLOVES)
+            {
                 plural = true;
+            }
             you.activated.set(slot);
         }
     }


### PR DESCRIPTION
There are two different attunement messages for items with Regen. The
first one is displayed when a character puts on such item while at full
health. When an injured character puts on an item with Regen and then
reaches full health, the second message is printed.

The first attunement message was fixed in 68df51542, and this commit
fixes the second one.