### PR TITLE
Fix and improve CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: Code Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Checkwhite
         run: util/checkwhite -n
         working-directory: crawl-ref/source
@@ -87,16 +87,14 @@ jobs:
             debug: ""
             tag_upgrade: false
             build_all: BUILD_ALL=1
-    env:
-      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
           submodules: true
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install requirements.txt
@@ -107,10 +105,9 @@ jobs:
       - name: Install dependencies
         run: ./deps.py --compiler ${{ matrix.compiler }} --build-opts "${{ matrix.build_opts }}" --debug-opts "${{ matrix.debug }}"
         working-directory: .github/workflows
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ matrix.build_all }}-${{ github.sha }}
           restore-keys: |
             ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ matrix.build_all }}-
@@ -118,16 +115,10 @@ jobs:
             ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-
             ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-
             ccache-linux-${{ matrix.compiler }}-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - name: Run tag upgrade scripts
         if: matrix.tag_upgrade == true
         run: |
@@ -147,8 +138,6 @@ jobs:
         working-directory: crawl-ref/source
         env:
           TERM: dumb
-      - name: Print ccache stats
-        run: ccache -p -s
 
   build_appimage:
     permissions:
@@ -170,10 +159,8 @@ jobs:
             build_opts: TILES=1 LINUXDEPLOY=/tmp/linuxdeploy-x86_64.AppImage
           - build_type: tiles
             build_opts: LINUXDEPLOY=/tmp/linuxdeploy-x86_64.AppImage
-    env:
-      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
           submodules: false
@@ -181,28 +168,19 @@ jobs:
       - name: Install dependencies
         run: ./deps.py --build-opts "${{ matrix.build_opts }}" --appimage
         working-directory: .github/workflows
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-appimage-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-appimage-${{ matrix.build_type }}-
             ccache-appimage-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - run: make -j$(nproc) ${{ matrix.build_opts }} appimage
         working-directory: crawl-ref/source
-      - name: Print ccache stats
-        run: ccache -p -s
       - name: Add build to release
         uses: svenstaro/upload-release-action@v2
         with:
@@ -224,7 +202,7 @@ jobs:
           - i386
           - amd64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
           submodules: false
@@ -287,13 +265,11 @@ jobs:
             build_opts: ""
           - build_type: console-universal
             build_opts: TILES=y
-    env:
-      CCACHE_DIR: /Users/runner/Library/Caches/ccache
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -307,26 +283,17 @@ jobs:
         run: |
           brew install pkg-config libpng
           sudo pip3 install PyYAML
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-macos-clang-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-macos-clang-${{ matrix.build_type }}-
             ccache-macos-clang-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo $(brew --prefix)/opt/ccache/libexec >> $GITHUB_PATH"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - run: make -j$(sysctl -n hw.ncpu) mac-app-${{ matrix.build_type }} ${{matrix.build_opts }}
         working-directory: crawl-ref/source
-      - name: Print ccache stats
-        run: ccache -p -s
       - name: Add build to release
         if: github.event.release.tag_name != null
         uses: svenstaro/upload-release-action@v2
@@ -348,10 +315,8 @@ jobs:
           - tiles
           - console
           - installer
-    env:
-      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -362,7 +327,7 @@ jobs:
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install requirements.txt
@@ -373,28 +338,19 @@ jobs:
       - name: Install dependencies
         run: ./deps.py --crosscompile
         working-directory: .github/workflows
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-key2-mingw64-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-key2-mingw64-${{ matrix.build_type }}-
             ccache-key2-mingw64-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - run: make -j$(nproc) CROSSHOST=i686-w64-mingw32 package-windows-${{ matrix.build_type }}
         working-directory: crawl-ref/source
-      - name: Print ccache stats
-        run: ccache -p -s
       # The zip & installer targets create different sorts of names, so we need
       # a little shell script magic here.
       - name: Determine release file names
@@ -408,8 +364,8 @@ jobs:
             source='crawl-ref/source/stone_soup-latest-win32-installer.exe'
             dest='dcss-$tag-win32-installer.exe'
           fi
-          echo "::set-output name=source::$source"
-          echo "::set-output name=dest::$dest"
+          echo "name=source::$source" >> $GITHUB_OUTPUT
+          echo "name=dest::$dest" >> $GITHUB_OUTPUT
       - name: Add build to release
         if: github.event.release.tag_name != null
         uses: svenstaro/upload-release-action@v2
@@ -425,15 +381,13 @@ jobs:
 
     name: Catch2 (GCC/Linux) + Codecov
     runs-on: ubuntu-latest
