### PR TITLE
fix: local tiles sidebar height

### DIFF
--- a/crawl-ref/source/tilereg-tab.cc
+++ b/crawl-ref/source/tilereg-tab.cc
@@ -482,13 +482,13 @@ void TabbedRegion::set_small_layout(bool use_small_layout, const coord_def &wind
 
     if (m_tabs.size() == 0 || !use_small_layout)
     {
-        dx = 32;
-        dy = 32;
+        dx = Options.tile_sidebar_pixels;
+        dy = Options.tile_sidebar_pixels;
     }
     else
     {
         // original dx (32) * region height (240) / num tabs (7) / height of tab (20)
-        int scale = (32-1) * windowsz.y/num_tabs()/m_tabs[m_active].height -1;
+        int scale = (Options.tile_sidebar_pixels-1) * windowsz.y/num_tabs()/m_tabs[m_active].height -1;
         scale /= 2; // half size fits better
         dx = scale;
         dy = scale;


### PR DESCRIPTION
<img width="518" alt="Screenshot 2022-12-26 at 12 24 30" src="https://user-images.githubusercontent.com/11316827/209552776-1f21a865-6a46-404c-9e26-084f4300f79b.png">
<img width="522" alt="Screenshot 2022-12-26 at 12 23 52" src="https://user-images.githubusercontent.com/11316827/209552800-9693f0d7-2890-4796-9a3f-78655316f201.png">

Andoird branch merge broke some menu height calculations. Options.tile_sidebar_pixels is 32px by default, so wouldn't affect rendering in all cases but then tile_sidebar_pixels is actually changed.
