### PR TITLE
fix vault formatting

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -1318,7 +1318,7 @@ MONS:    tengu reaver ; lajatang ego:freezing good_item \
 MONS:    vampire knight; quick blade ego:antimagic . buckler good_item \
              . shadow dragon scales good_item \
          / spriggan defender; quick blade ego:antimagic w:20 \
-             . robe good_item . buckler good_item . wand of paralysis \
+             . robe good_item . buckler good_item . wand of paralysis
 MONS:    minotaur ; broad axe ego:speed good_item \
              | broad axe ego:speed randart | arga w:1 . plate armour good_item \
              . tower shield ego:reflection good_item \


### PR DESCRIPTION
Fixes: #3196 
 - remove unneeded "\" from beargit_hepliaklqana_dungeon_heroes

Seems like a typo from commit that removed monster potions https://github.com/crawl/crawl/commit/e8cad7f256b05d460fdf43d9ebf327ed34a94874