### PR TITLE
Simplify tomb card

### DIFF
--- a/crawl-ref/source/dat/descript/cards.txt
+++ b/crawl-ref/source/dat/descript/cards.txt
@@ -12,7 +12,7 @@ the Tomb card
 The card depicts a royal crypt, its entrance sealed by a heavy stone slab.
 
 Drawing this card entombs its user in protective, temporary walls of solid rock.
-At lower power levels or with adjacent creatures, the tomb may be imperfect.
+With adjacent creatures, the tomb may be imperfect.
 
 The tomb is sustained by the presence of its creator within it, and moving from
 the centre of the tomb will cause its walls to crumble away.

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -833,7 +833,7 @@ spret cast_tomb(int pow, actor* victim, int source, bool fail)
     for (adjacent_iterator ai(where); ai; ++ai)
     {
         // This is where power comes in.
-        if (!zin && one_chance_in(pow / 3))
+        if (!zin && one_chance_in(100))
             continue;
 
         // The tile is occupied.
@@ -911,7 +911,7 @@ spret cast_tomb(int pow, actor* victim, int source, bool fail)
 
         you.update_beholders();
         you.update_fearmongers();
-        const int tomb_duration = BASELINE_DELAY * pow;
+        const int tomb_duration = BASELINE_DELAY * (pow/3);
         env.markers.add(new map_tomb_marker(where,
                                             tomb_duration,
                                             source,


### PR DESCRIPTION
To alleviate the complexity of the card effect, I simplified the effect a little more. This card now locks the player completely at all times, regardless of power. Of course, players can still be hindered from creating walls by adjacent objects. It reduces the duration by one-third, as much as it can achieve a high shelter effect even when power is low.