### PR TITLE
Mail order catalogue and Alliterative Armaments

### DIFF
--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1189,26 +1189,29 @@ DEPTH:  D:8-, Orc, Elf, Depths
 {{
 local count = crawl.roll_dice(2, 3) + 5
 local name = "A" .. string.sub(string.lower(crawl.make_name()), 2)
+
+--Weights of equally rare weapons are divided by two for types with 
+--two alliterative egos
+local weaponnames = {"dagger", "short sword", "falchion", "scimitar",
+                    "w:3 demon blade","eudemon blade w:2", "double sword w:3",
+                    "hand axe", "executioner's axe w:6",
+                    "club w:20", "flail", "demon whip w:3", 
+                    "sacred scourge w:1", "dire flail", "eveningstar w:6",
+                    "spear", "halberd", "demon trident w:3"}
+local egos = {"chaos", "draining", "distortion", "electrocution", "flaming",
+              "freezing", "heavy", "speed", "spectral"}
 local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
              "suffix:Armaments count:" .. count .. " ; " ..
-             "dagger ego:draining | dagger ego:distortion | " ..
-             "short sword ego:speed | short sword ego:spectral | " ..
-             "falchion ego:flaming | falchion ego:freezing | " ..
-             "scimitar ego:speed | scimitar ego:spectral |" ..
-             "w:3 demon blade ego:draining | w:3 demon blade ego:distortion | "..
-             "w:2 eudemon blade ego:electrocution |" ..
-             "w:3 double sword ego:draining | w:3 double sword ego:distortion | "..
-             "w:6 executioner's axe ego:electrocution |" ..
-             "w:20 club ego:chaos |" ..
-             "flail ego:flaming | flail ego:freezing |" ..
-             "w:3 demon whip ego:draining | w:3 demon whip ego:distortion | " ..
-             "w:1 sacred scourge ego:speed | w:1 sacred scourge ego:spectral |" ..
-             "dire flail ego:draining | dire flail ego:distortion | " ..
-             "w:6 eveningstar ego:electrocution |" ..
-             "spear ego:speed | spear ego:spectral | " ..
              "halberd itemname:scythe tile:wpn_scythe wtile:scythe ego:speed | " ..
-             "halberd itemname:scythe tile:wpn_scythe wtile:scythe ego:spectral | " ..
-             "w:3 demon trident ego:draining | w:3 demon trident ego:distortion"
+             "halberd itemname:scythe tile:wpn_scythe wtile:scythe ego:spectral"
+--add any weapon-ego pair with matching first letter
+for _, weapon in ipairs(weaponnames) do
+  for _, ego in ipairs(egos) do
+    if weapon:sub(1, 1) == ego:sub(1, 1) then
+      kstr = kstr .. " | " .. weapon .. " ego:" .. ego
+    end
+  end
+end
 kfeat(kstr)
 }}
 MAP

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1155,44 +1155,53 @@ xxllxx
  xxxx
 ENDMAP
 
-NAME:   monkooky_mail_order_shop
+NAME:   monkooky_shop_mail_order
 TAGS:   transparent
 WEIGHT: 3
-DEPTH:  D:8-, Orc, Depths
+DEPTH:  D:6-, Vaults, Depths
 {{
-local kstr = "S = general shop type:Mail Order suffix:Catalogue ; " ..
-             "ring mail | " ..
-             "chain mail | " ..
-             "scale mail "
+local count = crawl.roll_dice(2, 2) + 3
+local kstr = "S = general shop type:Mail-Order suffix:Catalogue " ..
+             "count:" .. count .. " ; " ..
+             "w:5 ring mail | " ..
+             "ring mail good_item| " ..
+             "w:5 scale mail | " ..
+             "scale mail good_item| " ..
+             "w:5 chain mail | " ..
+             "chain mail good_item"
 
 -- Stealing nicolae's methodology from Mayhem Merchandise
 -- Again, could but probably won't result in an inappropriate lajatang appearing
 if not you.unrands("lajatang of order") then
-      kstr = kstr .. "| lajatang of order w:2"
+      kstr = kstr .. "|lajatang of order w:6"
 end
 
 kfeat(kstr)
 }}
-MAPMAP
+MAP
 S
 ENDMAP
 
-
-NAME:   monkooky_alliterative
+NAME:   monkooky_shop_alliterative
 TAGS:   transparent
 WEIGHT: 3
-DEPTH:  D:8-, Snake, Depths
+DEPTH:  D:8-, Orc, Elf, Depths
 {{
-local name =  A .. string.sub(string.lower(crawl.make_name()), 2)
-name = string.gsub(name, " ", "")
-
+local name = "A" .. string.sub(string.lower(crawl.make_name()), 2)
 local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
-             "suffix:Arms and Armor ; short sword ego:speed | "..
-             "short sword ego:spectral | falchion ego:flaming | scimitar ego:speed"
-
+             "suffix:Armaments ; " ..
+             "dagger ego:draining | dagger ego:distortion | " ..
+             "short sword ego:speed | short sword ego:spectral | " ..
+             "falchion ego:flaming | falchion ego:freezing | " ..
+             "scimitar ego:speed | scimitar ego:spectral |" .. 
+             "club ego:chaos |" ..
+             "flail ego:flaming | flail ego:freezing |" ..
+             "sacred scourge ego:speed | sacred scourge ego:spectral |" ..
+             "eveningstar ego:electrocution |" ..
+             "spear ego:speed | spear ego:spectral"
 kfeat(kstr)
 }}
