### PR TITLE
Remove steam trap from early dungeon floors to prevent deaths caused by autoexplore

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_features.des
+++ b/crawl-ref/source/dat/des/variable/mini_features.des
@@ -4096,7 +4096,7 @@ MAP
 ENDMAP
 
 NAME:   lemuel_another_geyser
-DEPTH:  D, Depths, Lair
+DEPTH:  D:6-, Depths, Lair
 TAGS:   uniq_geyser no_monster_gen layout_rooms transparent
 MONS:   nothing,nothing
 MARKER: 1 = lua:fog_machine { cloud_type="steam", \


### PR DESCRIPTION
!lg *  kaux~~steam map=lemuel_another_geyser s=place 
650 games for * (kaux~~steam map=lemuel_another_geyser): 452x D:1, 116x D:2, 53x D:3, 19x D:4, 5x D:5, 2x D:9, 2x D:7, D:6

!lg *  kaux~~steam map=lemuel_another_geyser s=species
650 games for * (kaux~~steam map=lemuel_another_geyser): 348x Octopode, 89x Merfolk, 29x Barachi, 25x Deep Elf, 19x Tengu, 19x Vampire, 14x Minotaur, 13x Spriggan, 12x Demonspawn, 9x Draconian, 8x Gargoyle, 7x Vine Stalker, 6x Kobold, 5x Felid, 5x Mummy, 5x Naga, 4x Formicid, 4x Gnoll, 4x Hill Orc, 3x Ogre, 3x Demigod, 3x Sludge Elf, 3x Human, 2x High Elf, 2x Deep Dwarf, 2x Centaur, 2x Halfling, ...