### PR TITLE
Fix estimation of the minimum usable window size

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1000,10 +1000,10 @@ bool TilesFramework::is_using_small_layout()
     if (Options.tile_use_small_layout == MB_MAYBE)
 #ifndef __ANDROID__
         // Rough estimation of the minimum usable window size
-        //   - width > stats font size * 28 + msg font size * 30
-        //   - height > tabs area size (192) + stats font size * 14
+        //   - width > stats font width * 45 + msg font width * 45
+        //   - height > tabs area size (192) + stats font height * 11
         // Not using Options.tile_font_xxx_size because it's reset on new game
-        return m_windowsz.x < m_fonts[2].size*28+m_fonts[1].size*30 || m_windowsz.y < 192+m_fonts[2].size*14;
+        return m_windowsz.x < m_stat_font->char_width()*45+m_msg_font->char_width()*45 || m_windowsz.y < 192+m_stat_font->char_height()*11;
 #else
         return true;
 #endif


### PR DESCRIPTION
We were using the m_fonts array to get the font sizes. This is wrong because caching leads to unpredictable array contents.

Now we are using proper char width and height. It also has the benefit of improved precision.

The bug was reported in reddit:
https://www.reddit.com/r/dcss/comments/107d1tj/what_has_changed_with_the_ui_trunk_compiled/