### PR TITLE
Remove unused variable

### DIFF
--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -2171,7 +2171,6 @@ void TextEntry::LineReader::killword()
 
     bool foundwc = false;
     char *word = cur;
-    int ew = 0;
     while (1)
     {
         char *np = prev_glyph(word, buffer);
@@ -2186,7 +2185,6 @@ void TextEntry::LineReader::killword()
             break;
 
         word = np;
-        ew += wcwidth(c);
     }
     memmove(word, cur, strlen(cur) + 1);
     length -= cur - word;


### PR DESCRIPTION
```
ui.cc:2174:9: warning: variable 'ew' set but not used [-Wunused-but-set-variable]
    int ew = 0;
        ^
```