### PR TITLE
Add `crawl.stack` function to return the current Lua stack

### DIFF
--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -141,6 +141,31 @@ LUAFN(crawl_dpr)
     return 0;
 }
 
+/*** Returns the current lua stack, for debugging.
+ * @treturn string channel name
+ * @function stack
+ */
+LUAFN(crawl_stack)
+{
+    string r;
+    struct lua_Debug dbg;
+    int i = 0;
+    while (lua_getstack(ls, i++, &dbg) == 1)
+    {
+        lua_getinfo(ls, "lnuS", &dbg);
+        char* file = strrchr(dbg.short_src, '/');
+        if (file == nullptr)
+            file = dbg.short_src;
+        else
+            file++;
+        char buf[1000];
+        sprintf(buf, "%s, function %s, line %d\n", file, dbg.name, dbg.currentline);
+        r += buf;
+    }
+    lua_pushstring(ls, r.c_str());
+    return 1;
+}
+
 /*** Delay the display.
  * @tparam int ms delay in milliseconds
  * @function delay
@@ -1448,6 +1473,7 @@ static const struct luaL_reg crawl_clib[] =
     { "mpr",                crawl_mpr },
     { "formatted_mpr",      crawl_formatted_mpr },
     { "dpr",                crawl_dpr },
+    { "stack",              crawl_stack },
     { "stderr",             crawl_stderr },
     { "more",               crawl_more },
     { "more_autoclear",     crawl_set_more_autoclear },

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -159,7 +159,7 @@ LUAFN(crawl_stack)
         else
             file++;
         char buf[1000];
-        sprintf(buf, "%s, function %s, line %d\n", file, dbg.name, dbg.currentline);
+        snprintf(buf, 1000, "%s, function %s, line %d\n", file, dbg.name, dbg.currentline);
         r += buf;
     }
     lua_pushstring(ls, r.c_str());


### PR DESCRIPTION
This PR adds a `stack` function to the `crawl` clua object, which provides much better (and I would say necessary) debugging information than currently available.

@rawlins this and my other two PRs are do-overs.  My crawl fork was stale and the git history was a horrid mess.  These and future PRs should be clean.

Re: your earlier comment (lost when I deleted my fork) to the effect that `crawl.stack` is a nice idea but you worry about it leaking info or causing security issues:  If it's called in clua it can only expose the stack in that script, which I would think has no exposure risk.  But of course making it debug-only is one way to address that.