### PR TITLE
Bugfix: Roots require solid ground

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -708,7 +708,7 @@ bool actor::can_constrict(const actor &defender, constrict_type typ) const
     if (!see_cell_no_trans(defender.pos()))
         return false;
 
-    return typ != CONSTRICT_BVC
+    return (typ != CONSTRICT_BVC && typ != CONSTRICT_ROOTS)
            || feat_has_solid_floor(env.grid(defender.pos()));
 }
 


### PR DESCRIPTION
Wand of roots and the grasping roots spell are allowed to constrict on non-solid ground.  The wand's description explicitly states the effect requires solid ground.  I tested locally with the wand, but no matter how long I stood there Jorgrun would not cast it at me standing over deep water.  Jorgrun was observed rooting me over deep water in 0.31-a0-108-gdf935468f2 which prompted this PR.

<img width="527" alt="Screen Shot 2023-05-27 at 8 24 39 AM" src="https://github.com/crawl/crawl/assets/553676/2bc48ed0-dec0-4bc1-be93-2b20c7fc7fb7">
