### PR TITLE
Make greedy explore less greedy

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -835,7 +835,7 @@ explore_greedy_visit += stacks
         Greedy exploration will visit squares with items based on
         these conditions.
 
-        stacks: makes explore_greedy visit stacks even if they don't
+        stacks: makes explore_greedy visit all stacks even if they don't
         necessarily have target auto pickup items
 
         glowing_items: makes explore_greedy visit glowing_items,

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -293,7 +293,8 @@ void Stash::update()
             artefact_item_on_square = true;
     }
 
-    const bool stack_greed      =  static_cast<int>(items.size()) > 1
+    int current_size = items.size();
+    const bool stack_greed      =  current_size > 1
                                 && (Options.explore_greedy_visit & EG_STACK);
     const bool glowing_greed    =  glowing_item_on_square
                                 && (Options.explore_greedy_visit & EG_GLOWING);
@@ -302,7 +303,7 @@ void Stash::update()
 
     visited = pos == you.pos()
               || !(stack_greed || glowing_greed || artefact_greed)
-              || static_cast<int>(items.size()) == previous_size && visited;
+              || current_size <= previous_size && visited;
 }
 
 static bool _is_rottable(const item_def &item)

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -286,10 +286,13 @@ void Stash::update()
         if (!(si->flags & ISFLAG_UNOBTAINABLE))
             add_item(*si);
 
-        if (si->base_type == OBJ_STAVES || si->flags & ISFLAG_COSMETIC_MASK)
+        if ((si->base_type == OBJ_STAVES || si->flags & ISFLAG_COSMETIC_MASK)
+            && !is_useless_item(*si))
+        {
             glowing_item_on_square = true;
+        }
 
-        if (si->flags & ISFLAG_ARTEFACT_MASK)
+        if (si->flags & ISFLAG_ARTEFACT_MASK && !is_useless_item(*si))
             artefact_item_on_square = true;
     }
 


### PR DESCRIPTION
Autoexplore does a lot of unnecessary item piles revisits now. For example, if you kill a monster that has a dagger of freezing, a plain +0 hat, and an artefact, autoexplore could visit the resulting pile of items up to four times. These (re)visits happen after

1) you kill the monster,
2) you apport the dagger,
3) the monster's corpse decays,
4) a Jiyva jelly eats the hat.

This PR fixes unnecessary revisits 2), 3), and 4).

Also, it reduces the number of unnecessary autotravel interruptions by ignoring piles of useless items during greedy explore.
