### PR TITLE
fix: allow Poisonous Vapours to work under Still Winds

### DIFF
--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1395,7 +1395,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         break;
 
         // fallthrough
-    case SPELL_POISONOUS_VAPOURS:
     case SPELL_CONJURE_FLAME:
     case SPELL_POISONOUS_CLOUD:
     case SPELL_FREEZING_CLOUD:


### PR DESCRIPTION
Allow Poisonous Vapours to work under `-Clouds`, since as of 3f0e5c0cc there are no clouds involved.