### PR TITLE
fix: show perma uselessness in shop and shopping list menus

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -888,7 +888,7 @@ class ShopEntry : public InvEntry
                                                   YELLOW;
         const string keystr = colour_to_str(keycol);
         const string itemstr =
-            colour_to_str(menu_colour(text, item_prefix(*item), tag));
+            colour_to_str(menu_colour(text, item_prefix(*item, false), tag));
         return make_stringf(" <%s>%c %c </%s><%s>%4d gold   %s%s</%s>",
                             keystr.c_str(),
                             hotkeys[0],
@@ -2245,7 +2245,7 @@ void ShoppingList::fill_out_menu(Menu& shopmenu)
             // Colour shopping list item according to menu colours.
             const item_def &item = get_thing_item(thing);
 
-            const string colprf = item_prefix(item);
+            const string colprf = item_prefix(item, false);
             const int col = menu_colour(item.name(DESC_A),
                                         colprf, "shop");
 


### PR DESCRIPTION
The menus have been showing temp uselessness of items for a long time. For example, potions of invisibility were greyed out for characters with enough magic contamination even in previous versions.

As a followup to 43e804b48, use perma-uselessness highlighting for these menus.