### PR TITLE
docs: update jiyva powers description

### DIFF
--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -309,8 +309,8 @@ will always grant followers resistance to fire.
 %%%%
 Jiyva powers
 
-Jiyva will gradually fill the dungeon with jellies, which will rapidly consume
-nearby items as well as slowly consuming items from elsewhere in the dungeon.
+Jiyva gradually fills the dungeon with jellies! Jellies and eyes will rapidly
+consume nearby items, and slowly consume items from elsewhere in the dungeon.
 As they spread slime across more of the dungeon, Jiyva will grant followers
 increasingly rapid health and magic regeneration, and will begin mutating them
 to better reflect Jiyva's image. Followers will later become able to call forth


### PR DESCRIPTION
Jiyva's powers description on ^ was mildly incomplete when referring to jellies consuming items: Most eyes also consume items under Jiyva, but as far as I could tell this wasn't documented anywhere in-game. Eyes and jellies use different console glyphs and internal genus, so this seems worth disambiguating; this commit clarifies the description slightly.