### PR TITLE
build: workaround for an actions/checkout bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           fetch-depth: 0 # all history
           submodules: true
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Build source packages
         run: make -j$(nproc) package-source
         working-directory: crawl-ref/source
@@ -115,6 +117,9 @@ jobs:
         with:
           fetch-depth: 0 # all history
           submodules: true
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        if: github.event.release.tag_name != null
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:
@@ -186,6 +191,8 @@ jobs:
         with:
           fetch-depth: 0 # all history
           submodules: false
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Install dependencies
         run: ./deps.py --build-opts "${{ matrix.build_opts }}" --appimage
         working-directory: .github/workflows
@@ -222,6 +229,8 @@ jobs:
         with:
           fetch-depth: 0 # all history
           submodules: false
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Install dependencies
         run: ./deps.py --build-opts TILES=1 --debian-packages
         working-directory: .github/workflows
@@ -292,6 +301,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        if: github.event.release.tag_name != null
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Checkout submodules
         shell: bash
         run: |
@@ -338,6 +350,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        if: github.event.release.tag_name != null
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Checkout submodules (for crosscompile)
         shell: bash
         run: |
@@ -537,6 +552,9 @@ jobs:
         with:
           fetch-depth: 0 # all history
           submodules: true
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        if: github.event.release.tag_name != null
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
       - name: Install dependencies
         run: ./deps.py --build-opts "${{ matrix.build_opts }}"
         working-directory: .github/workflows


### PR DESCRIPTION
a9a6e9e7af1 and ea43df2a32 removed a step that was probably intended to work around https://github.com/actions/checkout/issues/290 and https://github.com/actions/checkout/issues/882, but broke the CI build if anyone used a lightweight tag (because these fetch lines actually shallow the tag depth to 1). This commit attempts to thread the needle by making this workaround conditional only to releases, where (if the person doing the release has followed the steps correctly), there is guaranteed to be an annotated tag at depth 1 in the tag history. (If I'm parsing the checkout bugs correctly, they only trigger on a tag action anyways.)