### PR TITLE
No shelter for projectiles

### DIFF
--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -1121,7 +1121,9 @@ void guardian_golem_bond(monster& mons)
 {
     for (monster_near_iterator mi(&mons, LOS_NO_TRANS); mi; ++mi)
     {
-        if (mons_aligned(&mons, *mi) && !mi->has_ench(ENCH_CHARM)
+        if (mons_aligned(&mons, *mi)
+            && !mi->has_ench(ENCH_CHARM)
+            && !mons_is_projectile(**mi)
             && *mi != &mons)
         {
             mi->add_ench(mon_enchant(ENCH_INJURY_BOND, 1, &mons, INFINITE_DURATION));

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -3576,6 +3576,7 @@ static bool _can_injury_bond(const monster &protector, const monster &protectee)
         && !protectee.has_ench(ENCH_CHARM)
         && !protectee.has_ench(ENCH_HEXED)
         && !protectee.has_ench(ENCH_INJURY_BOND)
+        && !mons_is_projectile(protectee)
         && &protector != &protectee;
 }
 


### PR DESCRIPTION
Sheltering orbs of destruction from injuries does nothing, but ironbound preservers do it anyway.

Friendly guardian golems are so friendly, they protect even hostile OoDs. This happens because of how `mons_aligned()` treats all projectiles.