### PR TITLE
Add reduce_bream_redraw option to draw beams fast

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -798,6 +798,11 @@ void bolt::draw(const coord_def& p, bool force_refresh)
                                              : element_colour(colour);
     view_add_glyph_overlay(p, {glyph, c});
 #endif
+    // If reduce_beam_redraw is set, the redraw is unnecesary and
+    // should be done only once outside the loop calling the bolt::draw
+    if (Options.reduce_beam_redraw)
+        return;
+
     // to avoid redraws, set force_refresh = false, and draw_delay = 0. This
     // will still force a refresh if there is a draw_delay regardless of the
     // param, because a delay on drawing is pretty meaningless without a
@@ -1343,6 +1348,13 @@ void bolt::do_fire()
         noise_generated = false;
 
         ray.advance();
+    }
+
+    if (Options.reduce_beam_redraw)
+    {
+        viewwindow(false);
+        update_screen();
+        scaled_delay(15 + draw_delay);
     }
 
     if (!map_bounds(pos()))

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3295,7 +3295,7 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
     for (coord_def pos : affected)
         beam.draw(pos, false);
 
-    if (quiet)
+    if (quiet || Options.reduce_beam_redraw)
     {
         // When `quiet`, refresh the view after each complete draw pass.
         // why this call dance to refresh? I just copied it from bolt::draw

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -272,6 +272,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(cloud_status), !is_tiles()),
         new BoolGameOption(SIMPLE_NAME(always_show_zot), false),
         new BoolGameOption(SIMPLE_NAME(darken_beyond_range), true),
+        new BoolGameOption(SIMPLE_NAME(reduce_beam_redraw), false),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs), false),
         new BoolGameOption(SIMPLE_NAME(arena_dump_msgs_all), false),
         new BoolGameOption(SIMPLE_NAME(arena_list_eq), false),

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5375,6 +5375,15 @@ static void _mons_upheaval(monster& mons, actor& /*foe*/, bool randomize)
         for (coord_def pos : affected)
         {
             beam.draw(pos);
+            //No need to delay if we are not refreshing
+            if (!Options.reduce_beam_redraw)
+                scaled_delay(25);
+        }
+
+        if (Options.reduce_beam_redraw)
+        {
+            viewwindow(false);
+            update_screen();
             scaled_delay(25);
         }
     }

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -271,6 +271,7 @@ public:
     msg_colour_type channels[NUM_MESSAGE_CHANNELS];  // msg channel colouring
     use_animations_type use_animations; // which animations to show
     bool        darken_beyond_range; // whether to darken squares out of range
+    bool        reduce_beam_redraw; // whether to draw whole beam at once
 
     int         hp_warning;      // percentage hp for danger warning
     int         magic_point_warning;    // percentage mp for danger warning

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2587,7 +2587,14 @@ spret cast_discharge(int pow, const actor &agent, bool fail, bool prompt)
     if (dam > 0)
     {
         if (Options.use_animations & UA_BEAM)
+        {
+            if (Options.reduce_beam_redraw)
+            {
+                viewwindow(false);
+                update_screen();
+            }
             scaled_delay(100);
+        }
     }
     else
     {
@@ -2692,6 +2699,11 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
             beam.draw(entry.first);
         }
 
+        if (Options.reduce_beam_redraw)
+        {
+            viewwindow(false);
+            update_screen();
+        }
         scaled_delay(200);
     }
 
@@ -3489,10 +3501,17 @@ spret cast_glaciate(actor *caster, int pow, coord_def aim, bool fail)
 
                 beam.draw(entry.first);
             }
-            scaled_delay(25);
+
+            if (!Options.reduce_beam_redraw)
+                scaled_delay(25);
         }
 
-        scaled_delay(100);
+        if (Options.reduce_beam_redraw)
+        {
+            viewwindow(false);
+            update_screen();
+            scaled_delay(100);
+        }
     }
 
     if (you.can_see(*caster) || caster->is_player())


### PR DESCRIPTION
Add reduce_bream_redraw option to draw beams for animation without many redraws

The reduce_beam_redraw option now decides whether to draw whole beam at once
instead of animating every tile seperately with screen redraws in between. To achieve
this the bolt::draw function is modified to return after setting the tile to the bolt but
before trying to redraw. The redraw is then done only once outside the loop in which
bolt::draw function is called to draw the whole beam at once.