### PR TITLE
feat: Filter out useless altars from stash search

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1200,6 +1200,12 @@ static bool _is_duplicate_for_search(stash_search_result l,
     return l.match == r.match;
 }
 
+// Filter out useless results in search_stashes
+static bool _is_useless_result(const stash_search_result res)
+{
+    return res.item.defined() && is_useless_item(res.item, false) ||
+        feat_is_altar(res.feat) && !player_can_join_god(feat_altar_god(res.feat), false);
+}
 
 // helper for search_stashes
 static bool _compare_by_distance(const stash_search_result& lhs,
@@ -1456,9 +1462,7 @@ void StashTracker::search_stashes(string search_term)
     }
 
     dedup_results.erase(remove_if(dedup_results.begin(), dedup_results.end(),
-        [](const stash_search_result res) {
-            return res.item.defined() && is_useless_item(res.item, false);
-        }), dedup_results.end());
+        _is_useless_result), dedup_results.end());
 
     bool sort_by_dist = true;
     bool filter_useless = true;


### PR DESCRIPTION
Currently altars are always included in stash search results as "useful" even if the player could never use them, i.e. by playing a Demigod.

This change simply adds a check to the dedup/useless filter to filter these out. Since the predicate got so big I also thought it merited refactoring out into its own helper function.

![altar_filter](https://user-images.githubusercontent.com/1066352/209250939-e6b20797-f837-4294-b3a3-00649db47024.gif)
