### PR TITLE
FIX Initialise you.sacrifice_piety.

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5098,6 +5098,7 @@ player::player()
     temp_mutation.init(0);
     demonic_traits.clear();
     sacrifices.init(0);
+    sacrifice_piety.init(0);
 
     magic_contamination = 0;
 


### PR DESCRIPTION
Initialise you.sacrifice_piety before Crawl copies it to a new character's save file. Clear the whole thing (when only the section between ABIL_FIRST_SACRIFICE and ABIL_FINAL_SACRIFICE is saved) as that's what FixedVector provides a function for.

On Linux 3.16.0 with Crawl 0.30-a0-394-g3e4acdb0ae, this takes Crawl (on my system) from a situation where valgrind reports access to an uninitialised variable when I start a new character to one where it doesn't.

For what it's worth, this effect was tested on:
DCSS 0.30-a0-394-g3e4acdb0ae
Linux 3.16.0 console using XTerm(358)