### PR TITLE
Check if the player wants to use a "martial attack" with an odd weapon.

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5673,7 +5673,9 @@ bool wu_jian_do_wall_jump(coord_def targ)
     auto wall_jump_direction = (you.pos() - targ).sgn();
     auto wall_jump_landing_spot = (you.pos() + wall_jump_direction
                                    + wall_jump_direction);
-    if (!check_moveto(wall_jump_landing_spot, "wall jump"))
+    if ((wu_jian_wall_jump_triggers_attacks(wall_jump_landing_spot)
+         && !wielded_weapon_check(you.weapon())
+        || !check_moveto(wall_jump_landing_spot, "wall jump")))
     {
         you.turn_is_over = false;
         return false;

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1508,19 +1508,32 @@ static bool _wu_jian_trigger_martial_arts(coord_def old_pos,
     return attacked;
 }
 
-void wu_jian_wall_jump_effects()
+static vector<monster*> _wu_jian_wall_jump_monsters(const coord_def &pos)
 {
     vector<monster*> targets;
-    for (adjacent_iterator ai(you.pos(), true); ai; ++ai)
+    for (adjacent_iterator ai(pos, true); ai; ++ai)
     {
-        monster* target = monster_at(*ai);
+        monster *target = monster_at(*ai);
         if (target && _can_attack_martial(target) && target->alive())
             targets.push_back(target);
+    }
+    return targets;
+}
 
+// Return true if wu_jian_wall_jump_effects() would attack a monster when
+// called with you.pos() as pos.
+bool wu_jian_wall_jump_triggers_attacks(const coord_def &pos)
+{
+    return !_wu_jian_wall_jump_monsters(pos).empty();
+}
+
+void wu_jian_wall_jump_effects()
+{
+    for (adjacent_iterator ai(you.pos(), true); ai; ++ai)
         if (!cell_is_solid(*ai))
             check_place_cloud(CLOUD_DUST, *ai, 1 + random2(3) , &you, 0, -1);
-    }
 
+    vector<monster*> targets = _wu_jian_wall_jump_monsters(you.pos());
     for (auto target : targets)
     {
         if (!target->alive())

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -296,6 +296,7 @@ void uskayaw_bonds_audience();
 void wu_jian_heaven_tick();
 void wu_jian_decrement_heavenly_storm();
 void wu_jian_end_heavenly_storm();
+bool wu_jian_wall_jump_triggers_attacks(const coord_def &pos);
 void wu_jian_wall_jump_effects();
 bool wu_jian_has_momentum(wu_jian_attack_type);
 bool wu_jian_post_move_effects(bool did_wall_jump,

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -939,12 +939,6 @@ void move_player_action(coord_def move)
         return;
     }
 
-    if (!rampaged && wu_jian_move_triggers_attacks(targ)
-        && !wielded_weapon_check(you.weapon()))
-    {
-        return;
-    }
-
     // XX generalize?
     const string walkverb = you.airborne()                     ? "fly"
                           : you.swimming()                     ? "swim"
@@ -1096,6 +1090,13 @@ void move_player_action(coord_def move)
                  feature_description_at(targ, false, DESC_THE).c_str());
             you.apply_berserk_penalty = true;
             you.turn_is_over = true;
+            return;
+        }
+
+        // Allow (e.g.) "Really move and attack while wielding nothing?" abort.
+        if (!rampaged && wu_jian_move_triggers_attacks(targ)
+            && !wielded_weapon_check(you.weapon(), "move and attack"))
+        {
             return;
         }
 

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -939,6 +939,12 @@ void move_player_action(coord_def move)
         return;
     }
 
+    if (!rampaged && wu_jian_move_triggers_attacks(targ)
+        && !wielded_weapon_check(you.weapon()))
+    {
+        return;
+    }
+
     // XX generalize?
     const string walkverb = you.airborne()                     ? "fly"
                           : you.swimming()                     ? "swim"


### PR DESCRIPTION
Previously, the game asked for confirmation before attacking with (e.g.) a weapon inscribed with !a. It also did this before rampaging into a monster, but not for Wu Jian's "martial attacks".

It now carries out the same checks before Wu Jian's lunge and whirlwind attacks, and does it before a wall jump if this attacks a monster.