### PR TITLE
Edit layout_misc_corridors in Lair

### DIFF
--- a/crawl-ref/source/dat/des/builder/layout.des
+++ b/crawl-ref/source/dat/des/builder/layout.des
@@ -833,7 +833,11 @@ TAGS:   no_rotate no_vmirror no_hmirror
     end
 
     local iterations = math.floor(crawl.random_range(75, 125) * area_fraction)
-    spotty_map { boxy = true, iterations = iterations }
+    if you.in_branch("Lair") then
+        spotty_map { boxy = crawl.coinflip(), iterations = iterations }
+    else
+        spotty_map { boxy = true, iterations = iterations }
+    end
 
     theme.level_material(_G)
 }}


### PR DESCRIPTION
Make layout_misc_corridors sometimes use boxy=false when in Lair.  This provides a more "natural" look than the square rooms it generates otherwise, and works well with Lair ruination.  As a bonus, it also creates more crevices for the player to hide in.