### PR TITLE
Make condenser vane good god approved

### DIFF
--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -800,6 +800,12 @@ static spret _condenser()
         return spret::fail;
     }
 
+    if (is_good_god(you.religion) && cloud == CLOUD_NEGATIVE_ENERGY)
+    {
+        mprf("%s suppresses the foul vapours!", god_name(you.religion).c_str());
+        return spret::fail;
+    }
+
     for (auto p : target_cells)
     {
         const int cloud_power = 5

--- a/crawl-ref/source/god-item.cc
+++ b/crawl-ref/source/god-item.cc
@@ -96,8 +96,6 @@ bool is_potentially_evil_item(const item_def& item, bool calc_unid)
             return true;
         }
         break;
-    case OBJ_MISCELLANY:
-        return item.sub_type == MISC_CONDENSER_VANE;
     default:
         break;
     }


### PR DESCRIPTION
Good gods currently get upset only when condenser vane rolls Negative Energy clouds. The chance of rolling Negative Energy clouds is somewhere in the vicinity of 1/1000 at 0 evocations, rising dramatically as evo skill increases. This creates an odd incentive to not skill evocations.

Squashing negative energy clouds (as opposed to rerolling) was chosen to be the minimum change that resolved the problem, though rerolling instead is also sensible.