### PR TITLE
Improved resilience when terminal size changes

### DIFF
--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -837,6 +837,9 @@ namespace arena
                 mprf("---- Turn #%d ----", turns);
 #endif
 
+                if (crawl_state.terminal_resized)
+                    show_fight_banner();
+
                 // Check the consistency of our book-keeping every 100 turns.
                 if ((turns++ % 100) == 0)
                     count_foes();
@@ -1019,8 +1022,6 @@ namespace arena
             virtual void _render() override {};
             virtual void _allocate_region() override {
                 // XX sometimes this gets called spuriously?
-                show_fight_banner();
-                viewwindow();
                 update_screen();
                 display_message_window();
             };

--- a/crawl-ref/source/libunix.cc
+++ b/crawl-ref/source/libunix.cc
@@ -885,8 +885,6 @@ void console_startup()
     refresh();
     crawl_view.init_geometry();
 
-    set_mouse_enabled(false);
-
     // TODO: how does this relate to what tiles.resize does?
     ui::resize(crawl_view.termsz.x, crawl_view.termsz.y);
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1076,7 +1076,6 @@ static void _input()
                                       "repetition.");
         crawl_state.prev_cmd = CMD_NO_CMD;
         flush_prev_message();
-        getchm();
         return;
     }
 

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1908,8 +1908,6 @@ int update_monster_pane()
             textbackground(BLACK);
         }
 
-        assert_valid_cursor_pos();
-
         if (mons.empty())
             return -1;
 

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1573,6 +1573,8 @@ void print_stats_level()
 void draw_border()
 {
     textcolour(HUD_CAPTION_COLOUR);
+
+    CGOTOXY(1,1, GOTO_CRT);
     clrscr();
 
     textcolour(Options.status_caption_colour);
@@ -1609,8 +1611,8 @@ void draw_border()
 #ifndef USE_TILE_LOCAL
 void smallterm_warning()
 {
-    clrscr();
     CGOTOXY(1,1, GOTO_CRT);
+    clrscr();
     CPRINTF("Your terminal window is too small; please resize to at least %d,%d", MIN_COLS, MIN_LINES);
 }
 #endif

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -2553,13 +2553,9 @@ void UIRoot::resize(int w, int h)
     m_h = h;
     m_needs_layout = true;
 
-    // On console with the window size smaller than the minimum layout,
-    // enlarging the window will not cause any size reallocations, and the
-    // newly visible region of the terminal will not be filled.
-    // Fix: explicitly mark the entire screen as dirty on resize: it won't
-    // be strictly necessary for most resizes, but won't hurt.
 #ifndef USE_TILE_LOCAL
-    expose_region({0, 0, w, h});
+    cgotoxy(1, 1, GOTO_CRT);
+    clrscr();
 #endif
 }
 

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -2601,6 +2601,14 @@ bool should_render_current_regions = true;
 
 void UIRoot::render()
 {
+#ifndef USE_TILE_LOCAL
+    if (crawl_state.smallterm)
+    {
+        smallterm_warning();
+        return;
+    }
+#endif
+
     if (!needs_paint || in_headless_mode())
         return;
 

--- a/crawl-ref/source/viewgeom.cc
+++ b/crawl-ref/source/viewgeom.cc
@@ -389,41 +389,13 @@ void crawl_view_geometry::init_geometry()
 #ifndef USE_TILE_LOCAL
     const bool smallterm = termsz.x < MIN_COLS || termsz.y < MIN_LINES;
     crawl_state.smallterm = smallterm;
-    if (crawl_state.need_save)
-    {
-        // if the game has already started, just fake the terminal size.
-        // this can cause weird glitches, would be more elegant to actually
-        // crop this. (But is it worth it?) crawl_state.smallterm should mostly
-        // prevent drawing if this comes into play.
-        termsz.x = max(termsz.x, MIN_COLS);
-        termsz.y = max(termsz.y, MIN_LINES);
-    }
+    termsz.x = max(termsz.x, MIN_COLS);
+    termsz.y = max(termsz.y, MIN_LINES);
 #endif
     hudsz  = coord_def(HUD_WIDTH, HUD_HEIGHT);
 
     const _inline_layout lay_inline(termsz, hudsz);
     const _mlist_col_layout lay_mlist(termsz, hudsz);
-
-#ifndef USE_TILE_LOCAL
-    if (!crawl_state.need_save)
-    {
-        if (smallterm)
-        {
-            end(1, false, "Terminal too small (%d,%d); need at least (%d,%d)",
-                termsz.x, termsz.y, MIN_COLS, MIN_LINES);
-        }
-        else if (!lay_inline.valid)
-        {
-            const int x_left = lay_inline.leftover_x();
-            const int y_left = lay_inline.leftover_y();
-
-            end(1, false, "Terminal too small (%d,%d); layout needs (%d,%d)",
-                termsz.x, termsz.y,
-                x_left < 0 ? termsz.x - x_left : MIN_COLS,
-                y_left < 0 ? termsz.y - y_left : MIN_LINES);
-        }
-    }
-#endif
 
     const _layout* winner = &lay_inline;
     if (Options.mlist_allow_alternate_layout


### PR DESCRIPTION
Changes in the terminal size are very likely to make Crawl crash or misbehave. This small set of patches attempts to improve this situation.

Closes #1497
Closes #3045
Closes #2311