### PR TITLE
bugfix: Make _safe_move_player also clear the command buffer

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -2804,8 +2804,11 @@ static void _do_wait_spells()
 
 static void _safe_move_player(coord_def move)
 {
-    if (!i_feel_safe(true))
+    if (!i_feel_safe(true)) {
+        unwind_bool save_more(crawl_state.show_more_prompt);
+        macro_clear_buffers();
         return;
+    }
     move_player_action(move);
 }
 


### PR DESCRIPTION
Without doing this you get silly and possibly dangerous results if the command buffer has commands that will get executed after the safe move fails.

Basically, the problem is this:  `crawl.do_commands` lets you queue up a bunch of commands for the game to execute.  With this you can queue up a sequence of safe moves, like CMD_SAFE_MOVE_UP, CMD_SAFE_MOVE_UP, CMD_SAFE_MOVE_UP, CMD_SAFE_MOVE_RIGHT.  Ater the player encounters a monster then `_safe_move_player` won't execute the command, and instead it emits a warning ("a goblin is nearby!").  This is great, but then the game will continue to wind down the command queue, emitting the same warning over and over for every safe move, and -- much worse -- actually executing any other moves or commands AFTER you stopped moving.  So you can get insta-killed when in fact you really wanted just to move somewhere safely.

This PR fixes that by clearing the command queue when a safe move is stopped because you're unsafe.