### PR TITLE
fix: make Poisonous Vapours targeter ignore rPois enemies

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1318,6 +1318,8 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
                                             silence_max_range(pow),
                                             0, 0,
                                             silence_min_range(pow));
+    case SPELL_POISONOUS_VAPOURS:
+        return make_unique<targeter_poisonous_vapours>(&you, range);
 
     // at player's position only but not a selfench; most transmut spells go here:
     case SPELL_SPIDER_FORM:

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2133,3 +2133,13 @@ bool targeter_anguish::affects_monster(const monster_info& mon)
         && !mons_atts_aligned(agent->temp_attitude(), mon.attitude)
         && !mon.is(MB_ANGUISH);
 }
+
+targeter_poisonous_vapours::targeter_poisonous_vapours(const actor* act, int r)
+    : targeter_smite(act, r, 0, 0, false, nullptr)
+{
+}
+
+bool targeter_poisonous_vapours::affects_monster(const monster_info& mon)
+{
+    return get_resist(mon.resists(), MR_RES_POISON) <= 0;
+}

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -563,3 +563,10 @@ public:
     targeter_anguish();
     bool affects_monster(const monster_info& mon) override;
 };
+
+class targeter_poisonous_vapours : public targeter_smite
+{
+public:
+    targeter_poisonous_vapours(const actor *act, int range);
+    bool affects_monster(const monster_info& mon) override;
+};


### PR DESCRIPTION
Otherwise the targeter always starts on the closest monster, even if the monster is resistant or immune to poison.