### PR TITLE
fix: a few victory bugs

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1734,7 +1734,8 @@ static void _reset_victory_stats(item_def *item)
 
 static void _VICTORY_unequip(item_def *item, bool */*show_msgs*/)
 {
-    _reset_victory_stats(item);
+    if (!player_equip_unrand(UNRAND_VICTORY, true))
+        _reset_victory_stats(item);
 }
 
 #define VICTORY_STAT_CAP 7
@@ -1779,6 +1780,11 @@ static void _VICTORY_world_reacts(item_def *item)
         _reset_victory_stats(item);
         you.props.erase(VICTORY_CONDUCT_KEY);
     }
+}
+
+static void _VICTORY_equip(item_def *item, bool */*show_msgs*/, bool /*unmeld*/)
+{
+    _VICTORY_world_reacts(item);
 }
 
 ////////////////////////////////////////////////////

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2978,9 +2978,10 @@ bool drink(item_def* potion)
         return false;
     }
 
-    if (player_equip_unrand(UNRAND_VICTORY))
+    if (player_equip_unrand(UNRAND_VICTORY, true)
+        && !you.props.exists(VICTORY_CONDUCT_KEY))
     {
-        item_def *item = you.slot_item(EQ_BODY_ARMOUR);
+        item_def *item = you.slot_item(EQ_BODY_ARMOUR, true);
         string unrand_prompt = make_stringf("Really quaff with monsters nearby "
                                             "while wearing %s?",
                                             item->name(DESC_THE, false, true,
@@ -3037,7 +3038,7 @@ bool drink(item_def* potion)
     }
 
     // Drinking with hostile visible mons nearby resets unrand "Victory" stats.
-    if (player_equip_unrand(UNRAND_VICTORY)
+    if (player_equip_unrand(UNRAND_VICTORY, true)
         && there_are_monsters_nearby(true, true, false))
     {
         you.props[VICTORY_CONDUCT_KEY] = true;
@@ -3771,9 +3772,10 @@ bool read(item_def* scroll, dist *target)
         }
     }
 
-    if (player_equip_unrand(UNRAND_VICTORY))
+    if (player_equip_unrand(UNRAND_VICTORY, true)
+        && !you.props.exists(VICTORY_CONDUCT_KEY))
     {
-        item_def *item = you.slot_item(EQ_BODY_ARMOUR);
+        item_def *item = you.slot_item(EQ_BODY_ARMOUR, true);
         string unrand_prompt = make_stringf("Really read with monsters nearby "
                                             "while wearing %s?",
                                             item->name(DESC_THE, false, true,
@@ -4093,8 +4095,9 @@ bool read(item_def* scroll, dist *target)
     }
 
     // Reading with hostile visible mons nearby resets unrand "Victory" stats.
-    if (player_equip_unrand(UNRAND_VICTORY)
-        && there_are_monsters_nearby(true, true, false))
+    if (player_equip_unrand(UNRAND_VICTORY, true)
+        && there_are_monsters_nearby(true, true, false)
+        && !cancel_scroll)
     {
         you.props[VICTORY_CONDUCT_KEY] = true;
     }


### PR DESCRIPTION
Some assorted Victory bugfixes that I ran into when looking into PF's meld bug; please see the commits for details.

fix: don't reset victory stats on meld
fix: reset victory stats when quaffing lig
fix: don't reset victory for cancelled scrolls
