### PR TITLE
fix: tweak spacing on the dungeon overview screen

### DIFF
--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -343,7 +343,7 @@ static string _get_seen_branches(bool display)
                     7,
                     brname, lid.depth, brdepth[branch],
                     entry_desc.c_str());
-                cells.push_back(_pad_cs(main_desc, 21) + zclock_desc);
+                cells.push_back(_pad_cs(main_desc, 22) + zclock_desc);
             }
         }
     }


### PR DESCRIPTION
As a followup to ed30ed24e, this commit fixes column alignment in the two-columns mode.

There wasn't enough space for branch names:

![zot_clock_column](https://user-images.githubusercontent.com/3328424/179609380-f23efeea-b55f-43a9-88b7-05bad8126288.png)
