### PR TITLE
Force more for more portal messages

### DIFF
--- a/crawl-ref/source/dat/defaults/messages.txt
+++ b/crawl-ref/source/dat/defaults/messages.txt
@@ -122,6 +122,15 @@ force_more_message += sound of rushing water
 force_more_message += oppressive heat about you
 force_more_message += crackle of arcane power
 force_more_message += hear a distant wind
+force_more_message += The portal closes with a thud
+force_more_message += The archway melts and disappears
+force_more_message += The flow of magic halts
+force_more_message += The gateway collapses
+force_more_message += The gate to the bazaar disappears
+force_more_message += The hiss of flowing sand is gone
+force_more_message += The drain falls to bits
+force_more_message += a river of lava pours forth, sealing it permanently
+force_more_message += The walls and floor vibrate strangely for a moment
 
 # Religion
 force_more_message += press .* to convert to Beogh


### PR DESCRIPTION
Not all messages related to portals were forcing more. Force more for
the periodic "you hear the sound of" messages as well as the final
notification when the portal is closed.

A potential downside of this is that it will force many messages for each timed portal. I personally like the extra focus on the distance clues because they help me find the portal. We already force more multiple times for anyone stair dancing in and out of the level, or loading a save. This would force a few more messages so long as the timed portal is active.

I also force a final message once the timed portal is closed. I did a search through the code and believe it identified every "disappear" message and covered them all.

Thanks for your consideration. I know this PR was unbidden, so I welcome feedback, discussion, or just rejecting and closing if you want.