### PR TITLE
fix: make autoexplore wait for movement restrictions to expire

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5380,16 +5380,19 @@ bool player::is_sufficiently_rested(bool starting) const
     // if someone disables all these interrupts, resting becomes impossible.)
     const bool hp_interrupts = Options.activity_interrupts["rest"][
                                 static_cast<int>(activity_interrupt::full_hp)];
+    const bool mp_interrupts = Options.activity_interrupts["rest"][
+                                static_cast<int>(activity_interrupt::full_mp)];
+    const bool can_freely_move = you.is_motile() && !you.duration[DUR_BARBS];
+
     return (!player_regenerates_hp()
                 || _should_stop_resting(hp, hp_max, !starting)
                 || !hp_interrupts
                 || you.has_mutation(MUT_EXPLORE_REGEN))
         && (!player_regenerates_mp()
                 || _should_stop_resting(magic_points, max_magic_points, !starting)
-                || !Options.activity_interrupts["rest"][
-                                static_cast<int>(activity_interrupt::full_mp)]
+                || !mp_interrupts
                 || you.has_mutation(MUT_EXPLORE_REGEN))
-        && (!you.duration[DUR_BARBS] || !hp_interrupts);
+        && (can_freely_move || !hp_interrupts);
 }
 
 bool player::in_water() const


### PR DESCRIPTION
If you wear an amulet of magic regeneration, it's possible to cast Momentum Strike and then restore MP before -Move times out. Pressing `o` will just print "You cannot move." and you'll have to use `5` or `.` to rest -Move off.

Fix this by making autoexplore wait for -Move to expire before attempting to move. Tree form and Stuck status from Translocations miscasts also prevent autoexplore, so let's fix these cases too.