-    env:
-      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install requirements.txt
@@ -444,27 +398,18 @@ jobs:
       - name: Install dependencies
         run: ./deps.py --coverage
         working-directory: .github/workflows
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-catch2-${{ github.sha }}
           restore-keys: |
             ccache-catch2-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - run: make -j$(nproc) catch2-tests
         working-directory: crawl-ref/source
-      - name: Print ccache stats
-        run: ccache -p -s
       - name: Generate LCOV data
         working-directory: crawl-ref/source
         run: >
@@ -475,10 +420,10 @@ jobs:
           --ignore-errors source
           --rc lcov_branch_coverage=1
       - name: Send coverage data to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.info
+          files: ./coverage.info
           flags: catch2
           fail_ci_if_error: false
 
@@ -491,9 +436,9 @@ jobs:
       matrix:
         python-version: [3.6, 3.7, 3.8]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies (py3)
@@ -529,15 +474,13 @@ jobs:
         debug:
           - ""
           - FULLDEBUG=1
-    env:
-      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Install requirements.txt
@@ -548,30 +491,21 @@ jobs:
       - name: Install dependencies
         run: ./deps.py --compiler ${{ matrix.compiler }} --build-opts "${{ matrix.build_opts }}" --debug-opts "${{ matrix.debug }}"
         working-directory: .github/workflows
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-build-headers-${{ matrix.compiler }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ github.sha }}
           restore-keys: |
             ccache-build-headers-${{ matrix.compiler }}-${{ matrix.build_opts }}-${{ matrix.debug }}-
             ccache-build-headers-${{ matrix.compiler }}-${{ matrix.build_opts }}-
             ccache-build-headers-${{ matrix.compiler }}-
             ccache-build-headers-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - run: make -j$(nproc) header-build-tests
         working-directory: crawl-ref/source
-      - name: Print ccache stats
-        run: ccache -p -s
 
   build_android:
     name: Android
@@ -581,10 +515,9 @@ jobs:
         build_opts:
           - ANDROID=1
     env:
-      CCACHE_DIR: /home/runner/.cache/ccache
       NDK_CCACHE: ccache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
           submodules: true
@@ -596,34 +529,24 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.5 # known to work
-      - name: Cache compilation
-        uses: actions/cache@v3
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
         with:
-          path: ${{ env.CCACHE_DIR }}
           key: ccache-android-${{ github.sha }}
           restore-keys: |
             ccache-android-
-      - name: Setup ccache
-        uses: alexjurkiewicz/setup-ccache@master
-        with:
-          extra-config: |
-            compiler_check = content
-      - name: "Setup ccache: place config file"
-        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
+      - name: "Setup ccache: extra configuration"
+        run: "ccache --set-config compiler_check=content"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - name: "Setup ccache: clear stats"
-        run: ccache --zero-stats
       - name: Prepare Android build
         run: make -j$(nproc) ${{ matrix.build_opts }} android
         working-directory: crawl-ref/source
       - name: Build with Gradle
         run: gradle :app:assembleBuildTest
         working-directory: crawl-ref/source/android-project
-      - name: Print ccache stats
-        run: ccache -p -s
 
   notify_irc:
     name: "Notify #crawl-dev of build failure"
@@ -654,7 +577,7 @@ jobs:
           url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           message="${bold}${col}${red}Build failed${col}${bold} for ${col}${yellow}${branch}${col} @ $short_sha ${col}${magenta}${url}"
 
-          echo "::set-output name=message::${message}"
+          echo "name=message::${message}" >> $GITHUB_OUTPUT
       - uses: rectalogic/notify-irc@v1
         with:
           server: irc.libera.chat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
             debug: ""
             tag_upgrade: false
             build_all: BUILD_ALL=1
+    env:
+      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -108,7 +110,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ matrix.build_all }}-${{ github.sha }}
           restore-keys: |
             ccache-linux-${{ matrix.compiler }}-${{ matrix.tag_upgrade }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ matrix.build_all }}-
@@ -118,6 +120,8 @@ jobs:
             ccache-linux-${{ matrix.compiler }}-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
@@ -166,6 +170,8 @@ jobs:
             build_opts: TILES=1 LINUXDEPLOY=/tmp/linuxdeploy-x86_64.AppImage
           - build_type: tiles
             build_opts: LINUXDEPLOY=/tmp/linuxdeploy-x86_64.AppImage
+    env:
+      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -178,13 +184,15 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-appimage-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-appimage-${{ matrix.build_type }}-
-            ccache-appiamge-
+            ccache-appimage-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
@@ -279,6 +287,8 @@ jobs:
             build_opts: ""
           - build_type: console-universal
             build_opts: TILES=y
