### PR TITLE
Let's fix the summon forest spell in wizlabs

### DIFF
--- a/crawl-ref/source/mapmark.h
+++ b/crawl-ref/source/mapmark.h
@@ -214,6 +214,8 @@ public:
     map_terrain_change_marker (const coord_def& pos = coord_def(0, 0),
                     dungeon_feature_type oldfeat = DNGN_FLOOR,
                     dungeon_feature_type newfeat = DNGN_FLOOR,
+                    unsigned short flv_oldfeat = 0,
+                    unsigned short flv_oldfeat_idx = 0,
                     int dur = 0, terrain_change_type type = TERRAIN_CHANGE_GENERIC,
                     int mnum = 0, int oldcol = BLACK);
 
@@ -229,6 +231,8 @@ public:
     int mon_num;
     dungeon_feature_type old_feature;
     dungeon_feature_type new_feature;
+    unsigned short flv_old_feature;
+    unsigned short flv_old_feature_idx;
     terrain_change_type  change_type;
     int colour;
 };

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -280,6 +280,7 @@ enum tag_minor_version
     TAG_MINOR_WU_ABILITIES,        // Make Lunge and Whirlwind Abil, not Invok
     TAG_MINOR_MORE_WAYPOINTS,      // Increase the number of allowed waypoints.
     TAG_MINOR_GENERATED_MISC,      // Track generated misc item types.
+    TAG_MINOR_SAVE_TERRAIN_FLAVOUR, // Save flavour in terrain-change markers.
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -118,6 +118,8 @@ bool feat_eliminates_items(dungeon_feature_type feat);
 // Terrain changed under 'pos', perform necessary effects.
 void dungeon_terrain_changed(const coord_def &pos,
                              dungeon_feature_type feat = DNGN_UNSEEN,
+                             unsigned short flv_nfeat = 0,
+                             unsigned short flv_nfeat_idx = 0,
                              bool preserve_features = false,
                              bool preserve_items = false,
                              bool temporary = false,

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -588,7 +588,7 @@ tileidx_t tileidx_feature(const coord_def &gc)
                      feat == DNGN_ROCK_WALL ? env.rock_colour
                                             : 0; // meh
         }
-        if (colour >= ETC_FIRST)
+        else if (colour >= ETC_FIRST)
         {
             tileidx_t idx = (feat == DNGN_FLOOR) ? tile_env.flv(gc).floor :
                 (feat == DNGN_ROCK_WALL) ? tile_env.flv(gc).wall
@@ -604,6 +604,11 @@ tileidx_t tileidx_feature(const coord_def &gc)
             unsigned rc = real_colour(colour, gc);
             return tile_dngn_coloured(base, rc) + spec; // XXX
         }
+#ifdef USE_TILE
+        // There may be a change we haven't seen yet
+        else if (tile_env.bk_bg(gc))
+            return tile_env.bk_bg(gc);
+#endif
         return tileidx_feature_base(feat);
     }
 


### PR DESCRIPTION
**Fix 1: Save flavour in terrain-change markers**

Temporary terrain changes that replace walls (summon forest spell) are
not being properly reverted on wizlabs and some vaults with custom
walls. This change solves the problem by saving the old feature flavour
in the terrain-change markers.

**Fix 2: Fix the description of walls with unseen changes**

If a wall is changed but we haven't seen the new state yet, the
description shows the tile for the base wall without flavour.

Closes #2052