### PR TITLE
Don't crash on reading acquirement scrolls

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -413,6 +413,9 @@ static skill_type _acquirement_weapon_skill(bool divine, int agent)
          sk <= (agent == GOD_TROG ? SK_LAST_MELEE_WEAPON : SK_LAST_WEAPON);
          ++sk)
     {
+        // Don't choose a skill that's useless
+        if (is_useless_skill(sk))
+            continue;
         // Adding a small constant allows for the occasional
         // weapon in an untrained skill.
         int weight = _skill_rdiv(sk) + 1;

--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -727,6 +727,9 @@ static int _find_acquirement_subtype(object_class_type &class_wanted,
                 (*_subtype_finders[class_wanted])(divine, quantity, agent);
         }
 
+        // Double-check our subtype for weapons is valid
+        ASSERT(type_wanted != OBJ_WEAPONS || type_wanted <= get_max_subtype(class_wanted));
+
         item_def dummy;
         dummy.base_type = class_wanted;
         dummy.sub_type = type_wanted;

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -1946,6 +1946,8 @@ bool is_weapon_wieldable(const item_def &item, size_type size)
 
     const int subtype = OBJ_STAVES == item.base_type ? int{WPN_STAFF}
                                                      : item.sub_type;
+    // Check we aren't about to index with a bogus subtype for weapons
+    ASSERT(item.base_type != OBJ_WEAPONS || subtype <= get_max_subtype(item.base_type));
     return Weapon_prop[Weapon_index[subtype]].min_2h_size <= size;
 }
 


### PR DESCRIPTION
See commit messages for details. The second commit sprinkles in some extra asserts in case that's also desirable, but I'm not a huge fan of how it only checks subtypes for weapons, since I can imagine this bug coming up in other situations.

Maybe probably hopefully fixes #2714.