### PR TITLE
fix: tweak valid targets for rampaging

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -662,9 +662,10 @@ static spret _rampage_forward(coord_def move)
                 return spret::fail;
             continue;
         }
-        // Don't rampage if the closest mons is non-hostile or a (non-Fedhas) plant.
-        else if (mon && (mon->friendly()
-                         || mon->neutral()
+        // Don't rampage if the closest mons is non-hostile, a projectile,
+        // or a (non-Fedhas) plant.
+        else if (mon && (mon->wont_attack()
+                         || mons_is_projectile(*mon)
                          || mons_is_firewood(*mon)))
         {
             return spret::fail;


### PR DESCRIPTION
* Allow rampaging towards frenzied enemies. Treat them like regular hostile monsters.
* Disallow rampaging towards projectiles. The player cannot voluntarily move into an orb of destruction when it's right next to them, but it's possible to rampage into an orb if it's two tiles away.