### PR TITLE
Give robe of Misfortune more unique modifier

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -861,11 +861,14 @@ OBJ:      OBJ_ARMOUR/ARM_ROBE
 # try to make it bad, this is the only bad SPARM:
 FB_BRAND: SPARM_PONDEROUSNESS
 PLUS:     5
+INSCRIP:  fortune,
 COLOUR:   LIGHTMAGENTA
 TILE:     urand_misfortune
 TILE_EQ:  robe_misfortune
 EV:       5
 BOOL:     harm, slow, corrode
+DBRAND:   fortune:   It increases the success rate of its wearer's spells and
+ the severity of miscasts.
 
 # start TAG_MAJOR_VERSION == 34
 NAME:     cloak of Flash

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2144,7 +2144,8 @@ int player_armour_shield_spell_penalty()
 int player_wizardry()
 {
     return you.wearing(EQ_RINGS, RING_WIZARDRY)
-           + (you.get_mutation_level(MUT_BIG_BRAIN) == 3 ? 1 : 0);
+           + (you.get_mutation_level(MUT_BIG_BRAIN) == 3 ? 1 : 0)
+           + (player_equip_unrand(UNRAND_MISFORTUNE) ? 1 : 0);
 }
 
 int player_channeling()

--- a/crawl-ref/source/spl-miscast.cc
+++ b/crawl-ref/source/spl-miscast.cc
@@ -7,6 +7,7 @@
 
 #include "spl-miscast.h"
 
+#include "art-enum.h"
 #include "attack.h"
 #include "beam-type.h"
 #include "fight.h"
@@ -621,7 +622,8 @@ void miscast_effect(spell_type spell, int fail)
     miscast_effect(you, nullptr, {miscast_source::spell},
                    school,
                    spell_difficulty(spell),
-                   raw_spell_fail(spell), string("miscasting ") + spell_title(spell));
+                   raw_spell_fail(spell) + (player_equip_unrand(UNRAND_MISFORTUNE, false) ? 20 : 0),
+                   string("miscasting ") + spell_title(spell));
 }
 
 // Miscasts from other sources (god wrath, spellbinder melee, wild magic card,


### PR DESCRIPTION
# Summary
Adds fortune property to robe of Misfortune. Fortune's rule text would be
> Provides one level of wizardry. When you miscast, calculate miscast severity as if you have an additional 5 levels of wild magic.

# Pitch
There's still chatters that robe of Misfortune is a joke unrandart. I believe that a part of this perception comes from that Misfortune's upside is not unique, thus this PR proposes something that's more unique. So far, wizardry is only available on rings, so giving Misfortune wizardry is arguably a decent niche, and different enough from Folly/archmagi. Additionally, Wiz and +EV together makes sense - it's just as if this robe has negative encumbrance. Then, to keep Misfortune's theme of "good but sometimes bad", attach some -Wiz to when the wearer miscasts, and here we are.

Typical effect:
A midgame caster with 28 int, 10 spc, 14 ice. Without Misfortune refridgeration is 11% fail yellow text and miscast deals up to 28 damage. With Misfortune refridgeration is 4% fail bright red text and miscast deals up to 38 damage.

# Tuning knobs
The main tuning knob is the miscast severity modifier.
The goal/constraints are
- Make robe of misfortune bring some value to use. For occupying a caster niche, it should at least be not clearly inferior to things like archmagi robe.
- Make miscast (and miscast risk evaluation) feel different. In other words, if player usually considers spell X at 20% miscast usable, ideally player would put a different threshold value in Misfortune (since with the wiz player invested less skill to reach 20% miscast, plus fortune).
- Keep Misfortune power flavorful. It'd be undesirable that fortune significantly reduces overall miscast risk over a plain robe.

Severity modifier of 20 sounds like a lot, but it only means more miscast damage on 3%~4% worst outcomes per cast when the spell is not quite online (between 40~70 raw fail without wiz, i.e. 28%~86% fail rate without, 12%~52% fail rate with, see https://docs.google.com/spreadsheets/d/1e8PWpTnKwUkSq9Hco3VQ-ekcekQWdsV0fVcgpX8fn3c/edit#gid=0).

# Other thoughts
I don't like that other modifiers on Misfortune (Harm, Corrode, *Slow, EV+5) is making the stat line too long. On the other hand, I feel reluctant of removing them out of concern that some players might conclude that "the best use of Misfortune is to shoot ranged weapon in it and not bother with casting at all".

The name of dbrand, `fortune`, can use other ideas. Originally, as the name of this branch suggests, it was named epicfail, but the total effect turned out to be too positive for epicfail to be a good fit (probably only really broken miscast severity number can undo the benefit of Wiz). "You get fortune when you cast and Misfortune when you miscast" does feel cute, though.

Some other ideas of giving Misfortune something unique and luck-related could be "wild magic (equivalent spellpower and wiz modifiers) when you're contaminated", but that's hard to balance especially given that contam can be gained at-will by casting Irradiate.