### PR TITLE
Allow GameOption options to be set in the game

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1774,6 +1774,7 @@ menu_colour ^= <match>:<colour>:<regex>, <colour>:<regex>, ...
            pickup        (specific to pickup menus)
            shop          (shop menus)
            notes         (the ?: screen)
+           option        (the options menu - match option names but not values)
            resists       (the % screen)
            spell         (the Z and I screens)
            stash         (the results from Ctrl-F)

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -18,7 +18,8 @@ The contents of this text are:
                 name, remember_name, weapon, species, background, combo,
                 restart_after_game, restart_after_save, newgame_after_quit,
                 name_bypasses_menu, default_manual_training,
-                autopickup_starting_ammo, game_seed, pregen_dungeon
+                autopickup_starting_ammo, game_seed, pregen_dungeon,
+                suppress_startup_errors
 2-  File System and Sound.
                 crawl_dir, morgue_dir, save_dir, macro_dir, sound, hold_sound,
                 sound_file_path, one_SDL_sound_channel
@@ -43,11 +44,11 @@ The contents of this text are:
                 scroll_margin, always_show_exclusions
 3-f     Travel and Exploration.
                 travel_delay, explore_delay, rest_delay, travel_avoid_terrain,
-                explore_greedy, explore_greedy_visit, explore_stop,
-                explore_stop_pickup_ignore, explore_wall_bias, travel_key_stop,
-                travel_one_unsafe_move, tc_reachable, tc_dangerous,
-                tc_disconnected, tc_excluded, tc_exclude_circle,
-                runrest_ignore_message, runrest_stop_message,
+                explore_greedy, explore_greedy_visit, explore_item_greed,
+                explore_stop, explore_stop_pickup_ignore, explore_wall_bias,
+                travel_key_stop, travel_one_unsafe_move, tc_reachable,
+                tc_dangerous, tc_disconnected, tc_excluded, tc_exclude_circle,
+                tc_forbidden, runrest_ignore_message, runrest_stop_message,
                 interrupt_<delay>, delay_safe_poison, runrest_ignore_monster,
                 rest_wait_both, rest_wait_ancestor, rest_wait_percent,
                 explore_auto_rest, auto_exclude, travel_open_doors
@@ -150,7 +151,7 @@ The contents of this text are:
                 mouse_input, wiz_mode, explore_mode, char_set, colour,
                 display_char, feature, mon_glyph, item_glyph,
                 use_fake_player_cursor, show_player_species,
-                use_modifier_prefix_keys, language, fake_lang,
+                use_modifier_prefix_keys, language, fake_lang, messaging
                 read_persist_options
 
 5-b     DOS and Windows.
@@ -459,6 +460,15 @@ pregen_dungeon = incremental
         level entry, as was the rule before 0.23. Dungeons will not be stable
         given a seed with this option.
 
+suppress_startup_errors = false
+        If this is false, and an error was detected as the game first started
+        (such as a mistake in a configuration file), bring up a screen before
+        loading to display these.
+
+        The main menu will contain a warning of errors regardless of this
+        setting, and it does not affect errors which are detected as a
+        character is loaded.
+
 2-  File System.
 ================
 
@@ -487,8 +497,11 @@ macro_dir = <path>
         It should end with the path delimiter. The default value for this
         is dependent on system and build type.
 
-sound ^= <regex>:<path to sound file>, <regex>:<path>,
+sounds_on = true
         (Requires "Sound support"; check your version info)
+        If true, plays sound effects in various situations.
+
+sound ^= <regex>:<path to sound file>, <regex>:<path>,
         (Ordered list option)
         Plays the sound file if a message contains regex. In case of
         multiple matching regexes, only the sound of the last regex
@@ -698,7 +711,7 @@ feature_item_highlight = reverse
         hidden by items. If you use this option, the item glyph(s) on the
         square are hidden by the feature symbol.
 
-trap_item_highlights = reverse
+trap_item_highlight = reverse
         Highlights traps that would otherwise be hidden by items. If you
         use this option, the item glyph(s) on the square are hidden by the trap
         symbol (^).
@@ -846,6 +859,11 @@ explore_greedy_visit += stacks
         artefacts: makes explore_greedy visit artefacts, even
         if not in a stack
 
