### PR TITLE
Linearize piety pips

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -478,11 +478,9 @@ int chei_stat_boost(int piety)
 {
     if (!have_passive(passive_t::stat_boost))
         return 0;
-    if (piety < piety_breakpoint(0))  // Since you've already begun to slow down.
-        return 1;
     if (piety >= piety_breakpoint(5))
         return 15;
-    return (piety - 10) / 10;
+    return max(piety / 10, 1);
 }
 
 // Eat from one random off-level item stack.
@@ -854,7 +852,7 @@ int qazlal_sh_boost(int piety)
     if (!have_passive(passive_t::storm_shield))
         return 0;
 
-    return min(piety, piety_breakpoint(5)) / 10;
+    return 1 + min(piety, piety_breakpoint(5)) / 10;
 }
 
 // Not actually passive, but placing it here so that it can be easily compared

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3700,7 +3700,7 @@ static void _apply_monk_bonus()
     else if (you_worship(GOD_YREDELEMNUL))
         give_yred_bonus_zombies(2); // top up to **
     else
-        gain_piety(35, 1, false, true);
+        gain_piety(40, 1, false, true);
 }
 
 /// Transfer some piety from an old good god to a new one, if applicable.

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3822,7 +3822,7 @@ static void _set_initial_god_piety()
         break;
 
     case GOD_RU:
-        you.piety = 10; // one moderate sacrifice should get you to *.
+        you.piety = 5; // one moderate sacrifice should get you to *.
         you.piety_hysteresis = 0;
         you.gift_timeout = 0;
 
@@ -3851,9 +3851,9 @@ static void _set_initial_god_piety()
         break;
 
     default:
-        you.piety = 15; // to prevent near instant excommunication
-        if (you.piety_max[you.religion] < 15)
-            you.piety_max[you.religion] = 15;
+        you.piety = 10; // to prevent near instant excommunication
+        if (you.piety_max[you.religion] < 10)
+            you.piety_max[you.religion] = 10;
         you.piety_hysteresis = 0;
         you.gift_timeout = 0;
         break;
@@ -4664,11 +4664,10 @@ int piety_rank(int piety)
 
 int piety_breakpoint(int i)
 {
-    int breakpoints[NUM_PIETY_STARS] = { 30, 50, 75, 100, 120, 160 };
     if (i >= NUM_PIETY_STARS || i < 0)
         return 255;
     else
-        return breakpoints[i];
+        return 25 * (i + 1);
 }
 
 int get_monster_tension(const monster& mons, god_type god)


### PR DESCRIPTION
Based on a discord conversation. The piety scale is really weird for presumably legacy reasons and could probably just be linear 25 piety per pip. Since this makes the first pip come earlier, I nerfed starting piety slightly to compensate. There are a few knock on effects worth considering; this effectively nerfs Ru by capping piety lower (reducing max ability power) and Uskayaw by lowering the piety floor (making it take longer to hit 3-4* for the juicy abilities). The first of these should be fine, but Uskayaw could maybe use a small adjustment. Ignis and Yred might also want some changes; I didn't mess with them at all yet. 
The last piety star encompassing 150-200 piety is still a bit weird, but adding an additional piety level would require a lot more adjusting and I'm not convinced it's worth it. Tbh the game clarity benefits of linearizing this scale aren't that big, but I thought I'd give it a try.