### PR TITLE
increase player regen and decrease max hp

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1164,10 +1164,7 @@ int player_regen()
     // Note: if some condition can set rr = 0, can't be rested off, and
     // would allow travel, please update is_sufficiently_rested.
 
-    int rr = you.hp_max / 3;
-
-    if (rr > 20)
-        rr = 20 + ((rr - 20) / 2);
+    int rr = (you.hp_max * 100) / 150;
 
     // Add in miscellaneous bonuses
     rr += _player_bonus_regen();
@@ -3859,7 +3856,7 @@ int get_real_hp(bool trans, bool drained)
 {
     int hitp;
 
-    hitp  = you.experience_level * 11 / 2 + 8;
+    hitp  = you.experience_level * 5 + 8;
     hitp += you.hp_max_adj_perm;
     // Important: we shouldn't add Heroism boosts here.
     // ^ The above is a 2011 comment from 1kb, in 2021 this isn't

--- a/crawl-ref/source/zot.h
+++ b/crawl-ref/source/zot.h
@@ -7,7 +7,7 @@
 
 // How many auts does the clock roll back every time the player
 // enters a new floor?
-const int ZOT_CLOCK_PER_FLOOR = 6000 * BASELINE_DELAY;
+const int ZOT_CLOCK_PER_FLOOR = 4500 * BASELINE_DELAY;
 // After how many auts without visiting new floors does the player die instantly?
 const int MAX_ZOT_CLOCK = 27000 * BASELINE_DELAY;
 


### PR DESCRIPTION
Based on discord conversation with elliptic. Low base regen makes resting take forever, which feels pretty bad. To improve quality of life, increase the base regen rate substantially, and to prevent that from being a large player buff for long duration combat situations (and/or make it easier to spend a long time doing tedious things), reduce max hp and zot duration to compensate. Probably needs savecompat and should also do something about piety decay either as part of this branch or immediately afterward.