### PR TITLE
Fix autofight_nomove_fires option being ignored

### DIFF
--- a/crawl-ref/source/dat/clua/autofight.lua
+++ b/crawl-ref/source/dat/clua/autofight.lua
@@ -102,8 +102,15 @@ local function have_ranged()
   return wp and wp.is_ranged and not wp.is_melded
 end
 
+local function should_quiver_be_used(no_move)
+  if no_move then
+      return AUTOFIGHT_THROW_NOMOVE
+  end
+  return AUTOFIGHT_THROW
+end
+
 local function have_quiver_action(no_move)
-  return ((AUTOFIGHT_THROW or no_move and AUTOFIGHT_THROW_NOMOVE)
+  return (should_quiver_be_used(no_move)
           and you.quiver_valid(1) and you.quiver_enabled(1)
           -- TODO: armataur roll passes the following check, which may be
           -- counterintuitive for the nomove case


### PR DESCRIPTION
Due to the erroneous condition, autofight_nomove_fires option was ignored if autofight_fires was set to true. Added a function should_quiver_be_used(no_move), which returns true if the quiver may be used based on the current settings and action. Let me know if this name is unsuitable.
Ideally, i would rework this system to have 3 tactics - AUTOFIGHT-A, -B, -C, aliased to AUTOFIGHT, AUTOFIGHT-NOMOVE and AUTOFIRE respectively - that could be configured separately without assumptions. Let me know if you think it is a good change.