### PR TITLE
remove invisibility from chaos effects

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -666,7 +666,7 @@ static const vector<chaos_effect> chaos_effects = {
     { "hasting", 10, _is_chaos_slowable, BEAM_HASTE },
     { "mighting", 10, nullptr, BEAM_MIGHT },
     { "agilitying", 10, nullptr, BEAM_AGILITY },
-    { "invisible", 10, nullptr, BEAM_INVISIBILITY, },
+    { "resistance", 10, nullptr, BEAM_RESISTANCE, },
     { "slowing", 10, _is_chaos_slowable, BEAM_SLOW },
     {
         "paralysis", 5, [](const actor &defender) {

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -613,7 +613,7 @@ static beam_type _chaos_beam_flavour(bolt* beam)
          // Weights similar to those from chaos_effects in attack.cc
          10, BEAM_SLOW,
          10, BEAM_HASTE,
-         10, BEAM_INVISIBILITY,
+         10, BEAM_AGILITY,
           5, BEAM_PARALYSIS,
           5, BEAM_PETRIFY,
           5, BEAM_BERSERK,
@@ -630,7 +630,7 @@ static beam_type _chaos_beam_flavour(bolt* beam)
          // analogous BEAM_ type.
           4, BEAM_MIGHT,
           4, BEAM_HEALING,
-          4, BEAM_AGILITY,
+          4, BEAM_RESISTANCE,
           4, BEAM_ENSNARE);
 
     return flavour;


### PR DESCRIPTION
It's a very annoying interface tax without sinv. To replace it, increase the odds of agility for the beam version and add a chance of resistance for both beam and attack flavor versions.