### PR TITLE
Fix infusion cost

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -527,6 +527,16 @@ bool melee_attack::handle_phase_hit()
              defender_name(true).c_str(),
              attacker->is_player() ? "do" : "does");
     }
+    
+    if (attacker->is_player())
+    {
+        const int infusion = you.infusion_amount();
+        if (infusion)
+        {
+            pay_mp(infusion);
+            finalize_mp_cost();
+        }
+    }
 
     // Check for weapon brand & inflict that damage too
     apply_damage_brand();
@@ -552,13 +562,6 @@ bool melee_attack::handle_phase_hit()
 
     if (attacker->is_player())
     {
-        const int infusion = you.infusion_amount();
-        if (infusion)
-        {
-            pay_mp(infusion);
-            finalize_mp_cost();
-        }
-
         // Always upset monster regardless of damage.
         // However, successful stabs inhibit shouting.
         behaviour_event(defender->as_monster(), ME_WHACK, attacker,


### PR DESCRIPTION
Currently, if you attack while wielding something with a check_unrand_effects effect, the damage bonus from infusion will be applied, but handle_phase_hit will exit before paying the infusion cost (this is especially exploitable with mad mage's maulers). This commit fixes that behavior.

This is a fairly conservative change, I think there is more weirdness with check_unrand_effects causing handle_phase_hit to exit early and return false rather than true, but I don't know what the consequences of changing that would be, and I think this commit fixes the only exploitable bug the current behavior causes.