### PR TITLE
Disable Bog status when using chei time step powers

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1978,6 +1978,7 @@ static void _run_time_step()
         run_environment_effects();
         handle_monsters();
         manage_clouds();
+        you.duration[DUR_NOXIOUS_BOG] = 0;
     }
     while (--you.duration[DUR_TIME_STEP] > 0);
 }


### PR DESCRIPTION
Fixes #2749
Does not address the other commented issues since those could be intentional.