### PR TITLE
fix: don't leak usefulness of unidentified scrolls (#2877)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3143,7 +3143,7 @@ static string _no_items_reason(object_selector type, bool check_floor = false)
  */
 string cannot_read_item_reason(const item_def *item)
 {
-    if (item && item->base_type == OBJ_SCROLLS)
+    if (item && item->base_type == OBJ_SCROLLS && item_type_known(*item))
     {
         // this function handles a few cases of perma-uselessness. For those,
         // be sure to print the message first. (XX generalize)


### PR DESCRIPTION
After 4b7bca3bf, unidentified perma-useless scrolls are greyed out in the read menu. This affects ?butterflies and ?summoning for followers of Okawaru and ?teleport and ?blinking for Formicids. Also, it's not possible to read-identify permanently useless scrolls.

Fix this by checking perma-uselessness only of identified scrolls.

Closes #2877.