### PR TITLE
Fix tile_shield_offsets option

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -766,7 +766,7 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(ON_SET_NAME(tile_weapon_offsets), "reset", false,
             [this]() { set_tile_offsets(tile_weapon_offsets_option, false); }),
         new StringGameOption(ON_SET_NAME(tile_shield_offsets), "reset", false,
-            [this]() { set_tile_offsets(tile_weapon_offsets_option, true); }),
+            [this]() { set_tile_offsets(tile_shield_offsets_option, true); }),
         new StringGameOption(ON_SET_NAME(tile_tag_pref), "auto", false,
             [this]() { tile_tag_pref = _str_to_tag_pref(tile_tag_pref_option); }),
 


### PR DESCRIPTION
Resolves issue #3133 . I think there was simply a typo/oversight to put `tile_weapon_offsets_option` instead of `tile_shield_offsets_option`. Either way, the `tile_shield_offsets` option now works as far as I can tell.

Here is an example with `tile_weapon_offsets = 20,10` and `tile_shield_offsets = -20,-10`

![player tile with weapon in the bottom right and shield in the top left](https://cdn.discordapp.com/attachments/996669199432810526/1111497466748092466/image.png)