### PR TITLE
fix: Make a flavor gimmick wand no_pickup

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -4404,7 +4404,7 @@ TAGS:   temple_overflow_2 temple_overflow_zin temple_overflow_gozag
 TAGS:   no_item_gen no_monster_gen
 KFEAT:  _ = altar_zin
 KFEAT:  O = altar_gozag
-KITEM:  O = wand of digging charges:1
+KITEM:  O = wand of digging charges:1 no_pickup
 KFEAT:  m = iron_grate
 KPROP:  $ = no_tele_into
 KITEM:  $ = gold q:1 / gold q:2


### PR DESCRIPTION
Imagine my delight when I stumbled upon my very own vault in an online game, and then my abject horror when the wand, which really ties the whole room together, was missing!

I tested the game seed (4877243199622027174) locally and found that the wand had been placed correctly, so unless there are some possibilities I don't know about I think it's likely that a monster waltzed in and walked away with it.