### PR TITLE
Allow adjusting of explore_greedy non autopickup item visit method

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -829,14 +829,20 @@ explore_greedy = true
         otherwise identical to regular explore. Explore greed is
         disabled if autopickup is off (Ctrl-A).
 
-explore_greedy_visit = (pile | enchanted | both)
-        By default greedy explore travels to piles of items on each
-        square in addition to items that are eligible for autopickup
-        this setting allows to also/only go to enchanted items instead.
-        By choosing "enchanted" greedy exploration will ignore piles
-        of mundane items and only visit the squares which contain
-        enchanted items. Choosing "both" will visit piles if they
-        contain enchanted items or not and singular enchanted items.
+explore_greedy_visit = artefacts,glowing_item
+explore_greedy_visit += stacks
+        (List option)
+        Greedy exploration will visit squares with items based on
+        these conditions.
+
+        stacks: makes explore_greedy visit stacks even if they don't
+        necessarily have target auto pickup items
+
+        glowing_items: makes explore_greedy visit glowing_items,
+        even if not in a stack
+
+        artefacts: makes explore_greedy visit artefacts, even
+        if not in a stack
 
 explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack
@@ -3139,3 +3145,7 @@ Set a separate glyph for unvisited stairs and transporters:
     feature += stone staircase leading up {<,x25C2}
     feature += stone staircase leading down {>,x25B8}
     feature += transporter {xA9, x25CE}
+
+Visit squares with stacks of items when exploring to print all newly
+encountered items:
+    explore_greedy_visit += stacks

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -43,14 +43,14 @@ The contents of this text are:
                 scroll_margin, always_show_exclusions
 3-f     Travel and Exploration.
                 travel_delay, explore_delay, rest_delay, travel_avoid_terrain,
-                explore_greedy, explore_stop, explore_stop_pickup_ignore,
-                explore_wall_bias, travel_key_stop, travel_one_unsafe_move,
-                tc_reachable, tc_dangerous, tc_disconnected, tc_excluded,
-                tc_exclude_circle, runrest_ignore_message,
-                runrest_stop_message, interrupt_<delay>, delay_safe_poison,
-                runrest_ignore_monster, rest_wait_both, rest_wait_ancestor,
-                rest_wait_percent, explore_auto_rest, auto_exclude,
-                travel_open_doors
+                explore_greedy, explore_greedy_visit, explore_stop,
+                explore_stop_pickup_ignore, explore_wall_bias, travel_key_stop,
+                travel_one_unsafe_move, tc_reachable, tc_dangerous,
+                tc_disconnected, tc_excluded, tc_exclude_circle,
+                runrest_ignore_message, runrest_stop_message,
+                interrupt_<delay>, delay_safe_poison, runrest_ignore_monster,
+                rest_wait_both, rest_wait_ancestor, rest_wait_percent,
+                explore_auto_rest, auto_exclude, travel_open_doors
 3-g     Command Enhancements.
                 auto_switch, easy_unequip, equip_unequip, jewellery_prompt,
                 easy_confirm, simple_targeting, force_spell_targeter,
@@ -828,6 +828,15 @@ explore_greedy = true
         autopickup in addition to exploring the level, but is
         otherwise identical to regular explore. Explore greed is
         disabled if autopickup is off (Ctrl-A).
+
+explore_greedy_visit = (pile | enchanted | both)
+        By default greedy explore travels to piles of items on each
+        square in addition to items that are eligible for autopickup
+        this setting allows to also/only go to enchanted items instead.
+        By choosing "enchanted" greedy exploration will ignore piles
+        of mundane items and only visit the squares which contain
+        enchanted items. Choosing "both" will visit piles if they
+        contain enchanted items or not and singular enchanted items.
 
 explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -829,7 +829,7 @@ explore_greedy = true
         otherwise identical to regular explore. Explore greed is
         disabled if autopickup is off (Ctrl-A).
 
-explore_greedy_visit = artefacts,glowing_item
+explore_greedy_visit = artefacts,glowing_items
 explore_greedy_visit += stacks
         (List option)
         Greedy exploration will visit squares with items based on

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -392,6 +392,7 @@ enum.h.o \
 equipment-type.h.o \
 errors.h.o \
 externs.h.o \
+explore-greedy-options.h.o \
 fight.h.o \
 filter-enum.h.o \
 fineff.h.o \

--- a/crawl-ref/source/explore-greedy-options.h
+++ b/crawl-ref/source/explore-greedy-options.h
@@ -3,10 +3,10 @@
 enum class explore_greedy_options
 {
     // Default, same as before the change, greedy visits piles of items
-    EG_PILE, 
+    EG_PILE,
     // Greedy explore now visits enchanted items both in stacks and not,
     // ignores piles of mundane items
-    EG_ENCHANTED, 
+    EG_ENCHANTED,
     // Greedy explore visits both piles and single enchanted items
     EG_BOTH,
 };

