### PR TITLE
Tweaking spider text labels to be more consistent

### DIFF
--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -79,8 +79,8 @@ static const form_entry formdata[] =
     2, 0, 0, true, 10, true, 5,
     SPWPN_VENOM, LIGHTGREEN, "Fangs", ANIMAL_VERBS,
     FC_DEFAULT, FC_FORBID, FC_FORBID, false,
-    "hiss", -4, "front leg", "", "crawl onto", "flesh",
-    { {"venomous fangs", "You have poisonous fangs."},
+    "hiss", -4, "front pincers", "", "crawl onto", "flesh",
+    { {"venomous fangs", "You have venomous fangs."},
       {"", "You are tiny and dextrous."} // short-form "tiny" is automatically added
     }
 },


### PR DESCRIPTION
Fixed #2742, changing front legs to front pincers, which we could also call Pedipalps if we wanted to follow more closely with real anatomy. Venomous is the more commonly used term for things that can poison, and technically is the right term here, so let's be consistent.