### PR TITLE
decouple gold aura duration and corpse size

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -399,7 +399,7 @@ static void _gold_pile(item_def &corpse, monster_type corpse_class)
     item_colour(corpse);
 
     // Apply the gold aura effect to the player.
-    const int dur = corpse.quantity * 2;
+    const int dur = 6 + random2avg(14, 2);
     if (dur > you.duration[DUR_GOZAG_GOLD_AURA])
         you.set_duration(DUR_GOZAG_GOLD_AURA, dur);
 


### PR DESCRIPTION
Killing bigger monsters gave you longer gold aura duration, which is mechanically weird (also not great that you could pseudo-count the duration by looking at the size of a gold stack that dropped!) Just roll independently instead, choosing numbers roughly equal to the case for human size. Gold amount being tied to corpse size is also weird in a post-chunk universe, but the gameplay implications there are mostly fine and it would be a significant balance change to decouple it - worth looking at if gozag needs another nerf, but I've left it alone for now.