### PR TITLE
Give Makh 2 more greater servants

### DIFF
--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -530,7 +530,7 @@ static int _makhleb_num_greater_servants()
                            + random2(you.experience_level / 2);
 
     if (severity > 13)
-        return 2 + random2(you.experience_level / 5 - 2); // up to 6 at XL27
+        return 2 + random2((you.experience_level - 2) / 5); // up to 6 at XL27
     else if (severity > 7 && !one_chance_in(5))
         return 1;
     return 0;


### PR DESCRIPTION
The comment suggests this should go up to 6, but oldcode didn't permit this. Fixed this unjust deprival of Makhleb's wrath to puny mortal players!