### PR TITLE
Extract more user-customisation from webserver files

### DIFF
--- a/crawl-ref/source/webserver/.gitignore
+++ b/crawl-ref/source/webserver/.gitignore
@@ -1,3 +1,4 @@
 .tox/
 venv/
 htmlcov/
+config.yml

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -1,3 +1,10 @@
+# ### Server Operators ###
+# If you want to customise any settings in this file, create config.yml and
+# write your overrides in there. This file is version controlled, so you'll get
+# merge conflicts if you modify this file and later attempt to pull upstream
+# updates.
+#
+# ### Developers ###
 # Warning! Servers will not update or merge with the version controlled copy of
 # this file, so any parameters here should be presented as recommendations or
 # documentation of the default, not a default value, and option name changes
@@ -21,7 +28,7 @@ import os
 
 import yaml
 
-# directory to look for `games.d` files among other things.
+# Where to look for `games.d/`, `config.yml`, and other things.
 server_path = os.path.dirname(os.path.abspath(__file__))
 
 # dgl_mode = True

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -63,19 +63,12 @@ game_data_no_cache = True
 # Watch socket dirs for games not started by the server
 # watch_socket_dirs = False
 
-# use_game_yaml = True
-
 # Game configs
 #
 # You can define game configs in two ways:
 # 1. With a static dictionary `games`
 # 2. As extra games to append to this list from `load_games.load_games` (which
 #    by default loads games as defined in `games.d/*.yaml`).
-#
-# All options in this config are documented in games.d/base.yaml.
-# the directory name can be changed with `games_config_dir`, and set to None
-# to disable yaml loading.
-# games_config_dir = None
 
 # Example of a games dictionary:
 # use of an OrderedDict (pre python 3.6) is necessary to show the lobby in

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -73,7 +73,8 @@ game_data_no_cache = True
 # Game configs
 # You can define game configs in two ways:
 # 1. As *.yml files in `games.d/`. (preferred)
-# 2. With a dictionary `games` in this file (for dgamelaunch servers).
+# 2. With a dictionary `games` in this file (for dgamelaunch-config servers).
+use_game_yaml = True # Set to False (or leave unset) to disable method 1 above.
 #    (use of an OrderedDict (pre python 3.6) is necessary to show the lobby in
 #    a stable order.)
 games = collections.OrderedDict([])

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -71,36 +71,12 @@ game_data_no_cache = True
 # watch_socket_dirs = False
 
 # Game configs
-#
 # You can define game configs in two ways:
-# 1. With a static dictionary `games`
-# 2. As extra games to append to this list from `load_games.load_games` (which
-#    by default loads games as defined in `games.d/*.yaml`).
-
-# Example of a games dictionary:
-# use of an OrderedDict (pre python 3.6) is necessary to show the lobby in
-# a stable order.
-games = collections.OrderedDict([
-    ("dcss-web-trunk", dict(
-        name = "Play trunk",
-        crawl_binary = "./crawl",
-        rcfile_path = "./rcs/",
-        macro_path = "./rcs/",
-        morgue_path = "./rcs/%n",
-        inprogress_path = "./rcs/running",
-        ttyrec_path = "./rcs/ttyrecs/%n",
-        socket_path = "./rcs",
-        client_path = "./webserver/game_data/",
-        # dir_path = ".",
-        # cwd = ".",
-        morgue_url = None,
-        show_save_info = True,
-        allowed_with_hold = True,
-        # milestone_path = "./rcs/milestones",
-        send_json_options = True,
-        # env = {"LANG": "en_US.UTF8"},
-        )),
-])
+# 1. As *.yml files in `games.d/`. (preferred)
+# 2. With a dictionary `games` in this file (for dgamelaunch servers).
+#    (use of an OrderedDict (pre python 3.6) is necessary to show the lobby in
+#    a stable order.)
+games = collections.OrderedDict([])
 
 
 dgl_status_file = "./rcs/status"

--- a/crawl-ref/source/webserver/games.d/base.yaml
+++ b/crawl-ref/source/webserver/games.d/base.yaml
@@ -3,9 +3,9 @@
 # %n in paths and urls is replaced by the current username.
 games:
   # id must be unique for each game
-  - id: seeded-web-trunk
+  - id: dcss-web-trunk
     # The name for this game, displayed on the webtiles HTML interface
-    name: Custom seed
+    name: Play trunk
     # Games are called with the following argv:
     # [
     #   $crawl_binary,
@@ -69,9 +69,9 @@ games:
     # # Array of extra options to add to the start of the DCSS command. Prefer
     # # using 'options' unless the ordering is critical.
     # pre_options: []
-    # Array of extra options to add to the DCSS command.
-    options:
-      - -seed
+    # # Array of extra options to add to the DCSS command.
+    # options:
+    #   - -seed
     # # Map of extra environment variables to set when executing the DCSS command.
     # # All env vars from the webtiles server environment are automatically
     # # inherited.
@@ -90,6 +90,23 @@ games:
     # send_json_options is a legacy option. Always include this set to 'true'.
     # (Or submit a PR to remove it.)
     send_json_options: True
