### PR TITLE
Add some uselessness to the action panel

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2927,9 +2927,6 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         case SCR_ENCHANT_ARMOUR:
         case SCR_BRAND_WEAPON:
             return you.has_mutation(MUT_NO_GRASPING);
-        case SCR_FOG:
-        case SCR_POISON:
-            return temp && (env.level_state & LSTATE_STILL_WINDS);
         case SCR_IDENTIFY:
             return you.props.exists(IDENTIFIED_ALL_KEY)
                    || have_passive(passive_t::identify_items);

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -2825,6 +2825,9 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         // all cases.
     }
 
+    if (temp && you.cannot_act())
+        return true;
+
     switch (item.base_type)
     {
     case OBJ_WEAPONS:
@@ -2901,8 +2904,8 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         return false;
 
     case OBJ_SCROLLS:
-        if (temp && silenced(you.pos()))
-            return true; // can't use scrolls while silenced
+        if (temp && cannot_read_item_reason(&item).size())
+            return true;
 
         if (!ident && !item_type_known(item))
             return false;
@@ -2913,12 +2916,7 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
 
         switch (item.sub_type)
         {
-        case SCR_TELEPORTATION:
-            return you.stasis()
-                   || crawl_state.game_is_sprint()
-                   || temp && player_in_branch(BRANCH_GAUNTLET);
-        case SCR_BLINKING:
-            return you.stasis();
+        // Checks for other subtypes are in cannot_read_item_reason().
         case SCR_AMNESIA:
             return you_worship(GOD_TROG) || you.has_mutation(MUT_INNATE_CASTER);
 #if TAG_MAJOR_VERSION == 34
@@ -2929,9 +2927,6 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         case SCR_ENCHANT_ARMOUR:
         case SCR_BRAND_WEAPON:
             return you.has_mutation(MUT_NO_GRASPING);
-        case SCR_SUMMONING:
-        case SCR_BUTTERFLIES:
-            return you.allies_forbidden();
         case SCR_FOG:
         case SCR_POISON:
             return temp && (env.level_state & LSTATE_STILL_WINDS);
@@ -2944,6 +2939,9 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
 
     case OBJ_WANDS:
         if (you.get_mutation_level(MUT_NO_ARTIFICE))
+            return true;
+
+        if (temp && (you.confused() || you.berserk()))
             return true;
 
 #if TAG_MAJOR_VERSION == 34
@@ -2963,6 +2961,12 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         // Mummies and liches can't use potions.
         if (!you.can_drink(temp))
             return true;
+
+        if (temp && (player_in_branch(BRANCH_COCYTUS)
+                     || you.berserk()))
+        {
+            return true;
+        }
 
         if (!ident && !item_type_known(item))
             return false;
@@ -3079,19 +3083,25 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         return true;
 
     case OBJ_MISCELLANY:
+        // The figurine can always be used.
+        if (item.sub_type == MISC_ZIGGURAT)
+            return false;
+
+        if (temp && (you.confused() || you.berserk()))
+            return true;
+
+        if (temp && is_xp_evoker(item) && !evoker_charges(item.sub_type))
+            return true;
+
         switch (item.sub_type)
         {
 #if TAG_MAJOR_VERSION == 34
         case MISC_BUGGY_EBONY_CASKET:
             return item_type_known(item);
-#endif
-        // These can always be used.
-#if TAG_MAJOR_VERSION == 34
+        // It can always be used.
         case MISC_BUGGY_LANTERN_OF_SHADOWS:
-#endif
-        case MISC_ZIGGURAT:
             return false;
-
+#endif
         // Purely summoning misc items don't work w/ sac love
         case MISC_BOX_OF_BEASTS:
         case MISC_HORN_OF_GERYON:

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3194,6 +3194,11 @@ string cannot_read_item_reason(const item_def *item)
                 return "You cannot coerce anything to answer your summons.";
             return "";
 
+        case SCR_MAGIC_MAPPING:
+            if (!is_map_persistent())
+                return "It would have no effect in this place.";
+            return "";
+
 #if TAG_MAJOR_VERSION == 34
         case SCR_CURSE_WEAPON:
             if (!you.weapon())
@@ -3663,12 +3668,6 @@ void read(item_def* scroll, dist *target)
     }
 
     case SCR_MAGIC_MAPPING:
-        if (alreadyknown && !is_map_persistent())
-        {
-            cancel_scroll = true;
-            mpr("It would have no effect in this place.");
-            break;
-        }
         mpr(pre_succ_msg);
         magic_mapping(500, 100, false);
         break;

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3194,6 +3194,12 @@ string cannot_read_item_reason(const item_def *item)
                 return "You cannot coerce anything to answer your summons.";
             return "";
 
+        case SCR_FOG:
+        case SCR_POISON:
+            if (env.level_state & LSTATE_STILL_WINDS)
+                return "The air is too still for clouds to form.";
+            return "";
+
         case SCR_MAGIC_MAPPING:
             if (!is_map_persistent())
                 return "It would have no effect in this place.";
@@ -3655,12 +3661,6 @@ void read(item_def* scroll, dist *target)
 
     case SCR_FOG:
     {
-        if (alreadyknown && (env.level_state & LSTATE_STILL_WINDS))
-        {
-            mpr("The air is too still for clouds to form.");
-            cancel_scroll = true;
-            break;
-        }
         mpr("The scroll dissolves into smoke.");
         auto smoke = random_smoke_type();
         big_cloud(smoke, &you, you.pos(), 50, 8 + random2(8));

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1225,7 +1225,7 @@ void TilesFramework::_send_player(bool force_full)
         item_def item = get_item_known_info(you.inv[i]);
         if ((char)i == you.equip[EQ_WEAPON] && is_weapon(item) && you.corrosion_amount())
             item.plus -= 4 * you.corrosion_amount();
-        _send_item(c.inv[i], item, force_full);
+        _send_item(c.inv[i], item, c.inv_uselessness[i], force_full);
         json_close_object(true);
     }
     json_close_object(true);
@@ -1293,6 +1293,7 @@ static string _qty_field_name(const item_def &item)
 }
 
 void TilesFramework::_send_item(item_def& current, const item_def& next,
+                                bool& current_uselessness,
                                 bool force_full)
 {
     bool changed = false;
@@ -1349,6 +1350,9 @@ void TilesFramework::_send_item(item_def& current, const item_def& next,
     changed |= (current.special != next.special);
 
     // Derived stuff
+    changed |= _update_int(force_full, current_uselessness,
+                           is_useless_item(next, true), "useless");
+
     if (changed && defined)
     {
         string name = next.name(DESC_A, true, false, true);

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -81,6 +81,7 @@ struct player_info
     vector<status_info> status;
 
     FixedVector<item_def, ENDOFPACK> inv;
+    FixedVector<bool, ENDOFPACK> inv_uselessness;
     FixedVector<int8_t, NUM_EQUIP> equip;
     int8_t quiver_item;
     string quiver_desc;
@@ -329,6 +330,7 @@ protected:
                        bool force_full);
     void _send_player(bool force_full = false);
     void _send_item(item_def& current, const item_def& next,
+                    bool& current_uselessness,
                     bool force_full);
     void _send_messages();
 };

--- a/crawl-ref/source/webserver/game_data/static/action_panel.js
+++ b/crawl-ref/source/webserver/game_data/static/action_panel.js
@@ -339,7 +339,8 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
         }
     }
 
