### PR TITLE
feat: add tile_min_stat_width_characters option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -117,7 +117,7 @@ The contents of this text are:
                 tile_tag_pref, tile_window_width, tile_window_height,
                 tile_map_pixels, tile_viewport_scale, tile_map_scale,
                 tile_cell_pixels, tile_sidebar_pixels, tile_filter_scaling,
-                tile_force_overlay, tile_overlay_col,
+                tile_force_overlay, tile_overlay_col, min_stat_width_characters,
                 tile_overlay_alpha_percent, tile_full_screen,
                 tile_font_crt_file, tile_font_stat_file, tile_font_msg_file,
                 tile_font_tip_file, tile_font_lbl_file, tile_font_crt_family,
@@ -2263,6 +2263,9 @@ tile_cell_pixels = 32
         The width and height of tiles in the dungeon view at 1.0 scale, in
         (logical) pixels. This is a legacy option, and it is recommended that
         you adjust scaling via tile_viewport_scale instead.
+
+tile_min_stat_width_characters = 42
+        Minimal width of the stats sidebar in characters.
 
 tile_sidebar_pixels = 32
         The width and height of tiles in the local tiles sidebar view,

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -483,6 +483,7 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(SIMPLE_NAME(tile_font_stat_file), MONOSPACED_FONT),
         new StringGameOption(SIMPLE_NAME(tile_font_tip_file), MONOSPACED_FONT),
         new StringGameOption(SIMPLE_NAME(tile_font_lbl_file), PROPORTIONAL_FONT),
+        new IntGameOption(SIMPLE_NAME(tile_min_stat_width_characters), 42, 1, INT_MAX),
         new IntGameOption(SIMPLE_NAME(tile_sidebar_pixels), 32, 1, INT_MAX),
         new MultipleChoiceGameOption<screen_mode>(
             SIMPLE_NAME(tile_full_screen),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -600,6 +600,7 @@ public:
     bool        tile_window_limit_size;
     maybe_bool  tile_use_small_layout;
 #endif
+    int         tile_min_stat_width_characters;
     int         tile_sidebar_pixels;
     int         tile_cell_pixels;
     int         tile_viewport_scale;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -784,9 +784,6 @@ static const int min_inv_height  = 4;
 static const int max_inv_height  = 6;
 static const int max_mon_height  = 3;
 
-// Width of status area in characters.
-static const int stat_width      = 42;
-
 static int round_up_to_multiple(int a, int b)
 {
     int m = a % b;
@@ -866,7 +863,7 @@ void TilesFramework::do_layout()
         m_region_tab->resize_to_fit(m_windowsz.x, m_windowsz.y);
 
         const int sidebar_min_pw = m_region_stat->grid_width_to_pixels(
-                                                                stat_width);
+                                                        Options.tile_min_stat_width_characters);
         sidebar_pw = m_region_tab->grid_width_to_pixels(14) - 10;
         if (sidebar_pw > m_windowsz.x / 3)
             sidebar_pw = m_region_tab->grid_width_to_pixels(7) - 10;


### PR DESCRIPTION
The option allows to change minimal width of the sidebar in characters for regular layout. Previously has been hardcoded to 42.

Extreme example, tile_min_stat_width_characters = 80:
<img width="1401" alt="Screenshot 2023-02-28 at 02 35 52" src="https://user-images.githubusercontent.com/11316827/221731011-793be780-10d2-4a18-a935-37ece6cb2564.png">
