### PR TITLE
Fixes info screen for draconians to show they can fly based on the type of draconian

### DIFF
--- a/crawl-ref/CREDITS.txt
+++ b/crawl-ref/CREDITS.txt
@@ -409,6 +409,7 @@
     Rob Young
     Zannick
     Zooko
+    Roadster Tracker
 
 The Dungeon Crawl Stone Soup development team is:
     advil

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -117,7 +117,7 @@ bool monster_inherently_flies(const monster &mons)
     // check both so spectral humans and zombified dragons both fly
     // checks base type to ensure draconians with a specific type can also fly
     return monster_class_flies(mons.type)
-        || mons_is_draconian_job(mon.type) ? draconian_subspecies(mon) : mons_base_type(mon)
+        || mons_is_draconian_job(mons.type) ? draconian_subspecies(mons) : mons_base_type(mons)
         || mons_is_ghost_demon(mons.type) && mons.ghost && mons.ghost->flies
         || mons.has_facet(BF_BAT);
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -118,7 +118,7 @@ bool monster_inherently_flies(const monster &mons)
     // checks base type to ensure draconians with a specific type can also fly
     return monster_class_flies(mons.type)
         || monster_class_flies(mons_base_type(mons))
-        || monster_class_flies(mons.base_type)
+        || monster_class_flies(mons.base_monster)
         || mons_is_ghost_demon(mons.type) && mons.ghost && mons.ghost->flies
         || mons.has_facet(BF_BAT);
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -115,8 +115,10 @@ bool monster_class_flies(monster_type mc)
 bool monster_inherently_flies(const monster &mons)
 {
     // check both so spectral humans and zombified dragons both fly
+    // checks base type to ensure draconians with a specific type can also fly
     return monster_class_flies(mons.type)
         || monster_class_flies(mons_base_type(mons))
+        || monster_class_flies(mons.base_type)
         || mons_is_ghost_demon(mons.type) && mons.ghost && mons.ghost->flies
         || mons.has_facet(BF_BAT);
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -117,7 +117,7 @@ bool monster_inherently_flies(const monster &mons)
     // check both so spectral humans and zombified dragons both fly
     // checks base type to ensure draconians with a specific type can also fly
     return monster_class_flies(mons.type)
-        || mons_is_draconian_job(mons.type) ? draconian_subspecies(mons) : mons_base_type(mons)
+        || mons_base_type(mons)
         || mons_is_ghost_demon(mons.type) && mons.ghost && mons.ghost->flies
         || mons.has_facet(BF_BAT);
 }
@@ -1664,6 +1664,8 @@ monster_type mons_base_type(const monster& mon)
 {
     if (mons_class_is_zombified(mon.type))
         return mons_zombie_base(mon);
+    if (mons_is_draconian_job(mon.type))
+        return draconian_subspecies(mon);
     return mon.type;
 }
 
@@ -3245,8 +3247,7 @@ habitat_type mons_class_primary_habitat(monster_type mc)
 
 habitat_type mons_primary_habitat(const monster& mon)
 {
-    const monster_type type = mons_is_draconian_job(mon.type)
-        ? draconian_subspecies(mon) : mons_base_type(mon);
+    const monster_type type = mons_base_type(mon);
 
     return mons_class_primary_habitat(type);
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -117,8 +117,7 @@ bool monster_inherently_flies(const monster &mons)
     // check both so spectral humans and zombified dragons both fly
     // checks base type to ensure draconians with a specific type can also fly
     return monster_class_flies(mons.type)
-        || monster_class_flies(mons_base_type(mons))
-        || monster_class_flies(mons.base_monster)
+        || mons_is_draconian_job(mon.type) ? draconian_subspecies(mon) : mons_base_type(mon)
         || mons_is_ghost_demon(mons.type) && mons.ghost && mons.ghost->flies
         || mons.has_facet(BF_BAT);
 }


### PR DESCRIPTION
This small change will allow draconians with a base type that can fly to fly, and specifically to show it correctly in the information screen. Draconian's base type can't be determined purely from the mons.type, but instead should use draconian subspecies if the species is a draconian.

After toying with this a while, I have changed it in `mons_base_type` to return the draconian subspecies for draconians. 

This likely will cover many other similar bugs in the future, and in fact I can see several places in the code that an improved `mons_base_type` to cover draconians would result in less code. I did fix one of these, and will look for others when I get a chance. I would appreciate any assistance in identifying any negative consequences with those with more experience to the code.

Fixes #2752