-    function draw_action(texture, tiles, item, offset, scale, needs_cursor, text)
+    function draw_action(texture, tiles, item, offset, scale, needs_cursor,
+                         text, useless)
     {
         if (item && draw_glyphs)
         {
@@ -376,6 +377,15 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
         if (needs_cursor)
         {
             renderer.draw_icon(icons.CURSOR3,
+                               _horizontal() ? offset : 0,
+                               _horizontal() ? 0 : offset,
+                               undefined, undefined,
+                               scale);
+        }
+
+        if (useless)
+        {
+            renderer.draw_icon(icons.OOR_MESH,
                                _horizontal() ? offset : 0,
                                _horizontal() ? 0 : offset,
                                undefined, undefined,
@@ -473,7 +483,7 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
             let cursor_required = selected == idx + NUM_RESERVED_BUTTONS;
 
             draw_action(main, item.tile, item, offset, adjusted_scale,
-                        cursor_required, qty);
+                        cursor_required, qty, item.useless);
         });
 
         if (available_length < required_length)


### PR DESCRIPTION
This PR adds better indication for currently useless items. If you can't use a consumable, it'll be greyed out on the action panel. There are already a lot of uselessness checks, but the second commit makes them more consistent and adds a few new ones. Also, there's a bonus bug fix in the third commit.
