### PR TITLE
Abyssal rune detection

### DIFF
--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -241,8 +241,6 @@ static void _abyss_postvault_fixup()
     env.markers.activate_all();
 }
 
-#define ABYSSAL_RUNE_LOC_KEY "abyssal_rune_loc"
-
 // returns whether the abyssal rune is at `p`, updating map knowledge as a
 // side-effect
 static bool _sync_rune_knowledge(coord_def p)

--- a/crawl-ref/source/abyss.h
+++ b/crawl-ref/source/abyss.h
@@ -19,6 +19,8 @@ extern const coord_def ABYSS_CENTRE;
 const int EXIT_XP_COST = 10; // ref _reduce_abyss_xp_timer() for details
 // but it's equivalent to roughly half the recharge xp for an elemental evoker
 
+#define ABYSSAL_RUNE_LOC_KEY "abyssal_rune_loc"
+
 struct abyss_state
 {
     coord_def major_coord;

--- a/crawl-ref/source/dat/defaults/messages.txt
+++ b/crawl-ref/source/dat/defaults/messages.txt
@@ -147,6 +147,8 @@ force_more_message += You fall asleep
 # Abyss exits and rune
 force_more_message += Found a gateway leading out of the Abyss
 force_more_message += a gateway leading .* appears
+force_more_message += You detect the abyssal rune
+force_more_message += the detected abyssal rune vanishes
 force_more_message += Found .* abyssal rune of Zot
 
 # Water nymph stair temp-drowning - people seem to miss these...

--- a/crawl-ref/source/dat/des/branches/abyss.des
+++ b/crawl-ref/source/dat/des/branches/abyss.des
@@ -1079,19 +1079,19 @@ NSUBST: 0 = 4:1 / 2:2 / *:3
 FTILE:  "AO = floor_crystal_squares
 COLOUR: "O = lightmagenta
 MAP
-    """"""""
- ""..xxxAxx..
- "xxxx.xx1xx."
- .x0x.x0xx.xx"
-".xx.xxx.xx.x"
-"xx.xx3x.x0xx"
-"x.xx1O2xx.xx"
-"xx.xx4xx.xxx"
-".xx.xxxxx0xx"
- .x0x.x0x.xx."
- "xxxx.x.xx..
- ""..xxxxx..
-    """""""
+    ..."""..
+ ....xxxAxx..
+ .xxxx.xx1xx..
+ .x0x.x0xx.xx.
+..xx.xxx.xx.x.
+.xx.xx3x.x0xx.
+.x.xx1O2xx.xx.
+.xx.xx4xx.xxx.
+..xx.xxxxx0xx.
+ .x0x.x0x.xx..
+ .xxxx.x.xx..
+ ....xxxxx..
+    .......
 ENDMAP
 
 NAME:   evilmike_abyss_rune_tso_outpost
@@ -1134,13 +1134,13 @@ MAP
 6ccccGclcGcccc6
  .cOccclccccc.
   c+c0"l"0ccc
-"cc1ccclcccccc"
+.cc1ccclcccccc.
  .c4c0"l"0ccc.
   c5c clc ccc
-"cc.c0"l"0cccc"
+.cc.c0"l"0cccc.
  .c.ccclccccc.
   c.c0"l"0ccc
-"cc.ccclcccdcc"
+.cc.ccclcccdcc.
  .c+c2c!c5c+c.
   c 3 c1c 7 c
 6cc2 2+ +5 5cc6
@@ -1168,22 +1168,22 @@ SUBST:  c = ccccvb
 FTILE:  "A+@W48O = floor_crystal_squares
 COLOUR: "48 = lightmagenta
 MAP
- "cccccc4@4cccccc"
+ .cccccc4@4cccccc.
  cc .. ccAcc .. cc
-"c 44"" x5x ""44 c"
+.c 44"" x5x ""44 c.
 cc44nnn.c+c.nnn44cc
 c 4nn7n.....n7nn4 c
 c44+13n5.c.5n31+44c
 c 4nn2n.....n2nn4 c
 cc"4nnn.....nnn4"cc
-"c ......6...... c"
+.c ......6...... c.
  ccc "4nnnnn4" ccc
-  "cc84n2O2n48cc"
-   "c 4nn1nn4 c"
+  .cc84n2O2n48cc.
+   .c 4nn1nn4 c.
     cc44n+n44cc
-    "c 44444 c"
+    .c 44444 c.
      ccc 4 ccc
-      "ccccc"
+      .ccccc.
 ENDMAP
 
 # This theme is even more disparate than the literal vault combinations...
@@ -1217,10 +1217,10 @@ xaa1aaa1aaa1aaa1aaa1aaa1aax
 xa..'a'.'a'.'a'.'a'.'a'..ax
 aa.a'."a".'a'.'a'."a".'a.aa
 ..aaa1aaa1aaa1aaa1aaa1aaa..
- ..a.."a".'a'.'a'."a"..a..
+ ..a.."a".'a'"'a'."a"..a..
    .....................
         .....A......
-           ..@..
+           ""@""
 ENDMAP
 
 NAME:    nicolae_abyss_rune_star_stuff
@@ -1241,7 +1241,7 @@ NSUBST:  s = 2:1 / 2:2 / 2:3
 SUBST:   a = +, ' = A, DE = ., bdef = c
 SUBST:   c = cccxbv
 CLEAR:   "-_~
-FTILE:   1234O = floor_crystal_squares
+FTILE:   O = floor_crystal_squares
 COLOUR:  1234O = lightmagenta
 MAP
      4ccc4
@@ -1517,10 +1517,10 @@ FTILE:   .t23579ACE = floor_grass
 FTILE:   'a1 = floor_crystal_squares
 COLOUR:  '1 = lightmagenta
 MAP
-    ..'.'.
+    ......
   ....XXX....
  ..XWwtttwWX..
- .X.Tt.w.tT1X..'..
+ .X.Tt.w.tT1X.....
 ..WT.WXAXW.xxxxxxx.
 1.wt.tt'xxxxcccccx'
 .Xt.Xt3'x0--c6--cx.
@@ -1528,10 +1528,10 @@ aXtw...'+-U-+-O4cx1
 .Xt.Xt2'x6--c0--cx.
 1.wt.tt'xxxxcccccx'
 ..WT..XCX..xxxxxxx.
- .X.Tt.w.tT1X..'..
+ .X.Tt.w.tT1X.....
  ..XWwtttwWX..
   ....XXX....
-    ..'.'.
+    ......
 ENDMAP
 
 NAME:    evilmike_nicolae_abyss_rune_betentacled_crabyss

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2233,6 +2233,13 @@ void forget_map(bool rot)
         if (!env.map_knowledge(p).known() || you.see_cell(p))
             continue;
 
+        if (player_in_branch(BRANCH_ABYSS)
+            && env.map_knowledge(p).item()
+            && env.map_knowledge(p).item()->is_type(OBJ_RUNES, RUNE_ABYSSAL))
+        {
+            continue;
+        }
+
         if (rot)
         {
             const int dist = grid_distance(you.pos(), p);

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -276,6 +276,11 @@ void leaving_level_now(dungeon_feature_type stair_used)
         auto &vault_list =  you.vault_list[level_id::current()];
         vault_list.push_back("[exit]");
 #endif
+        // XX can this go somewhere else?
+        coord_def &cur_loc = you.props[ABYSSAL_RUNE_LOC_KEY].get_coord();
+        if (in_bounds(cur_loc))
+            mpr("Your memory of the abyssal rune fades away.");
+        cur_loc = coord_def(-1,-1);
     }
 
     dungeon_events.fire_position_event(DET_PLAYER_CLIMBS, you.pos());


### PR DESCRIPTION
This branch implements an idea for removing some of the aimlessness of looking for the abyss rune in newabyss: when the abyssal rune generates, it indicates to the player that it has generated, and shows the location on the level map. If it goes away or moves, the player also gets notified and map knowledge updated.

I had originally been aiming at much less direct versions of this, and my theorycrafting told me that simply showing it to the player might make getting the rune "too easy". However, on testing, I'm not sure this is really true. Often, the rune generates quite far away, and so this change tells you which direction to go, but it's still challenging to navigate the abyss and it might shift anyways. In this scenario, previously the player would just have to pick a random direction to wander. When it is closer, this change will speed things up somewhat, but also in large part just ends up substituting for the need to know about the special abyss tiles (which are toned down in this branch). So I'm not sure it will be vastly easier, just reduces the impact of luck (and spoiler knowledge) on knowing which way to go. It also introduces choices like, if you have a distant rune on abyss 3, should you head towards it or take a downstairs you find along the way.
