### PR TITLE
Auto-exclude Strange Machine by default

### DIFF
--- a/crawl-ref/source/dat/defaults/misc.txt
+++ b/crawl-ref/source/dat/defaults/misc.txt
@@ -1,6 +1,6 @@
 drop_filter += useless_item
 
-auto_exclude += oklob,statue,roxanne,lightning spire,starflower
+auto_exclude += oklob,statue,roxanne,lightning spire,starflower,strange machine
 
 # Interrupting run and rest compound commands:
 runrest_ignore_monster += ^butterfly$:1


### PR DESCRIPTION
Resolves issue #3139. This makes the default auto-exclude behavior for strange machines consistent with other dangerous stationary monsters like oklob plants, statues, etc.