### PR TITLE
New init file option: lua_max_memory

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -162,6 +162,7 @@ The contents of this text are:
                 background_colour, foreground_colour, use_fake_cursor
 
 6-  Lua.
+                lua_max_memory
 6-a     Including lua files.
 6-b     Executing inline lua.
 6-c     Conditional options.
@@ -3095,6 +3096,9 @@ use_fake_cursor = true
 
 6-  Lua.
 ========
+
+lua_max_memory = 16
+        Max memory in MB allowed for user Lua scripts.
 
 6-a  Including lua files.
 -------------------------

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3607,6 +3607,15 @@ void base_game_options::read_option_line(const string &str, bool runscripts)
                 [this](const string & s, bool b) { set_option_fragment(s, b); });
         return;
     }
+    else if (state.key == "lua_max_memory")
+    {
+#ifdef DGAMELAUNCH
+        report_error("Option 'lua_max_memory' is disabled in this build.", state.field.c_str());
+#else
+        if (!sscanf(state.field.c_str(), "%" SCNu64, &crawl_state.clua_max_memory_mb))
+            report_error("Couldn't parse integer option lua_max_memory: \"%s\"", state.field.c_str());
+#endif
+    }
     else if (state.key == "lua_file")
     {
 #ifdef CLUA_BINDINGS


### PR DESCRIPTION
The max memory in MB allowed for user Lua scripts is only configurable via command line options. Setting this value in the init file can be useful in platforms where the command line is not available, e.g. Android.