### PR TITLE
Have Wall Jump's targeter only highlight monsters it could affect.

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1508,15 +1508,21 @@ static bool _wu_jian_trigger_martial_arts(coord_def old_pos,
     return attacked;
 }
 
+// Return a monster at pos which a wall jump could attack, nullptr if none.
+monster *wu_jian_wall_jump_monster_at(const coord_def &pos)
+{
+    monster *target = monster_at(pos);
+    if (target && target->alive() && _can_attack_martial(target))
+        return target;
+    return nullptr;
+}
+
 static vector<monster*> _wu_jian_wall_jump_monsters(const coord_def &pos)
 {
     vector<monster*> targets;
     for (adjacent_iterator ai(pos, true); ai; ++ai)
-    {
-        monster *target = monster_at(*ai);
-        if (target && _can_attack_martial(target) && target->alive())
+        if (monster *target = wu_jian_wall_jump_monster_at(*ai))
             targets.push_back(target);
-    }
     return targets;
 }
 

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -296,6 +296,7 @@ void uskayaw_bonds_audience();
 void wu_jian_heaven_tick();
 void wu_jian_decrement_heavenly_storm();
 void wu_jian_end_heavenly_storm();
+monster *wu_jian_wall_jump_monster_at(const coord_def &pos);
 bool wu_jian_wall_jump_triggers_attacks(const coord_def &pos);
 void wu_jian_wall_jump_effects();
 bool wu_jian_has_momentum(wu_jian_attack_type);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -13,6 +13,7 @@
 #include "env.h"
 #include "fight.h"
 #include "god-abil.h"
+#include "god-passive.h"
 #include "items.h"
 #include "libutil.h"
 #include "los-def.h"
@@ -552,7 +553,8 @@ aff_type targeter_walljump::is_affected(coord_def loc)
     if (loc == wall_jump_landing_spot)
         return AFF_YES;
 
-    if (loc.distance_from(wall_jump_landing_spot) == 1 && monster_at(loc))
+    auto d = loc.distance_from(wall_jump_landing_spot);
+    if (d == 1 && wu_jian_wall_jump_monster_at(loc))
         return AFF_YES;
 
     return AFF_NO;


### PR DESCRIPTION
As things stood, the targeter for Wall Jump included every monster next to the landing location, revealing invisible monsters and making it harder to tell what the ability did. It now only highlights monsters the action would try to attack.