### PR TITLE
Fix util/gather_abilities wrongly expecting the Ability_List variable to be an array, instead of a vector

### DIFF
--- a/crawl-ref/source/util/gather_abilities
+++ b/crawl-ref/source/util/gather_abilities
@@ -7,7 +7,7 @@ open IN, "util/cpp_version ability.cc|" or die "Can't read ability.cc\n";
 $_ = <IN>;
 close IN;
 
-s/.*Ability_List\[\] =(.*?)};.*/$1/s
-    or die "Can't find Ability_List[] in ability.cc\n";
+s/.*Ability_List =(.*?)};.*/$1/s
+    or die "Can't find Ability_List in ability.cc\n";
 
 print join("\n", sort /ABIL_[A-Z0-9_]+\s*,\s*"([*-Za-z0-9 '-]+)"/sg), "\n";


### PR DESCRIPTION
You'll notice that the gather_abilities utility is not currently working. It seems like the Ability_List variable (present in abillities.cc) was an array at some point (ending with "[]") and was eventually turned into a vector.

The gather_abililties script expects the "[]" at the end of the variable name and thus fails.