### PR TITLE
Allow explore_stop_pickup_ignore for all spellbooks

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -3089,8 +3089,17 @@ static bool _interesting_explore_pickup(const item_def& item)
         const string name = item.name(DESC_PLAIN);
 
         for (const text_pattern &pat : ignores)
+        {
             if (pat.matches(name))
                 return false;
+
+            const string c = lowercase_string(pat.tostring());
+            if ((c == "book" || c == "books" || c == "spellbook" || c == "spellbooks")
+                && item_is_spellbook(item))
+            {
+                return false;
+            }
+        }
     }
 
     if (!(Options.explore_stop & ES_GREEDY_PICKUP_SMART))


### PR DESCRIPTION
Each explore_stop_pickup_ignore regex is checked against DESC_PLAIN.
Ignoring all spellbooks requires listing every book by name in RC file.
Added a check for values of "book"|"books"|"spellbook"|"spellbooks".
If found, spellbooks are ignored. Manuals are unaffected.