### PR TITLE
Better numeric keypad support in Linux

### DIFF
--- a/crawl-ref/source/cio.cc
+++ b/crawl-ref/source/cio.cc
@@ -28,15 +28,16 @@
 // they work?
 static keycode_type _numpad2vi(keycode_type key)
 {
-#if defined(UNIX) && !defined(USE_TILE_LOCAL)
-    key = unixcurses_get_vi_key(key);
-#endif
     switch (key)
     {
-    case CK_UP:    key = 'k'; break;
-    case CK_DOWN:  key = 'j'; break;
-    case CK_LEFT:  key = 'h'; break;
-    case CK_RIGHT: key = 'l'; break;
+    case CK_HOME:        key = 'y'; break;
+    case CK_END:         key = 'b'; break;
+    case CK_PGUP:        key = 'u'; break;
+    case CK_PGDN:        key = 'n'; break;
+    case CK_UP:          key = 'k'; break;
+    case CK_DOWN:        key = 'j'; break;
+    case CK_LEFT:        key = 'h'; break;
+    case CK_RIGHT:       key = 'l'; break;
 #if defined(UNIX)
     case CK_NUMPAD_1:    key = 'b'; break;
     case CK_NUMPAD_2:    key = 'j'; break;
@@ -194,12 +195,6 @@ int unmangle_direction_keys(int keyin, KeymapContext keymap,
     case '7': return 'y';
     case '8': return 'k';
     case '9': return 'u';
-
-# if !defined(USE_TILE_LOCAL)
-    // equivalent to return keyin for the headless case
-    default: return unixcurses_get_vi_key(keyin);
-# endif
-
 #else
     case '1': return 'B';
     case '2': return 'J';

--- a/crawl-ref/source/cmd-keys.h
+++ b/crawl-ref/source/cmd-keys.h
@@ -10,9 +10,7 @@
 {'s', CMD_WAIT},
 {CK_CLEAR, CMD_WAIT},
 {CK_NUMPAD_DECIMAL, CMD_WAIT},
-#ifdef USE_TILE_LOCAL
-{CK_DELETE, CMD_WAIT}, // numpad . on some keyboards on sdl??
-#endif
+{CK_DELETE, CMD_WAIT},
 {'.', CMD_WAIT},
 {CK_END, CMD_MOVE_DOWN_LEFT},
 {CK_LEFT, CMD_MOVE_LEFT},

--- a/crawl-ref/source/libunix.h
+++ b/crawl-ref/source/libunix.h
@@ -5,7 +5,6 @@
 #endif
 
 void fakecursorxy(int x, int y);
-int unixcurses_get_vi_key(int keyin);
 
 #ifdef DGAMELAUNCH
 class suppress_dgl_clrscr


### PR DESCRIPTION
* Fixes #3174
* Fixes the insert, delete and clear keys
* Fixes the control variations
* Fixes some /+ and *+ combinations
* Reduces duplicate code, unixcurses_get_vi_keys is not more