### PR TITLE
Fix: Ref to scroll of ID may break in _identify()

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3745,6 +3745,9 @@ void read(item_def* scroll, dist *target)
             set_ident_type(*scroll, true);
         }
         cancel_scroll = !_identify(alreadyknown, pre_succ_msg, link);
+
+        if (link >= 0 && link < int(you.inv.size()))
+          scroll = &you.inv[link];
         break;
 
     case SCR_ENCHANT_ARMOUR:


### PR DESCRIPTION
Break caused by auto_assign_item_slot() and swap_inv_slots(),
when the ID'd item swaps with the scroll of ID.
Parameter 'link' is already provided to accommodate this.
Checking validity of link in case scroll is on ground (link==-1).

Mainly, fixing this means scroll of ID will be assigned to its assigned item_slot if it was previously unknown.