### PR TITLE
Three fixes for release CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,8 +364,8 @@ jobs:
             source='crawl-ref/source/stone_soup-latest-win32-installer.exe'
             dest='dcss-$tag-win32-installer.exe'
           fi
-          echo "name=source::$source" >> $GITHUB_OUTPUT
-          echo "name=dest::$dest" >> $GITHUB_OUTPUT
+          echo "source=${source}" >> $GITHUB_OUTPUT
+          echo "dest=${dest}" >> $GITHUB_OUTPUT
       - name: Add build to release
         if: github.event.release.tag_name != null
         uses: svenstaro/upload-release-action@v2
@@ -577,7 +577,7 @@ jobs:
           url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           message="${bold}${col}${red}Build failed${col}${bold} for ${col}${yellow}${branch}${col} @ $short_sha ${col}${magenta}${url}"
 
-          echo "name=message::${message}" >> $GITHUB_OUTPUT
+          echo "message=${message}" >> $GITHUB_OUTPUT
       - uses: rectalogic/notify-irc@v1
         with:
           server: irc.libera.chat

--- a/.github/workflows/deps.py
+++ b/.github/workflows/deps.py
@@ -81,6 +81,8 @@ def _packages_to_install(args: argparse.Namespace) -> Set[str]:
     if args.compiler == "clang":
         # dependencies for llvm.sh
         packages.update(["lsb-release", "wget", "software-properties-common"])
+    if args.appimage:
+        packages.add("libfuse2")
     if args.debian_packages:
         packages.update(["cowbuilder", "debhelper"])
     return packages

--- a/crawl-ref/source/debian/control
+++ b/crawl-ref/source/debian/control
@@ -6,7 +6,7 @@ Uploaders: the DCSS Development Team <crawl-ref-discuss@lists.sourceforge.net>
 Standards-Version: 3.9.5
 Build-Depends: debhelper (>= 7), libncursesw5-dev, bison, flex, liblua5.1-0-dev,
 	pkg-config, libsdl2-image-dev, libsdl2-dev, libsqlite3-dev,
-	libfreetype6-dev, advancecomp, libpng-dev, python3-yaml
+	libfreetype6-dev, advancecomp, libpng-dev, python3-yaml, fonts-dejavu-core
 Homepage: http://crawl.develz.org/
 
 Package: crawl-common

--- a/crawl-ref/source/debian/rules
+++ b/crawl-ref/source/debian/rules
@@ -60,8 +60,8 @@ endif
 # The makefile is unorthodox, requiring all options to be specified on every invocation.
 ARGS_CONSOLE = prefix=/usr CFOPTIMIZE="$(CFOPTIMIZE)" STRIP=: $(CROSS) $(VERBOSE)
 ARGS_TILES   = $(ARGS_CONSOLE) TILES=y GAME=crawl-tiles \
-	PROPORTIONAL_FONT=/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf \
-	MONOSPACED_FONT=/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf
+	PROPORTIONAL_FONT=$(shell fc-match -f "${file}" dejavusans) \
+	MONOSPACED_FONT=$(shell fc-match -f "${file}" dejavusansmono)
 
 build-arch build-indep: build-stamp
 build-stamp: tree-stamp


### PR DESCRIPTION
1. I made a fix for an old issue: #1344.  The implementation is very similar to the one used in the Fedora packages. While testing, I found two errors in release workflows.

2. AppImage builds can't run linuxdeploy because FUSE 2 is not available by default. The GitHub runners must have changed, they're probably using FUSE 3 now. The solution is easy because v2 is still in the repos and can be installed alongside v3.

3. The migration from the obsolete set-output commands in 94e0f26 was incorrect. My fault, sorry :disappointed:

Closes #1344