+explore_item_greed = 10
+        Greedy exploration treats items as if they were this much closer (or
+        further away, if negative) when deciding whether to visit a square with
+        an item or to explore a new square.
+
 explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack
         (List option)
@@ -927,7 +945,8 @@ tc_dangerous      = cyan
 tc_disconnected   = darkgrey
 tc_excluded       = lightmagenta
 tc_exclude_circle = red
-        The above five settle the colouring of the level map ('X').
+tc_forbidden      = lightcyan
+        The above six settle the colouring of the level map ('X').
         They are
           reachable: all squares safely reachable (without leaving the
                      level)
@@ -938,6 +957,8 @@ tc_exclude_circle = red
           excluded: the colour for the centre of travel exclusions ('e')
           excluded_circle: the colour for travel exclusions apart from
                            centre
+          forbidden: squares which cannot be reached without crossing excluded
+                     squares.
 
 runrest_ignore_message ^= <regex>, <regex>, ...
 runrest_stop_message ^= <regex>, <regex>, ...
@@ -2885,6 +2906,10 @@ fake_lang = <lang1>[,<lang2>[,...]]
 
         Options are: (dwarven|jagerkin|kraut|runes|wide|grunt|butt:<n>)
         Experiment to find out what they do!
+
+messaging = true
+        If set to true, this allows you to receive DGL messages sent
+        by other players. (This setting only applies on the online servers).
 
 read_persist_options = false
         When set to true, the game will read additional options from

--- a/crawl-ref/source/command-type.h
+++ b/crawl-ref/source/command-type.h
@@ -156,6 +156,7 @@ enum command_type
 
     CMD_SHOW_CHARACTER_DUMP,
     CMD_GAME_MENU,
+    CMD_EDIT_PREFS,
 #ifdef TARGET_OS_MACOSX
     CMD_REVEAL_OPTIONS,
 #endif

--- a/crawl-ref/source/dat/defaults/menu_colours.txt
+++ b/crawl-ref/source/dat/defaults/menu_colours.txt
@@ -8,52 +8,52 @@ menu += darkgrey:(melded)
 menu += darkgrey:(inert)
 
 # Bad items
-menu += lightred:.*bad_item.*
+menu += lightred:.*\bbad_item\b.*
 
 # Useless items, comes here to override artefacts etc.
-menu += darkgrey:.*useless_item.*
+menu += darkgrey:.*\buseless_item\b.*
 
 # Items disliked by your god.
-menu += $forbidden:.*forbidden.*
+menu += $forbidden:.*\bforbidden\b.*
 
 # Handle cursed and equipped items early to override other colour settings.
-menu += lightred:.*equipped.* cursed
-menu += red: (a|the) cursed
-menu += inventory:lightgreen:.*equipped.*
+menu += lightred:.*\bequipped\b.* cursed\b
+menu += red: \b(a|the)\b \bcursed\b
+menu += inventory:lightgreen:.*\bequipped\b.*
 
 # Important game items
 #
-menu += lightmagenta:.*misc.*rune of Zot
-menu += lightmagenta:.*orb.*Zot
+menu += lightmagenta:.*\bmisc\b.*\brune of Zot\b
+menu += lightmagenta:.*\borb\b.*\bZot\b
 
 # Artefacts
 #
-menu += lightcyan:.*unrand.*
-menu += white:.*artefact.*
+menu += lightcyan:.*\bunrand\b.*
+menu += white:.*\bartefact\b.*
 
-#menu += white:.*identified.*artefact.*
-#menu += lightblue:.*unidentified.*artefact.*
+#menu += white:.*\bidentified\b.*\bartefact\b.*
+#menu += lightblue:.*\bunidentified\b.*\bartefact\b.*
 
 # Possible egos
-menu += lightblue:^unidentified .*weapon.*(runed|glowing)
-menu += lightblue:^unidentified .*armour.*(runed|glowing|embroidered|shiny|dyed)
+menu += lightblue:^unidentified .*\bweapon\b.*\b(runed|glowing)\b
+menu += lightblue:^unidentified .*\barmour\b.*\b(runed|glowing|embroidered|shiny|dyed)\b
 
 # Enchanté
-menu += green:enchanted
-menu += green:staff of
-menu += green:ego
+menu += green:\benchanted\b
+menu += green:\bstaff of\b
+menu += green:\bego\b
 
 # Emergency items
