### PR TITLE
added leading space to text message on uselessness

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2242,7 +2242,7 @@ static void _uselessness_desc(ostringstream &description, const item_def &item)
         if (is_useless_item(item, false))
         {
             description << "This " << base_type_string(item.base_type)
-                        << "is completely useless to you";
+                        << " is completely useless to you";
             r = _cannot_use_reason(item, false);
         }
         else
@@ -2271,7 +2271,7 @@ static void _uselessness_desc(ostringstream &description, const item_def &item)
                 break;
             default:
                 description << "This " << base_type_string(item.base_type)
-                            << "is useless to you right now";
+                            << " is useless to you right now";
                 break;
             }
             r = _cannot_use_reason(item, true);


### PR DESCRIPTION
Add space to fix description text.

<img width="612" alt="image" src="https://user-images.githubusercontent.com/23780/215453861-079614d1-d6f5-4e1d-9737-3f8cdd93d1b2.png">
