### PR TITLE
Documents insubstantial in the monster x-V view

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1393,11 +1393,15 @@ Sticky Flame Range spell
 
 Launches a glob of sticky flame, covering a targeted creature with liquid fire
 for a short time.
+
+If the target is insubstantial, the liquid fire will fail to stick.
 %%%%
 Sticky Flame spell
 
 Conjures a glob of sticky flame, covering an adjacent creature with liquid fire
 for a short time.
+
+If the target is insubstantial, the liquid fire will fail to stick.
 %%%%
 Still Winds spell
 

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -5048,6 +5048,14 @@ static string _monster_stat_description(const monster_info& mi, bool mark_spells
                << conjugate_verb("are", plural)
                << " immune to blinding.\n";
     }
+
+    if (mons_class_flag(mi.type, M_INSUBSTANTIAL))
+    {
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("are", plural)
+               << " insubstantial and immune to ensnarement.\n";
+    }
+
     // XXX: could mention "immune to dazzling" here, but that's spammy, since
     // it's true of such a huge number of monsters. (undead, statues, plants).
     // Might be better to have some place where players can see holiness &


### PR DESCRIPTION
As per title.
Also documents Sticky Flame's inability to stick to insubstantial monsters.

This is a needed change because currently insubstantiality of monsters is highly spoilery, and I still need to check the wiki on occasion to see if a monster will be affected by e.g. roots.