### PR TITLE
Clear the training target before the message, rather than afterwards.

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1110,14 +1110,12 @@ bool check_training_target(skill_type sk)
     if (you.training_targets[sk] && target_met(sk))
     {
         bool base = you.skill(sk, 10, false, false) != you.skill(sk, 10);
-        mprf("%sraining target %d.%d for %s reached!",
-            base ? "Base t" : "T",
-            you.training_targets[sk] / 10,
-            you.training_targets[sk] % 10, skill_name(sk));
-
+        auto targ = you.training_targets[sk];
         you.training_targets[sk] = 0;
         you.train[sk] = TRAINING_DISABLED;
         you.train_alt[sk] = TRAINING_DISABLED;
+        mprf("%sraining target %d.%d for %s reached!",
+            base ? "Base t" : "T", targ / 10, targ % 10, skill_name(sk));
         return true;
     }
     return false;


### PR DESCRIPTION
This means that a lua hook which catches the message can change the skill target for the relevant skill (imagine a script which sets an Axes target at 3, and sets it to 4 when it reaches 3). Previously, the game set the target to 0 after the message returned, whether or not the skill was still at its target.