### PR TITLE
Fix missing newline in the options guide

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -454,7 +454,8 @@ pregen_dungeon = incremental
         and no load times when entering levels, but at the cost of a slow game
         start. Some servers may disallow full pregeneration for online play.
 
-        When set to `false` or `classic`, the game will generate all levels on level entry, as was the rule before 0.23. Dungeons will not be stable
+        When set to `false` or `classic`, the game will generate all levels on
+        level entry, as was the rule before 0.23. Dungeons will not be stable
         given a seed with this option.
 
 2-  File System.


### PR DESCRIPTION
This breaks the corresponding help dialog in small screens.
Bug introduced in f02deff4a79ecda93b89ecfb91e49eea323dc6f2.

Credit to the Android player who reported the bug.

![Captura de pantalla -2022-09-08 17-38-52](https://user-images.githubusercontent.com/9676118/189165808-fd3a4508-b03c-49d0-851f-49aab2694902.png)
