### PR TITLE
bugfix: Restore "original" (unsorted) as the default ordering for shops, to unbreak Lua

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -809,16 +809,17 @@ static bool _purchase(shop_struct& shop, const level_pos& pos, int index)
 
 enum shopping_order
 {
-    ORDER_TYPE,
-    ORDER_DEFAULT = ORDER_TYPE,
+    ORDER_ORIGINAL,
+    ORDER_DEFAULT = ORDER_ORIGINAL,
     ORDER_PRICE,
     ORDER_ALPHABETICAL,
+    ORDER_TYPE,
     NUM_ORDERS
 };
 
 static const char * const shopping_order_names[NUM_ORDERS] =
 {
-    "type", "price", "name"
+    "original", "type", "price", "name"
 };
 
 static shopping_order operator++(shopping_order &x)
@@ -1176,6 +1177,9 @@ void ShopMenu::resort()
 {
     switch (order)
     {
+    case ORDER_ORIGINAL:
+        // noop
+        break;
     case ORDER_TYPE:
     {
         const bool id = shoptype_identifies_stock(shop.type);

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -811,9 +811,9 @@ enum shopping_order
 {
     ORDER_ORIGINAL,
     ORDER_DEFAULT = ORDER_ORIGINAL,
+    ORDER_TYPE,
     ORDER_PRICE,
     ORDER_ALPHABETICAL,
-    ORDER_TYPE,
     NUM_ORDERS
 };
 

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -810,6 +810,7 @@ static bool _purchase(shop_struct& shop, const level_pos& pos, int index)
 enum shopping_order
 {
     ORDER_ORIGINAL,
+    // default order must be original (stock) order, or index_to_letter breaks
     ORDER_DEFAULT = ORDER_ORIGINAL,
     ORDER_TYPE,
     ORDER_PRICE,
@@ -819,7 +820,8 @@ enum shopping_order
 
 static const char * const shopping_order_names[NUM_ORDERS] =
 {
-    "original", "type", "price", "name"
+    // XXX no name longer than 6 letters
+    "none", "type", "price", "name"
 };
 
 static shopping_order operator++(shopping_order &x)


### PR DESCRIPTION
Sorting the shopping menu by type, name, or price is neat, but it breaks the Lua integration because the sorted menu scrambles item letters, so that `items.shopping_list` has no relationship to any menu you can currently see in the game.  That is, `items.letter_to_index` fails to work properly.

This PR restores the original "stock" order as the default, which means that `items.letter_to_index` will work again.

In practice, the stock order is very often exactly the same as the type order (the former default) -- and it's always the same for shops with only one type of inventory.  So the PR unbreaks Lua and should have an almost unnoticeable effect on regular play.