### PR TITLE
Fix bug in lua `target_weapon` -- cannot select weapon

### DIFF
--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -339,16 +339,15 @@ static int moninf_get_target_desc(lua_State *ls)
 }
 
 /*** Returns the string displayed if you target this monster with a weapon (or unarmed attack).
- * @tparam[opt] weapon (item object) to use; omit for unarmed attack.
  * @treturn string (such as "about 18% to evade your dagger")
  * @function target_weapon
  */
 static int moninf_get_target_weapon(lua_State *ls)
 {
     MONINF(ls, 1, mi);
-    item_def *item = (lua_isnone(ls, 2) || lua_isnil(ls, 2)) ? nullptr : *(item_def **) luaL_checkudata(ls, 2, ITEM_METATABLE);
+    // item_def *item = (lua_isnone(ls, 2) || lua_isnil(ls, 2)) ? nullptr : *(item_def **) luaL_checkudata(ls, 2, ITEM_METATABLE);
     ostringstream result;
-    describe_to_hit(*mi, result, false, item);
+    describe_to_hit(*mi, result, false, you.weapon());
     lua_pushstring(ls, result.str().c_str());
     return 1;
 }


### PR DESCRIPTION
Crawl currently lacks the ability to speculatively examine the to-hit value of a non-wielded weapon.  The underlying `melee_attack` and `ranged_attack` objects appear to allow weapon selection, but for a player, they always use the currently wielded weapon.  This commit removes the misleading `item` parameter and corrects the function description.

In future it would be nice to support this ability, for parity with spells, items, and thrown missiles -- all of which allow you to select your option and evaluate the success rate with the targetting system, without actually choosing or wielding anything.