### PR TITLE
fix: highscores crash on stats-heavy characters

### DIFF
--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -611,7 +611,7 @@ static void _hs_close(FILE *handle)
 
 static bool _hs_read(FILE *scores, scorefile_entry &dest)
 {
-    char inbuf[1300];
+    char inbuf[1500];
     if (!scores || feof(scores))
         return false;
 


### PR DESCRIPTION
buffer size changed from 1300 to 1500.

P.S. my converted megaziging character from .26.1 got 1300+ characters string in highscores. Mouseover causes to crash
<img width="984" alt="Screenshot 2022-12-26 at 21 03 30" src="https://user-images.githubusercontent.com/11316827/209580250-59c18a75-9fd3-4ee7-99b5-739928d08872.png">
