### PR TITLE
Only list gods you can ever worship in the dungeon overview & dump.

### DIFF
--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -477,6 +477,9 @@ static string _print_altars_for_gods(const vector<god_type>& gods,
 
     for (const god_type god : gods)
     {
+        if (!player_can_join_god(god, false))
+            continue;
+
         // for each god, look through the notable altars list for a match
         bool has_altar_been_seen = false;
         for (const auto &entry : altars_present)


### PR DESCRIPTION
Different gods forbid worship from different species (some despise undead, some abhor djinn, Beogh can only stand orcs and everyone hates demigods).

This change gives a way for the player to check which gods are available, and hides irrelevant information about whether an unusable altar has been found.

This list only changes during a game when a character sacrifices love to Ru. This seems fine to me.