### PR TITLE
Clean up spell power code

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1376,7 +1376,7 @@ static void _BATTLE_world_reacts(item_def */*item*/)
         && there_are_monsters_nearby(true, true, false)
         && stop_summoning_reason(MR_RES_POISON, M_FLIES).empty())
     {
-        cast_battlesphere(&you, calc_spell_power(SPELL_BATTLESPHERE, true),
+        cast_battlesphere(&you, calc_spell_power(SPELL_BATTLESPHERE),
                           GOD_NO_GOD, false);
         did_god_conduct(DID_WIZARDLY_ITEM, 10);
     }

--- a/crawl-ref/source/l-moninf.cc
+++ b/crawl-ref/source/l-moninf.cc
@@ -270,7 +270,7 @@ static int moninf_get_defeat_wl(lua_State *ls)
     bool is_evoked = lua_isboolean(ls, 3) ? lua_toboolean(ls, 3) : false;
     int power = is_evoked ?
         (15 + you.skill(SK_EVOCATIONS, 7) / 2) * (wand_mp_cost() + 9) / 9 :
-        calc_spell_power(spell, true);
+        calc_spell_power(spell);
     spell_flags flags = get_spell_flags(spell);
     bool wl_check = testbits(flags, spflag::WL_check)
         && testbits(flags, spflag::dir_or_target)

--- a/crawl-ref/source/l-spells.cc
+++ b/crawl-ref/source/l-spells.cc
@@ -71,7 +71,7 @@ LUAFN(l_spells_mana_cost)
 LUAFN(l_spells_range)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    PLUARET(number, spell_range(spell, calc_spell_power(spell, true)));
+    PLUARET(number, spell_range(spell, calc_spell_power(spell)));
 }
 
 /*** The maximum range of the spell.
@@ -112,7 +112,7 @@ LUAFN(l_spells_path)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
     zap_type zap = spell_to_zap(spell);
-    int power = calc_spell_power(spell, true);
+    int power = calc_spell_power(spell);
     int range = spell_range(spell, power);
     // return nil for non-zap or zero-range spells
     if (range <= 0 || zap >= NUM_ZAPS)
@@ -210,7 +210,7 @@ LUAFN(l_spells_power_perc)
 LUAFN(l_spells_power)
 {
     spell_type spell = spell_by_name(luaL_checkstring(ls, 1), false);
-    PLUARET(number, power_to_barcount(calc_spell_power(spell, true)));
+    PLUARET(number, power_to_barcount(calc_spell_power(spell)));
 }
 
 /*** The maximum spellpower (in bars).

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -471,7 +471,7 @@ int calc_spell_power(spell_type spell)
     if (you.divine_exegesis)
         power += you.skill(SK_INVOCATIONS, 300);
 
-   
+
     power = (power * you.intel()) / 10;
 
     // [dshaligram] Enhancers don't affect fail rates any more, only spell

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -93,9 +93,7 @@ int list_spells(bool toggle_with_I = true, bool viewing = false,
                 bool allow_preselect = true,
                 const string &title = "Your Spells");
 int raw_spell_fail(spell_type spell);
-int calc_spell_power(spell_type spell, bool apply_intel,
-                     bool fail_rate_chk = false, bool cap_power = true,
-                     int scale = 1);
+int calc_spell_power(spell_type spell);
 int calc_spell_range(spell_type spell, int power = 0, bool allow_bonus = true,
                      bool ignore_shadows = false);
 

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1503,7 +1503,7 @@ bool spell_no_hostile_in_range(spell_type spell)
 
     const int range = calc_spell_range(spell, 0);
     const int minRange = get_dist_to_nearest_monster();
-    const int pow = calc_spell_power(spell, true, false, true);
+    const int pow = calc_spell_power(spell);
 
     switch (spell)
     {
@@ -1655,7 +1655,7 @@ bool spell_no_hostile_in_range(spell_type spell)
     if (zap != NUM_ZAPS)
     {
         beam.thrower = KILL_YOU_MISSILE;
-        zappy(zap, calc_spell_power(spell, true, false, true), false,
+        zappy(zap, calc_spell_power(spell), false,
               beam);
         if (spell == SPELL_MEPHITIC_CLOUD)
             beam.damage = dice_def(1, 1); // so that foe_info is populated


### PR DESCRIPTION
calc_spell_power previously took 5 parameters; 4 of which were unneeded. 
apply_intel, fail_rate_check, and scale were used exclusively in raw_spell_fail to make calc_spell_power function as
_skill_power * scale / 100. 
This has been corrected by replacing the call with _skill_power * scale / 100.

cap_power was used in three calls:
spell failure, which no longer uses check_spell_power 
target_desc, which now applies the cap twice
and one of the two calls for spell_range passed uncapped spell power.

The only 'material' change is that the impact of schools on failure chance no longer depends on spell power cap. However, this does not have an impact unless you have 75 skill, and probably was not intended in the first place.