--- a/crawl-ref/source/explore-greedy-options.h
+++ b/crawl-ref/source/explore-greedy-options.h
@@ -1,12 +1,16 @@
 #pragma once
 
-enum class explore_greedy_options
+enum explore_greedy_options
 {
-    // Default, same as before the change, greedy visits piles of items
-    EG_PILE,
-    // Greedy explore now visits enchanted items both in stacks and not,
-    // ignores piles of mundane items
-    EG_ENCHANTED,
-    // Greedy explore visits both piles and single enchanted items
-    EG_BOTH,
+    // Greedy explore doesn't visit any non-autopickup items
+    EG_NONE = 0x00000,
+
+    // Greedy explore visits stacks of items
+    EG_STACK = 0x00001,
+
+    // Greedy explore visits glowing items both in stacks and not,
+    EG_GLOWING = 0x0002,
+
+    // Greedy explore visits artefact items
+    EG_ARTEFACT = 0x0004,
 };

--- a/crawl-ref/source/explore-greedy-options.h
+++ b/crawl-ref/source/explore-greedy-options.h
@@ -1,0 +1,12 @@
+#pragma once
+
+enum class explore_greedy_options
+{
+    // Default, same as before the change, greedy visits piles of items
+    EG_PILE, 
+    // Greedy explore now visits enchanted items both in stacks and not,
+    // ignores piles of mundane items
+    EG_ENCHANTED, 
+    // Greedy explore visits both piles and single enchanted items
+    EG_BOTH,
+};

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -37,6 +37,7 @@
 #include "dlua.h"
 #include "end.h"
 #include "errors.h"
+#include "explore-greedy-options.h"
 #include "files.h"
 #include "game-options.h"
 #include "ghost.h"
@@ -262,6 +263,12 @@ const vector<GameOption*> game_options::build_options_list()
              {"backward", SS_BACKWARD}}),
         new BoolGameOption(SIMPLE_NAME(dos_use_background_intensity), true),
         new BoolGameOption(SIMPLE_NAME(explore_greedy), true),
+        new MultipleChoiceGameOption<explore_greedy_options>(
+            SIMPLE_NAME(explore_greedy_visit),
+            explore_greedy_options::EG_PILE,
+            {{"pile", explore_greedy_options::EG_PILE},
+             {"enchanted", explore_greedy_options::EG_ENCHANTED},
+             {"both", explore_greedy_options::EG_BOTH}}),
         new BoolGameOption(SIMPLE_NAME(explore_auto_rest), true),
         new BoolGameOption(SIMPLE_NAME(travel_key_stop), true),
         new BoolGameOption(SIMPLE_NAME(travel_one_unsafe_move), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -409,8 +409,7 @@ public:
 
     bool        explore_greedy;    // Explore goes after items as well.
 
-    // Set what type of items explore_greedy visits.
-    explore_greedy_options explore_greedy_visit;
+    int explore_greedy_visit; // Set what type of items explore_greedy visits.
 
     // How much more eager greedy-explore is for items than to explore.
     int         explore_item_greed;
@@ -699,6 +698,7 @@ private:
                          bool prepend = false);
     void do_kill_map(const string &from, const string &to);
     int  read_explore_stop_conditions(const string &) const;
+    int  read_explore_greedy_visit_conditions(const string &) const;
     use_animations_type read_use_animations(const string &) const;
 
     void split_parse(const string &s, const string &separator,

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -9,6 +9,7 @@
 #include "char-set-type.h"
 #include "confirm-prompt-type.h"
 #include "easy-confirm-type.h"
+#include "explore-greedy-options.h"
 #include "feature.h"
 #include "flang-t.h"
 #include "flush-reason-type.h"
@@ -407,6 +408,9 @@ public:
     vector<text_pattern> explore_stop_pickup_ignore;
 
     bool        explore_greedy;    // Explore goes after items as well.
+
+    // Set what type of items explore_greedy visits.
+    explore_greedy_options explore_greedy_visit;
 
     // How much more eager greedy-explore is for items than to explore.
     int         explore_item_greed;

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -286,8 +286,7 @@ void Stash::update()
         if (!(si->flags & ISFLAG_UNOBTAINABLE))
             add_item(*si);
 
-        if (si->base_type == OBJ_STAVES
-            || si->flags & ISFLAG_COSMETIC_MASK)
+        if (si->base_type == OBJ_STAVES || si->flags & ISFLAG_COSMETIC_MASK)
             glowing_item_on_square = true;
 
         if (si->flags & ISFLAG_ARTEFACT_MASK)

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -276,7 +276,8 @@ void Stash::update()
     item_def *pitem = &env.item[you.visible_igrd(pos)];
     hints_first_item(*pitem);
 
-    bool enchanted_item_on_square = false;
+    bool glowing_item_on_square = false;
+    bool artefact_item_on_square = false;
     // Now, grab all items on that square and fill our vector
     for (stack_iterator si(pos, true); si; ++si)
     {
@@ -286,22 +287,26 @@ void Stash::update()
             add_item(*si);
 
         if (si->base_type == OBJ_STAVES
-            || si->flags & ISFLAG_COSMETIC_MASK
-            || si->flags & ISFLAG_ARTEFACT_MASK)
+            || si->flags & ISFLAG_COSMETIC_MASK)
         {
-            enchanted_item_on_square = true;
+            glowing_item_on_square = true;
         }
+
+        if (si->flags & ISFLAG_ARTEFACT_MASK)
+        {
+            artefact_item_on_square = true;
+        }      
     }
 
