### PR TITLE
FIX: Make the "browse character notes" screen obey menu_colour.

### DIFF
--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -1693,12 +1693,21 @@ static bool _write_dump(const string &fname, const dump_params &par, bool quiet)
     return succeeded;
 }
 
+static int _add_text(formatted_scroller &scr, const string &tag,
+                     const string &text)
+{
+    int colour = menu_colour(text, "", tag);
+    scr.add_formatted_string(formatted_string(text, colour));
+    return colour;
+}
+
 void display_notes()
 {
     formatted_scroller scr(FS_START_AT_END | FS_PREWRAPPED_TEXT);
     scr.set_more();
-    scr.set_tag("notes");
-    scr.add_raw_text("Turn   | Place    | Note\n");
+    const string tag = "notes";
+    scr.set_tag(tag);
+    _add_text(scr, tag, "Turn   | Place    | Note\n");
     for (const Note &note : note_list)
     {
         if (note.hidden())
@@ -1716,9 +1725,12 @@ void display_notes()
         if (parts.empty()) // Disregard pure-whitespace notes.
             continue;
 
-        scr.add_raw_text(prefix + parts[0] + "\n");
+        auto colour = _add_text(scr, tag, prefix + parts[0] + "\n");
         for (unsigned int j = 1; j < parts.size(); ++j)
-            scr.add_raw_text(string(prefix.length()-2, ' ') + string("| ") + parts[j] + "\n");
+        {
+            auto str = string(prefix.length()-2, ' ') + "| " + parts[j] + "\n";
+            scr.add_formatted_string(formatted_string(str, colour));
+        }
     }
     scr.show();
 }


### PR DESCRIPTION
The ability to highlight notes in different colours in the "browse character notes" display (constrolled with the menu_colour option) was lost with a02aae867c.

This returns it, but with one small change. If a note is too long to display on a single line of the display, the colour is chosen based on the whole note, instead of assessing each line of output separately.

The immediate effect on the user will be that "Reached XP level"
notes change from grey to white. The setting in [menu_colours.txt](https://github.com/crawl/crawl/blob/master/crawl-ref/source/dat/defaults/menu_colours.txt) is
still there.