-menu += yellow:.*emergency_item.*
+menu += yellow:.*\bemergency_item\b.*
 
 # Good items
-menu += cyan:.*good_item.*
+menu += cyan:.*\bgood_item\b.*
 
 # Dangerous (but still useful) items
-menu += $dangerous:.*dangerous_item.*
+menu += $dangerous:.*\bdangerous_item\b.*
 
 # Defaults for normal items
-menu += lightblue:unidentified.*(potion|scroll|wand|jewellery|magical staff)
+menu += lightblue:\bunidentified\b.*(potion|scroll|wand|jewellery|magical staff)
 
 
 # Colouring of autoinscribed god gifts
@@ -66,4 +66,4 @@ menu_colour += inventory:white:\w \*\s
 
 
 # Not really menu.
-menu_colour += notes:white:Reached XP level
+menu_colour += notes:white:\bReached XP level\b

--- a/crawl-ref/source/game-options.cc
+++ b/crawl-ref/source/game-options.cc
@@ -135,19 +135,22 @@ static string _choose_one_from_list(const string prompt,
 /// @param[in,out] caller  Option to edit. Reads the name and current value.
 ///                        Writes the new value.
 /// @param[in]     choices Options to choose between.
-void choose_option_from_UI(GameOption *caller, vector<string> choices)
+/// @returns       True if something is chosen, false otherwise.
+bool choose_option_from_UI(GameOption *caller, vector<string> choices)
 {
     string prompt = string("Select a value for ")+caller->name()+":";
     string selected = _choose_one_from_list(prompt, choices, caller->str());
     if (!selected.empty())
         caller->loadFromString(selected, RCFILE_LINE_EQUALS);
+    return !selected.empty();
 }
 
 /// Ask the user to edit a game option using a text box.
 ///
 /// @param[in,out] caller Option to edit. Reads the name and current value.
 ///                       Writes the new value.
-void load_string_from_UI(GameOption *caller)
+/// @returns       True if something is chosen, false otherwise.
+bool load_string_from_UI(GameOption *caller)
 {
     string prompt = string("Enter a value for ")+caller->name()+":";
     /// XXX - shouldn't use a fixed length string here.
@@ -158,11 +161,11 @@ void load_string_from_UI(GameOption *caller)
         if (msgwin_get_line(prompt, select, sizeof(select), nullptr, old))
         {
             caller->loadFromString(caller->str(), RCFILE_LINE_EQUALS);
-            return;
+            return false;
         }
         string error = caller->loadFromString(select, RCFILE_LINE_EQUALS);
         if (error.empty())
-            return;
+            return true;
         show_type_response(error);
         old = select;
     }
@@ -182,10 +185,10 @@ string BoolGameOption::loadFromString(const string &field, rc_line_type ltyp)
     return GameOption::loadFromString(field, ltyp);
 }
 
-void BoolGameOption::load_from_UI()
+bool BoolGameOption::load_from_UI()
 {
     vector<string> choices = {"false", "true"};
-    choose_option_from_UI(this, choices);
+    return choose_option_from_UI(this, choices);
 }
 
 string ColourGameOption::loadFromString(const string &field, rc_line_type ltyp)
@@ -204,12 +207,12 @@ const string ColourGameOption::str() const
     return colour_to_str(value);
 }
 
-void ColourGameOption::load_from_UI()
+bool ColourGameOption::load_from_UI()
 {
     vector<string> choices;
     for (colour_t i = COLOUR_UNDEF; i < NUM_TERM_COLOURS; ++i)
         choices.emplace_back(colour_to_str(i));
-    choose_option_from_UI(this, choices);
+    return choose_option_from_UI(this, choices);
 }
 
 string CursesGameOption::loadFromString(const string &field, rc_line_type ltyp)
@@ -231,12 +234,12 @@ const string CursesGameOption::str() const
     return x->second;
 }
 
-void CursesGameOption::load_from_UI()
+bool CursesGameOption::load_from_UI()
 {
     vector<string> choices;
     for (auto &x : _curses_attribute_map()) // Add the names in numerical order.
         choices.emplace_back(x.second);
-    choose_option_from_UI(this, choices);
+    return choose_option_from_UI(this, choices);
 }
 
 #ifdef USE_TILE

--- a/crawl-ref/source/game-options.cc
+++ b/crawl-ref/source/game-options.cc
@@ -240,8 +240,8 @@ void CursesGameOption::load_from_UI()
 }
 
 #ifdef USE_TILE
