### PR TITLE
Fix Scorch description to note that damage is reduced by armour.

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1195,8 +1195,8 @@ damage is strongly reduced by armour.
 %%%%
 Scorch spell
 
-Scorches a random foe. Those injured by this have their resistance to fire
-burned away for a short time.
+Scorches a random foe. Its damage is reduced by armour.  Those injured by this
+have their resistance to fire burned away for a short time.
 %%%%
 Seal Doors spell
 


### PR DESCRIPTION
Scorch is misleading as it is a pure fire spell that is actually reduced by armour.  The wiki also describes it as doing "unavoidable fire damage" but in fact this is not the case.  Scorch damage is reduced by both armour and fire resistance.  Probably the wiki should be updated as well.