### PR TITLE
Make artefact orbs use slightly orbier names

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -1199,6 +1199,8 @@ static string _get_artefact_type(const item_def &item, bool appear = false)
         if (get_item_slot(item) == EQ_BODY_ARMOUR)
             return "body armour";
         return "armour";
+    case OBJ_ORBS:
+        return "orb";
     case OBJ_JEWELLERY:
         // Distinguish between amulets and rings only in appearance.
         if (!appear)


### PR DESCRIPTION
The case for 'orb' was missing from _get_artefact_type, meaning it's name would not reference it's orbiness, defaulting to it's artefactitude instead.

This corrects that, even though it is perhaps the world's most trivial omission.