-TileColGameOption::TileColGameOption(VColour &val, std::set<std::string> _names,
-                    string _default)
+TileColGameOption::TileColGameOption(VColour &val, vector<string> _names,
+                                     string _default)
         : GameOption(_names), value(val),
           default_value(str_to_tile_colour(_default)) { }
 

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -91,6 +91,18 @@ protected:
     friend struct game_options;
 };
 
+// Class used by edit_game_prefs() to insert MEL_SUBTITLE lines.
+// name() returns "" and str() returns the heading.
+class GameOptionHeading : public GameOption
+{
+public:
+    GameOptionHeading(string _heading) : GameOption({""}), heading(_heading) { }
+    const string str() const override { return heading; }
+    bool load_from_UI() override { return false; }
+private:
+    const string heading;
+};
+
 bool load_string_from_UI(GameOption *option);
 bool choose_option_from_UI(GameOption *caller, vector<string> choices);
 

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -56,6 +56,13 @@ public:
         loadFromString(other->str(), RCFILE_LINE_EQUALS);
         loaded = real_loaded;
     }
+    void set_help(int file, int line);
+    void set_help(GameOption *other);
+    void show_help();
+    bool has_help()
+    {
+        return help_file != '&' || help_line != 0;
+    }
     virtual string loadFromString(const std::string &, rc_line_type)
     {
         loaded = true;
@@ -80,6 +87,7 @@ protected:
     bool loaded; // tracks whether the option has changed via loadFromString.
                  // will miss whether it was changed directly in c++ code. (TODO)
 
+    int help_file='&', help_line=0;
     friend struct game_options;
 };
 

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -41,7 +41,7 @@ L& remove_matching(L& lis, const E& entry)
 class GameOption
 {
 public:
-    GameOption(std::set<std::string> _names)
+    GameOption(vector<string> _names)
         : names(_names), loaded(false) { }
     virtual ~GameOption() {};
 
@@ -63,13 +63,13 @@ public:
     }
 
 
-    const std::set<std::string> &getNames() const { return names; }
+    const vector<string> &getNames() const { return names; }
     const std::string name() const { return *names.begin(); }
 
     bool was_loaded() const { return loaded; }
 
 protected:
-    std::set<std::string> names;
+    vector<string> names;
     bool loaded; // tracks whether the option has changed via loadFromString.
                  // will miss whether it was changed directly in c++ code. (TODO)
 
