### PR TITLE
fix: remove -scroll and -potion from Xom muts

### DIFF
--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -1840,7 +1840,7 @@ static const mutation_def mut_data[] =
 },
 #endif
 
-{ MUT_DRINK_SAFETY, 7, 2, mutflag::bad | mutflag::xom, false,
+{ MUT_DRINK_SAFETY, 7, 2, mutflag::bad, false,
   "inability to drink while threatened",
 
   {"You occasionally lose the ability to drink potions when taking damage.",
@@ -1854,7 +1854,7 @@ static const mutation_def mut_data[] =
    ""},
 },
 
-{ MUT_READ_SAFETY, 7, 2, mutflag::bad | mutflag::xom, false,
+{ MUT_READ_SAFETY, 7, 2, mutflag::bad, false,
   "inability to read while threatened",
 
   {"You occasionally lose the ability to read scrolls when taking damage.",


### PR DESCRIPTION
Since 0d03ebdc04, characters taking Xom are signing up for a semi-persistent
dual -potion -scroll challenge conduct, on top of Xom's regular actions.

That's pretty extreme! Let's dial it back a bit.

This commit removes -scroll and -potion from Xom's mutation pool, aligning
these muts with Xom's behavior of not explicitly granting teleportitis or
devolution.

These muts can still be granted randomly by Xom with one_chance_in(1000),
but that's quite a bit less punishing than mutflag::xom's one_chance_in(5).