+    env:
+      CCACHE_DIR: /Users/runner/Library/Caches/ccache
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -300,13 +310,15 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/Library/Caches/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-macos-clang-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-macos-clang-${{ matrix.build_type }}-
             ccache-macos-clang-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo $(brew --prefix)/opt/ccache/libexec >> $GITHUB_PATH"
       - name: "Setup ccache: clear stats"
@@ -336,6 +348,8 @@ jobs:
           - tiles
           - console
           - installer
+    env:
+      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -362,13 +376,15 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-key2-mingw64-${{ matrix.build_type }}-${{ github.sha }}
           restore-keys: |
             ccache-key2-mingw64-${{ matrix.build_type }}-
             ccache-key2-mingw64-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
@@ -409,6 +425,8 @@ jobs:
 
     name: Catch2 (GCC/Linux) + Codecov
     runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -429,12 +447,14 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-catch2-${{ github.sha }}
           restore-keys: |
             ccache-catch2-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
@@ -509,6 +529,8 @@ jobs:
         debug:
           - ""
           - FULLDEBUG=1
+    env:
+      CCACHE_DIR: /home/runner/.cache/ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -529,7 +551,7 @@ jobs:
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-build-headers-${{ matrix.compiler }}-${{ matrix.build_opts }}-${{ matrix.debug }}-${{ github.sha }}
           restore-keys: |
             ccache-build-headers-${{ matrix.compiler }}-${{ matrix.build_opts }}-${{ matrix.debug }}-
@@ -538,6 +560,8 @@ jobs:
             ccache-build-headers-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
@@ -557,9 +581,8 @@ jobs:
         build_opts:
           - ANDROID=1
     env:
-      USE_CCACHE: 1
-      CCACHE_EXEC: /usr/bin/ccache
-      NDK_CCACHE: /usr/bin/ccache
+      CCACHE_DIR: /home/runner/.cache/ccache
+      NDK_CCACHE: ccache
     steps:
       - uses: actions/checkout@v2
         with:
@@ -572,25 +595,31 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.6 # known to work
+          gradle-version: 7.5 # known to work
       - name: Cache compilation
         uses: actions/cache@v3
         with:
-          path: ~/.cache/ccache
+          path: ${{ env.CCACHE_DIR }}
           key: ccache-android-${{ github.sha }}
           restore-keys: |
             ccache-android-
       - name: Setup ccache
         uses: alexjurkiewicz/setup-ccache@master
+        with:
+          extra-config: |
+            compiler_check = content
+      - name: "Setup ccache: place config file"
+        run: "mkdir -p $CCACHE_DIR && mv ~/.ccache.conf $CCACHE_DIR/ccache.conf"
       - name: "Setup ccache: prepend path"
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
       - name: "Setup ccache: clear stats"
         run: ccache --zero-stats
-      - run: make -j$(nproc) ${{ matrix.build_opts }} android
+      - name: Prepare Android build
+        run: make -j$(nproc) ${{ matrix.build_opts }} android
         working-directory: crawl-ref/source
-      - name: Run gradle
+      - name: Build with Gradle
         run: gradle :app:assembleBuildTest
         working-directory: crawl-ref/source/android-project
       - name: Print ccache stats

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1667,7 +1667,7 @@ clean-contrib:
 	+$(MAKE) -C contrib clean
 
 clean-android:
-# 	$(RM) -r $(datadir_fp)
+	$(RM) -r android-project/app/src/main/assets
 	+cd android-project && rm -f local.properties && rm -f app/build.gradle
 
 distclean: clean clean-contrib clean-rltiles

--- a/crawl-ref/source/android-project/build.gradle
+++ b/crawl-ref/source/android-project/build.gradle
@@ -2,10 +2,10 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {


### PR DESCRIPTION
### GENERAL

- Fix Github Actions deprecation warnings. 
  * The current ccache action cannot be updated, it has been replaced with the most starred one. This obsoletes the cache action and the  manual ccache stats management.
  * Update the checkout action to v3.
  * Update the setup-python action to v4.
  * Update the codecov action to v3.
  * Replace the obsolete set-outputs commands with the new GITHUB_OUTPUT environment file.

### ANDROID

- Update the Android Gradle plugin and use a compatible Gradle version.  This improves the build times and fixes the SDK XML related warnings.
- Ccache doesn't get hits on Android because the compiler's mtime  is different in every build. Change the compiler check strategy to  content.
- Proper fix for 093205a. I'm very sorry for that.
- Use the Maven Central repository instead of the deprecated JCenter.

### APPIMAGE
- Fix a typo in the cache config for the AppImage builds.