### PR TITLE
Compiler warnings

### DIFF
--- a/crawl-ref/source/rltiles/tool/tile.cc
+++ b/crawl-ref/source/rltiles/tool/tile.cc
@@ -371,6 +371,18 @@ bool tile::texture(const tile &img)
     return true;
 }
 
+#ifdef USE_TILE
+// Suppress two warning messages which may occur as libpng reads images.
+// XXX - Can, and should, these warnings be avoided altogether?
+static void _libpng_warning(png_structp png_ptr, png_const_charp warning_msg)
+{
+    auto w1 = "iCCP: known incorrect sRGB profile",
+        w2 = "Interlace handling should be turned on when using png_read_image";
+    if (strcmp(warning_msg, w1) && strcmp(warning_msg, w2))
+        fprintf(stderr, "libpng: %s\n", warning_msg);
+}
+#endif
+
 bool tile::load(const string &new_filename)
 {
     m_filename = new_filename;
@@ -394,7 +406,8 @@ bool tile::load(const string &new_filename)
     }
 
     png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
-                                                 nullptr, nullptr, nullptr);
+                                                 nullptr, nullptr,
+                                                 _libpng_warning);
     png_infop info_ptr = png_create_info_struct(png_ptr);
 
     // libpng error handling!

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1525,10 +1525,12 @@ struct glyph_overlay
 static vector<glyph_overlay> glyph_overlays;
 static unsigned int glyph_overlay_i;
 
+#ifndef USE_TILE_LOCAL
 void view_add_glyph_overlay(const coord_def &gc, cglyph_t glyph)
 {
     glyph_overlays.push_back({gc, glyph});
 }
+#endif
 
 void view_clear_overlays()
 {


### PR DESCRIPTION
Remove two types of compiler warning (which have no connection to one another):

1. compile out view_add_glyph_overlay() when USE_TILE_LOCAL is set.

2. Suppress two specific libPNG warnings from tilegen.elf.

There may be other ways of achieving the second thing (I know one error message goes if you call `png_set_interlace_handling(png_ptr)` before `png_read_update_info()`), but user_warning_fn should have no impact on the image files the program produces.