### PR TITLE
fix c++ warning

### DIFF
--- a/crawl-ref/source/defines.h
+++ b/crawl-ref/source/defines.h
@@ -194,12 +194,16 @@ const int AGILITY_BONUS = 5;
 
 #define MAX_MONSTER_HP 10000
 
+// Many, MANY places currently hard-code this to 8 bits, but we need to
+// expand it. Please use colour_t in new code.
+typedef uint8_t colour_t;
+
 // colours, such pretty colours ...
 // The order is important (IRGB bit patterns).
-enum COLOURS
+enum COLOURS : colour_t
 {
-    COLOUR_INHERIT = -1,
-    BLACK,
+    COLOUR_INHERIT = (colour_t)-1,
+    BLACK = 0,
     COLOUR_UNDEF = BLACK,
     BLUE,
     GREEN,
@@ -220,10 +224,6 @@ enum COLOURS
     WHITE,
     NUM_TERM_COLOURS
 };
-
-// Many, MANY places currently hard-code this to 8 bits, but we need to
-// expand it. Please use colour_t in new code.
-typedef uint8_t colour_t;
 
 // Colour options... these are used as bit flags along with the colour
 // value in the low byte.

--- a/crawl-ref/source/fixedarray.h
+++ b/crawl-ref/source/fixedarray.h
@@ -42,9 +42,13 @@ public:
 
     FixedArray(const FixedArray &other)
     {
-        for (int i = 0; i < width(); i++)
-            for (int j = 0; j < height(); j++)
-                (*this)[i][j] = other[i][j];
+        copy(other);
+    }
+
+    FixedArray& operator = (const FixedArray &other)
+    {
+        copy(other);
+        return *this;
     }
 
 public:
@@ -93,6 +97,14 @@ public:
 
 protected:
     FixedVector<Column, WIDTH> mData;
+
+
+    void copy(const FixedArray &other)
+    {
+        for (int i = 0; i < width(); i++)
+            for (int j = 0; j < height(); j++)
+                (*this)[i][j] = other[i][j];
+    }
 };
 
 // A fixed array centered around the origin.

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -722,7 +722,7 @@ monster_info::monster_info(const monster* m, int milev)
     if (m->has_ghost_brand())
         props[SPECIAL_WEAPON_KEY] = m->ghost_brand();
 
-    ghost_colour = m->ghost ? m->ghost->colour : COLOUR_INHERIT;
+    ghost_colour = m->ghost ? m->ghost->colour : (colour_t)COLOUR_INHERIT;
 
     // book loading for player ghost and vault monsters
     spells.clear();

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -232,7 +232,7 @@ struct monster_info_base
         int is_active;   ///< Whether this ballisto is active or not
     };
     int _colour;
-    int ghost_colour;
+    colour_t ghost_colour;
     mon_attitude_type attitude;
     mon_threat_level_type threat;
     mon_dam_level_type dam;


### PR DESCRIPTION
Fix compile warning from deprecated implicit declaration of operator overload

```
dgn-proclayouts.cc: In constructor ‘LevelLayout::LevelLayout(level_id, uint32_t, const ProceduralLayout&)’:
dgn-proclayouts.cc:237:33: warning: implicitly-declared ‘FixedArray<dungeon_feature_type, 80, 70>& FixedArray<dungeon_feature_type, 80, 70>::operator=(const FixedArray<dungeon_feature_type, 80, 70>&)’ is deprecated [-Wdeprecated-copy]
  237 |     grid = feature_grid(env.grid);
      |                                 ^
In file included from externs.h:29,
                 from AppHdr.h:316,
                 from dgn-proclayouts.cc:5:
fixedarray.h:43:5: note: because ‘FixedArray<dungeon_feature_type, 80, 70>’ has user-provided ‘FixedArray<TYPE, WIDTH, HEIGHT>::FixedArray(const FixedArray<TYPE, WIDTH, HEIGHT>&) [with TYPE = dungeon_feature_type; int WIDTH = 80; int HEIGHT = 70]’
   43 |     FixedArray(const FixedArray &other)
      |     ^~~~~~~~~~
```

To avoid duplicating code I introduced a copy method and call that from both copy and assignment operators