### PR TITLE
Sling of Outrageous Fortune

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -207,8 +207,11 @@ void actor::shield_block_succeeded()
 
 int actor::inaccuracy() const
 {
+    int degree = 0;
     const item_def *amu = slot_item(EQ_AMULET);
-    return amu && is_unrandom_artefact(*amu, UNRAND_AIR);
+    if (amu && is_unrandom_artefact(*amu, UNRAND_AIR))
+        degree += 5;
+    return degree;
 }
 
 bool actor::res_corr(bool /*allow_random*/, bool temp) const

--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -211,6 +211,9 @@ int actor::inaccuracy() const
     const item_def *amu = slot_item(EQ_AMULET);
     if (amu && is_unrandom_artefact(*amu, UNRAND_AIR))
         degree += 5;
+    const item_def *weap = slot_item(EQ_WEAPON);
+    if (weap && is_unrandom_artefact(*weap, UNRAND_FORTUNE))
+        degree += 5;
     return degree;
 }
 

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1761,6 +1761,23 @@ DESCRIP:  *Victory:  When the wearer kills a threatening monster, it has a
  a scroll or a potion with a hostile monster in sight, its bonuses reset to +0.
  Unequipping it also resets its bonuses to +0.
 
+ENUM:       FORTUNE
+NAME:       Sling of Outrageous Fortune
+OBJ:        OBJ_WEAPONS/WPN_HAND_CROSSBOW
+TYPE:       sling
+PLUS:       +7
+BASE_ACC:   -8
+BASE_DAM:   -9
+BASE_DELAY: -5
+COLOUR:     WHITE
+TILE:       urand_punk
+TILE_EQ:    punk
+BRAND:      SPWPN_HEAVY
+BOOL:       no_upgrade
+INSCRIP:    Fortune
+DESCRIP:    Fortune:    Slaying and Enchantment bonuses apply thrice to damage, 
+ but do not apply to accuracy.
+
 # This entry must always be last.
 ENUM:   DUMMY2
 NAME:   DUMMY UNRANDART 2

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -197,7 +197,7 @@ int attack::calc_pre_roll_to_hit(bool random)
         }
 
         // weapon bonus contribution
-        if (using_weapon())
+        if (using_weapon() && !is_unrandom_artefact(*weapon, UNRAND_FORTUNE))
         {
             if (weapon->base_type == OBJ_WEAPONS)
             {
@@ -209,7 +209,9 @@ int attack::calc_pre_roll_to_hit(bool random)
         }
 
         // slaying bonus
-        mhit += slaying_bonus(wpn_skill == SK_THROWING);
+        if (!using_weapon()
+            || !is_unrandom_artefact(*weapon, UNRAND_FORTUNE))
+            mhit += slaying_bonus(wpn_skill == SK_THROWING);
 
         // vertigo penalty
         if (you.duration[DUR_VERTIGO])
@@ -1080,6 +1082,8 @@ int attack::player_apply_slaying_bonuses(int damage, bool aux)
                         || (weapon && is_range_weapon(*weapon)
                                    && using_weapon());
     damage_plus += slaying_bonus(throwing);
+    if(weapon && is_unrandom_artefact(*weapon, UNRAND_FORTUNE))
+        damage_plus *= 3;
     damage_plus -= 4 * you.corrosion_amount();
 
     // XXX: should this also trigger on auxes?

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -247,7 +247,7 @@ int attack::post_roll_to_hit_modifiers(int mhit, bool /*random*/)
     int modifiers = 0;
 
     // Penalties for both players and monsters:
-    modifiers -= 5 * attacker->inaccuracy();
+    modifiers -= attacker->inaccuracy();
 
     if (attacker->confused())
         modifiers += CONFUSION_TO_HIT_MALUS;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -454,7 +454,7 @@ int zap_to_hit(zap_type z_type, int power, bool is_monster)
     ASSERT(hit_calc);
     const int hit = (*hit_calc)(power);
     if (hit != AUTOMATIC_HIT && !is_monster && crawl_state.need_save)
-        return max(0, hit - 5 * you.inaccuracy());
+        return max(0, hit - you.inaccuracy());
     return hit;
 }
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -781,3 +781,9 @@ An ancient artefact of Okawaru, these woolen robes were lost when a former
 champion failed a duel. Its enchantments increase in power when the wearer
 emerges victorious from threatening combat, but resorting to the use of scrolls
 or potions for assistance causes them to fade away again.
+%%%%
+Sling of Outrageous Fortune
+
+A sling designed by a madman that launches arrows instead of traditional sling
+bullets. Magical enchantments provide no aid in hitting with this unwieldy
+weapon, but are startlingly effective in making it hurt.

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1276,7 +1276,10 @@ string damage_rating(const item_def *item)
 
     const int slaying = slaying_bonus(thrown);
     const int ench = item && item_ident(*item, ISFLAG_KNOW_PLUSES) ? item->plus : 0;
-    const int plusses = slaying + ench;
+    int plusses = slaying + ench;
+
+    if (item && is_unrandom_artefact(*item, UNRAND_FORTUNE))
+        plusses *= 3;
 
     const int DAM_RATE_SCALE = 100;
     int rating = (base_dam + extra_base_dam) * DAM_RATE_SCALE;

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -254,7 +254,6 @@ static void _fuzz_direction(const actor *caster, monster& mon, int pow)
     float tan = (random2(31) - 15) * 0.019; // approx from degrees
     tan *= 75.0 / pow;
     const int inaccuracy = caster ? caster->inaccuracy() : 0;
-    //TODO this is kind of terrible
     if (inaccuracy > 0)
         tan *= 2 * inaccuracy / 5;
 

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -254,8 +254,9 @@ static void _fuzz_direction(const actor *caster, monster& mon, int pow)
     float tan = (random2(31) - 15) * 0.019; // approx from degrees
     tan *= 75.0 / pow;
     const int inaccuracy = caster ? caster->inaccuracy() : 0;
+    //TODO this is kind of terrible
     if (inaccuracy > 0)
-        tan *= 2 * inaccuracy;
+        tan *= 2 * inaccuracy / 5;
 
     // Cast either from left or right hand.
     mon.props[IOOD_X] = x + vy*off;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -8288,8 +8288,7 @@ string player::hands_act(const string &plural_verb,
 int player::inaccuracy() const
 {
     int degree = 0;
-    if (player_equip_unrand(UNRAND_AIR))
-        degree++;
+    degree += actor::inaccuracy();
     if (get_mutation_level(MUT_MISSING_EYE))
         degree++;
     return degree;


### PR DESCRIPTION
Adds a new unrand 'sling' with very poor accuracy that is not affected by slay/enchantment bonuses, but whose damage scales 3x with slay/enchantment bonuses. 

The purpose of this sling is, admittedly, the joke. 

The design is meant to scratch the same itch as the Dark Maul through a completely separate vector- silly high damage at the cost of usability, but achieved with poor accuracy rather than high delay. 
The sling's effect encourages seeking slay, while also utilizing non-slay based means of increasing accuracy. Ideally it should hit a balance point where the sling is not worth using for a character with a decently enchanted ranged weapon but no slay, means of constriction, or source of halo, and is competitive with a especially strong randart hand crossbow for a character with all of the above.

The description could likely use rewriting, and the effect is probably in need of tweaks.