+  # id must be unique for each game
+  - id: seeded-web-trunk
+    name: Custom seed
+    crawl_binary: ./crawl
+    rcfile_path: ./rcs/
+    macro_path: ./rcs/
+    morgue_path: ./rcs/%n
+    socket_path: ./rcs
+    inprogress_path: ./rcs/running
+    ttyrec_path: ./rcs/ttyrecs/%n
+    client_path: ./webserver/game_data/
+    morgue_url: None
+    show_save_info: True
+    allowed_with_hold: True
+    send_json_options: True
+    options:
+      - -seed
   - id: tut-web-trunk
     name: Tutorial
     crawl_binary: ./crawl

--- a/crawl-ref/source/webserver/webtiles/config.py
+++ b/crawl-ref/source/webserver/webtiles/config.py
@@ -85,7 +85,6 @@ defaults = {
     },
     'server_socket_path': None,
     'watch_socket_dirs': False,
-    'use_game_yaml': True,
     'milestone_file': [],
     'status_file_update_rate': 5,
     'lobby_update_rate': 2,
@@ -166,8 +165,7 @@ def load_game_data():
     # TODO: should the `load_games` module be refactored into config?
     global games
     games = get('games', collections.OrderedDict())
-    if get('use_game_yaml', False):
-        games = load_games.load_games(games)
+    games = load_games.load_games(games)
     # TODO: check_games here or in validate?
     if len(games) == 0:
         raise ValueError("No games defined!")

--- a/crawl-ref/source/webserver/webtiles/config.py
+++ b/crawl-ref/source/webserver/webtiles/config.py
@@ -183,7 +183,10 @@ def load_game_data():
     # TODO: should the `load_games` module be refactored into config?
     global games
     games = get('games', collections.OrderedDict())
-    games = load_games.load_games(games)
+    if get('use_game_yaml', False):
+        games = load_games.load_games(games)
+    else:
+        logging.warn("Config setting use_game_yaml is False/unset, won't load game definitions in games.d/")
     # TODO: check_games here or in validate?
     if len(games) == 0:
         raise ValueError("No games defined!")

--- a/crawl-ref/source/webserver/webtiles/config.py
+++ b/crawl-ref/source/webserver/webtiles/config.py
@@ -4,6 +4,8 @@
 import collections
 import os.path
 import logging
+import sys
+import yaml
 
 from webtiles import load_games
 
@@ -16,6 +18,22 @@ source_module = None
 class ConfigModuleWrapper(object):
     def __init__(self, module):
         self.module = module
+
+        self._load_override_file(os.path.join(
+            self.get("server_path", ""),
+            "config.yml"))
+
+    def _load_override_file(self, path):
+        if not os.path.isfile(path):
+            return
+        with open(path) as f:
+            override_data = yaml.safe_load(f)
+            if not isinstance(override_data, dict):
+                sys.exit("config.yml must be a map")
+            for key, value in override_data.items():
+                if key == 'games':
+                    sys.exit("Can't override 'games' in override_file. Use games.d/ instead.")
+                setattr(self.module, key, value)
 
     def get(self, key, default):
         return getattr(self.module, key, default)

--- a/crawl-ref/source/webserver/webtiles/load_games.py
+++ b/crawl-ref/source/webserver/webtiles/load_games.py
@@ -47,13 +47,9 @@ def load_games(existing_games):  # type: (GamesConfig) -> GamesConfig
        cause spectating to fail until the player restarts with new settings.
     """
     import webtiles.config
-    conf_subdir = webtiles.config.get('games_config_dir')
     new_games = collections.OrderedDict()  # type: GamesConfig
     new_games.update(existing_games)
-    if not conf_subdir:
-        logging.info("Skipping game data directory")
-        return new_games
-    base_path = os.path.join(webtiles.config.server_path, conf_subdir)
+    base_path = os.path.join(webtiles.config.server_path, "games.d")
     if not os.path.exists(base_path):
         logging.warn("Game data directory for YAML configuration does not exist: '%s'" % base_path)
         return new_games
@@ -75,7 +71,7 @@ def load_games(existing_games):  # type: (GamesConfig) -> GamesConfig
             logging.warning("Failed to load games from %s, skipping (parse failure: %s).",
                             file_name, e)
             continue
-        if data is None or 'games' not in data:
+        if not isinstance(data, dict) or 'games' not in data:
             logging.warning("Failed to load games from %s, skipping (no 'games' key).",
                             file_name)
             continue
@@ -85,7 +81,7 @@ def load_games(existing_games):  # type: (GamesConfig) -> GamesConfig
               "Found extra top-level keys '%s' in %s, ignoring them"
               " (only 'games' key will be parsed).",
               extra_keys, file_name)
-        logging.info("Loading data from %s", file_name)
+        logging.info("Parsing %s games in %s", len(data['games']), file_name)
         for game in data['games']:  # noqa
             if not validate_game_dict(game):
                 continue
@@ -96,11 +92,10 @@ def load_games(existing_games):  # type: (GamesConfig) -> GamesConfig
                   game_id, path)
             delta[game_id] = game  # noqa
             action = "Updated" if game_id in existing_games else "Loaded"
-            msg = ("%s game config %s (from %s).", action, game_id, file_name)
+            msg = ("%s %s (from %s).", action, game_id, file_name)
             delta_messages.append(msg)
     if delta:
         assert len(delta.keys()) == len(delta_messages)
-        logging.info("Updating live games config")
         new_games.update(delta)
         for message in delta_messages:
             logging.info(*message)


### PR DESCRIPTION
1. Add support for loading config overrides from `config.yml`, so server operators don't have to modify `config.py`
2. Move all default game definitions to `games.d/base.yaml`, so server operators can disable all default games with one file rename