### PR TITLE
feat: Ball lightning scatters

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2333,7 +2333,7 @@ static spret _do_cast(spell_type spell, int powc, const dist& spd,
         return cast_summon_mana_viper(powc, god, fail);
 
     case SPELL_CONJURE_BALL_LIGHTNING:
-        return cast_conjure_ball_lightning(powc, god, fail);
+        return cast_conjure_ball_lightning(you, powc, god, fail);
 
     case SPELL_SUMMON_LIGHTNING_SPIRE:
         return cast_summon_lightning_spire(powc, god, fail);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -5,6 +5,8 @@
 
 #include "AppHdr.h"
 
+#include "mgen-enum.h"
+#include "monster-type.h"
 #include "spl-summoning.h"
 
 #include <algorithm>
@@ -822,8 +824,18 @@ spret cast_conjure_ball_lightning(int pow, god_type god, bool fail)
     fail_check();
     bool success = false;
 
-    mgen_data cbl =_pal_data(MONS_BALL_LIGHTNING, 0, god,
-                             SPELL_CONJURE_BALL_LIGHTNING);
+    // mgen_data cbl2 =_pal_data(MONS_BALL_LIGHTNING, 0, god,
+    //                          SPELL_CONJURE_BALL_LIGHTNING);
+
+    // == _summon_data(you, MONS_BALL_LIGHTNING, 0, god, spell);
+
+    // == mgen_data(MONS_BALL_LIGHTNING, BEH_COPY, you.pos(), _auto_autofoe(&you))
+    //      .set_summoned(&you, 0, SPELL_CONJURE_BALL_LIGHTNING, god);
+
+
+    mgen_data cbl(MONS_BALL_LIGHTNING, BEH_FRIENDLY, you.pos(), MHITNOT, MG_FORCE_PLACE | MG_AUTOFOE);
+
+    cbl.set_summoned(&you, 0, SPELL_CONJURE_BALL_LIGHTNING, god);
     cbl.hd = ball_lightning_hd(pow);
 
     for (int i = 0; i < 3; ++i)

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -819,23 +819,16 @@ int mons_ball_lightning_hd(int pow, bool random)
     return ball_lightning_hd(pow, random) / 2;
 }
 
-spret cast_conjure_ball_lightning(int pow, god_type god, bool fail)
+spret cast_conjure_ball_lightning(const actor &agent, int pow, god_type god, bool fail)
 {
     fail_check();
     bool success = false;
 
-    // mgen_data cbl2 =_pal_data(MONS_BALL_LIGHTNING, 0, god,
-    //                          SPELL_CONJURE_BALL_LIGHTNING);
-
-    // == _summon_data(you, MONS_BALL_LIGHTNING, 0, god, spell);
-
-    // == mgen_data(MONS_BALL_LIGHTNING, BEH_COPY, you.pos(), _auto_autofoe(&you))
-    //      .set_summoned(&you, 0, SPELL_CONJURE_BALL_LIGHTNING, god);
-
-
-    mgen_data cbl(MONS_BALL_LIGHTNING, BEH_FRIENDLY, you.pos(), MHITNOT, MG_FORCE_PLACE | MG_AUTOFOE);
-
-    cbl.set_summoned(&you, 0, SPELL_CONJURE_BALL_LIGHTNING, god);
+    const auto att = agent.is_player() ? BEH_FRIENDLY
+                                       : SAME_ATTITUDE(agent.as_monster());
+    mgen_data cbl(MONS_BALL_LIGHTNING, att,
+      agent.pos(), MHITNOT, MG_FORCE_PLACE | MG_AUTOFOE);
+    cbl.set_summoned(&agent, 0, SPELL_CONJURE_BALL_LIGHTNING, god);
     cbl.hd = ball_lightning_hd(pow);
 
     for (int i = 0; i < 3; ++i)

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -5,8 +5,6 @@
 
 #include "AppHdr.h"
 
-#include "mgen-enum.h"
-#include "monster-type.h"
 #include "spl-summoning.h"
 
 #include <algorithm>

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -31,7 +31,7 @@ bool summon_holy_warrior(int pow, bool punish);
 
 bool tukima_affects(const actor &target);
 void cast_tukimas_dance(int pow, actor *target);
-spret cast_conjure_ball_lightning(int pow, god_type god, bool fail);
+spret cast_conjure_ball_lightning(const actor &agent, int pow, god_type god, bool fail);
 int ball_lightning_hd(int pow, bool random = true);
 int mons_ball_lightning_hd(int pow, bool random = true);
 int mons_ball_lightning_per_cast(int pow, bool random = true);


### PR DESCRIPTION
# Summary
ball lightnings summoned by `Conjure Ball Lightning` now moves similar to foxfire. Or in other words, they wander off randomly. It has following advantages:

- accidently casting cbl on empty field is less suicidal
- from 'ball' lightning to ball 'lightning': their movement is more chaotic and interesting

# Screenshots

## After PR
![Dungeon Crawl Stone Soup 0 30-a0-344-g23b102bf_01](https://user-images.githubusercontent.com/54838975/199910077-fea0efd7-d704-494f-bcfd-3c950d4d4821.png)
![Dungeon Crawl Stone Soup 0 30-a0-344-g23b102bf_02](https://user-images.githubusercontent.com/54838975/199910081-bd04e066-9551-4cc9-9bbe-aafe48129dce.png)

the balls fly in random way, similar to foxfires
(trail is from #2809)

## Before PR
![Dungeon Crawl Stone Soup 0 30-a0-341-g68270651_02](https://user-images.githubusercontent.com/54838975/199910075-5b9468fc-7397-439e-bf74-9b22a21425fb.png)

when there is no enemy in vision, the balls home into player.
