### PR TITLE
Resonance strike damage tweaks

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -400,6 +400,8 @@ static dice_def _spell_damage(spell_type spell, int hd)
             return base_airstrike_damage(pow);
         case SPELL_ARCJOLT:
             return arcjolt_damage(pow, false);
+        case SPELL_RESONANCE_STRIKE:
+            return resonance_strike_base_damage(hd);
         default:
             break;
     }
@@ -505,13 +507,16 @@ static string _effect_string(spell_type spell, const monster_info *mon_owner)
     if (spell == SPELL_SMITING)
         return "7-17"; // sigh
 
-
     const dice_def dam = _spell_damage(spell, hd);
     if (dam.num == 0 || dam.size == 0)
         return "";
-    string mult = "";
+
     if (spell == SPELL_AIRSTRIKE)
         return describe_airstrike_dam(dam);
+    else if (spell == SPELL_RESONANCE_STRIKE)
+        return describe_resonance_strike_dam(dam);
+
+    string mult = "";
     if (spell == SPELL_MARSHLIGHT)
         mult = "2x";
     else if (spell == SPELL_CONJURE_BALL_LIGHTNING)

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -5188,10 +5188,12 @@ static void _cast_resonance_strike(monster &caster, mon_spell_slot, bolt&)
     if (!target)
         return;
 
+    // base damage 3d(spell hd)
+    const int pow = caster.spell_hd(SPELL_RESONANCE_STRIKE);
+    dice_def dice = resonance_strike_base_damage(pow);
+    // + 1 die for every 2 adjacent constructs, up to a total of 7 dice when
+    // fully surrounded by 8 constructs
     const int constructs = _count_nearby_constructs(caster, target->pos());
-    // base damage 3d(spell hd) (probably 3d12)
-    // + 1 die for every 2 adjacent constructs (so at 4 constructs, 5dhd)
-    dice_def dice = resonance_strike_base_damage(caster);
     dice.num += div_rand_round(constructs, 2);
     const int dam = target->apply_ac(dice.roll());
     const string constructs_desc
@@ -5251,9 +5253,9 @@ dice_def waterstrike_damage(int spell_hd)
  * How much damage does the given monster do when casting Resonance Strike,
  * assuming no allied constructs are boosting damage?
  */
-dice_def resonance_strike_base_damage(const monster &mons)
+dice_def resonance_strike_base_damage(int spell_hd)
 {
-    return dice_def(3, mons.spell_hd(SPELL_RESONANCE_STRIKE));
+    return dice_def(3, spell_hd);
 }
 
 static const int MIN_DREAM_SUCCESS_POWER = 25;

--- a/crawl-ref/source/mon-cast.h
+++ b/crawl-ref/source/mon-cast.h
@@ -23,7 +23,7 @@ void aura_of_brilliance(monster* agent);
 bool mons_should_cloud_cone(monster* agent, int power, const coord_def pos);
 
 dice_def waterstrike_damage(int spell_hd);
-dice_def resonance_strike_base_damage(const monster &caster);
+dice_def resonance_strike_base_damage(int spell_hd);
 
 dice_def eruption_damage();
 

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1014,6 +1014,11 @@ string describe_airstrike_dam(dice_def dice)
                         dice.size + MAX_AIRSTRIKE_BONUS);
 }
 
+string describe_resonance_strike_dam(dice_def dice)
+{
+    return make_stringf("(%d-%d)d%d", dice.num, dice.num + 4, dice.size);
+}
+
 spret cast_momentum_strike(int pow, coord_def target, bool fail)
 {
     if (cell_is_solid(target))

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -45,6 +45,7 @@ spret cast_airstrike(int pow, coord_def target, bool fail);
 int airstrike_space_around(coord_def target, bool count_invis);
 dice_def base_airstrike_damage(int pow, bool random = false);
 string describe_airstrike_dam(dice_def dice);
+string describe_resonance_strike_dam(dice_def dice);
 spret cast_momentum_strike(int pow, coord_def target, bool fail);
 spret cast_shatter(int pow, bool fail);
 dice_def shatter_damage(int pow, monster *mons = nullptr, bool random = false);

--- a/crawl-ref/source/util/monster/monster-main.cc
+++ b/crawl-ref/source/util/monster/monster-main.cc
@@ -319,6 +319,13 @@ static string mi_calc_irradiate_damage(const monster &mon)
     return dice_def_string(irradiate_damage(pow));
 }
 
+static string mi_calc_resonance_strike_damage(monster* mons)
+{
+    const int pow = mons->spell_hd(SPELL_RESONANCE_STRIKE);
+    dice_def dice = resonance_strike_base_damage(pow);
+    return describe_resonance_strike_dam(dice);
+}
+
 /**
  * @return e.g.: "2d6", "5-12".
  */
@@ -350,8 +357,7 @@ static string mons_human_readable_spell_damage_string(monster* monster,
             spell_beam.damage = waterstrike_damage(monster->spell_hd(sp));
             break;
         case SPELL_RESONANCE_STRIKE:
-            return dice_def_string(resonance_strike_base_damage(*monster))
-                   + "+"; // could clarify further?
+            return mi_calc_resonance_strike_damage(monster);
         case SPELL_IOOD:
             spell_beam.damage = mi_calc_iood_damage(monster);
             break;


### PR DESCRIPTION
This PR caps the ally-dependent part of Resonance Strike damage and adds the damage numbers to the `xv` screen.