@@ -82,8 +82,7 @@ void choose_option_from_UI(GameOption *caller, vector<string> choices);
 class BoolGameOption : public GameOption
 {
 public:
-    BoolGameOption(bool &val, std::set<std::string> _names,
-                   bool _default)
+    BoolGameOption(bool &val, vector<string> _names, bool _default)
         : GameOption(_names), value(val), default_value(_default) { }
 
     void reset() override
@@ -108,8 +107,8 @@ private:
 class ColourGameOption : public GameOption
 {
 public:
-    ColourGameOption(unsigned &val, std::set<std::string> _names,
-                     unsigned _default, bool _elemental = false)
+    ColourGameOption(unsigned &val, vector<string> _names, unsigned _default,
+                     bool _elemental = false)
         : GameOption(_names), value(val), default_value(_default),
           elemental(_elemental) { }
 
@@ -132,8 +131,7 @@ private:
 class CursesGameOption : public GameOption
 {
 public:
-    CursesGameOption(unsigned &val, std::set<std::string> _names,
-                     unsigned _default)
+    CursesGameOption(unsigned &val, vector<string> _names, unsigned _default)
         : GameOption(_names), value(val), default_value(_default) { }
 
     void reset() override
@@ -154,7 +152,7 @@ private:
 class IntGameOption : public GameOption
 {
 public:
-    IntGameOption(int &val, std::set<std::string> _names, int _default,
+    IntGameOption(int &val, vector<string> _names, int _default,
                   int min_val = INT_MIN, int max_val = INT_MAX)
         : GameOption(_names), value(val), default_value(_default),
           min_value(min_val), max_value(max_val) { }
@@ -177,8 +175,7 @@ private:
 class StringGameOption : public GameOption
 {
 public:
-    StringGameOption(string &val, std::set<std::string> _names,
-                     string _default)
+    StringGameOption(string &val, vector<string> _names, string _default)
         : GameOption(_names), value(val), default_value(_default) { }
 
     void reset() override
@@ -200,8 +197,7 @@ private:
 class TileColGameOption : public GameOption
 {
 public:
-    TileColGameOption(VColour &val, std::set<std::string> _names,
-                      string _default);
+    TileColGameOption(VColour &val, vector<string> _names, string _default);
 
     void reset() override
     {
@@ -227,7 +223,7 @@ typedef function<bool(const colour_threshold &l, const colour_threshold &r)>
 class ColourThresholdOption : public GameOption
 {
 public:
-    ColourThresholdOption(colour_thresholds &val, std::set<std::string> _names,
+    ColourThresholdOption(colour_thresholds &val, vector<string> _names,
                           string _default, colour_ordering ordering_func)
         : GameOption(_names), value(val), ordering_function(ordering_func),
           default_value(parse_colour_thresholds(_default)) { }
@@ -256,7 +252,7 @@ template<typename T>
 class ListGameOption : public GameOption
 {
 public:
-    ListGameOption(vector<T> &list, std::set<std::string> _names,
+    ListGameOption(vector<T> &list, vector<string> _names,
                    vector<T> _default = {})
         : GameOption(_names), value(list), default_value(_default) { }
 
@@ -311,7 +307,7 @@ template<typename T>
 class MultipleChoiceGameOption : public GameOption
 {
 public:
-    MultipleChoiceGameOption(T &_val, std::set<std::string> _names, T _default,
+    MultipleChoiceGameOption(T &_val, vector<string> _names, T _default,
                              vector<pair<string, T>> _choices,
                              bool _normalize_bools=false)
         : GameOption(_names), value(_val), default_value(_default),

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -48,7 +48,7 @@ public:
     // XX reset and some other stuff could be templated for most
     // subclasses, but this is hard to reconcile with the polymorphism involved
     virtual void reset() { loaded = false; }
-    virtual void load_from_UI() = 0;
+    virtual bool load_from_UI() = 0;
     virtual const string str() const = 0;
     void set_from(const GameOption *other)
     {
@@ -68,6 +68,13 @@ public:
 
     bool was_loaded() const { return loaded; }
 
+    void (*on_change)(game_options *) = [](game_options *) {};
+    GameOption *set_on_change(void (*_on_change)(game_options *))
+    {
+        on_change = _on_change;
+        return this;
+    }
+
 protected:
     vector<string> names;
     bool loaded; // tracks whether the option has changed via loadFromString.
@@ -76,8 +83,8 @@ protected:
     friend struct game_options;
 };
 
-void load_string_from_UI(GameOption *option);
-void choose_option_from_UI(GameOption *caller, vector<string> choices);
+bool load_string_from_UI(GameOption *option);
+bool choose_option_from_UI(GameOption *caller, vector<string> choices);
 
 class BoolGameOption : public GameOption
 {
@@ -97,7 +104,7 @@ public:
     }
 
     string loadFromString(const std::string &field, rc_line_type) override;
-    void load_from_UI() override;
+    bool load_from_UI() override;
 
 private:
     bool &value;
@@ -120,7 +127,7 @@ public:
 
     string loadFromString(const std::string &field, rc_line_type) override;
     const string str() const override;
-    void load_from_UI() override;
+    bool load_from_UI() override;
 
 private:
     unsigned &value;
@@ -142,7 +149,7 @@ public:
 
     string loadFromString(const std::string &field, rc_line_type) override;
     const string str() const override;
-    void load_from_UI() override;
+    bool load_from_UI() override;
 
 private:
     unsigned &value;
@@ -165,7 +172,7 @@ public:
 
     string loadFromString(const std::string &field, rc_line_type) override;
     const string str() const override;
-    void load_from_UI() override { load_string_from_UI(this); }
+    bool load_from_UI() override { return load_string_from_UI(this); }
 
 private:
     int &value;
@@ -186,7 +193,7 @@ public:
 
     string loadFromString(const std::string &field, rc_line_type) override;
     const string str() const override;
-    void load_from_UI() override { load_string_from_UI(this); }
+    bool load_from_UI() override { return load_string_from_UI(this); }
 
 private:
     string &value;
@@ -207,7 +214,7 @@ public:
 
     string loadFromString(const std::string &field, rc_line_type) override;
     const string str() const override;
-    void load_from_UI() override { load_string_from_UI(this); }
+    bool load_from_UI() override { return load_string_from_UI(this); }
 
 private:
     VColour &value;
@@ -236,7 +243,7 @@ public:
 
     string loadFromString(const string &field, rc_line_type ltyp) override;
     const string str() const override;
-    void load_from_UI() override { load_string_from_UI(this); }
+    bool load_from_UI() override { return load_string_from_UI(this); }
 
 private:
     colour_thresholds parse_colour_thresholds(const string &field,
@@ -290,9 +297,9 @@ public:
             ss << ", " << s;
         return ss.str().substr(2);
     }
-    void load_from_UI() override
+    bool load_from_UI() override
     {
-        load_string_from_UI(this);
+        return load_string_from_UI(this);
     }
 
 private:
@@ -365,14 +372,14 @@ public:
         return choice->second;
     }
 
-    void load_from_UI() override
+    bool load_from_UI() override
     {
         const string prompt = string("Select a value for ")+name()+":";
         vector<string> list;
         for (auto c : rchoices)
             list.emplace_back(c.second);
 
-        choose_option_from_UI(this, list);
+        return choose_option_from_UI(this, list);
     }
 
 private:

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -47,6 +47,7 @@
 #include "jobs.h"
 #include "kills.h"
 #include "libutil.h"
+#include "lookup-help.h"
 #include "macro.h"
 #include "mapdef.h"
 #include "maps.h"
@@ -5696,6 +5697,110 @@ private:
     int highlight_until;
 };
 
+class EGP_Menu : public Menu
+{
+public:
+    EGP_Menu(int _flags) : Menu(_flags)
+                           { set_title(new MenuEntry(base_title, MEL_TITLE));}
+
+    ~EGP_Menu()
+    {
+        deleteAll(all_items);
+        items.clear();
+    }
+
+    void add_entry_all(MenuEntry *entry)
+    {
+        add_entry(entry);
+        all_items.push_back(entry);
+    }
+
+    void filter_items()
+    {
+        string prompt = "Search for what? (regex, leave blank to show all)";
+        char select[1024];
+        auto old_search_pat = search_pat;
+        int new_hovered = -1;
+        vector<MenuEntry*> chosen_items;
+        while (1)
+        {
+            if (msgwin_get_line(prompt, select, sizeof(select), nullptr,
+                                       search_pat.tostring())
+                || old_search_pat.tostring() == select)
+            {
+                search_pat = old_search_pat;
+                return;
+            }
+            search_pat = select;
+            MenuEntry *heading = nullptr;
+            bool found_hover = false;
+            int i = 0;
+            for (auto entry : all_items)
+            {
+                if (entry == items[last_hovered])
+                    found_hover = true;
+                auto g = static_cast<GameOption*>(entry->data);
+                if (!g)
+                    heading = entry;
+                else if (search_pat.empty() || search_pat.matches(g->name()))
+                {
+                    if (heading)
+                        chosen_items.emplace_back(heading);
+                    heading = nullptr;
+                    if (found_hover && new_hovered < 0)
+                        new_hovered = chosen_items.size();
+                    entry->hotkeys[0] = index_to_letter((i++)%52);
+                    chosen_items.emplace_back(entry);
+                }
+            }
+            if (!chosen_items.empty())
+                break;
+
+            show_type_response("No option names match.");
+        }
+
+        items = chosen_items;
+        string new_title = base_title;
+        if (!search_pat.empty())
+        {
+            string search = search_pat.tostring();
+            if (search.length() > 42)
+                search = search.substr(39)+"...";
+            search = replace_all(search, "<", "<<");
+            new_title += " <h>(Matches \""+search+"\")</h>";
+        }
+        set_title(new MenuEntry(new_title, MEL_TITLE));
+        reset();
+        update_menu(true);
+        if (new_hovered < 0)
+            set_hovered(all_items.size()-1);
+        else
+            set_hovered(new_hovered);
+    }
+
+    string get_keyhelp(bool) const override
+    {
+        return "<lightgrey>[<w>Up</w>|<w>Down</w>|<w>PgUp</w>|<w><<</w>"
+               "|<w>PgDn</w>|<w>></w>] select  "
+               "[<w>Esc</w>] close  "
+               "[<w>Ctrl-f</w>] find</lightgrey>";
+    }
+    int pre_process(int key) override
+    {
+        if (CONTROL('F') == key)
+            filter_items();
+        else
+            return key;
+        return CK_NO_KEY;
+    }
+
+private:
+
+    text_pattern search_pat;
+    vector<MenuEntry*> all_items;
+    string base_title = "<w>Select a preference to set.</w>";
+};
+
 static string _option_line(const GameOption *option, int name_len, int text_len)
 {
     auto name0 = option->name(), value0 = option->str();
@@ -5709,15 +5814,12 @@ static string _option_line(const GameOption *option, int name_len, int text_len)
 // Show (and perhaps edit) options for the game.
 void edit_game_prefs()
 {
-    string prompt = "<w>Select a preference to set</w>";
     auto list = Options.get_option_behaviour();
     string selected;
 
     // The caller should remove any user-provided formatting.
-    Menu menu(MF_SINGLESELECT | MF_ARROWS_SELECT
-              | MF_ALLOW_FORMATTING | MF_INIT_HOVER);
-
-    menu.set_title(new MenuEntry(prompt, MEL_TITLE));
+    EGP_Menu menu(MF_SINGLESELECT | MF_ARROWS_SELECT
+                  | MF_ALLOW_FORMATTING | MF_INIT_HOVER);
     menu.set_tag("option");
 
     int i = 0;
@@ -5737,7 +5839,7 @@ void edit_game_prefs()
             }
             return true;
         };
-        menu.add_entry(entry);
+        menu.add_entry_all(entry);
     }
 
     menu.set_hovered(0);

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -30,6 +30,7 @@
 #include "chardump.h"
 #include "clua.h"
 #include "colour.h"
+#include "command.h"
 #include "defines.h"
 #include "delay.h"
 #include "describe.h"
@@ -5783,12 +5784,15 @@ public:
         return "<lightgrey>[<w>Up</w>|<w>Down</w>|<w>PgUp</w>|<w><<</w>"
                "|<w>PgDn</w>|<w>></w>] select  "
                "[<w>Esc</w>] close  "
-               "[<w>Ctrl-f</w>] find</lightgrey>";
+               "[<w>Ctrl-f</w>] find  "
+               "[<w>?</w>] help</lightgrey>";
     }
     int pre_process(int key) override
     {
         if (CONTROL('F') == key)
             filter_items();
+        else if ('?' == key)
+            (static_cast<GameOption*>(items[last_hovered]->data))->show_help();
         else
             return key;
         return CK_NO_KEY;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -412,7 +412,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(name_bypasses_menu), true),
         new BoolGameOption(SIMPLE_NAME(restart_after_save), true),
         new BoolGameOption(SIMPLE_NAME(newgame_after_quit), false),
-        new StringGameOption(SIMPLE_NAME(map_file_name), ""),
         new StringGameOption(SIMPLE_NAME(morgue_dir),
                              _get_save_path("morgue/")),
 #endif

--- a/crawl-ref/source/initfile.h
+++ b/crawl-ref/source/initfile.h
@@ -73,6 +73,7 @@ public:
 extern system_environment SysEnv;
 
 bool parse_args(int argc, char **argv, bool rc_only);
+void edit_game_prefs();
 
 struct newgame_def;
 void write_newgame_options_file(const newgame_def& prefs);

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -1406,7 +1406,7 @@ static string _keylist_invalid_reason(const vector<string> &key_list,
     return "";
 }
 
-static void _show_type_response(string response)
+void show_type_response(string response)
 {
     // possibly overkill, but this renders very reliably
     formatted_scroller fs(FS_EASY_EXIT);
@@ -1421,7 +1421,7 @@ bool find_description_of_type(lookup_help_type lht)
     string response;
     bool done = lookup_types[lht].find_description(response);
     if (!response.empty() && response != "Okay, then.") // TODO: ...
-        _show_type_response(response);
+        show_type_response(response);
     return done;
 }
 

--- a/crawl-ref/source/lookup-help.h
+++ b/crawl-ref/source/lookup-help.h
@@ -16,4 +16,5 @@ void keyhelp_query_descriptions(command_type where_from=CMD_NO_CMD);
 
 string lookup_help_type_name(lookup_help_type lht);
 char lookup_help_type_shortcut(lookup_help_type lht);
+void show_type_response(string response);
 bool find_description_of_type(lookup_help_type lht);

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1960,6 +1960,8 @@ public:
             MEL_ITEM, 'S', CMD_SAVE_GAME_NOW, false));
         add_entry(new CmdMenuEntry("Generate and view character dump",
             MEL_ITEM, '#', CMD_SHOW_CHARACTER_DUMP));
+        add_entry(new CmdMenuEntry("Edit preferences",
+            MEL_ITEM, 'p', CMD_EDIT_PREFS));
 #ifdef USE_TILE_LOCAL
         add_entry(new CmdMenuEntry("Edit player tile",
             MEL_ITEM, '-', CMD_EDIT_PLAYER_TILE));
@@ -2078,6 +2080,8 @@ void process_command(command_type cmd, command_type prev_cmd)
     case CMD_PREV_CMD_AGAIN: _do_prev_cmd_again(); break;
     case CMD_MACRO_ADD:      macro_quick_add();    break;
     case CMD_MACRO_MENU:     macro_menu();    break;
+
+    case CMD_EDIT_PREFS:   edit_game_prefs(); break;
 
     // Toggle commands.
     case CMD_DISABLE_MORE: crawl_state.show_more_prompt = false; break;

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -658,6 +658,7 @@ public:
     {
         return option_behaviour;
     }
+    vector<GameOption*> get_sorted_options();
     void merge(const game_options &other);
     GameOption *option_from_name(string name) const
     {
@@ -725,7 +726,7 @@ private:
 
     static const string interrupt_prefix;
 
-    vector<GameOption*> option_behaviour;
+    vector<GameOption*> option_behaviour, options_sorted;
     map<string, GameOption*> options_by_name;
     const vector<GameOption*> build_options_list();
     map<string, GameOption*> build_options_map(const vector<GameOption*> &opts);

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -341,7 +341,6 @@ public:
     vector<pair<int, int> > stat_colour;
     vector<int> enemy_hp_colour;
 
-    string map_file_name;   // name of mapping file to use
     vector<pair<text_pattern, bool> > force_autopickup;
     vector<text_pattern> note_monsters;  // Interesting monsters
     vector<text_pattern> note_messages;  // Interesting messages

--- a/crawl-ref/source/pattern.cc
+++ b/crawl-ref/source/pattern.cc
@@ -118,6 +118,12 @@ static pattern_match _pattern_match_location(void *compiled_pattern,
 ////////////////////////////////////////////////////////////////////
 #endif
 
+ostream &operator<< (ostream &out, const base_pattern &t)
+{
+    out << t.tostring();
+    return out;
+}
+
 string pattern_match::annotate_string(const string &color) const
 {
     string ret(text);

--- a/crawl-ref/source/pattern.h
+++ b/crawl-ref/source/pattern.h
@@ -49,6 +49,8 @@ public:
     virtual const string &tostring() const = 0;
 };
 
+ostream &operator<< (ostream &out, const base_pattern &t);
+
 class text_pattern : public base_pattern
 {
 public:

--- a/crawl-ref/source/scroller.h
+++ b/crawl-ref/source/scroller.h
@@ -41,7 +41,7 @@ public:
     void set_title(formatted_string title) { m_title = move(title); };
 
     void scroll_to_end();
-    void set_scroll(int y);
+    void scroll_to_line(int y, bool use_shade = true);
 
     const formatted_string& get_contents() { return contents; };
 


### PR DESCRIPTION
This implements an options menu for Crawl (accessed from the "main menu") which let the player set options based on the GameOption class. The list appears in the order in which they appear in options_guide.txt, arena.txt or fight_simulator.txt, with section headings to break up the list.

You can:
- View and change option settings.
- Bring up help text for each option.
- Search for options where the name matches a pattern.
- Save options to the .crawlrc file used for that game.

You can't yet:
- Interact with options which weren't already implemented as GameOptions.
- Tell from the UI whether changes made with it will affect the current game.
- Select where options should be saved.
- Access the options menu before starting the game.

In addition:
- Some of the option-setting functions are still a bit basic.
- There are many options which do not use `GameOption`, and so are unaffected.
- There isn't an icon for the options menu.
- There is no documentation for `tile_use_small_layout` in `options_guide.txt`.

I intend to work further on some of these issues, but I think this is useful as things stand.