### PR TITLE
fix: correct webtiles hidpi implementation

### DIFF
--- a/crawl-ref/source/webserver/game_data/static/action_panel.js
+++ b/crawl-ref/source/webserver/game_data/static/action_panel.js
@@ -343,17 +343,12 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
     {
         if (item && draw_glyphs)
         {
-            // ugh, couldn't get this to work without a transform.
-            // Also, I don't know why the font size here looks
-            // different than map view, something about scaling?
-            renderer.ctx.setTransform(scale, 0, 0, scale, 0, 0);
             // XX just the glyph is not very informative. One idea might
             // be to tack on the subtype icon, but those are currently
             // baked into the item tile so this would be a lot of work.
-            renderer.render_glyph(_horizontal() ? offset / scale : 0,
-                                  _horizontal() ? 0 : offset / scale,
-                                  item, true, true);
-            renderer.ctx.setTransform(1, 0, 0, 1, 0, 0);
+            renderer.render_glyph(_horizontal() ? offset : 0,
+                                  _horizontal() ? 0 : offset,
+                                  item, true, true, scale);
         }
         else
         {
@@ -370,6 +365,8 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
 
         if (text)
         {
+            // TODO: at some scalings, this don't dodge the green highlight
+            // square very well
             renderer.draw_quantity(text,
                                    _horizontal() ? offset : 0,
                                    _horizontal() ? 0 : offset,
@@ -423,7 +420,7 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
         // Render
         // renderer here stores unscaled values. (This is different than how
         // it is done for the dungeon rendering.)
-        var adjusted_scale = scale * window.devicePixelRatio / 100;
+        var adjusted_scale = scale / 100;
 
         var cell_width = renderer.cell_width * adjusted_scale;
         var cell_height = renderer.cell_height * adjusted_scale;
@@ -431,8 +428,8 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
                                         : cell_height;
         var required_length = cell_length * (filtered_inv.length + NUM_RESERVED_BUTTONS);
         var available_length = _horizontal()
-                            ? $("#dungeon").width() * window.devicePixelRatio
-                            : $("#dungeon").height() * window.devicePixelRatio;
+                            ? $("#dungeon").width()
+                            : $("#dungeon").height();
         available_length -= borders_width;
         var max_cells = Math.floor(available_length / cell_length);
         var panel_length = Math.min(required_length, available_length);

--- a/crawl-ref/source/webserver/game_data/static/util.js
+++ b/crawl-ref/source/webserver/game_data/static/util.js
@@ -123,11 +123,14 @@ function () {
     }
 
     function init_canvas(element, w, h) {
-        var ratio = window.devicePixelRatio;
-        element.width = w;
-        element.height = h;
-        element.style.width = (w / ratio) + 'px';
-        element.style.height = (h / ratio) + 'px';
+        const ratio = window.devicePixelRatio;
+        element.width = Math.floor(w * ratio);
+        element.height = Math.floor(h * ratio);
+        var ctx = element.getContext('2d');
+        ctx.resetTransform();
+        ctx.scale(ratio, ratio);
+        element.style.width = w + 'px';
+        element.style.height = h + 'px';
     }
 
     function make_key(x, y) {


### PR DESCRIPTION
This commit reverts 3925e268bea408. (And could use some eyes because of this.)

To get hidpi to work in a browser canvas object, the internal dimensions
need to be twice that of the external dimensions (essentially). The
normal way of implementing this is to multiply the internal dimensions
by devicePixelRatio, and scale the canvas accordingly. We used to do
this, but 3925e268bea40 changed things so that the external dimensions
were halved. This was, according to the commit message, in order to
prevent scaling artifacts on firefox. (Where the salient fact is that
window.devicePixelRatio on some browsers, these days including
chrome/firefox but not safari, also changes with browser zoom.) However,
a consequence is that tile rendering is halved on hidpi devices, exactly
not what should happen. This change also made for a lot of messy code
that had to interact directly with devicePixelRatio.

The half-size tile rendering wasn't immediately noticeable because the
dungeon is auto-scaled, and the monster list matches its scale to the
dungeon. But, icons in menus and popups instantiate the problem, and
scaling them to the dungeon size is not ideal. The action panel also had
some workarounds for this that I didn't fully understand at the time. (I
only noticed this myself after many years of working on this stuff
because I switched from a regular-density monitor to a 4k monitor of
similar size, even though I've used retina devices for a long time.
Hidpi devices have been broken for so long that I won't be surprised if
we get requests to readd this behavior as an option or something, menus
may look odd now to people who have only ever played on hidpi.)

In my testing so far, I can't really detect any rendering differences
between the approach after this commit and the approach in
3925e268bea408. However, I'm not exactly sure of what the original
issues were, and this commit should be tested on a non-hidpi device
before merge.