### PR TITLE
Add a diverse assortment of Vaults vaults

### DIFF
--- a/crawl-ref/source/dat/des/branches/vaults_rooms_empty.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_empty.des
@@ -1610,3 +1610,651 @@ x..           ..x
 .....x.....x.....
  ...xxx...xxx...
 ENDMAP
+
+NAME:    nicolae_vaults_apartment_1
+TAGS:    vaults_empty allow_dup
+SHUFFLE: pqrs
+SUBST:   p : pP., q : qQ., r : rR, s : sS
+NSUBST:  p = +. / x, q = +. / x, r = +. / x, s = +. / x, \
+         P = x / ., Q = x / ., R = x / ., S = x / .
+MAP
+...p...
+.(.p.(.
+...p...
+rrrxqqq
+...s...
+.(.s.(.
+...s...
+ENDMAP
+
+NAME:    nicolae_vaults_apartment_2
+TAGS:    vaults_empty allow_dup
+SHUFFLE: pqr
+SUBST:   p : pP., q : qQ., r : rR
+NSUBST:  p = +. / x, q = +. / x, r = +. / x, P = x / ., Q = x / ., R = x / .
+MAP
+    ...
+    .(.
+    ...
+    qqq
+...p...r...
+.(.p.(.r.(.
+...p...r...
+ENDMAP
+
+NAME:  nicolae_vaults_cochlea
+TAGS:  vaults_empty allow_dup
+SUBST: x = +:1 x:14, - = x
+MAP
+-.........
+-..-xxx-..
+-.-.....-.
+-.x..-..x.
+-.x.(.-.x.
+-.-...-.x.
+-..-x-..x.
+-.......-.
+.-xxxxx-..
+..........
+ENDMAP
+
+NAME: nicolae_vaults_diamond_1
+TAGS: vaults_empty allow_dup
+MAP
+  .
+ ...
+..(..
+ ...
+  .
+ENDMAP
+
+NAME: nicolae_vaults_diamond_2
+TAGS: vaults_empty allow_dup
+MAP
+    ..
+  ......
+...(..(...
+  ......
+    ..
+ENDMAP
+
+NAME: nicolae_vaults_double_plus_1
+TAGS: vaults_empty allow_dup
+MAP
+ . .
+.....
+ . .
+ENDMAP
+
+NAME: nicolae_vaults_double_plus_2
+TAGS: vaults_empty allow_dup
+MAP
+  ..  ..
+  ..  ..
+..(...(...
+...(...(..
+  ..  ..
+  ..  ..
+ENDMAP
+
+NAME: nicolae_vaults_double_plus_3
+TAGS: vaults_empty allow_dup
+MAP
+   ...   ...
+   .(.   .(.
+   ...   ...
+...............
+.(..(..(..(..(.
+...............
+   ...   ...
+   .(.   .(.
+   ...   ...
+ENDMAP
+
+NAME: nicolae_vaults_hexular_roomagon
+TAGS: vaults_empty allow_dup
+MAP
+    ...
+   x.(.x
+...+...+...
+.(.xx+xx.(.
+...+...+...
+x+xx.(.xx+x
+...+...+...
+.(.xx+xx.(.
+...+...+...
+   x.(.x
+    ...
+ENDMAP
+
+NAME: nicolae_vaults_house_1
+TAGS: vaults_empty allow_dup
+MAP
+  .
+ ...
+..(..
+.....
+ENDMAP
+
+NAME: nicolae_vaults_house_2
+TAGS: vaults_empty allow_dup
+MAP
+   .
+  ...
+ ..(..
+.......
+.(...(.
+.......
+ENDMAP
+
+NAME: nicolae_vaults_house_3
+TAGS: vaults_empty allow_dup
+MAP
+    .
+   ...
+  ..(..
+ .......
+.........
+....(....
+.(.....(.
+.........
+ENDMAP
+
+NAME:   nicolae_vaults_layer_cake_slice
+TAGS:   vaults_empty allow_dup
+NSUBST: D = + / x, E = + / x
+MAP
+.
+..
+x..
+xx..
+.xD..
+..DD..
+x..DD..
+xE..DD..
+.EE..xx..
+..xx..xx..
+ENDMAP
+
+NAME: nicolae_vaults_lightning_bolt
+TAGS: vaults_empty
+MAP
+            .
+           ...
+          ..(..
+..       .......
+ ...    .... ....
+  .... ....    ...
+   .......       ..
+    ..(..
+     ...
+      .
+ENDMAP
+
+NAME:  nicolae_vaults_octothorpe
+TAGS:  vaults_empty allow_dup
+MAP
+  ..  ..
+  ..  ..
+..(....(..
+...(..(...
+  ..  ..
+  ..  ..
+...(..(...
+..(....(..
+  ..  ..
+  ..  ..
+ENDMAP
+
+NAME: nicolae_vaults_offset_grid_hallway_1
+TAGS: vaults_empty allow_dup
+MAP
+  ..
+  ....
+ ..x....
+ ....x....
+..x....x....
+....x....x....
+  ....x....x..
+    ....x....
+      ....x..
+        ....
+          ..
+ENDMAP
+
+NAME: nicolae_vaults_offset_grid_hallway_2
+TAGS: vaults_empty allow_dup
+MAP
+                 ..
+              ..x..
+           ..x....
+        ..x....x..
+     ..x....x....
+  ..x....x....x..
+  ....x....x..
+ ..x....x..
+ ....x..
+..x..
+..
+ENDMAP
+
+NAME: nicolae_vaults_offset_grid_hallway_3
+TAGS: vaults_empty allow_dup
+MAP
+      ..
+   ..x....
+..x....x....
+....x....x....
+  ....x....x....
+    ....x....x....
+      ....x....x..
+        ....x..
+          ..
+ENDMAP
+
+NAME: nicolae_vaults_offset_grid_hallway_4
+TAGS: vaults_empty allow_dup
+MAP
+..
+....
+ x....
+ ..x....
+ ....x....
+  x....x....
+  ..x....x..
+  ....x....x
+    ....x....
+      ....x..
+        ....x
+          ....
+            ..
+ENDMAP
+
+NAME:  nicolae_vaults_oval_intersection
+TAGS:  vaults_empty allow_dup
+SUBST: D : .x, E : .x, F : .x
+MAP
+    ...
+   .....
+   ..(..
+ ..D...D..
+....E.E....
+..(..F..(..
+....E.E....
+ ..D...D..
+   ..(..
+   .....
+    ...
+ENDMAP
+
+NAME: nicolae_vaults_prndl
+TAGS: vaults_empty allow_dup
+MAP
+..  ..  ..
+..  ..  ..
+..  ..  ..
+..  ..  ..
+.(......(.
+...(..(...
+  ..  ..
+  ..  ..
+  ..  ..
+  ..  ..
+ENDMAP
+
+# Gotta keep 'em somewhere.
+NAME:   nicolae_vaults_storage_room_doors
+TAGS:   vaults_empty no_windows
+WEIGHT: 5
+SUBST: + = .+++
+:lua_marker('+', props_marker { connected_exclude="true" })
+MAP
++++...+++
++++...+++
++++++++++
+..+++++..
+..+++++..
+..+++++..
++++++++++
++++...+++
++++...+++
+ENDMAP
+
+# Gotta keep it somewhere.
+NAME:   nicolae_vaults_storage_room_glass
+TAGS:   vaults_empty vaults_orient_s no_windows
+WEIGHT: 5
+SUBST:  ' = n...
+MAP
+nnn''nnn
+nn'.''nn
+n''..'nn
+''...''n
+'.....'n
+''....''
+n''....'
+nn''....
+ENDMAP
+
+# Gotta keep 'em somewhere.
+NAME:   nicolae_vaults_storage_room_statues
+TAGS:   vaults_empty no_windows
+WEIGHT: 5
+SUBST:  ` = G....
+MAP
+`GGGGGG`
+.`GGG``.
+`.`G`...
+..`....`
+`..`.`G`
+``..`GGG
+GG`..`GG
+GG``...`
+ENDMAP
+
+# Gotta keep it somewhere. Unless the vat leaks.
+NAME:   nicolae_vaults_storage_room_water
+TAGS:   vaults_empty
+WEIGHT: 5
+: if crawl.one_chance_in( 5 ) then
+SUBST:  Nsw = W, q = W..
+: else
+SUBST:  qs = ., N = n
+: end
+KMASK:  w = opaque
+KPROP:  w = no_tele_into
+MAP
+...qqssqq
+..qssssss
+.qxxNxxsq
+..xwwwxqq
+..nwwwnq.
+..xwwwx.q
+..xxnxx..
+.........
+.........
+ENDMAP
+
+NAME:  nicolae_vaults_swerve
+TAGS:  vaults_empty vaults_orient_e vaults_orient_w
+MAP
+     ..
+    ....
+    ....
+   ......
+.....xx..      ...
+....xxxx..    ....
+.(..x..x..    ..(.
+...x....x..  .....
+xxxx....x......xxx
+xxx......x....xxxx
+.....  ..x....x...
+.(..    ..x..x..(.
+....    ..xxxx....
+...      ..xx.....
+         ......
+          ....
+          ....
+           ..
+ENDMAP
+
+NAME: nicolae_vaults_tangram_1
+TAGS: vaults_empty allow_dup
+MAP
+...
+.(.
+...
+  .
+  ..
+  ...
+  .(..
+  ........
+       .(.
+       ...
+ENDMAP
+
+NAME: nicolae_vaults_tangram_2
+TAGS: vaults_empty allow_dup
+MAP
+         ..
+        ....
+        ....
+         ..
+     .....
+    ..(..
+   ..(..
+  .....
+ ..
+....
+....
+ ..
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_L_1
+TAGS: vaults_empty allow_dup
+MAP
+......
+......
+..
+..
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_L_2
+TAGS: vaults_empty allow_dup
+MAP
+.........
+.(..(..(.
+.........
+...
+.(.
+...
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_T_1
+TAGS: vaults_empty allow_dup
+MAP
+......
+......
+  ..
+  ..
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_T_2
+TAGS: vaults_empty allow_dup
+MAP
+.........
+.(..(..(.
+.........
+   ...
+   .(.
+   ...
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_Z_1
+TAGS: vaults_empty allow_dup
+MAP
+....
+....
+  ....
+  ....
+ENDMAP
+
+NAME: nicolae_vaults_tetromino_Z_2
+TAGS: vaults_empty allow_dup
+MAP
+......
+.(..(.
+......
+   ......
+   .(..(.
+   ......
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_1
+TAGS: vaults_empty allow_dup
+MAP
+  .....
+  ..(..
+ .......
+ .......
+..(.(.(..
+.........
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_2
+TAGS: vaults_empty allow_dup
+MAP
+   ...
+  ..(..
+  .....
+ ...(...
+ .(...(.
+.........
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_3
+TAGS: vaults_empty allow_dup
+MAP
+   ....
+   ....
+  ......
+  .(..(.
+ ........
+ ........
+..(....(..
+..........
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_4
+TAGS: vaults_empty allow_dup
+MAP
+  .....
+  .(.(.
+  .....
+ .......
+ .(.(.(.
+ .......
+.........
+.(.(.(.(.
+.........
+ENDMAP
+
+NAME:   nicolae_vaults_trapezoid_layered
+TAGS:   vaults_empty allow_dup
+NSUBST: x = + / +x / x
+MAP
+   .......
+   ...(...
+  .........
+  ..xx+xx..
+ ...+...+...
+ ..xx...xx..
+...+..(..+...
+...x.....x...
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_lopsided_1
+TAGS: vaults_empty allow_dup
+MAP
+  ....
+  ....
+ ..(..
+ ....
+..(..
+.....
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_lopsided_2
+TAGS: vaults_empty allow_dup
+MAP
+     .......
+     ....(..
+    ..(.....
+    .......
+   ..(..(..
+   ........
+  ..(.....
+  .....(..
+ ..(......
+ ........
+..(...(..
+.........
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_lopsided_3
+TAGS: vaults_empty allow_dup
+MAP
+  ...
+  ...
+ ....
+ ..(..
+......
+......
+ENDMAP
+
+NAME: nicolae_vaults_trapezoid_lopsided_4
+TAGS: vaults_empty allow_dup
+MAP
+     ....
+     ....
+    ..(..
+    ......
+   ..(.(..
+   .......
+  ..(......
+  ......(..
+ ..(.......
+ ...........
+..(......(..
+............
+ENDMAP
+
+NAME: nicolae_vaults_two_Ls
+TAGS: vaults_empty allow_dup
+MAP
+.. ......
+.. ......
+..  +  ..
+..  +  ..
+...... ..
+...... ..
+ENDMAP
+
+NAME: nicolae_vaults_variable_pillar_hall
+TAGS: vaults_empty allow_dup
+{{
+local i = crawl.random2(5) + 2
+for j = 1, i, 1 do
+   map("......")
+   map(".x..x.")
+end
+map("......")
+}}
+
+NAME:   nicolae_vaults_variable_pillar_hall_cross
+TAGS:   vaults_empty allow_dup luniq
+# Reduced weight, since it can get somewhat large and doesn't place stairs
+WEIGHT: 3
+{{
+local n = crawl.random2(4)
+local e = crawl.random2(4)
+local s = crawl.random2(4)
+local w = crawl.random2(4)
+local wspace = string.rep("  ", w)
+local wpillr = string.rep(".x", w)
+local wfloor = string.rep("..", w)
+local epillr = string.rep("x.", e)
+local efloor = string.rep("..", e)
+local pillr = wpillr .. ".x..x." .. epillr
+local floor = wfloor .. "......" .. efloor
+for j = 0, n, 1 do
+   map(wspace .. "......")
+   map(wspace .. ".x..x.")
+end
+map(floor); map(pillr); map(floor)
+map(floor); map(pillr); map(floor)
+for j = 0, s, 1 do
+   map(wspace .. ".x..x.")
+   map(wspace .. "......")
+end
+}}

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
@@ -1322,3 +1322,716 @@ vv.cc|...|cc.vv
    vvv999vvv
      vv.vv
 ENDMAP
+
+NAME:  nicolae_vaults_antechamber_and_loot_room
+TAGS:  vaults_hard vaults_orient_s vaults_orient_n vaults_orient_e
+KITEM: 8 = |
+KMONS: 8 = 8 band
+SUBST: 0 = .00009, % = ..%%%**
+MAP
+xxxx0...0
+%%%x.....
+%8.+..9..
+%%%x.....
+xxxx0...0
+ENDMAP
+
+NAME:   nicolae_vaults_corpse_flower
+TAGS:   vaults_hard
+KMONS:  0 = 0 band
+KMONS:  9 = 9 band
+KMONS:  8 = 8 band
+SUBST:  0 = 0009, 9 = 9998, * = ***|
+NSUBST: D = + / x, E = + / x, F = + / x, H = + / x
+MAP
+          ...
+         ..(..
+         .....
+        .......
+        ...0...
+        .......
+        .......
+         xDDDx
+   .... xx...xx ....
+ ......xx*...*xx......
+.......H.......E.......
+.(..0..H...9...E..0..(.
+.......H.......E.......
+ ......xx*...*xx......
+   .... xx...xx ....
+         xFFFx
+        .......
+        .......
+        ...0...
+        .......
+         .....
+         ..(..
+          ...
+ENDMAP
+
+NAME:   nicolae_vaults_corridor_and_loot_room
+TAGS:   vaults_hard vaults_orient_e
+KITEM:  8 = |
+KMONS:  0 = 0 / 0 band w:5
+KMONS:  8 = 8 band
+NSUBST: D = + / n
+SUBST:  0 = .0, % = ..%%%**
+MAP
+.......x%%%x
+.0...9.+.8%x
+.......x%%%x
+...xxxxxnnnx
+...x...x....
+.0.x.0.+.0..
+...x...x....
+...xxDxxx+xx
+.......x...x
+.0...0.D.0.x
+.......x...x
+ENDMAP
+
+NAME:   nicolae_vaults_crenellated_ambush
+TAGS:   vaults_hard
+NSUBST: ' = 4=0 / 4=.0 / ..%
+SUBST:  0 = 0000998
+MAP
+x'x'x'x
+'.....'
+x.....x
+'..(..'
+x.....x
+'.....'
+x'x'x'x
+ENDMAP
+
+NAME:  nicolae_vaults_diffraction_hallways
+TAGS:  vaults_hard
+SUBST: 0 = .009, 9 = .998, * = .**|
+MAP
+..........
+x.xxxxxx.x
+x...00...x
+x.x.xx.x.x
+x.x9**9x.x
+x.x9**9x.x
+x.x.xx.x.x
+x...00...x
+x.xxxxxx.x
+..........
+ENDMAP
+
+NAME:    nicolae_vaults_disappearing_quadrants
+TAGS:    vaults_hard
+SHUFFLE: FMNS, DEH, JKL, OPQ, RZ-
+SUBST:   FJORD = ., MEKPZ = x, N : xx., S : xx., H : xx., L : xx., Q : xx., \
+         - : xx., 0 = .0, 9 = ...9, 0 = 0009, 9 = 9998, * = ***|
+MAP
+......................
+.(..DDEE......JJKK..(.
+..DDD..EEE..JJJ..KKK..
+..D......E..J......K..
+.DD.0..0.EEJJ.0..0.KK.
+.D...xx...EJ...xx...K.
+.H...xx...FM...xx...L.
+.HH.0..0.FFMM.0..0.LL.
+..H......F..M......L..
+..HHH..FFF99MMM..LLL..
+....HHFF.9**9.MMLL....
+....RRSS.9**9.NNOO....
+..RRR..SSS99NNN..OOO..
+..R......S..N......O..
+.RR.0..0.SSNN.0..0.OO.
+.R...xx...SN...xx...O.
+.-...xx...ZQ...xx...P.
+.--.0..0.ZZQQ.0..0.PP.
+..-......Z..Q......P..
+..---..ZZZ..QQQ..PPP..
+.(..--ZZ......QQPP..(.
+......................
+ENDMAP
+
+NAME:  nicolae_vaults_enemy_cabinets
+TAGS:  vaults_hard vaults_orient_s
+KITEM: 0 = %
+KITEM: 9 = *
+KITEM: 8 = |
+KMONS: 0 = 0
+KMONS: 9 = 9
+KMONS: 8 = 8
+SUBST: 0 = 099988
+MAP
+0x0x0x0
+.......
+..x.x..
+.......
+x..x..x
+x.....x
+x.....x
+ENDMAP
+
+NAME:  nicolae_vaults_library_corner
+TAGS:  vaults_hard vaults_orient_e vaults_orient_s
+# The deep elf librarian is doing some reshelving. There might be a second
+# (or even third) librarian hanging out in the reading nooks. And of course,
+# some ironbound vault security.
+KITEM: L = any manual, any book good_item / any scroll good_item / nothing, \
+           any book / any scroll / nothing
+KITEM: RN = any book good_item / any scroll good_item
+KMONS: LN = deep elf annihilator / deep elf sorcerer / deep elf high priest / \
+           deep elf death mage / deep elf demonologist
+KMONS: R = wizard / necromancer / lich / ogre mage / deep troll earth mage
+KMONS: S = vault sentinel / vault warden / ironbound preserver / \
+           ironbound convoker
+SUBST: R = R:80 N, S = SSS.
+TILE:  c = wall_studio
+MAP
+cRcRcRc
+R.....c
+c.....c
+R..LcS.
+c..cn..
+R..S...
+ccc....
+ENDMAP
+
+NAME: nicolae_vaults_little_guard_posts
+TAGS: vaults_hard
+MAP
+..xxxx
+..+.9x
+x++..x
+x..++x
+x9.+..
+xxxx..
+ENDMAP
+
+NAME:   nicolae_vaults_loss_of_containment
+TAGS:   vaults_hard
+KMONS:  S = glowing shapeshifter
+NSUBST: ' = . / xxx., S = 3=S / S..
+SUBST:  - = x.
+MAP
+...........
+.---.S.---.
+.-S..-..S-.
+.-.'''''.-.
+...'...'...
+.S-'.S.'-S.
+...'...'...
+.-.'''''.-.
+.-S..-..S-.
+.---.S.---.
+...........
+ENDMAP
+
+NAME:  nicolae_vaults_murder_corner
+TAGS:  vaults_hard vaults_orient_s vaults_orient_w
+KITEM: 9 = *
+KITEM: 8 = |
+KMONS: 9 = 9
+KMONS: 8 = 8
+MAP
+x9.x.8
+x.....
+xx.0.x
+......
+...x.9
+...xxx
+ENDMAP
+
+NAME:   nicolae_vaults_museum
+TAGS:   vaults_hard
+WEIGHT: 3
+KITEM:  M = any weapon randart / any armour randart / any jewellery randart / \
+            any magical staff randart / any randbook
+KMONS:  R = vault warden band
+KMONS:  S = vault sentinel
+KMONS:  s = vault guard w:40 / ironbound preserver / ironbound convoker
+KFEAT:  M = alarm trap
+KMASK:  M = no_monster_gen
+KMASK:  M = opaque
+KPROP:  M = no_tele_into
+NSUBST: ! = R / S / s0..., D = m / n
+SUBST:  0 = 009, 9 = 998
+MAP
+.............
+.!....!....!.
+..nnn...nnn..
+..nMn.0.nMn..
+..nnm...mnn..
+.....DDD.....
+.!.0.DMD.0.!.
+.....DDD.....
+..nnm...mnn..
+..nMn.0.nMn..
+..nnn...nnn..
+.!....!....!.
+.............
+ENDMAP
+
+NAME:  nicolae_vaults_mush_room
+TAGS:  vaults_hard vaults_orient_s
+KMONS: 8 = 8 band
+KMONS: 9 = 9 band
+SUBST: * = **|, 0 = ...0000
+MAP
+    0...0
+  .........
+ ...........
+..0...9...0..
+.............
+.............
++xx.0...0.xx+
+..xx.....xx..
+...xx...xx...
+....x.0.x....
+.8..x...x..8.
+x***x...x***x
+xxxxx...xxxxx
+ENDMAP
+
+
+NAME:    nicolae_vaults_off_center_swirl
+TAGS:    vaults_hard
+SHUFFLE: PQRS/pqrs
+NSUBST:  PD = + / x, QE = + / x, RF = + / x, SH = + / x, 0 = 9 / 0.
+SUBST:   pqrs = .
+MAP
+    .P...
+  ..0P.0.q0
+ ppppDp%QEQQ
+ ....Pxxxq..
+....0%xxx%0..
+.....sxxxR...
+SSSSSHS%rFrrr
+....0s.0.R0..
+.....s...R...
+ ....s...R..
+ ....s...R..
+  ...s...R.
+    .s...
+ENDMAP
+
+NAME:    nicolae_vaults_oozy_zoo
+TAGS:    vaults_hard
+KITEM:   O = * / | w:3
+KMONS:   O = slime creature w:40 / glowing orange brain / great orb of eyes / \
+             large slime creature / very large slime creature w:5 / \
+             quicksilver ooze w:5
+KMASK:   O = no_trap_gen
+KPROP:   O = no_tele_into
+SHUFFLE: xn
+NSUBST:  n = 1== / n
+MAP
+.........
+.........
+..xnxnx..
+..nOOOn..
+..xOOOx..
+..nOOOn..
+..xnxnx..
+.........
+.........
+ENDMAP
+
+NAME:    nicolae_vaults_security_offices_1
+TAGS:    vaults_hard vaults_orient_n
+SHUFFLE: DEF
+SUBST:   D = +, EF = n, 0 = ...000998
+MAP
+.....
+.....
+DEFED
+.....
+00000
+ENDMAP
+
+NAME:  nicolae_vaults_security_offices_2
+TAGS:  vaults_hard vaults_orient_e
+KITEM: L = % w:5 / * / | w:5
+KMONS: L = 0 / 9 / 9 band / 8
+MAP
+........x
+........x
+........x
++xnxx...x
+...Ln....
+...Ln.(..
+...Ln....
+ENDMAP
+
+NAME:  nicolae_vaults_security_offices_3
+TAGS:  vaults_hard
+SUBST: 0 = 000998, * = **|
+MAP
+...xxxxx...
+.(.xxxxx.(.
+...xx*xx...
+...+.0.x...
+...n...n...
+...n0*0n...
+...n...n...
+...x.0.+...
+...xx*xx...
+.(.xxxxx.(.
+...xxxxx...
+ENDMAP
+
+NAME:    nicolae_vaults_security_offices_4
+TAGS:    vaults_hard
+SHUFFLE: DE, FH
+SUBST:   D : xxn .:5, E : xnn .:5, F : xxn .:5, H : xnn .:5, 9 = 9998
+MAP
+x...xxxxx
+..D..+.9x
+.DED.n..x
+..D0.xnnx
+x.......x
+xnnx.0F..
+x..n.FHF.
+x9.+..F..
+xxxxx...x
+ENDMAP
+
+NAME:  nicolae_vaults_security_offices_5
+TAGS:  vaults_hard
+SUBST: 0 = .0009
+MAP
+...xxxxx...
+.(.xx..+...
+...xx..x...
+...xx+xx...
+...n0.0n...
+...n.0.n...
+...n0.0n...
+...xnnnx...
+...........
+.(.......(.
+...........
+ENDMAP
+
+NAME:   nicolae_vaults_security_offices_6
+TAGS:   vaults_hard
+NSUBST: D = + / x, E = + / x
+SUBST:  O = .0
+MAP
+.............
+.O....(....O.
+.............
+xDnnx...xnnEx
+x.0%n...n*9.x
+x.9*n...n%0.x
+xDnnx...xnnEx
+.............
+.O....(....O.
+.............
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_1
+TAGS:    vaults_hard
+SHUFFLE: DE, FH, JK, LM, NO
+SUBST:   DFJLN = +, E : xxxx+, H : xxxx+, K : xxxx+, M : xxxx+, O : xxxx+, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+........................
+......xFFx..............
+..xDDxx--xxJJxxLLx.xNNx.
+..x--xx--xx--xx--x.x--x.
+..x--xx--xx--xx--x.x--x.
+..x--xx--xx--xx--x.x--x.
+..x--xxHHxx--xx--x.x--x.
+..xEEx....xKKxxMMx.xOOx.
+........................
+........................
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_2
+TAGS:    vaults_hard
+SHUFFLE: DE, FH, JK, LM
+SUBST:   DFJL = +, E : xxxx+, H : xxxx+, K : xxxx+, M : xxxx+, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+.......xxxxxx.
+.xDDx..J----K.
+.x--x..J----K.
+.x--x..xxxxxx.
+.x--x.........
+.x--xxxxxxx...
+.xEExF----H...
+.....F----H...
+.....xxxxxx...
+.......xxxxxx.
+xxxxxx.L----M.
+x----+.L----M.
+x----+.xxxxxx.
+xxxxxx........
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_3
+TAGS:    vaults_hard
+SHUFFLE: DE, FH, JK
+SUBST:   DFJ = +, E : xxxx+, H : xxxx+, K : xxxx+, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+..............
+......xxxxxx..
+xDDx..F----H..
+x--x..F----H..
+x--x..xxxxxx..
+x--x..........
+x--x..........
+xEEx.xxxxxx...
+.....J----K...
+.....J----K...
+.....xxxxxx...
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_4
+TAGS:    vaults_hard
+SHUFFLE: DE, FH
+SUBST:   DF = +, E : xxxx+, H : xxxx+, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+.xxxxxx..
+.D----E..
+.D----E..
+.xxxxxx..
+..xxxxxx.
+..F----H.
+..F----H.
+..xxxxxx.
+.........
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_5
+TAGS:    vaults_hard
+SHUFFLE: DEFH
+SUBST:   DEF = +, H : xxxx+, - = ......%0, % = %%%**|, 0 = 000998
+MAP
+xxxxxx.......
+x----+.......
+x----+.......
+xxxxxx.......
+.........xFFx
+...xxxxxxx--x
+...+----xx--x
+...+----xx--x
+...xxxxxxx--x
+...xxxxxxxHHx
+...D----E....
+...D----E....
+...xxxxxx....
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_6
+TAGS:    vaults_hard
+SHUFFLE: DE, FH, JK/ML, LM
+SUBST:   DFJL = +, E : xxxx+, H : xxxx+, K = x, M : ++++x, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+................
+................
+.xxxxxx.xxxxxx..
+.D----E.F----H..
+.D----E.F----H..
+.xxxxxx.xxxxxx..
+..xxxxxxxxxxxx..
+..+----xx----+..
+..+----xx----+..
+..xxxxxxxxxxxx..
+..xxxxxx........
+..J----Kxxxxxx..
+..J----KL----M..
+..xxxxxxL----M..
+........xxxxxx..
+................
+ENDMAP
+
+NAME:    nicolae_vaults_shipping_containers_7
+TAGS:    vaults_hard
+SHUFFLE: DE/FH/JK, FH, JK
+SUBST:   DEFJ = +, H : xxxx+, K : xxxx+, \
+         - = ......%0, % = %%%**|, 0 = 000998
+MAP
+.....xxxxxx.
+.....D----E.
+.....D----E.
+.....xxxxxx.
+...xxxxxx...
+...F----H...
+...F----H...
+...xxxxxx...
+..xxxxxx....
+..J----K....
+..J----K....
+..xxxxxx....
+ENDMAP
+
+NAME:  nicolae_vaults_shock_wave
+TAGS:  vaults_hard vaults_orient_w
+SUBST: 0 = ..0009, 9 = 9998, % = %%%*, * = ***|
+MAP
+            .....
+        .....xxx.
+    .....xxx.x*x.
+......xx.x%x.x+x.
+..0x..0x..0x..9x.
+..0x..0x..0x..9x.
+......xx.x%x.x+x.
+    .....xxx.x*x.
+        .....xxx.
+            .....
+ENDMAP
+
+NAME:   nicolae_vaults_stand_back
+TAGS:   vaults_hard
+KITEM:  EH = * w:15 / | w:5
+KMONS:  E = patrolling eidolon
+KMONS:  F = patrolling ironbound frostheart
+KMONS:  H = patrolling ironbound thunderhulk
+NSUBST: F = 2=F / 0
+MAP
+x..........x
+............
+..x......x..
+............
+....x.Fx....
+....FEH.....
+.....HEF....
+....xF.x....
+............
+..x......x..
+............
+x..........x
+ENDMAP
+
+NAME:  nicolae_vaults_storing_the_good_stuff
+TAGS:  vaults_hard vaults_orient_w no_windows
+KITEM: LM = any weapon randart w:15 / any armour randart w:15 / \
+            any jewellery randart w:15 / any magical staff randart w:5 / \
+            gold good_item w:5 / | w:5
+KMONS: L = 9
+KMONS: M = 8
+SUBST: 0 = .009
+MAP
+.....xLM
+....0x**
+..n++x++
+.0n.0+.0
+.0n.0+.0
+..n++x++
+....0x**
+.....xLM
+ENDMAP
+
+NAME:  nicolae_vaults_surprise_closet_hard
+TAGS:  vaults_hard allow_dup
+KITEM: 9 = *
+KITEM: 8 = |
+KMONS: 9 = 9
+KMONS: 8 = 8
+SUBST: 9 : 998
+MAP
+8
+ENDMAP
+
+NAME:  nicolae_vaults_tangent_ellipses
+TAGS:  vaults_hard
+KMONS: 8 = 8 band
+SUBST: * = ***|, 0 = ...0, 9 = ..9, 0 = 0009
+MAP
+.....xxxxxxxxxxxxxxx.....
+.....xx...........xx.....
+..0.0.+..0.0.0.0..+.0.0..
+......xx.........xx......
+..0.0..xxx.....xxx..0.0..
+xx.......xxx+xxx.......xx
+xx+x....xx.....xx....x+xx
+x..xx..xx...9...xx..xx..x
+x...x.xx.........xx.x...x
+x.0.xxx..9.xxx.9..xxx.0.x
+x....x....xx*xx....x....x
+x.0..x...xx*.*xx...x..0.x
+x....+.9.x*.8.*x.9.+....x
+x.0..x...xx*.*xx...x..0.x
+x....x....xx.xx....x....x
+x.0.xxx..9.x+x.9..xxx.0.x
+x...x.xx.........xx.x...x
+x..xx..xx...9...xx..xx..x
+xx+x....xx.....xx....x+xx
+xx.......xxx+xxx.......xx
+..0.0..xxx.....xxx..0.0..
+......xx.........xx......
+..0.0.+..0.0.0.0..+.0.0..
+.....xx...........xx.....
+.....xxxxxxxxxxxxxxx.....
+ENDMAP
+
+NAME:   nicolae_vaults_thirteen_compartments
+TAGS:   vaults_hard
+NSUBST: D = + / x, E = + / x, F = + / x, H = + / x, \
+        p = p / x, q = q / x, r = r / x, s = s / x, \
+        Jp = + / x, Kp = + / x, Lq = + / x, Mq = + / x, \
+        Nr = + / x, Or = + / x, Ps = + / x, Qs = + / x, - = + / x
+SUBST:  9 = 999., 0 = ...%0009, 9 = 99998, * = ***|
+MAP
+.................
+.................
+..xDDxJJxKKxEEx..
+..D..J..p..K..E..
+..D.0J.0p0.K0.E..
+..xQQx--x--xLLx..
+..Q..-.....-..L..
+..Q.0-.9*9.-0.L..
+..xssx.*x*.xqqx..
+..P.0-.9*9.-0.M..
+..P..-.....-..M..
+..xPPx--x--xMMx..
+..H.0O.0r0.N0.F..
+..H..O..r..N..F..
+..xHHxOOxNNxFFF..
+.................
+.................
+ENDMAP
+
+NAME:  nicolae_vaults_whirlpool_walls
+TAGS:  vaults_hard
+KITEM: L = * w:15 / | w:5
+KMONS: 0 = 0 band
+KMONS: L = 9 w:15 / 8 w:5
+SUBST: ( = .(0
+MAP
+.............
+...xxx..(....
+..x...x...x..
+....(..x...x.
+.(.....x.(.x.
+...xxxLx...x.
+..x..LxL..x..
+.x...xLxxx...
+.x.(.x.....(.
+.x...x..(....
+..x...x...x..
+....(..xxx...
+.............
+ENDMAP
+
+NAME:  nicolae_vaults_you_can_take_it_with_you
+TAGS:  vaults_hard vaults_orient_w
+KMONS: L = patrolling dread lich / patrolling ancient lich
+KMONS: P = necromancer / hell knight / phantasmal warrior / lich / \
+           shadow wraith / freezing wraith / flayed ghost / eidolon
+SUBST: p = P.., * = **|
+MAP
+....n...n**|.
+.p..n.p.n**P.
+..x+x...xxx..
+xxx...x..px+x
+xp....n......
+x..p..n..P.L.
+xp....n......
+xxx...x..px+x
+..x+x...xxx..
+.p..n.p.n**P.
+....n...n**|.
+ENDMAP

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_standard.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_standard.des
@@ -1973,3 +1973,630 @@ fe..            ..ef
 .)...de......ed...).
 ......fx....xf......
 ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_1
+TAGS:   vaults_room allow_dup
+KITEM:  L = % / nothing w:15
+KMONS:  L = 0 / nothing w:15
+NSUBST: p = + / x, q = + / x, r = + / x, s = + / x
+# The s glyph intentionally doesn't appear in the middle of the shape; this
+# ensures at least one opening to the outside.
+MAP
+.........
+..xpxL...
+..p.xqqx.
+.LpLqL.q.
+.xxpxrxx.
+.s.LxLrL.
+.xssx.r..
+...Lxrx..
+.........
+ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_2
+TAGS:   vaults_room allow_dup
+KITEM:  L = % / nothing w:15
+KMONS:  L = 0 / nothing w:15
+NSUBST: p = + / x, q = + / x, r = + / x, s = + / x
+MAP
+...........
+.(.xppx..(.
+...p..pL...
+..Lp.xxqqx.
+.xsxLpL..q.
+.s.xxxqx.q.
+.s..LrLxqx.
+.xssxx.rL..
+...Lr..r...
+.(..xrrx.(.
+...........
+ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_3
+TAGS:   vaults_room allow_dup
+KITEM:  L = % / nothing w:15
+KMONS:  L = 0 / nothing w:15
+NSUBST: p = + / x, q = + / x, r = + / x, s = + / x
+MAP
+...........
+.(.xpxL..(.
+...p.xqx...
+..xx.p.xqx.
+.Lp.LpL..q.
+.xxxxxqqxx.
+.s..LrL.rL.
+.xsx.r.xx..
+...xsx.r...
+.(..Lxrx.(.
+...........
+ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_4
+TAGS:   vaults_room allow_dup
+KITEM:  L = % / nothing w:15
+KMONS:  L = 0 / nothing w:15
+NSUBST: p = + / x, q = + / x, r = + / x, s = + / x
+MAP
+...L....
+.xpxqqx.
+.p.pL.q.
+.pLxxqxL
+LxxxxLr.
+.s.Lr.r.
+.xssxrx.
+....L...
+ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_5
+TAGS:   vaults_room allow_dup
+KITEM:  ! = % / nothing w:15
+KMONS:  ! = 0 / nothing w:15
+: if crawl.coinflip() then
+# outer ring guaranteed exit
+NSUBST: D = + / x, Js = + / x, Pp = + / x, Sr = + / x, LQRq = + / x, \
+        HM = + / x, FL = + / x, EK = + / x
+: else
+# inner ring guaranteed exit
+NSUBST: s = +, DJ = + / x, Pp = + / x, Sr = + / x, QRq = + / x, \
+        EK = + / x, HM = + / x, FL = + / x
+: end
+MAP
+...........
+.xDDx..xEx.
+.D.!xxpx.E.
+.xxJxx.K!E.
+..s.!P!xxx.
+..xxSxQxx..
+.xxx!R!.q..
+.H!M.xxLxx.
+.H.xrxx!.F.
+.xHx..xFFx.
+...........
+ENDMAP
+
+NAME:   nicolae_vaults_closet_pinwheel_6
+TAGS:   vaults_room
+KITEM:  - = % / nothing w:15
+KMONS:  - = 0 / nothing w:15
+NSUBST: D = D / x, E = E / x, F = F / x, H = H / x, \
+        J = J / x, K = K / x, L = L / x, M = M / x
+: if crawl.coinflip() then
+# guaranteed corner exit
+NSUBST: D = + / x, JNs = + / x, Qas = + / x, HMZ = + / x, PZrq = + / x, \
+        OKpq = + / x, ERK = + / x, FLS = + / x
+: else
+# guaranteed side exit
+NSUBST: N = +, DJa = + / x, Qas = + / x, ERK = + / x, KOp = + / x, \
+        HMZ = + / x, PZrq = + / x, FLS = + / x
+: end
+MAP
+...........
+.xDxNxEEEx.
+.D.J.R.-.E.
+.D-J-xKKKx.
+.D.J.p.-.O.
+.xaxsxqxSx.
+.Q.-.r.L.F.
+.xMMMx-L-F.
+.H.-.Z.L.F.
+.xHHHxPxFx.
+.......UUU.
+ENDMAP
+
+NAME:    nicolae_vaults_cornered_office
+TAGS:    vaults_room allow_dup
+KMONS:   0 = 0 band
+SHUFFLE: Pp, Qq, Rr, Ss
+SUBST:   0 = .0, PQRS = ., pqrs = _
+CLEAR:   _
+MAP
+     P   p
+     PP pp
+     PP0pp
+     P...p
+     .....
+ssss.xx+xx.QQQQ
+ ss..x...x..QQ
+  0..+.(.+..0
+ SS..x...x..qq
+SSSS.xx+xx.qqqq
+     .....
+     r...R
+     rr0RR
+     rr RR
+     r   R
+ENDMAP
+
+NAME:  nicolae_vaults_door_testing_chamber
+TAGS:  vaults_room
+SUBST: ' = 0%++..
+: lua_marker('+', props_marker { connected_exclude="true" })
+MAP
+..x..'..x..
+..'..x..'..
+'x+x'+'x+x'
+..'..x..'..
+..x..'..x..
+x'+'x+x'+'x
+..x..'..x..
+..'..x..'..
+'x+x'+'x+x'
+..'..x..'..
+..x..'..x..
+ENDMAP
+
+NAME:  nicolae_vaults_doubleplus_tesselated
+TAGS:  vaults_room
+KFEAT: ' = closed_clear_door
+SUBST: 0 = ...0, . = % .:180
+MAP
+...x.x...x.x
+x'xx+xx'xx+x
+.0.x.x.0.x.x
+x.x.0.x.x.0.
+x+xx'xx+xx'x
+x.x.0.x.x.0.
+.0.x.x.0.x.x
+x'xx+xx'xx+x
+.0.x.x.0.x.x
+x.x.0.x.x.0.
+x+xx'xx+xx'x
+x.x...x.x...
+ENDMAP
+
+NAME:  nicolae_vaults_ellipses_ellipsis
+TAGS:  vaults_room
+KMONS: 0 = 0 band
+SUBST: ( = (((0
+MAP
+   .....xxxxxxx.....xxxxxxx.....
+ ....(....xxx....(....xxx....(....
+...........x...........x...........
+...(...(...+...(...(...+...(...(...
+...........x...........x...........
+ ....(....xxx....(....xxx....(....
+   .....xxxxxxx.....xxxxxxx.....
+ENDMAP
+
+NAME:   nicolae_vaults_frosty_reception
+TAGS:   vaults_room
+KMONS:  1 = ironbound frostheart
+NSUBST: 1 = 1 / 10 / 0.
+MAP
+     ...x...
+   ...x...x...
+ ...x...x...x...
+..x...1...1...x..
+x...x.x.x.x.x...x
+..x...1...1...x..
+  ..x...x...x..
+    ..x...x..
+      ..x..
+ENDMAP
+
+NAME:  nicolae_vaults_heart-shaped_vault
+TAGS:  vaults_room allow_dup
+SUBST: ( = (((0, 0 = .0
+MAP
+ .0   0.
+.... ....
+0.(...(.0
+ .......
+  ..(..
+   ...
+    0
+ENDMAP
+
+NAME:   nicolae_vaults_heist
+TAGS:   vaults_room
+WEIGHT: 5
+KITEM:  H = any weapon good_item randart / any armour good_item randart / \
+            any jewellery good_item randart / any manual / \
+            any magical staff good_item randart
+KMONS:  D = vault warden band
+KMONS:  S = vault sentinel
+KMONS:  s = vault guard
+KFEAT:  H = alarm trap
+KMASK:  H = no_monster_gen
+KMASK:  H = opaque
+KPROP:  H = no_tele_into
+NSUBST: ! = D / S / s..
+MAP
+.........
+.........
+..!.!.!..
+...mmm...
+..!mHm!..
+...mmm...
+..!.!.!..
+.........
+.........
+ENDMAP
+
+NAME:  nicolae_vaults_meiosis
+TAGS:  vaults_room
+SUBST: ( = (0
+MAP
+ ...          ...
+.....xxxxxxxx.....
+..(............(..
+.......xxxx.......
+ ................
+ x...(..xx..(...x
+ x..............x
+ x.x...xxxx...x.x
+ x.x.x.xxxx.x.x.x
+ x.x.x.xxxx.x.x.x
+ x.x...xxxx...x.x
+ x..............x
+ x...(..xx..(...x
+ ................
+.......xxxx.......
+..(............(..
+.....xxxxxxxx.....
+ ...          ...
+ENDMAP
+
+NAME:  nicolae_vaults_mitosis
+TAGS:  vaults_room
+SUBST: ( = (0
+MAP
+  ...xxxxxx...
+ ..............
+ ..(..xxxx..(..
+................
+.......xx.......
+...(........(...
+.......xx.......
+................
+ ..(..xxxx..(..
+ ..............
+  ...xxxxxx...
+ENDMAP
+
+NAME:    nicolae_vaults_more_shelving_1
+TAGS:    vaults_room vaults_orient_e vaults_orient_w
+SHUFFLE: Pp/Qq
+SUBST:   P = x, p = ', Qq = ., ' = .%0
+MAP
+x'x'x'x'x
+.........
+x'x'xpxqx
+xxxxxPxQx
+x'x'xpxqx
+.........
+x'x'x'x'x
+ENDMAP
+
+
+NAME:   nicolae_vaults_more_shelving_2
+TAGS:   vaults_room vaults_orient_n vaults_orient_s
+KITEM:  L = %
+KMONS:  L = 0
+NSUBST: D = + / x, E = + / x, ' = L / L.., - = L / L..
+MAP
+xxxx...xxxx
+'..x.(.x..-
+x..x...x..x
+'..D...E..-
+x..D...E..x
+'..D...E..-
+x..D...E..x
+'..D...E..-
+x..x...x..x
+'..x.(.x..-
+xxxx...xxxx
+ENDMAP
+
+NAME:  nicolae_vaults_sesquioval_fish
+TAGS:  vaults_room allow_dup
+SUBST: 0 = .0
+MAP
+xx..xxx.
+x0..0x0.
+x....x..
+........
+........
+x....x..
+x0..0x0.
+xx..xxx.
+ENDMAP
+
+NAME:  nicolae_vaults_shrinking_rooms_1
+TAGS:  vaults_room
+SUBST: 0 = 00.
+MAP
+        .
+      xx+xx
+      x...x
+     .+.0.+.
+      x...x
+   . xxx+xxx .
+ xx+xx.....xx+xx
+ x...x.(.(.x...x
+.+.0.+.....+.0.+.
+ x...x.(.(.x...x
+ xx+xx.....xx+xx
+   . xxx+xxx .
+      x...x
+     .+.0.+.
+      x...x
+      xx+xx
+        .
+ENDMAP
+
+NAME:  nicolae_vaults_shrinking_rooms_2
+TAGS:  vaults_room
+SUBST: 0 = 0.
+MAP
+        ..
+        ..
+       ....
+     ........
+     ..0..0..
+   ..xx....xx..
+   ..x......x..
+  ..0..(..(..0..
+..................
+..................
+  ..0..(..(..0..
+   ..x......x..
+   ..xx....xx..
+     ..0..0..
+     ........
+       ....
+        ..
+        ..
+ENDMAP
+
+NAME:  nicolae_vaults_sightless_eye
+TAGS:  vaults_room
+KITEM: 0 = %
+KMONS: 0 = 0
+MAP
+    ....
+  ........
+....x++x....
+....+00+....
+....+00+....
+....x++x....
+  ........
+    ....
+ENDMAP
+
+NAME:  nicolae_vaults_six-pack
+TAGS:  vaults_room allow_dup
+SUBST: 0 = 0.
+MAP
+..x..x..
+.0x0.x0.
+........
+xx.xx.xx
+........
+.0x.0x0.
+..x..x..
+ENDMAP
+
+NAME:  nicolae_vaults_spaceships
+TAGS:  vaults_room
+SUBST: 0 = .0
+MAP
+................
+.x....x....x....
+.xxx..xxx..xxx..
+.0xxx.0xxx.0xxx.
+.xxx..xxx..xxx..
+.x....x....x....
+...(....(....(...
+ ....x....x....x.
+ ..xxx..xxx..xxx.
+ .xxx0.xxx0.xxx0.
+ ..xxx..xxx..xxx.
+ ....x....x....x.
+ ................
+ENDMAP
+
+NAME:  nicolae_vaults_steering_wheel
+TAGS:  vaults_room
+SUBST: 0 = ..%0
+MAP
+      0.
+      .....
+   .0xxx.(.
+   ..xxx.....
+ ...xx...xx.0
+ .(.x0...0xxx
+ ..........xx.0
+..xx...(...xx..
+0.xx..........
+  xxx0...0x.(.
+  0.xx...xx...
+  .....xxx..
+    .(.xxx0.
+    .....
+       .0
+ENDMAP
+
+NAME:    nicolae_vaults_stepped_doors
+TAGS:    vaults_room vaults_orient_w vaults_orient_e
+SHUFFLE: DE, FHJ, KLMN
+SUBST:   DFK = +, EHJLMN = x, 0 = ...0, % = .%%%
+MAP
+      %K%
+   .F.0L0.F.
+.D.0H..M..H0.D.
+0E..J.0N0.J..E0
+.D.0H..M..H0.D.
+   .F.0L0.F.
+      %K%
+ENDMAP
+
+NAME:  nicolae_vaults_storage_closets_1
+TAGS:  vaults_room vaults_orient_w vaults_orient_e
+KITEM: L = % w:20 / nothing w:30
+KMONS: L = 0 / nothing w:15
+MAP
+xLLxLLxLLx
+x..x..x..x
+x+xx+xx+xx
+..........
+..........
+..........
+xx+xx+xx+x
+x..x..x..x
+xLLxLLxLLx
+ENDMAP
+
+NAME:    nicolae_vaults_storage_closets_2
+TAGS:    vaults_room vaults_orient_e
+KITEM:   L = % w:20 / nothing w:30
+KMONS:   L = 0 / nothing w:15
+SHUFFLE: DE
+SUBST:   D = +, E = x
+MAP
+L.E...D.Lx
+L.D...E.Lx
+xxx...xxxx
+L.x.......
+L.+.......
+L.x.......
+xxx...xxxx
+L.D...E.Lx
+L.E...D.Lx
+ENDMAP
+
+NAME:   nicolae_vaults_storage_closets_3
+TAGS:   vaults_room
+KITEM:  L = % w:20 / nothing w:30
+KMONS:  L = 0 / nothing w:15
+NSUBST: P = + / x, Q = + / x, R = + / x, S = + / x, \
+        p = L / ., q = L / ., r = L / ., s = L / .
+MAP
+...........
+...........
+..xPPxQQx..
+..P.pxq.Q..
+..PpLxLqQ..
+..xxxxxxx..
+..RrLxLsS..
+..R.rxs.S..
+..xRRxSSx..
+...........
+...........
+ENDMAP
+
+NAME:  nicolae_vaults_surprise_closet
+TAGS:  vaults_room allow_dup
+KITEM: 0 = %
+KMONS: 0 = 0
+MAP
+0
+ENDMAP
+
+NAME:  nicolae_vaults_taking_the_gang_shopping
+TAGS:  vaults_room
+KMONS: S = vault warden band / yaktaur captain band / orc warlord band / \
+           ironbound preserver band
+KFEAT: S = weapon shop / armour shop
+MAP
+...x...
+...x...
+.......
+xx.S.xx
+.......
+...x...
+...x...
+ENDMAP
+
+NAME:   nicolae_vaults_turnstiles
+TAGS:   vaults_room
+NSUBST: 0 = 2=0 / 0...
+MAP
+.............
+.(....(....(.
+.............
+xn0xn0xn0xn0x
+x..n..n..n..x
+x0nx0nx0nx0nx
+.............
+.(....(....(.
+.............
+ENDMAP
+
+NAME:  nicolae_vaults_weapon_check
+TAGS:  vaults_room vaults_orient_s
+KITEM: L = any weapon / any armour w:5
+KFEAT: - = iron_grate
+SUBST: M = 0.
+MAP
+.........
+..M...M..
++xxx+xxx+
+L.-...-.L
+LM-M.M-ML
+L.-.0.-.L
+L.-...-.L
+L.x-+-x.L
+xxx...xxx
+ENDMAP
+
+NAME:    nicolae_vaults_wine_cellar
+TAGS:    vaults_room vaults_orient_e
+KITEM:   ' = any potion w:15 / potion of degeneration / nothing
+SHUFFLE: Pp/Qq/Rr
+: if crawl.coinflip() then
+NSUBST:  J = 2=x.. / ., DEFH = x.. / .
+: else
+NSUBST:  D = x.. / ., E = x.. / ., F = x.. / ., H = x.. / ., J = .
+: end
+NSUBST:  . = 2=0 / 2=0. / .
+SUBST:   Pp = ., QR = x, qr = '
+MAP
+x'x'x'xx
+'.D.E.pP
+xDxJxExx
+'.J.J.qQ
+xFxJxHxx
+'.F.H.rR
+x'x'x'xx
+ENDMAP
+
+NAME:  nicolae_vaults_wrenched
+TAGS:  vaults_room
+KITEM: 0 = %
+KMONS: 0 = 0
+SUBST: ' = ...0
+MAP
+............
+.......x'x..
+.xx'xx.xxx..
+.'xxx'.'x'..
+.xx'xx.xxx..
+.......x'x..
+..x'x.......
+..xxx.xx'xx.
+..'x'.'xxx'.
+..xxx.xx'xx.
+..x'x.......
+............
+ENDMAP


### PR DESCRIPTION
Includes vaults for _empty, _standard, and _hard. I looked over the existing vaults, but Vaults vaults tend to have a simpler variety than other vaults because they tend to use a reduced glyph set. If I've accidentally duplicated some other existing vault, my apologies. Unless I've accidentally duplicated one of my own vaults, in which case I absolve myself completely of all wrongdoing.