### PR TITLE
Record Wu Jian's Lunge and Whirlwind as CACT_ABIL, not CACT_INVOKE.

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1401,7 +1401,7 @@ static bool _wu_jian_lunge(coord_def old_pos, coord_def new_pos,
              number_of_attacks > 1 ? ", in a flurry of attacks" : "");
     }
 
-    count_action(CACT_INVOKE, ABIL_WU_JIAN_LUNGE);
+    count_action(CACT_ABIL, ABIL_WU_JIAN_LUNGE);
 
     for (int i = 0; i < number_of_attacks; i++)
     {
@@ -1469,7 +1469,7 @@ static bool _wu_jian_whirlwind(coord_def old_pos, coord_def new_pos,
                      ", with incredible momentum" : "");
         }
 
-        count_action(CACT_INVOKE, ABIL_WU_JIAN_WHIRLWIND);
+        count_action(CACT_ABIL, ABIL_WU_JIAN_WHIRLWIND);
 
         for (int i = 0; i < number_of_attacks; i++)
         {

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -277,6 +277,7 @@ enum tag_minor_version
     TAG_MINOR_SPAWN_RATE,          // Remove the env.spawn_random_rate field.
     TAG_MINOR_REMOVE_AK,           // Remove Abyssal Knight.
     TAG_MINOR_BUTTERSUMMONS,       // Alternate ?butt with ?summ, not ?fog.
+    TAG_MINOR_WU_ABILITIES,        // Make Lunge and Whirlwind Abil, not Invok
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2555,6 +2555,22 @@ static void _fixup_species_mutations(mutation_type mut)
     you.innate_mutation[mut] = you.mutation[mut] = total;
 }
 
+#if TAG_MAJOR_VERSION == 34
+/// Copy action counts from one action to another, keeping the sub-action the
+/// same. Retain any counts which were already against the "new" action.
+static void _move_action_count(caction_type old_action, caction_type new_action,
+                               int subtype)
+{
+    pair<caction_type, int> oldkey(old_action, caction_compound(subtype)),
+        newkey(new_action, caction_compound(subtype));
+    if (!you.action_count.count(oldkey))
+        return;
+    for (int i = you.action_count[oldkey].size()-1; i>=0; --i)
+        you.action_count[newkey][i] += you.action_count[oldkey][i];
+    you.action_count.erase(oldkey);
+}
+#endif
+
 static void _tag_read_you(reader &th)
 {
     int count;
@@ -3848,6 +3864,11 @@ static void _tag_read_you(reader &th)
     }
 
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() < TAG_MINOR_WU_ABILITIES)
+    {
+        _move_action_count(CACT_INVOKE, CACT_ABIL, ABIL_WU_JIAN_LUNGE);
+        _move_action_count(CACT_INVOKE, CACT_ABIL, ABIL_WU_JIAN_WHIRLWIND);
+    }
     if (th.getMinorVersion() >= TAG_MINOR_BRANCHES_LEFT) // 33:17 has it
     {
 #endif


### PR DESCRIPTION
Previously, Lunge, Whirlwind, Serpents Lash and Heavenly Storm were recorded with CACT_INVOKE, and Wall Jump with CACT_ABIL.

This change means that Wu Jian's powers are now split into martial attacks (abilities which do not consume piety or fail if you are silenced) and other powers (invocations which do both).