### PR TITLE
Fix teleportitis-related messaging and status display

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -403,8 +403,12 @@ mutation_activity_type mutation_activity_level(mutation_type mut)
     if (you.form == transformation::blade_hands && mut == MUT_PAWS)
         return mutation_activity_type::INACTIVE;
 
-    if (you.form == transformation::tree && mut == MUT_TELEPORT)
+    if (mut == MUT_TELEPORT
+        && (you.no_tele() || player_in_branch(BRANCH_ABYSS)))
+    {
         return mutation_activity_type::INACTIVE;
+    }
+
 #if TAG_MAJOR_VERSION == 34
     if ((you_worship(GOD_PAKELLAS) || player_under_penance(GOD_PAKELLAS))
          && (mut == MUT_MANA_LINK || mut == MUT_MANA_REGENERATION))

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2469,7 +2469,7 @@ static vector<formatted_string> _get_overview_resistances(
     {
         if (you.no_tele())
             out += _resist_composer("NoTele", cwidth, 1, 1, false) + "\n";
-        else if (player_teleport())
+        else if (get_teleportitis_level())
             out += _resist_composer("Rnd*Tele", cwidth, 1, 1, false) + "\n";
     }
 

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -983,7 +983,7 @@ void player_reacts()
 
     if (x_chance_in_y(you.time_taken, 10 * BASELINE_DELAY))
     {
-        const int teleportitis_level = player_teleport();
+        const int teleportitis_level = get_teleportitis_level();
         // this is instantaneous
         if (teleportitis_level > 0 && one_chance_in(100 / teleportitis_level))
             you_teleport_now(false, true, "You feel strangely unstable.");

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1068,15 +1068,17 @@ bool player_can_hear(const coord_def& p, int hear_distance)
            && you.pos().distance_from(p) <= hear_distance;
 }
 
-int player_teleport()
+int get_teleportitis_level()
 {
     ASSERT(!crawl_state.game_is_arena());
 
-    // Don't allow any form of teleportation in Sprint or Gauntlets.
-    if (crawl_state.game_is_sprint() || player_in_branch(BRANCH_GAUNTLET))
+    // Teleportitis doesn't trigger in Sprint, Abyss, or Gauntlets.
+    if (crawl_state.game_is_sprint() || player_in_branch(BRANCH_GAUNTLET)
+        || player_in_branch(BRANCH_ABYSS))
+    {
         return 0;
+    }
 
-    // Short-circuit rings of teleport to prevent spam.
     if (you.stasis())
         return 0;
 

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1036,7 +1036,7 @@ int player_speed();
 int player_spell_levels(bool floored = true);
 int player_total_spell_levels();
 
-int player_teleport();
+int get_teleportitis_level();
 
 int player_monster_detect_radius();
 

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -852,9 +852,6 @@ static bool _teleport_player(bool wizard_tele, bool teleportitis,
 
     if (player_in_branch(BRANCH_ABYSS) && !wizard_tele)
     {
-        if (teleportitis)
-            return false;
-
         if (!reason.empty())
             mpr(reason);
         abyss_teleport();

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -456,7 +456,7 @@ static void _gauntlet_effect()
 
     mprf(MSGCH_WARN, "The nature of this place prevents you from teleporting.");
 
-    if (player_teleport())
+    if (you.get_base_mutation_level(MUT_TELEPORT))
         mpr("You feel stable on this floor.");
 }
 


### PR DESCRIPTION
This PR adds some indication that teleportitis is suppressed in the Abyss to the mutations and character overview screens.
Also, it marks teleportitis as inactive on the ``A`` and ``%`` screens in more cases.
