### PR TITLE
Rework slime walls

### DIFF
--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -506,7 +506,7 @@ corporeal undead monster hit into a neutral slime.
 Oozemancy ability
 
 Calls forth acidic ooze from the walls of the dungeon around you, damaging foes
-depending on the number of affected walls they remain adjacent to.
+depending on the number of slimy walls they remain adjacent to.
 %%%%
 # Ashenzari
 Curse Item ability

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -224,7 +224,8 @@ walls.
 %%%%
 A slime covered rock wall
 
-A rock wall coated with bright green slime. It is acidic to the touch.
+A rock wall coated with bright green slime. It is acidic to the touch; just
+standing near it is enough to cause temporary corrosion.
 %%%%
 A metal wall
 

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1706,9 +1706,6 @@ void handle_monster_move(monster* mons)
     if (!mons->alive())
         return;
 
-    if (env.level_state & LSTATE_SLIMY_WALL)
-        slime_wall_damage(mons, speed_to_duration(mons->speed));
-
     if (!mons->alive())
         return;
 

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1706,6 +1706,9 @@ void handle_monster_move(monster* mons)
     if (!mons->alive())
         return;
 
+    if (you.duration[DUR_OOZEMANCY] && (env.level_state & LSTATE_SLIMY_WALL))
+        slime_wall_damage(mons, speed_to_duration(mons->speed));
+
     if (!mons->alive())
         return;
 

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -1013,9 +1013,6 @@ void player_reacts()
 
     actor_apply_toxic_bog(&you);
 
-    if (env.level_state & LSTATE_SLIMY_WALL)
-        slime_wall_damage(&you, you.time_taken);
-
     _decrement_durations();
 
     // Translocations and possibly other duration decrements can

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6075,6 +6075,9 @@ int player::corrosion_amount() const
     if (duration[DUR_CORROSION])
         corrosion += you.props[CORROSION_KEY].get_int();
 
+    if (env.level_state & LSTATE_SLIMY_WALL)
+        corrosion += slime_wall_corrosion(&you);
+
     if (player_in_branch(BRANCH_DIS))
         corrosion += 2;
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -865,44 +865,14 @@ int count_adjacent_slime_walls(const coord_def &pos)
     return count;
 }
 
-void slime_wall_damage(actor* act, int delay)
+int slime_wall_corrosion(actor* act)
 {
     ASSERT(act);
 
     if (actor_slime_wall_immune(act))
-        return;
+        return 0;
 
-    const int walls = count_adjacent_slime_walls(act->pos());
-    if (!walls)
-        return;
-
-    // Consider pulling out damage from splash_with_acid() into
-    // its own function and calling that.
-    const int strength = div_rand_round(3 * walls * delay, BASELINE_DELAY);
-    const int base_dam = act->is_player() ? roll_dice(4, strength) : roll_dice(2, 4);
-    const int dam = resist_adjust_damage(act, BEAM_ACID, base_dam);
-    if (act->is_player())
-    {
-        mprf("You are splashed with acid%s%s",
-             dam > 0 ? "" : " but take no damage",
-             attack_strength_punctuation(dam).c_str());
-        ouch(dam, KILLED_BY_ACID, MID_NOBODY);
-    }
-    else if (dam > 0 && you.see_cell_no_trans(act->pos()))
-    {
-        const actor *agent = you.duration[DUR_OOZEMANCY] ? &you : nullptr;
-        const char *verb = act->is_icy() ? "melt" : "burn";
-        mprf((walls > 1) ? "The walls %s %s!" : "The wall %ss %s!",
-              verb, act->name(DESC_THE).c_str());
-        act->hurt(agent, dam, BEAM_ACID);
-        if (act->alive())
-        {
-            if (agent)
-                behaviour_event(act->as_monster(), ME_WHACK, agent, agent->pos());
-            else
-                behaviour_event(act->as_monster(), ME_DISTURB, 0, act->pos());
-        }
-    }
+    return count_adjacent_slime_walls(act->pos());
 }
 
 int count_adjacent_icy_walls(const coord_def &pos)

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -875,6 +875,32 @@ int slime_wall_corrosion(actor* act)
     return count_adjacent_slime_walls(act->pos());
 }
 
+// slime wall damage under Jiyva's oozemancy; this should only affect monsters
+void slime_wall_damage(actor* act, int delay)
+{
+    ASSERT(act);
+
+    if (actor_slime_wall_immune(act))
+        return;
+
+    const int walls = count_adjacent_slime_walls(act->pos());
+    if (!walls)
+        return;
+
+    const int strength = div_rand_round(3 * walls * delay, BASELINE_DELAY);
+    const int base_dam = roll_dice(2, strength);
+    const int dam = resist_adjust_damage(act, BEAM_ACID, base_dam);
+    if (dam > 0 && you.see_cell_no_trans(act->pos()))
+    {
+        const char *verb = act->is_icy() ? "melt" : "burn";
+        mprf((walls > 1) ? "The walls %s %s!" : "The wall %ss %s!",
+              verb, act->name(DESC_THE).c_str());
+        act->hurt(&you, dam, BEAM_ACID);
+        if (act->alive())
+            behaviour_event(act->as_monster(), ME_WHACK, &you, you.pos());
+    }
+}
+
 int count_adjacent_icy_walls(const coord_def &pos)
 {
     int count = 0;

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -104,7 +104,7 @@ void find_connected_identical(const coord_def& d, set<coord_def>& out, bool know
 
 bool slime_wall_neighbour(const coord_def& c);
 int count_adjacent_slime_walls(const coord_def &pos);
-void slime_wall_damage(actor* act, int delay);
+int slime_wall_corrosion(actor* act);
 
 int count_adjacent_icy_walls(const coord_def &pos);
 

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -105,6 +105,7 @@ void find_connected_identical(const coord_def& d, set<coord_def>& out, bool know
 bool slime_wall_neighbour(const coord_def& c);
 int count_adjacent_slime_walls(const coord_def &pos);
 int slime_wall_corrosion(actor* act);
+void slime_wall_damage(actor* act, int delay);
 
 int count_adjacent_icy_walls(const coord_def &pos);
 


### PR DESCRIPTION
Based on a conversation in crawl-dev. Current slime walls impose a strict limit on the types of monsters and possible layouts that can be used in slime, making the branch feel samey from run to run due to similar non-end floor layouts and small monster pool (even post-rework). This pr reworks slime walls to apply 1 level of corrosion each to the player for as long as they remain adjacent instead of doing damage; they do nothing to monsters unless oozemancy is active, in which case they deal damage as before. Ideally this change would be incorporated into a larger slime rework that varies layouts and expands the monster set to some degree.