### PR TITLE
Refactor inaccuracy

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -207,8 +207,11 @@ void actor::shield_block_succeeded()
 
 int actor::inaccuracy() const
 {
+    int degree = 0;
     const item_def *amu = slot_item(EQ_AMULET);
-    return amu && is_unrandom_artefact(*amu, UNRAND_AIR);
+    if (amu && is_unrandom_artefact(*amu, UNRAND_AIR))
+        degree += 5;
+    return degree;
 }
 
 bool actor::res_corr(bool /*allow_random*/, bool temp) const

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -247,7 +247,7 @@ int attack::post_roll_to_hit_modifiers(int mhit, bool /*random*/)
     int modifiers = 0;
 
     // Penalties for both players and monsters:
-    modifiers -= 5 * attacker->inaccuracy();
+    modifiers -= attacker->inaccuracy();
 
     if (attacker->confused())
         modifiers += CONFUSION_TO_HIT_MALUS;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -454,7 +454,7 @@ int zap_to_hit(zap_type z_type, int power, bool is_monster)
     ASSERT(hit_calc);
     const int hit = (*hit_calc)(power);
     if (hit != AUTOMATIC_HIT && !is_monster && crawl_state.need_save)
-        return max(0, hit - 5 * you.inaccuracy());
+        return max(0, hit - you.inaccuracy());
     return hit;
 }
 

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -254,7 +254,6 @@ static void _fuzz_direction(const actor *caster, monster& mon, int pow)
     float tan = (random2(31) - 15) * 0.019; // approx from degrees
     tan *= 75.0 / pow;
     const int inaccuracy = caster ? caster->inaccuracy() : 0;
-    //TODO this is kind of terrible
     if (inaccuracy > 0)
         tan *= 2 * inaccuracy / 5;
 

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -254,8 +254,9 @@ static void _fuzz_direction(const actor *caster, monster& mon, int pow)
     float tan = (random2(31) - 15) * 0.019; // approx from degrees
     tan *= 75.0 / pow;
     const int inaccuracy = caster ? caster->inaccuracy() : 0;
+    //TODO this is kind of terrible
     if (inaccuracy > 0)
-        tan *= 2 * inaccuracy;
+        tan *= 2 * inaccuracy / 5;
 
     // Cast either from left or right hand.
     mon.props[IOOD_X] = x + vy*off;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -8288,8 +8288,7 @@ string player::hands_act(const string &plural_verb,
 int player::inaccuracy() const
 {
     int degree = 0;
-    if (player_equip_unrand(UNRAND_AIR))
-        degree++;
+    degree += actor::inaccuracy();
     if (get_mutation_level(MUT_MISSING_EYE))
         degree++;
     return degree;


### PR DESCRIPTION
adjust inaccuracy to
1: return actual inaccuracy modifier rather than an indicator of 'degree'
2: use superclass code in player::inaccuracy() rather than duplicating it
3: not use heinous implicit typing
