### PR TITLE
Hooves and talons shouldn't force bardings off

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1505,7 +1505,7 @@ static string _mut_blocks_item_reason(const item_def &item, mutation_type mut, i
     case EQ_BOOTS:
         if (mut == MUT_FLOAT)
             return "You have no feet!"; // or legs
-        if (level < 3)
+        if (level < 3 || item.sub_type == ARM_BARDING)
             break;
         if (mut == MUT_HOOVES)
             return "You can't wear boots with hooves!";


### PR DESCRIPTION
As it stands, if an armataur gets hooves 3, any barding they're wearing will be forced off – but then they can immediately put it right back on.  As I understand it, the intended behavior is the latter, since bardings don't go directly over the feet, so this PR prevents them from falling away.

Test:
* Start up a game as an armataur
* Enter wizmode (<kbd>&</kbd> <kbd>yes</kbd> <kbd>&nbsp;</kbd>)
* Get a barding with <kbd>&</kbd> <kbd>o</kbd> <kbd>[</kbd> <kbd>barding</kbd> <kbd>&nbsp;</kbd> and wear it
* Ask for hooves 3 with <kbd>&</kbd> <kbd>]</kbd> <kbd>hooves</kbd> <kbd>3</kbd>
* If you haven't applied this PR:
  * See "Your +0 barding falls away!"
  * Put your barding back on
* If you have applied this PR:
  * You now have hooves and are still wearing your barding