### PR TITLE
Permit a Temple map to actually be placed.

### DIFF
--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -1059,7 +1059,7 @@ ENDMAP
 
 # 6 gods
 NAME:   nicolae_temple_stand_before_the_council
-TAGS:   temple_altar_6
+TAGS:   temple_altars_6
 PLACE:  Temple
 ORIENT: encompass
 FTILE:  `B = floor_limestone


### PR DESCRIPTION
I suspect this TAG typo is preventing the level builder from choosing this map.