-    const bool pile_greed = static_cast<int>(items.size()) > 1
-                                    && (Options.explore_greedy_visit == explore_greedy_options::EG_PILE
-                                    || Options.explore_greedy_visit == explore_greedy_options::EG_BOTH);
-    const bool enchanted_greed = enchanted_item_on_square
-                                    && (Options.explore_greedy_visit == explore_greedy_options::EG_ENCHANTED
-                                    || Options.explore_greedy_visit == explore_greedy_options::EG_BOTH);
+    const bool stack_greed      =  static_cast<int>(items.size()) > 1
+                                && (Options.explore_greedy_visit & EG_STACK);
+    const bool glowing_greed    =  glowing_item_on_square
+                                && (Options.explore_greedy_visit & EG_GLOWING);
+    const bool artefact_greed   = artefact_item_on_square
+                                && (Options.explore_greedy_visit & EG_ARTEFACT);
 
     visited = pos == you.pos()
-              || !(pile_greed || enchanted_greed)
+              || !(stack_greed || glowing_greed || artefact_greed)
               || static_cast<int>(items.size()) == previous_size && visited;
 }
 

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -276,6 +276,7 @@ void Stash::update()
     item_def *pitem = &env.item[you.visible_igrd(pos)];
     hints_first_item(*pitem);
 
+    bool enchanted_item_on_square = false;
     // Now, grab all items on that square and fill our vector
     for (stack_iterator si(pos, true); si; ++si)
     {
@@ -283,10 +284,22 @@ void Stash::update()
         maybe_identify_base_type(*si);
         if (!(si->flags & ISFLAG_UNOBTAINABLE))
             add_item(*si);
+
+        if (si->base_type == OBJ_STAVES
+            || si->flags & ISFLAG_COSMETIC_MASK
+            || si->flags & ISFLAG_ARTEFACT_MASK)
+            enchanted_item_on_square = true;
     }
 
+    const bool pile_greed = static_cast<int>(items.size()) > 1
+                                    && (Options.explore_greedy_visit == explore_greedy_options::EG_PILE
+                                    || Options.explore_greedy_visit == explore_greedy_options::EG_BOTH);
+    const bool enchanted_greed = enchanted_item_on_square
+                                    && (Options.explore_greedy_visit == explore_greedy_options::EG_ENCHANTED
+                                    || Options.explore_greedy_visit == explore_greedy_options::EG_BOTH);
+
     visited = pos == you.pos()
-              || static_cast<int>(items.size()) == 1
+              || !(pile_greed || enchanted_greed)
               || static_cast<int>(items.size()) == previous_size && visited;
 }
 

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -288,7 +288,9 @@ void Stash::update()
         if (si->base_type == OBJ_STAVES
             || si->flags & ISFLAG_COSMETIC_MASK
             || si->flags & ISFLAG_ARTEFACT_MASK)
+        {
             enchanted_item_on_square = true;
+        }
     }
 
     const bool pile_greed = static_cast<int>(items.size()) > 1

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -288,14 +288,10 @@ void Stash::update()
 
         if (si->base_type == OBJ_STAVES
             || si->flags & ISFLAG_COSMETIC_MASK)
-        {
             glowing_item_on_square = true;
-        }
 
         if (si->flags & ISFLAG_ARTEFACT_MASK)
-        {
             artefact_item_on_square = true;
-        }      
     }
 
     const bool stack_greed      =  static_cast<int>(items.size()) > 1


### PR DESCRIPTION
explore_greedy_visit is added as an rc file option to adjust explore_greedy behavior. By default greedy explore travels to piles of items on each square in addition to items that are eligible for autopickup. This setting allows to also/only go to enchanted items instead. By choosing "enchanted" greedy exploration will ignore piles of mundane items and only visit the squares which contain
enchanted items. Choosing "both" will visit piles and singular enchanted items.