-MAPMAP
+MAP
 S
 ENDMAP
 

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1187,7 +1187,7 @@ TAGS:   transparent
 WEIGHT: 3
 DEPTH:  D:8-, Orc, Elf, Depths
 {{
-local count = crawl.roll_dice(2, 3) + 3
+local count = crawl.roll_dice(2, 3) + 5
 local name = "A" .. string.sub(string.lower(crawl.make_name()), 2)
 local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
              "suffix:Armaments count:" .. count .. " ; " ..
@@ -1195,11 +1195,20 @@ local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
              "short sword ego:speed | short sword ego:spectral | " ..
              "falchion ego:flaming | falchion ego:freezing | " ..
              "scimitar ego:speed | scimitar ego:spectral |" .. 
-             "club ego:chaos |" ..
+             "w:3 demon blade ego:draining | w:3 demon blade ego:distortion | "..
+             "w:2 eudemon blade ego:electrocution |" ..
+             "w:3 double sword ego:draining | w:3 double sword ego:distortion | "..
+             "w:6 executioner's axe ego:electrocution |" ..
+             "w:20 club ego:chaos |" ..
              "flail ego:flaming | flail ego:freezing |" ..
-             "sacred scourge ego:speed | sacred scourge ego:spectral |" ..
-             "eveningstar ego:electrocution |" ..
-             "spear ego:speed | spear ego:spectral"
+             "w:3 demon whip ego:draining | w:3 demon whip ego:distortion | " ..
+             "w:1 sacred scourge ego:speed | w:1 sacred scourge ego:spectral |" ..
+             "dire flail ego:draining | dire flail ego:distortion | " ..
+             "w:6 eveningstar ego:electrocution |" ..
+             "spear ego:speed | spear ego:spectral | " ..
+             "halberd itemname:scythe tile:wpn_scythe wtile:scythe ego:speed | " ..
+             "halberd itemname:scythe tile:wpn_scythe wtile:scythe ego:spectral | " ..
+             "w:3 demon trident ego:draining | w:3 demon trident ego:distortion"
 kfeat(kstr)
 }}
 MAP

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1155,6 +1155,48 @@ xxllxx
  xxxx
 ENDMAP
 
+NAME:   monkooky_mail_order_shop
+TAGS:   transparent
+WEIGHT: 3
+DEPTH:  D:8-, Orc, Depths
+{{
+local kstr = "S = general shop type:Mail Order suffix:Catalogue ; " ..
+             "ring mail | " ..
+             "chain mail | " ..
+             "scale mail "
+
+-- Stealing nicolae's methodology from Mayhem Merchandise
+-- Again, could but probably won't result in an inappropriate lajatang appearing
+if not you.unrands("lajatang of order") then
+      kstr = kstr .. "| lajatang of order w:2"
+end
+
+kfeat(kstr)
+}}
+MAPMAP
+S
+ENDMAP
+
+
+NAME:   monkooky_alliterative
+TAGS:   transparent
+WEIGHT: 3
+DEPTH:  D:8-, Snake, Depths
+{{
+local name =  A .. string.sub(string.lower(crawl.make_name()), 2)
+name = string.gsub(name, " ", "")
+
+local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
+             "suffix:Arms and Armor ; short sword ego:speed | "..
+             "short sword ego:spectral | falchion ego:flaming | scimitar ego:speed"
+
+kfeat(kstr)
+}}
+MAPMAP
+S
+ENDMAP
+
+
 # Q: Why is the shop across from your fire supplies store burned down?
 # A: Don't worry about it. Are you going to buy something or not?
 NAME:     nicolae_shop_fire_sale

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1187,9 +1187,10 @@ TAGS:   transparent
 WEIGHT: 3
 DEPTH:  D:8-, Orc, Elf, Depths
 {{
+local count = crawl.roll_dice(2, 3) + 3
 local name = "A" .. string.sub(string.lower(crawl.make_name()), 2)
 local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
-             "suffix:Armaments ; " ..
+             "suffix:Armaments count:" .. count .. " ; " ..
              "dagger ego:draining | dagger ego:distortion | " ..
              "short sword ego:speed | short sword ego:spectral | " ..
              "falchion ego:flaming | falchion ego:freezing | " ..

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1194,7 +1194,7 @@ local kstr = "S = general shop name:" .. name .. " type:Alliterative " ..
              "dagger ego:draining | dagger ego:distortion | " ..
              "short sword ego:speed | short sword ego:spectral | " ..
              "falchion ego:flaming | falchion ego:freezing | " ..
-             "scimitar ego:speed | scimitar ego:spectral |" .. 
+             "scimitar ego:speed | scimitar ego:spectral |" ..
              "w:3 demon blade ego:draining | w:3 demon blade ego:distortion | "..
              "w:2 eudemon blade ego:electrocution |" ..
              "w:3 double sword ego:draining | w:3 double sword ego:distortion | "..


### PR DESCRIPTION
Adds two new shop vaults:
the Mail Order catalogue stocks mail and order. There's not much else to it.

Alliterative Armaments stocks melee weapons with alliterative brands; e.g. flaming falchion or short sword of speed.
This includes the otherwise unobtainable spectral/speed sacred scourge and eudemon blade of electrocution, which I suspect devs will remove.
Weapons are weighted so that equally rare base types are equally rare in-shop, and rarer base types are rarer in-shop.