### PR TITLE
FIX: Put both DescMenu classes in unnamed namespaces.

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -542,23 +542,26 @@ public:
     }
 };
 
-// XX this probably shouldn't use InvMenu, why does it?
-class DescMenu : public InvMenu
+namespace
 {
-public:
-    DescMenu()
-        : InvMenu(MF_SINGLESELECT | MF_ANYPRINTABLE
-                        | MF_ALLOW_FORMATTING | MF_SELECT_BY_PAGE
-                        | MF_INIT_HOVER)
-    { }
-
-    // TODO: move more stuff into this class
-    bool skip_process_command(int) override
+    // XX this probably shouldn't use InvMenu, why does it?
+    class DescMenu : public InvMenu
     {
-        // override InvMenu behavior
-        return false;
-    }
-};
+    public:
+        DescMenu()
+            : InvMenu(MF_SINGLESELECT | MF_ANYPRINTABLE
+                            | MF_ALLOW_FORMATTING | MF_SELECT_BY_PAGE
+                            | MF_INIT_HOVER)
+        { }
+
+        // TODO: move more stuff into this class
+        bool skip_process_command(int) override
+        {
+            // override InvMenu behavior
+            return false;
+        }
+    };
+}
 
 static coord_def _full_describe_menu(vector<monster_info> const &list_mons,
                                      vector<item_def *> const &list_items,

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -236,67 +236,70 @@ static bool _compare_mon_toughness(MenuEntry *entry_a, MenuEntry* entry_b)
     return a_toughness > b_toughness;
 }
 
-class DescMenu : public Menu
+namespace
 {
-public:
-    DescMenu(int _flags, bool _toggleable_sort) : Menu(_flags, ""), sort_alpha(true),
-    toggleable_sort(_toggleable_sort)
+    class DescMenu : public Menu
     {
-        set_highlighter(nullptr);
-
-        if (_toggleable_sort)
-            toggle_sorting();
-
-        set_prompt();
-    }
-
-    bool sort_alpha;
-    bool toggleable_sort;
-
-    void set_prompt()
-    {
-        string prompt = "Describe which? ";
-
-        if (toggleable_sort)
+    public:
+        DescMenu(int _flags, bool _toggleable_sort) : Menu(_flags, ""),
+            sort_alpha(true), toggleable_sort(_toggleable_sort)
         {
+            set_highlighter(nullptr);
+
+            if (_toggleable_sort)
+                toggle_sorting();
+
+            set_prompt();
+        }
+
+        bool sort_alpha;
+        bool toggleable_sort;
+
+        void set_prompt()
+        {
+            string prompt = "Describe which? ";
+
+            if (toggleable_sort)
+            {
+                if (sort_alpha)
+                    prompt += "(CTRL-S to sort by monster toughness)";
+                else
+                    prompt += "(CTRL-S to sort by name)";
+            }
+            set_title(new MenuEntry(prompt, MEL_TITLE));
+        }
+
+        void sort()
+        {
+            if (!toggleable_sort)
+                return;
+
             if (sort_alpha)
-                prompt += "(CTRL-S to sort by monster toughness)";
+                ::sort(items.begin(), items.end(), _compare_mon_names);
             else
-                prompt += "(CTRL-S to sort by name)";
+                ::sort(items.begin(), items.end(), _compare_mon_toughness);
+
+            for (unsigned int i = 0, size = items.size(); i < size; i++)
+            {
+                const char letter = index_to_letter(i % 52);
+
+                items[i]->hotkeys.clear();
+                items[i]->add_hotkey(letter);
+            }
         }
-        set_title(new MenuEntry(prompt, MEL_TITLE));
-    }
 
-    void sort()
-    {
-        if (!toggleable_sort)
-            return;
-
-        if (sort_alpha)
-            ::sort(items.begin(), items.end(), _compare_mon_names);
-        else
-            ::sort(items.begin(), items.end(), _compare_mon_toughness);
-
-        for (unsigned int i = 0, size = items.size(); i < size; i++)
+        void toggle_sorting()
         {
-            const char letter = index_to_letter(i % 52);
+            if (!toggleable_sort)
+                return;
 
-            items[i]->hotkeys.clear();
-            items[i]->add_hotkey(letter);
+            sort_alpha = !sort_alpha;
+
+            sort();
+            set_prompt();
         }
-    }
-
-    void toggle_sorting()
-    {
-        if (!toggleable_sort)
-            return;
-
-        sort_alpha = !sort_alpha;
-
-        sort();
-        set_prompt();
-    }
-};
+    };
+}
 
 static vector<string> _get_desc_keys(string regex, db_find_filter filter)
 {
@@ -888,10 +891,6 @@ void LookupType::display_keys(vector<string> &key_list) const
         describe(key);
         return true;
     };
-
-    // for some reason DescMenu is an InvMenu, so we need to do something to
-    // prevent examine crashes. Just alias it to regular selection.
-    desc_menu.on_examine = desc_menu.on_single_selection;
 
     while (true)
     {


### PR DESCRIPTION
This resolves any confusion between them, and fixes #2824.

This is apparently what you do if you only want a class to be used in its own .cc file.

I also deleted some code which a comment said was to do with DescMenu being an InvMenu. It shouldn't be needed as that DescMenu isn't an InvMenu.