### PR TITLE
Fix fear.

### DIFF
--- a/crawl-ref/source/mon-behv.cc
+++ b/crawl-ref/source/mon-behv.cc
@@ -743,7 +743,7 @@ void handle_behaviour(monster* mon)
 
         case BEH_FLEE:
             // Check for healed.
-            if (isHealthy && !isScared)
+            if (!isScared)
                 new_beh = BEH_SEEK;
 
             // Smart monsters flee until they can flee no more...


### PR DESCRIPTION
Monsters would previously snap out of fear even when hit, so long as they were below half health and were not cornered. This fixes that.

Fixes #2421 