### PR TITLE
adjust fight.cc to work when recieving cleave while wielding rift

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -795,7 +795,7 @@ bool force_player_cleave(coord_def target)
     if (!cleave_targets.empty())
     {
         // Rift is too funky and hence gets no special treatment.
-        const int range = you.reach_range() == REACH_TWO ? 2 : 1;
+        const int range = you.reach_range();
         targeter_cleave hitfunc(&you, target, range);
         if (stop_attack_prompt(hitfunc, "attack"))
             return true;

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -851,7 +851,9 @@ void get_cleave_targets(const actor &attacker, const coord_def& def,
     if (attack_cleaves(attacker, which_attack))
     {
         const coord_def atk = attacker.pos();
-        const int cleave_radius = weap && weapon_reach(*weap) == REACH_TWO ? 2 : 1;
+        //If someone adds a funky reach which isn't just a number
+        //They will need to special case it here.
+        const int cleave_radius = weap ? weapon_reach(*weap) : 1;
 
         for (distance_iterator di(atk, true, true, cleave_radius); di; ++di)
         {

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -100,7 +100,7 @@ bool melee_attack::bad_attempt()
 
     if (!cleave_targets.empty())
     {
-        const int range = you.reach_range() == REACH_TWO ? 2 : 1;
+        const int range = you.reach_range();
         targeter_cleave hitfunc(attacker, defender->pos(), range);
         return stop_attack_prompt(hitfunc, "attack");
     }

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -607,7 +607,7 @@ namespace quiver
             unique_ptr<targeter> hitfunc;
             if (attack_cleaves(you, -1))
             {
-                const int range = reach_range == REACH_TWO ? 2 : 1;
+                const int range = reach_range;
                 hitfunc = make_unique<targeter_cleave>(&you, you.pos(), range);
             }
             else


### PR DESCRIPTION
Rift breaks the assumption that the only number besides two is one. This removes said assumption.

However, it still makes the assumption that every REACH enum is just an int with a fancy title. This will break spectacularly if a weapon is ever given a reach that isn't just a number.

Fixes #2683