### PR TITLE
Fix various typos across documents and source

### DIFF
--- a/crawl-ref/docs/changelog.txt
+++ b/crawl-ref/docs/changelog.txt
@@ -1106,7 +1106,7 @@ Spells
   more powerful, arcing between visible foes for massive damage that partially
   ignores AC and rElec.
 * Tornado has been renamed to Polar Vortex. It is now a Level 9 Ice spell, and
-  its damage has been increased by 33% but is partially resistable by rC.
+  its damage has been increased by 33% but is partially resistible by rC.
 * Other spell level adjustments:
   - Ozocubu's Refrigeration is now level 7 (from 6).
   - Freezing Cloud is now level 5 (from 6).
@@ -1246,7 +1246,7 @@ Items
 * Bardings are merged into a single item type.
 * Staves of earth deal higher damage, but with the shrapnel effect of being
   affected 3 times by AC.
-* Staves of conjuration deal bonus irresistable damage that checks AC.
+* Staves of conjuration deal bonus irresistible damage that checks AC.
 * The full contents of item piles are revealed on sight.
 * Potions of stabbing, wands of clouds, and staves of energy, summoning, and
   wizardry are removed.
@@ -1522,7 +1522,7 @@ Items
   - Maxwell's Etheric Cage has been removed.
 * Phial of floods now applies a silencing "waterlogged" debuff to all monsters
   in the flooded area and no longer summons water elementals.
-* Staves of poison now do resistable poison damage on hit like other staves
+* Staves of poison now do resistible poison damage on hit like other staves
   instead of just having a chance to poison.
 * Distortion branded weapons no longer teleport foes.
 * Distortion unwield effects no longer cause a translocations miscast. Instead,
@@ -1656,10 +1656,10 @@ Spells
     + Force Lance is removed.
   - Poison spells poison things or perform some kind of alchemy
     + Sting is now a range 3 Poison/Transmutations spell using the same
-      partly-resistable beam type previously used by Poison Arrow.
+      partly-resistible beam type previously used by Poison Arrow.
     + New L6 Poison/Transmutations spell Eringya's Noxious Bog that creates a
       temporary toxic bog trail as the player moves. The bog terrain applies
-      the same partly-resistable damage flavor as Sting as well as the
+      the same partly-resistible damage flavor as Sting as well as the
       movement and combat penalties of shallow water.
     + Removed spells: Venom Bolt, Poison Arrow
     + As a result of these changes, Venom Mages now put starting skill in
@@ -1686,7 +1686,7 @@ Spells
   - Summoning: durably summon a nameless horror (new monster).
   - Translocation: dimension anchor.
   - Transmutation: extra contamination for the player, malmutate a monster.
-  - Conjuration: irresistable AC-ignoring damage.
+  - Conjuration: irresistible AC-ignoring damage.
   - Elemental schools: school flavored damage (Earth uses fragmentation
     damage).
 * The Deflect Missiles spell has been removed.
@@ -2771,7 +2771,7 @@ Monsters
 * Battlecry has been simplified, affecting all monsters of the same genus.
 * Blood Saints's Legendary Destruction now casts two spells at a time.
 * Necromancers gain Bind Soul, reviving slain monsters as simulacrula.
-* Ghostly Fireball is now completely resistable by rN and causes draining.
+* Ghostly Fireball is now completely resistible by rN and causes draining.
 * Obsidian statues can Mesmerise.
 * Wizards and Ogre Mages have split up and re-arranged their many spell sets
   to arrive at three sets each, with minimal overlap.
@@ -4098,7 +4098,7 @@ Stone Soup 0.14.1 (20140428)
 ----------------------------
 * Several crash fixes.
 * Fire dragons correctly grant bonus Dithmenos piety.
-* Ranged attacks from invisibile monsters correctly turn off autopickup.
+* Ranged attacks from invisible monsters correctly turn off autopickup.
 * Good gods punish the player properly for negative energy clouds.
 * Natasha no longer revives after being pacified, and does not get a new
   item when reviving.
@@ -5197,7 +5197,7 @@ Stone Soup 0.11.2 (20130125)
 * Handle forcibly closing the game a bit better (save corruption, crashes,
   possible cheating).
 * No more false annotations in the Abyss.
-* Octopodes can't grow claws on their non-existant hands anymore.
+* Octopodes can't grow claws on their non-existent hands anymore.
 * Tile games did not always draw overlays properly.
 * Invocation based titles were wrong on the high scores list.
 * A number of other misc fixes.

--- a/crawl-ref/docs/changelog.txt
+++ b/crawl-ref/docs/changelog.txt
@@ -143,10 +143,10 @@ Monsters
     enraged on drawing blood - first becoming Mighty, then Berserk!
 * Demonic Crawlers lose the Warning Cry ability and elemental resistances in
   exchange for higher damage and very fast regeneration.
-* Doom Hounds' Howl is now resistable by Will.
+* Doom Hounds' Howl is now resistible by Will.
 * Many monsters do somewhat less damage.
 * Walking Tomes are now unable to cast while silenced.
-* Ironbound Frosthearts' Creeping Frost spell is now fully resistable by rC.
+* Ironbound Frosthearts' Creeping Frost spell is now fully resistible by rC.
 * Fleeing monsters will no longer avoid harmful clouds.
 * Monsters, notably Asterion, can now use spectral weapons.
 
@@ -431,7 +431,7 @@ Spells
   - Animate Dead reworked: for a duration after being cast, the dead have a
     power-dependent chance of rising as allied zombies. The zombies are
     permanent until the player leaves the level or re-casts Animate Dead.
-  - Simulacrum is now a smite-targeted spell that gives an irresistable status.
+  - Simulacrum is now a smite-targeted spell that gives an irresistible status.
     Monsters that die with this status spawn a power-dependent number of
     simulacra.
   - Corpse Rot is now Level 4 Necromancy/Poison/Air. For a duration after being
@@ -747,7 +747,7 @@ Monsters
 * Demonic and holy monsters are now susceptible to fear, berserk, alistairs
   intoxication, and ballistomycete spores.
 * Monsters have a chance to break a door permanently when opening it. This
-  chance is higher if the mosnter is berserk.
+  chance is higher if the monster is berserk.
 * Classed draconians have a fixed colour per job.
 * When Dowan dies Duvessa goes berserk permanently; when Duvessa dies Dowan
   gains haste permanently.

--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -1544,7 +1544,7 @@ Hill Orcs (HO)
   convert to Beogh even without an altar whenever an orc priest is in sight.
 
 Minotaurs (Mi)
-  The Minotaurs are a species of hybrids, posessing human bodies with bovine
+  The Minotaurs are a species of hybrids, possessing human bodies with bovine
   heads. They delve into the Dungeon because of their instinctive love of
   twisting passageways.
 

--- a/crawl-ref/docs/develop/git/pre-commit
+++ b/crawl-ref/docs/develop/git/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ## This pre-commit hook calls scripts to check the diff contents of the commit
-## before it's commited.
+## before it's committed.
 
 crawl-ref/source/util/checkcommit || exit 1
 

--- a/crawl-ref/docs/develop/god_creation.txt
+++ b/crawl-ref/docs/develop/god_creation.txt
@@ -327,7 +327,7 @@ look there. Here each type of delay has been class-ified, so we can
 implement our own pretty easily.
 
         // in delay.h:
-        // Copied from AscnedingStairsDelay
+        // Copied from AscendingStairsDelay
         class RalphDelay : public Delay
         {
             void finish() override;
@@ -362,7 +362,7 @@ implement our own pretty easily.
         }
 
 Now this should only need one small change into ability.cc to activate:
-a case in the _do_abilty switch:
+a case in the _do_ability switch:
 
         case ABIL_RALPH_NOTHING:
             start_delay<RalphDelay>(500);

--- a/crawl-ref/docs/develop/levels/advanced.txt
+++ b/crawl-ref/docs/develop/levels/advanced.txt
@@ -335,7 +335,7 @@ not guaranteed. Also, there is only one go at a portal vault - if you
 leave, it's gone for good. You can apply special rules to a portal vault,
 like enforcing maprot.
 
-Portal vaults can be particulary thematic, using specialised monster
+Portal vaults can be particularly thematic, using specialised monster
 sets, fitting loot, coloured dungeon features etc. Avoid death traps; it
 is no fun to enter a vault, being unable to leave and be killed outright.
 In order to provide fun and reduce spoiler effects, randomise. For portal

--- a/crawl-ref/docs/develop/levels/triggerables.txt
+++ b/crawl-ref/docs/develop/levels/triggerables.txt
@@ -458,7 +458,7 @@ parameters for each.
 
    * monster_dies: Waits for a monster to die. Needs the parameter
          "target", who's value is the name of the monster who's death
-         we're wating for. Doesn't matter where the triggerable/marker
+         we're waiting for. Doesn't matter where the triggerable/marker
          is placed.
    * feat_change: Waits for a cell's feature to change. Accepts the
          optional parameter "target", which if set delays the trigger

--- a/crawl-ref/docs/develop/mutation_creation.txt
+++ b/crawl-ref/docs/develop/mutation_creation.txt
@@ -201,7 +201,7 @@ in addition to the files we handled at the beginning.
 transform.cc handles gaining MUT_HORNS via the Beastly Appendage spell,
 so we won't need to copy that part. All of the mutation.cc entries
 involve conflicting mutations and gear slots, and the item-use.cc
-entires stop you from equipping gear that won't fit over horns. This is
+entries stop you from equipping gear that won't fit over horns. This is
 worth taking a look at, especially if you want to do similar body mods
 like new scale mutations, or blade-hands, or something else that should
 replace a piece of gear. We'll assume that beards can be tucked through

--- a/crawl-ref/docs/develop/release/debian.md
+++ b/crawl-ref/docs/develop/release/debian.md
@@ -77,7 +77,7 @@ To create these, run the following:
 
 In principle you can leave some of these environment variables out where they
 match your current system, but it is safest not to simplify. In order for
-these to run succesfully in docker, you will need to be running the docker
+these to run successfully in docker, you will need to be running the docker
 image with `--privileged`.
 
 We build the debs against either debian stable, or debian oldstable. Basically,

--- a/crawl-ref/docs/develop/release/pbuilderrc
+++ b/crawl-ref/docs/develop/release/pbuilderrc
@@ -1,7 +1,7 @@
 # pbuilder defaults; edit /etc/pbuilderrc to override these and see
 # pbuilderrc.5 for documentation
 
-## set e.g. ARCH=i386 to make the i386 packges on an amd64 system
+## set e.g. ARCH=i386 to make the i386 packages on an amd64 system
 : ${ARCH:="$(dpkg --print-architecture)"}
 ##
 . /etc/lsb-release
@@ -142,7 +142,7 @@ export SHELL=/bin/bash
 DEBOOTSTRAP="debootstrap"
 
 # default file extension for pkgname-logfile
-PKGNAME_LOGFILE_EXTENTION="_$(dpkg --print-architecture).build"
+PKGNAME_LOGFILE_EXTENSION="_$(dpkg --print-architecture).build"
 
 # default PKGNAME_LOGFILE
 PKGNAME_LOGFILE=""

--- a/crawl-ref/docs/develop/rng_guidelines.md
+++ b/crawl-ref/docs/develop/rng_guidelines.md
@@ -34,7 +34,7 @@ seed *should* fully determine a dungeon, but this mapping is quite delicate.
 
 ## 2. Breaking seed mappings
 
-The following changes (which are often desireable changes) can break the seed
+The following changes (which are often desirable changes) can break the seed
 to dungeon mappings, in some way:
 
 * adding or removing a vault
@@ -257,7 +257,7 @@ different compilers or build options (or OSs, perhaps) lead to different
 choices. The biggest example is the ordering of random calls in arithmetic
 expressions, discussed in section 4.1, so this is definitely the first thing
 to look for. The #crawl-dev population on Libera IRC in aggregate has pretty
-detailed knowledge of the C++ specs, so if you aren't sure whether somethig in
+detailed knowledge of the C++ specs, so if you aren't sure whether something in
 particular is defined, this is a good place to ask.
 
 Before opening the VM, however, if what you are seeing is a difference between

--- a/crawl-ref/docs/develop/save_compatibility.txt
+++ b/crawl-ref/docs/develop/save_compatibility.txt
@@ -153,7 +153,7 @@ This happens because the tiles for floor and wall tiles get rolled once on
 level creation and are subsequently stored in the level files, so they don't
 change every time you reload the game. Any time a tile's number is changed,
 the actually displayed tile gets shifted a bit which can lead to floor
-looking like walls, staircases like shops and similar odd occurences.
+looking like walls, staircases like shops and similar odd occurrences.
 Items and monsters that are cached out of sight may similarly be affected.
 
 This is not a big problem and in the development version, we don't even
@@ -183,7 +183,7 @@ value that has to be manually compared to the relevant minor tag.
 
 The current major version of the software is accessible by calling
 file.major_version(). There's no need to pass the reader in, as if the major
-version of a file mis-matches, the game won't attempt to load it, and you will
+version of a file mismatches, the game won't attempt to load it, and you will
 never get to a stage of being able to look for it.
 
 All Lua markers will need to be checked for minor-version checks when updating

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1935,7 +1935,7 @@ fire_order  = launcher, throwing, inscribed, spell, evokable, ability
 
         'launcher' refers to firing a wielded ranged weapon (i.e. crossbow,
         bow, sling). 'throwing' refers to all throwing ammo. Specific throwing
-        ammo types can be refered to by name ('javelin', 'boomerang', 'stone',
+        ammo types can be referred to by name ('javelin', 'boomerang', 'stone',
         'rock', 'net', 'dart'), but order of these only affects order internal
         to throwing ammo types; 'inscribed' can also be used to control the
         order of ammo that has been inscribed with "+f". See the "Inscriptions"
@@ -2342,7 +2342,7 @@ tile_overlay_alpha_percent = 40
         Transparency value for the message window overlay background, as when
         tile_force_overlay is set to true. Setting this option to 0 will cause
         the message window to only display text without any background. And
-        setting this option to 100 will force an opaque backgroud to the
+        setting this option to 100 will force an opaque background to the
         message window.
 
 tile_full_screen = auto
@@ -2510,7 +2510,7 @@ tile_web_mouse_control = true
 
 tile_web_mobile_input_helper = auto
         This option controls an optional auxiliary input field in the WebTiles
-        interface that can be focused to enable the vitual keyboard on mobile
+        interface that can be focused to enable the virtual keyboard on mobile
         devices. When set to true or false, the field is manually enabled or
         disabled. When set to auto, the field is only shown on devices with
         a touch screen.
@@ -2993,7 +2993,7 @@ dos_use_background_intensity = false
 5-c     Unix.
 -------------
 allow_extended_colours = true
-        Atempt to use more than the eight basic terminal colours for crawl's
+        Attempt to use more than the eight basic terminal colours for crawl's
         bright colours. Most modern terminals should use this setting. If
         successful, this puts console into 16-color mode.
 

--- a/crawl-ref/git-hooks/crawl-ref-email
+++ b/crawl-ref/git-hooks/crawl-ref-email
@@ -393,7 +393,7 @@ generate_update_branch_email()
 			echo "            \\"
 			echo "             O -- O -- O ($oldrev)"
 			echo ""
-			echo "The removed revisions are not necessarilly gone - if another reference"
+			echo "The removed revisions are not necessarily gone - if another reference"
 			echo "still refers to them they will stay in the repository."
 			rewind_only=1
 		else

--- a/crawl-ref/source/AppHdr.h
+++ b/crawl-ref/source/AppHdr.h
@@ -42,7 +42,7 @@ static inline double pow(int x, double y) { return std::pow((double)x, y); }
 //
 // #define DISABLE_SAVEGAME_LISTS
 
-// Uncomment to let valgrind debug unitialized uses of global classes
+// Uncomment to let valgrind debug initialized uses of global classes
 // (you, env, clua, dlua, crawl_state).
 //
 // #define DEBUG_GLOBALS

--- a/crawl-ref/source/MSVC/include/unistd.h
+++ b/crawl-ref/source/MSVC/include/unistd.h
@@ -3,7 +3,7 @@
 
 /* This file intended to serve as a drop-in replacement for
  *  unistd.h on Windows
- *  Please add functionality as neeeded
+ *  Please add functionality as needed
  */
 
 #include <stdlib.h>

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -99,7 +99,7 @@ endif
 # down MinGW and Cygwin builds by a very VERY noticeable degree. Besides, we have
 # _explicit_ rules defined for everything. So we don't need them.
 MAKEFLAGS += -rR # This only works for recursive makes, i.e. contribs ...
-.SUFFIXES:       # ... so zap the suffix list to neutralize most predifined rules, too
+.SUFFIXES:       # ... so zap the suffix list to neutralize most predefined rules, too
 
 .PHONY: all test install clean clean-contrib clean-rltiles clean-android \
         clean-appimage clean-catch2 clean-plug-and-play-tests \
@@ -1788,7 +1788,7 @@ $(OBJECTS:%.o=%.cc) main.cc: $(CONTRIB_LIBS)
 $(UTIL)%.o: ALL_CFLAGS=$(YACC_CFLAGS)
 $(TILEDEFOBJS): ALL_CFLAGS=$(RLTILES_CFLAGS)
 
-# The "|" designates "order-only" dependancies. See: (make) Prerequisite Types.
+# The "|" designates "order-only" dependencies. See: (make) Prerequisite Types.
 #
 # This ensures that we update these headers before building anything
 # that might depend on them without our knowing it yet, but lets the

--- a/crawl-ref/source/SDLMain.m
+++ b/crawl-ref/source/SDLMain.m
@@ -10,7 +10,7 @@
 #import <sys/param.h> /* for MAXPATHLEN */
 #import <unistd.h>
 
-/* For some reaon, Apple removed setAppleMenu from the headers in 10.4,
+/* For some reason, Apple removed setAppleMenu from the headers in 10.4,
  but the method still is there and works. To avoid warnings, we declare
  it ourselves here. */
 @interface NSApplication(SDL_Missing_Methods)

--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -905,7 +905,7 @@ static void _abyss_move_entities(coord_def target_centre,
             if (map_bounds_with_margin(dst, MAPGEN_BORDER))
             {
                 shift_area_mask->set(dst);
-                // Wipe the dstination clean before dropping things on it.
+                // Wipe the destination clean before dropping things on it.
                 _abyss_wipe_square_at(dst);
                 _abyss_move_entities_at(src, dst);
                 _abyss_update_transporter(dst, source_centre, target_centre,

--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1616,7 +1616,7 @@ bool AcquireMenu::examine_index(int i)
     ASSERT(i >= 0 && i < static_cast<int>(items.size()));
     // Use a copy to set flags that make the description better
     // See the similar code in shopping.cc for details about const
-    // hygene
+    // hygiene
     item_def &item = *static_cast<item_def*>(items[i]->data);
 
     item.flags |= (ISFLAG_IDENT_MASK | ISFLAG_NOTED_ID
@@ -1646,7 +1646,7 @@ static item_def _acquirement_item_def(object_class_type item_type)
         // We make a copy of the item def, but we don't keep the real item.
         item = env.item[item_index];
         set_ident_flags(item,
-                // Act as if we've recieved this item already to prevent notes.
+                // Act as if we've received this item already to prevent notes.
                 ISFLAG_IDENT_MASK | ISFLAG_NOTED_ID | ISFLAG_NOTED_GET);
         destroy_item(item_index);
     }

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -258,7 +258,7 @@ bool is_random_artefact(const item_def &item)
  *  @param item The item to be checked.
  *  @param which The unrand enum to be checked against (default 0).
  *  @returns true if item is an unrand, and if which is not 0, if it is the unrand
- *           specfied by enum in which.
+ *           specified by enum in which.
  */
 bool is_unrandom_artefact(const item_def &item, int which)
 {

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -40,7 +40,7 @@ public:
     int     to_hit;
     int     damage_done;
     int     special_damage; // TODO: We'll see if we can remove this
-    int     aux_damage;     // TOOD: And this too
+    int     aux_damage;     // TODO: And this too
 
     int     min_delay;
     int     final_attack_delay;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -653,7 +653,7 @@ static beam_type _chaos_beam_flavour(bolt* beam)
           5, BEAM_DAMNATION,
           5, BEAM_STICKY_FLAME,
           5, BEAM_MINDBURST,
-         // These are not actualy used by SPWPN_CHAOS, but are here to augment
+         // These are not actually used by SPWPN_CHAOS, but are here to augment
          // the list of effects, since not every SPWN_CHAOS effect has an
          // analogous BEAM_ type.
           4, BEAM_MIGHT,
@@ -840,7 +840,7 @@ void bolt::draw(const coord_def& p, bool force_refresh)
                                              : element_colour(colour);
     view_add_glyph_overlay(p, {glyph, c});
 
-    // If reduce_animations is set, the redraw is unnecesary and
+    // If reduce_animations is set, the redraw is unnecessary and
     // should be done only once outside the loop calling the bolt::draw
     if (Options.reduce_animations)
         return;
@@ -2182,7 +2182,7 @@ void bolt_parent_init(const bolt &parent, bolt &child)
 
     child.flavour        = parent.flavour;
 
-    // We don't copy target since that is often overriden.
+    // We don't copy target since that is often overridden.
     child.thrower        = parent.thrower;
     child.source         = parent.source;
     child.source_name    = parent.source_name;
@@ -4263,7 +4263,7 @@ void bolt::handle_stop_attack_prompt(monster* mon)
 
     // If prompts for overshooting the target are disabled, instead
     // just let the caller know that there was something there. They
-    // should be resposible and keep the player from shooting friends.
+    // should be responsible and keep the player from shooting friends.
     if (passed_target && !overshoot_prompt && you.can_see(*mon))
     {
         string adj, suffix;
@@ -6133,7 +6133,7 @@ static sweep_type _radial_sweep(int r)
 
 /** How much noise does an explosion this big make?
  *
- *  @param the size of the explosion (radius, not diamater)
+ *  @param the size of the explosion (radius, not diameter)
  *  @returns how much noise it would make.
  */
 int explosion_noise(int rad)

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6888,7 +6888,7 @@ int omnireflect_chance_denom(int SH)
 }
 
 /// Set up a beam aiming from the given monster to their target.
-bolt setup_targetting_beam(const monster &mons)
+bolt setup_targeting_beam(const monster &mons)
 {
     bolt beem;
 

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -378,4 +378,4 @@ int omnireflect_chance_denom(int SH);
 void glaciate_freeze(monster* mon, killer_type englaciator,
                              int kindex);
 
-bolt setup_targetting_beam(const monster &mons);
+bolt setup_targeting_beam(const monster &mons);

--- a/crawl-ref/source/catch2-tests/catch_amalgamated.cc
+++ b/crawl-ref/source/catch2-tests/catch_amalgamated.cc
@@ -597,7 +597,7 @@ namespace Catch {
             elem = trim(elem);
         }
 
-        // Insert the default reporter if user hasn't asked for a specfic one
+        // Insert the default reporter if user hasn't asked for a specific one
         if ( m_data.reporterSpecifications.empty() ) {
             m_data.reporterSpecifications.push_back( {
 #if defined( CATCH_CONFIG_DEFAULT_REPORTER )

--- a/crawl-ref/source/catch2-tests/catch_amalgamated.cc
+++ b/crawl-ref/source/catch2-tests/catch_amalgamated.cc
@@ -8764,7 +8764,7 @@ namespace Catch {
             static_cast<void>(
                 assertionStats.assertionResult.getExpandedExpression() );
         }
-        if ( m_shouldStoreSuccesfulAssertions &&
+        if ( m_shouldStoreSuccessfulAssertions &&
              assertionStats.assertionResult.isOk() ) {
             static_cast<void>(
                 assertionStats.assertionResult.getExpandedExpression() );
@@ -9240,7 +9240,7 @@ namespace Catch {
         {
             m_preferences.shouldRedirectStdOut = true;
             m_preferences.shouldReportAllAssertions = true;
-            m_shouldStoreSuccesfulAssertions = false;
+            m_shouldStoreSuccessfulAssertions = false;
         }
 
     std::string JunitReporter::getDescription() {

--- a/crawl-ref/source/catch2-tests/catch_amalgamated.hpp
+++ b/crawl-ref/source/catch2-tests/catch_amalgamated.hpp
@@ -1560,7 +1560,7 @@ namespace Catch {
         //! Called with test cases that are skipped due to the test run aborting
         virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
 
-        //! Called if a fatal error (signal/structured exception) occured
+        //! Called if a fatal error (signal/structured exception) occurred
         virtual void fatalErrorEncountered( StringRef error ) = 0;
 
         //! Writes out information about provided reporters using reporter-specific format
@@ -9150,7 +9150,7 @@ namespace TestCaseTracking {
 
         //! Returns true if tracker run to completion (successfully or not)
         virtual bool isComplete() const = 0;
-        //! Returns true if tracker run to completion succesfully
+        //! Returns true if tracker run to completion successfully
         bool isSuccessfullyCompleted() const;
         //! Returns true if tracker has started but hasn't been completed
         bool isOpen() const;
@@ -11809,7 +11809,7 @@ namespace Catch {
      * even if they are later unused (e.g. because the deriving reporter does
      * not report successful assertions, or because the deriving reporter does
      * not use assertion expansion at all). Derived classes can use two
-     * customization points, `m_shouldStoreSuccesfulAssertions` and
+     * customization points, `m_shouldStoreSuccessfulAssertions` and
      * `m_shouldStoreFailedAssertions`, to disable the expansion and gain extra
      * performance. **Accessing the assertion expansions if it wasn't stored is
      * UB.**

--- a/crawl-ref/source/catch2-tests/catch_amalgamated.hpp
+++ b/crawl-ref/source/catch2-tests/catch_amalgamated.hpp
@@ -11879,8 +11879,8 @@ namespace Catch {
         void skipTest(TestCaseInfo const&) override {}
 
     protected:
-        //! Should the cumulative base store the assertion expansion for succesful assertions?
-        bool m_shouldStoreSuccesfulAssertions = true;
+        //! Should the cumulative base store the assertion expansion for successful assertions?
+        bool m_shouldStoreSuccessfulAssertions = true;
         //! Should the cumulative base store the assertion expansion for failed assertions?
         bool m_shouldStoreFailedAssertions = true;
 
@@ -12296,7 +12296,7 @@ namespace Catch {
         , xml(m_stream) {
             m_preferences.shouldRedirectStdOut = true;
             m_preferences.shouldReportAllAssertions = true;
-            m_shouldStoreSuccesfulAssertions = false;
+            m_shouldStoreSuccessfulAssertions = false;
         }
 
         ~SonarQubeReporter() override = default;

--- a/crawl-ref/source/clua.h
+++ b/crawl-ref/source/clua.h
@@ -147,7 +147,7 @@ public:
 
     void print_stack();
 
-    /* Add the libaries and globals currently used by clua and dlua */
+    /* Add the libraries and globals currently used by clua and dlua */
     void init_libraries();
 
 public:

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -1424,7 +1424,7 @@ private:
                 // disable these if there's no character to view
                 if (!crawl_state.game_started)
                     return maybe_bool::maybe;
-                // falltrough
+                // fall-through
             case CK_ESCAPE: case '/': case 'q': case 'v': case '!':
                 // exit the UI, these help screens are activated outside of
                 // the scroller popup

--- a/crawl-ref/source/coordit.h
+++ b/crawl-ref/source/coordit.h
@@ -28,7 +28,7 @@ private:
 /**
  * @class random_rectangle_iterator
  * Iterator over coordinates in a rectangular region in a
- * random order. This interator does not favour any given
+ * random order. This iterator does not favour any given
  * direction, but is slower than rectangle_iterator.
  *
  * When this iterator has returned all elements, it will just

--- a/crawl-ref/source/crawl_all.doxy
+++ b/crawl-ref/source/crawl_all.doxy
@@ -278,7 +278,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
 # a logarithmic scale so increasing the size by one will roughly double the

--- a/crawl-ref/source/crawl_simple.doxy
+++ b/crawl-ref/source/crawl_simple.doxy
@@ -278,7 +278,7 @@ TYPEDEF_HIDES_STRUCT   = NO
 # For small to medium size projects (<1000 input files) the default value is
 # probably good enough. For larger projects a too small cache size can cause
 # doxygen to be busy swapping symbols to and from disk most of the time
-# causing a significant performance penality.
+# causing a significant performance penalty.
 # If the system has enough physical memory increasing the cache will improve the
 # performance by keeping more symbols in memory. Note that the value works on
 # a logarithmic scale so increasing the size by one will roughly double the

--- a/crawl-ref/source/dat/des/altar/okawaru_arena.des
+++ b/crawl-ref/source/dat/des/altar/okawaru_arena.des
@@ -3,7 +3,7 @@
 
 # Typo below
 {{
-function callback.oka_start_challange(data, triggerable, triggerer, marker, ev)
+function callback.oka_start_challenge(data, triggerable, triggerer, marker, ev)
   -- Open the cages.
   for slave in iter.slave_iterator("cage_doors", 1) do
     dgn.terrain_changed(slave.x, slave.y, "floor", false)
@@ -98,7 +98,7 @@ COLOUR: -Lv = cyan
 local tlos_door = TriggerableFunction:new{
   func="callback.oka_populate_cages", repeated=true }
 local tlos_altar = TriggerableFunction:new{
-  func="callback.oka_start_challange" }
+  func="callback.oka_start_challenge" }
 local tmonsters_death = TriggerableFunction:new{
   func="callback.oka_monsters_death",
   repeated=true,

--- a/crawl-ref/source/dat/des/arrival/small.des
+++ b/crawl-ref/source/dat/des/arrival/small.des
@@ -2614,7 +2614,7 @@ MAP
 ENDMAP
 
 ##############################################################################
-#The maze will allways contain an exit to the rest of D:1, the player won't be
+#The maze will always contain an exit to the rest of D:1, the player won't be
 #forced to D:2.
 NAME:    co_arrival_random_square_maze
 TAGS:    arrival

--- a/crawl-ref/source/dat/des/branches/elf.des
+++ b/crawl-ref/source/dat/des/branches/elf.des
@@ -737,7 +737,7 @@ xxxx+xxxx-x_xx-xxxx+xxxx
             ..x..
 ENDMAP
 
-NAME:    hangedman_elf_targetted_burst
+NAME:    hangedman_elf_targeted_burst
 TAGS:    transparent extra
 DEPTH:   Elf
 SUBST:   x : xxc, Y : yycvb, y : xxcbv, z : cbv, Z = cbvwl

--- a/crawl-ref/source/dat/des/branches/lair.des
+++ b/crawl-ref/source/dat/des/branches/lair.des
@@ -3502,7 +3502,7 @@ KMONS:   5 = patrolling merfolk avatar
 KFEAT:   p12345de%*| = W
 NSUBST:  % = 2=d / 2=d% / e / %%*|
 # Open up squares on the fixed portions of the temple walls, on the outer
-# colums, and in the inner room.
+# columns, and in the inner room.
 SUBST:   c = c:20 .:1 W:1, a = ccc-, q = cccc'
 # Each wall has a 50% chance of being broken open
 SHUFFLE: DEFHJ / uuyzz

--- a/crawl-ref/source/dat/des/branches/temple_compat.des
+++ b/crawl-ref/source/dat/des/branches/temple_compat.des
@@ -1,7 +1,7 @@
 # temple_compat.des
 #
 # When cc390b852004c86 updated / revised / combined / renamed
-# a great deal of map variations, this screwed with save compatability:
+# a great deal of map variations, this screwed with save compatibility:
 # Crawl decides what temple map to use at the beginning of the game,
 # and most of the maps were made inaccessible by name. While Crawl can
 # still recover from this, it still quite easily means a dearth of gods

--- a/crawl-ref/source/dat/des/builder/layout.des
+++ b/crawl-ref/source/dat/des/builder/layout.des
@@ -1462,7 +1462,7 @@ TAGS:   no_rotate no_hmirror no_vmirror
 {{
   -- information for rooms of different sizes
 
-  local GLPYH_BY_RADIUS =
+  local GLYPH_BY_RADIUS =
     { [4] = { [0] = "c", "-", ".", ".", ":" },
       [5] = { [0] = "c", "-", ".", ".", ":", ":" },
       [6] = { [0] = "c", "c", "-", ".", ".", ":", ":" },
@@ -1524,7 +1524,7 @@ TAGS:   no_rotate no_hmirror no_vmirror
         local y = center_y + dy
         local abs_sum = math.abs(dx) + math.abs(dy)
         if (abs_sum <= radius) then
-          local new_glyph = GLPYH_BY_RADIUS[radius][abs_sum]
+          local new_glyph = GLYPH_BY_RADIUS[radius][abs_sum]
           if (GLYPH_PRIORITY[new_glyph] <
               GLYPH_PRIORITY[mapgrd[x][y]]) then
             mapgrd[x][y] = new_glyph

--- a/crawl-ref/source/dat/des/builder/layout_delve.des
+++ b/crawl-ref/source/dat/des/builder/layout_delve.des
@@ -1,5 +1,5 @@
 ###############################################################################
-# layout_geoelf.des: Layouts buit around the delve command
+# layout_geoelf.des: Layouts built around the delve command
 ###############################################################################
 
 : crawl_require("dlua/layout/zonify.lua")
@@ -130,7 +130,7 @@ TAGS:   no_rotate no_vmirror no_hmirror uniq_layout_twisted_delve
     --
     -- roughen the borders
     --  -> this stops delve from making straight paths
-    --  -> these will bever be seen in-game
+    --  -> these will never be seen in-game
     --
 
     smear_map { onto = "cvmn", smear = "X", iterations = 200 }

--- a/crawl-ref/source/dat/des/builder/layout_geoelf.des
+++ b/crawl-ref/source/dat/des/builder/layout_geoelf.des
@@ -45,7 +45,7 @@ TAGS:   no_rotate no_vmirror no_hmirror
 
   local depth_fraction = you.depth_fraction()
 
-  -- some paramters
+  -- some parameters
   local rooms_across = 5
   local room_spacing = 13
   local offset_max = 1
@@ -183,7 +183,7 @@ TAGS:   no_rotate no_vmirror no_hmirror
 
   local depth_fraction = you.depth_fraction()
 
-  -- some paramters
+  -- some parameters
   local rooms_across = 7
   local room_spacing = 9
   local offset_max = 1

--- a/crawl-ref/source/dat/des/builder/layout_geoelf.des
+++ b/crawl-ref/source/dat/des/builder/layout_geoelf.des
@@ -345,7 +345,7 @@ TAGS:   no_rotate no_vmirror no_hmirror
   local gxm, gym = dgn.max_bounds()
   extend_map{width = gxm, height = gym, fill = 'x'}
 
-  -- some paramters
+  -- some parameters
   local depth_fraction = you.depth_fraction()
   local place_rings = crawl.random_range(2, 4)
   local extra_corridor_fraction = 0.7 - depth_fraction * 0.2

--- a/crawl-ref/source/dat/des/builder/layout_loops.des
+++ b/crawl-ref/source/dat/des/builder/layout_loops.des
@@ -600,7 +600,7 @@ end
 #  .......   ...x...      NO
 #  .......   .xxxxx.              CENTER
 #  .......   .xxxxx.   OUTLINE
-#  .......   .xxxxx.              GLPYH
+#  .......   .xxxxx.              GLYPH
 #  .......   ...x...     FORM
 #    ...       ...                 FORM
 #
@@ -608,7 +608,7 @@ end
 #   .....     .xxx.       NO
 #  .......   ..xxx..              CENTER
 #  .......   .xxxxx.   OUTLINE
-#  .......   ..xxx..              GLPYH
+#  .......   ..xxx..              GLYPH
 #   .....     .xxx.      FORM
 #   .....     .....                FORM
 #

--- a/crawl-ref/source/dat/des/builder/layout_loops.des
+++ b/crawl-ref/source/dat/des/builder/layout_loops.des
@@ -93,7 +93,7 @@ end
 # c = y * 1000 + x
 #
 # The array starts at 1.  Special position count (corners.count)
-#  is reserved for the number of elments in the array.  This
+#  is reserved for the number of elements in the array.  This
 #  array is basically serving as a vector with data in the range
 #  [1, count].
 #
@@ -111,19 +111,19 @@ end
 # Draws a "blocky" line of open cells connecting the two
 #  specified points.  The line is divided into a number of
 #  intervals that each of their own y-coordinate in the
-#  specified range.  The y-coordinates can be wieghted to low
+#  specified range.  The y-coordinates can be weighted to low
 #  or high values.
 #
 # Parameters:
 #  <1> e: The global environment
 #  <2> corners: The array of corners to update
 #  <3> start_x
-#  <4> start_y: The corrdinates of the start point
+#  <4> start_y: The coordinates of the start point
 #  <5> end_x
-#  <6> end_y: The corrdinates of the end point
+#  <6> end_y: The coordinates of the end point
 #  <7> min_y: The minimum y-coordinate
 #  <8> max_y: The maximum y-coordinate
-#  <9> weight_type: How the y-ccordinates should be weighted
+#  <9> weight_type: How the y-coordinates should be weighted
 #         < 0: to low values
 #        == 0: evenly
 #         > 0: to high values
@@ -320,7 +320,7 @@ end
 # loopsInsertDividedLoop
 #
 # Draws a square "loop" with blocky, irregular edges around a
-#  point.  The edges are in a number of segements with a
+#  point.  The edges are in a number of segments with a
 #  distance from the center in a specified range.  The segments
 #  are weighted towards the outside of the square because there
 #  is more are farther from the center.  The loop is forced to
@@ -330,7 +330,7 @@ end
 #  <1> e: The global environment
 #  <2> corners: The array of corners to update
 #  <3> center_x
-#  <4> center_y: The corrdinates of the center point
+#  <4> center_y: The coordinates of the center point
 #  <5> radius_min: The minimum radius of the square
 #  <6> radius_max: The maximum radius of the square
 #  <7> divisions: How many segments each side of the square
@@ -1429,7 +1429,7 @@ TAGS:   no_rotate no_vmirror no_hmirror
 
   -- we have a chance of placing the stairs
   if crawl.random2(100) < PLACE_STAIRS_PERCENT then
-    -- In genral, we add 3 rooms on each arm to hold the stairs
+    -- In general, we add 3 rooms on each arm to hold the stairs
     --  and pick two arms at random to have the stairs.  We
     --  also connect these stairs rooms to the central room for
     --  the arm.  The connections are added first so that they

--- a/crawl-ref/source/dat/des/builder/layout_vaults.des
+++ b/crawl-ref/source/dat/des/builder/layout_vaults.des
@@ -254,7 +254,7 @@ TAGS: no_hmirror no_vmirror chance_vaults uniq_vaults_maze layout_type_vaults
 MAP
 ENDMAP
 
-# Snakey maze consitently struggles to place rooms. Set to weight zero for now.
+# Snakey maze consistently struggles to place rooms. Set to weight zero for now.
 NAME: layout_vaults_maze_snakey
 DEPTH: Vaults
 WEIGHT: 10

--- a/crawl-ref/source/dat/des/portals/desolation.des
+++ b/crawl-ref/source/dat/des/portals/desolation.des
@@ -9,7 +9,7 @@
 # cover.
 #
 # Difficulty & treasure are intended to be similar to Elf's. If the portal is
-# well-recieved, it could be expanded into a branch that alternates with Elf.
+# well-received, it could be expanded into a branch that alternates with Elf.
 #
 ##############################################################################
 

--- a/crawl-ref/source/dat/des/portals/icecave.des
+++ b/crawl-ref/source/dat/des/portals/icecave.des
@@ -390,7 +390,7 @@ function ice_cave_magic_loot(e, glyphs)
 end
 
 --[[
-Define some common loot items using six KITEM statments on the supplied glyphs.
+Define some common loot items using six KITEM statements on the supplied glyphs.
 The first three are armour, the next two are weapons, and that last is magical
 items. See comments for ice_cave_armour_loot, ice_cave_weapon_loot, and
 ice_cave_magic_loot for details.

--- a/crawl-ref/source/dat/des/portals/volcano.des
+++ b/crawl-ref/source/dat/des/portals/volcano.des
@@ -1428,7 +1428,7 @@ ENDMAP
 # portal, leaving you with 7 to discover. Quickly, now!
 #
 # XXX: A less craggy layout with more space per-chamber would better
-#      accomodate actually randomizing where the bosses and extra loot is.
+#      accommodate actually randomizing where the bosses and extra loot is.
 #      The teleport limits are also not communicated at all, but is a
 #      necessary evil to prevent optimal teleportation abuse-
 #      what should be done here?

--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -1463,7 +1463,7 @@ KMONS:   6 = executioner w:5 / balrug w:5 / cacodemon / shadow demon / hellion w
              starcursed mass w:30 / apocalypse crab w:20
 KMONS:   7 = eldritch tentacle
 KMONS:   8 = obsidian statue
-# Translocations items, abyss escape aides, shrouds, and an immeadiate aide.
+# Translocations items, abyss escape aides, shrouds, and an immediate aide.
 KITEM:   d = scroll of blinking / scroll of teleportation q:3 w:15 / \
              any scroll w:1
 KITEM:   e = any ring

--- a/crawl-ref/source/dat/des/serial/aquarium.des
+++ b/crawl-ref/source/dat/des/serial/aquarium.des
@@ -37,7 +37,7 @@
 #  never choose this serial vault (even with PLACE) on early
 #  levels (I did not test deeper levels).  I believe this is
 #  because they were detected to have unreachable floor cells
-#  and thus failed an implicit accesibility validation of some
+#  and thus failed an implicit accessibility validation of some
 #  sort.  Taking out transparent solved the problem.
 #
 # advil: I've readded transparent, in combination with explicit

--- a/crawl-ref/source/dat/des/serial/column_ruins.des
+++ b/crawl-ref/source/dat/des/serial/column_ruins.des
@@ -288,7 +288,7 @@ NMLlll!?!lllLMN
     NNNMNNN
 ENDMAP
 
-# Although it is hard to tell from the map, this enterance can
+# Although it is hard to tell from the map, this entrance can
 #  have a moat of lava around it too.
 NAME:    column_ruins_portal_squares
 TAGS:    serial_column_ruins_portal luniq_column_ruins_portal

--- a/crawl-ref/source/dat/des/variable/compat.des
+++ b/crawl-ref/source/dat/des/variable/compat.des
@@ -92,7 +92,7 @@ function teleporter_serial_action_fn
   my_slaves = dgn.find_marker_positions_by_prop("teleport_spot",
                                                 data.teleport_spot)
 
-  -- third parameter is whether to teleport whatever is on the reciving pad
+  -- third parameter is whether to teleport whatever is on the receiving pad
   if you.teleport_to(my_slaves[1].x, my_slaves[1].y, false) then
     crawl.mpr("Your surroundings suddenly seem different!")
   else

--- a/crawl-ref/source/dat/des/variable/compat.des
+++ b/crawl-ref/source/dat/des/variable/compat.des
@@ -1,4 +1,4 @@
-# DES-related lua only needed for save compatability.
+# DES-related lua only needed for save compatibility.
 # Please remove the code in this file when the next line is false.
 # TAG_MAJOR_VERSION == 34
 {{

--- a/crawl-ref/source/dat/des/variable/ghost.des
+++ b/crawl-ref/source/dat/des/variable/ghost.des
@@ -41,7 +41,7 @@ end
 function wrathful_weapon(class, quality)
     local egos
     -- Only the egos Trog gifts, using equal weights for good_item but giving
-    -- the more desireable antimagic brand for randarts, which are trying to be
+    -- the more desirable antimagic brand for randarts, which are trying to be
     -- better quality.
     if quality == "good_item" then
         egos = {["antimagic"] = 10, ["heavy"] = 10, ["flaming"] = 10}

--- a/crawl-ref/source/dat/des/variable/large_themed.des
+++ b/crawl-ref/source/dat/des/variable/large_themed.des
@@ -2107,7 +2107,7 @@ ENDMAP
 
 ###############################################################################
 
-NAME:    regret_index_dithmenos_brocken_genspenst
+NAME:    regret_index_dithmenos_broken_genspenst
 TAGS:    no_monster_gen no_item_gen no_rotate patrolling
 DEPTH:   Depths, !Depths:$
 ORIENT:  south

--- a/crawl-ref/source/dat/des/variable/mini_features.des
+++ b/crawl-ref/source/dat/des/variable/mini_features.des
@@ -1,6 +1,6 @@
 ##############################################################################
 # mini_features.des: This is the place for minivaults without monsters.
-#           So all vaults in this file should have neiter ORIENT nor MONS or
+#           So all vaults in this file should have neither ORIENT nor MONS or
 #           KMONS lines. Exceptions are made for vaults which generally have
 #           no monsters or are supposed to look as if they had no monsters.
 #

--- a/crawl-ref/source/dat/dlua/gauntlet.lua
+++ b/crawl-ref/source/dat/dlua/gauntlet.lua
@@ -157,7 +157,7 @@ end
 -- @param custom_loot If non-nil, place this as a guaranteed loot item.
 function gauntlet_arena_item_setup(e, custom_loot)
     -- Replace all 'd' after the first with the unused 'X' glyph so we can more
-    -- easilly apply any custom replacement for those extra items.
+    -- easily apply any custom replacement for those extra items.
     e.nsubst("d = d / X")
 
     -- Redefine these item class glyphs to use no_pickup

--- a/crawl-ref/source/dat/dlua/init.lua
+++ b/crawl-ref/source/dat/dlua/init.lua
@@ -15,7 +15,7 @@ __echo = echoall
 --- A wrapper for the low-level sequence of commands needed to produce
 -- message output.
 -- @tparam string message
--- @tparam int channel messge channel number
+-- @tparam int channel message channel number
 -- @see crawl.mpr, crawl.msgch_name, crawl.msgch_num
 function crawl.message(message, channel)
   crawl.mpr(message, channel)

--- a/crawl-ref/source/dat/dlua/iter.lua
+++ b/crawl-ref/source/dat/dlua/iter.lua
@@ -524,7 +524,7 @@ function iter.invent_iterator:next()
   return point
 end
 
---- Check an item agains the iterator's filter
+--- Check an item against the iterator's filter
 -- @param item
 -- @return either the item or filter(item) if rv is asked for
 function iter.invent_iterator:check_filter(item)

--- a/crawl-ref/source/dat/dlua/layout/hyper_decor.lua
+++ b/crawl-ref/source/dat/dlua/layout/hyper_decor.lua
@@ -76,7 +76,7 @@ function hyper.rooms.decorate_walls(state, connections, door_required, has_windo
      or state.options.no_windows or not crawl.one_chance_in(5) then return end
 
   -- Choose feature for window
-  -- TODO: Pick other features in way that's similarly overrideable at multiple levels
+  -- TODO: Pick other features in way that's similarly overridable at multiple levels
   local window_feature = "clear_stone_wall"
   if state.options.layout_window_type ~= nil then window_feature = state.options.layout_window_type end
   if state.room.generator_used.window_type ~= nil then window_feature = state.room.generator_used.window_type end

--- a/crawl-ref/source/dat/dlua/layout/hyper_place.lua
+++ b/crawl-ref/source/dat/dlua/layout/hyper_place.lua
@@ -62,7 +62,7 @@ function hyper.place.build_rooms(build,usage_grid,options)
       local result = hyper.place.place_room(room,build,usage_grid,options)
       if result ~= nil and result.placed then
         placed = true
-        -- Increment rooms placed in this build, and total rooms placed by all bulids
+        -- Increment rooms placed in this build, and total rooms placed by all builds
         -- TODO: Could increment this automatically when applying instead...
         rooms_placed = rooms_placed + 1
         total_rooms_placed = total_rooms_placed + 1

--- a/crawl-ref/source/dat/dlua/layout/hyper_rooms.lua
+++ b/crawl-ref/source/dat/dlua/layout/hyper_rooms.lua
@@ -342,7 +342,7 @@ function hyper.rooms.add_walls(room, options)
         end
         if any_open then
           -- There was at least one open square so we need to make a wall which *could* be carvable.
-          -- Note: carvable doesn't mean this can necessarily be used as a door, e.g. Fort crennelations ... that will still happen in room analysys. It
+          -- Note: carvable doesn't mean this can necessarily be used as a door, e.g. Fort crennelations ... that will still happen in room analysis. It
           -- makes the logic overall much simpler.
           -- TODO: Allow diagonal doors here too. Diagonals are problematic (in the previous loop and in analyse_room) because we'd get overlapping anchors
           --       with adjacent walls, this really doesn't sound good.

--- a/crawl-ref/source/dat/dlua/layout/hyper_rooms.lua
+++ b/crawl-ref/source/dat/dlua/layout/hyper_rooms.lua
@@ -111,7 +111,7 @@ function hyper.rooms.make_room(options,generator)
     profiler.push("AnalyseRoomInternal")
   end
 
-  if generator.analyse_interal then
+  if generator.analyse_internal then
     hyper.usage.analyse_grid_usage(room.grid,options)
   end
 

--- a/crawl-ref/source/dat/dlua/layout/layout.lua
+++ b/crawl-ref/source/dat/dlua/layout/layout.lua
@@ -41,7 +41,7 @@ end
 -- Returns: An array containing the areas. If there is no
 --          primary vault, the array will contain one area
 --          bounded by x1, y1, x2, and y2. If the primary
---          vault covers evrything (e.g. an encompass vault) the
+--          vault covers everything (e.g. an encompass vault) the
 --          array will contain zero areas. Otherwise, the array
 --          will contain 1 or more areas composing a
 --          non-overlapping subset of the area bounded by x1,

--- a/crawl-ref/source/dat/dlua/layout/omnigrid.lua
+++ b/crawl-ref/source/dat/dlua/layout/omnigrid.lua
@@ -158,7 +158,7 @@ function omnigrid.subdivide_recursive(x1,y1,x2,y2,options,chance,depth)
     local new_depth = depth + 1
     -- Could probably avoid this duplication but it's not that bad
     if which == "x" then
-      -- Don't reduce the chance until we satisy maximum size
+      -- Don't reduce the chance until we satisfy maximum size
       if req_x then new_chance = chance end
       local pos = crawl.random_range(options.minimum_size_x,width-options.minimum_size_x)
       -- Create the two new areas
@@ -201,7 +201,7 @@ function omnigrid.subdivide_recursive(x1,y1,x2,y2,options,chance,depth)
         table.insert(results,b)
       end
     else
-      -- Don't reduce the chance until we satisy maximum size
+      -- Don't reduce the chance until we satisfy maximum size
       if req_y then new_chance = chance end
       local pos = crawl.random_range(options.minimum_size_y,height-options.minimum_size_y)
       -- Create the two new areas

--- a/crawl-ref/source/dat/dlua/lm_fog.lua
+++ b/crawl-ref/source/dat/dlua/lm_fog.lua
@@ -18,7 +18,7 @@
 -- parameters, can be used to achieve different effects.
 --
 -- Fog machines can be "chained" together (activated at the same time) by using
--- the convenience function "chained_fog_machine" with the normal paramaters
+-- the convenience function "chained_fog_machine" with the normal parameters
 -- which are accepted by "fog_machine".
 --
 -- Marker parameters:
@@ -309,7 +309,7 @@ end
 --      turns before to trigger the message before the fog machine is
 --      fired. If only see_message is provided, the message will only
 --      be printed if the player can see the fog machine. If only
---      cantsee_mesage is provided, the message will be displayed
+--      cantsee_message is provided, the message will be displayed
 --      regardless. In combination, the message will be different
 --      depending on whether or not the player can see the marker. By
 --      default, the message will be displaying using the "warning"

--- a/crawl-ref/source/dat/dlua/lm_trig.lua
+++ b/crawl-ref/source/dat/dlua/lm_trig.lua
@@ -552,7 +552,7 @@ end
 --
 -- * monster_dies: Waits for a monster to die. Needs the parameter
 --       "target", who's value is the name of the monster who's death
---       we're wating for, or "any" for any monster. Doesn't matter where
+--       we're waiting for, or "any" for any monster. Doesn't matter where
 --       the triggerable/marker is placed.
 --
 -- * feat_change: Waits for a cell's feature to change. Accepts the

--- a/crawl-ref/source/dat/dlua/lm_trove.lua
+++ b/crawl-ref/source/dat/dlua/lm_trove.lua
@@ -484,7 +484,7 @@ function TroveMarker:item_with_lowest_pluses(marker, pname, dry_run, items)
       titem = it
       titem_p1 = titem.pluses()
       --crawl.mpr("Picking " .. titem.name() ..
-      --          " instead (lesser pluses instad)")
+      --          " instead (lesser pluses instead)")
       --crawl.mpr("This item p1: " .. titem_p1 .. ")
     elseif this_p1 == item.plus1 then
       titem = it

--- a/crawl-ref/source/dat/dlua/lm_trove.lua
+++ b/crawl-ref/source/dat/dlua/lm_trove.lua
@@ -166,7 +166,7 @@ function TroveMarker:debug_diag (marker)
     self:search_for_item(marker, nil, items.inventory(), true)
   end
 
-  if crawl.yesno("Run diagonstic on floor?", true, "n") then
+  if crawl.yesno("Run diagnostic on floor?", true, "n") then
     local _x, _y = marker:pos()
     self:search_for_item(marker, nil, dgn.items_at(_x, _y), true)
   end

--- a/crawl-ref/source/dat/dlua/userbase.lua
+++ b/crawl-ref/source/dat/dlua/userbase.lua
@@ -1,7 +1,7 @@
 --- Entry points crawl uses for calling into lua.
 --
 -- Crawl contacts clua through hooks. Hooks can be interacted with either by
--- altering a hook table, defining certian functions, or the interface
+-- altering a hook table, defining certain functions, or the interface
 -- functions described here.
 --
 -- *Note:* This is not a real module. All names described here are in the
@@ -50,7 +50,7 @@ chk_lua_option          = { }
 -- A list of functions which get called when saving. They are expected to
 -- return strings of lua that will be executed on load. Data saved with this
 -- method is associated with the character save and will be lost on death.
--- For permanet storage see @{c_persist}.
+-- For permanent storage see @{c_persist}.
 -- @table chk_lua_save
 chk_lua_save            = { }
 
@@ -199,7 +199,7 @@ end
 -- This variable can be set by lua before the user is shown the
 -- "Activate which ability?" prompt. If set to a valid ability letter that
 -- ability will be activated without prompting the user. Otherwise the ability
--- prompt proceedes as normal.
+-- prompt proceeds as normal.
 --
 -- This value is cleared after every ability activation.
 --

--- a/crawl-ref/source/dat/dlua/util.lua
+++ b/crawl-ref/source/dat/dlua/util.lua
@@ -28,7 +28,7 @@ function util.subclass(parent, subclassname)
   return subclass
 end
 
---- Instatiate a new object
+--- Instantiate a new object
 function util.newinstance(class)
   local instance = { }
   setmetatable(instance, class)

--- a/crawl-ref/source/dat/dlua/v_rooms.lua
+++ b/crawl-ref/source/dat/dlua/v_rooms.lua
@@ -371,7 +371,7 @@ function place_vaults_rooms(e, data, room_count, options)
         placed = true
         rooms_placed = rooms_placed + 1  -- Increment # rooms placed
         times_failed = 0 -- Reset fail count
-        -- Perform analysis for stairs (and perform inner wall substituion if applicable)
+        -- Perform analysis for stairs (and perform inner wall substitution if applicable)
         analyse_vault_post_placement(data,room,result,options)
         table.insert(results,result)
         -- Increment the count of rooms of this type
@@ -579,7 +579,7 @@ function vaults_maybe_place_vault(e, pos, usage_grid, usage, room, options)
     v_normal_dir = v_normal.dir
   end
 
-  -- If placing a room in an existing wall we have the normal stored alredy in the usage data
+  -- If placing a room in an existing wall we have the normal stored already in the usage data
   if usage.usage == "eligible" or usage.usage == "eligible_open" then
     v_normal = usage.normal
     v_normal_dir = usage.normal.dir

--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -25,8 +25,8 @@ end
 function initialise_ziggurat(z, portal)
   -- Any given ziggurat will use the same builder for all its levels,
   -- and the same colours for outer walls. Before choosing the builder,
-  -- we specify a global excentricity. If zig_exc=0, then the ellipses
-  -- will be circles etc. It is not the actual excentricity but some
+  -- we specify a global eccentricity. If zig_exc=0, then the ellipses
+  -- will be circles etc. It is not the actual eccentricity but some
   -- value between 0 and 100. For deformed ellipses and rectangles, make
   -- sure that the map is wider than it is high for the sake of ASCII.
 

--- a/crawl-ref/source/dbg-asrt.cc
+++ b/crawl-ref/source/dbg-asrt.cc
@@ -699,7 +699,7 @@ void do_crash_dump()
     // generation info if the crash happened during level generation.
     _dump_level_info(file);
 
-    // Dumping information on marker inconsistancy is unlikely to crash,
+    // Dumping information on marker inconsistency is unlikely to crash,
     // as is dumping the descriptions of non-Lua markers.
     fprintf(file, "Markers:\n");
     fprintf(file, "<<<<<<<<<<<<<<<<<<<<<<\n");

--- a/crawl-ref/source/dbg-objstat.cc
+++ b/crawl-ref/source/dbg-objstat.cc
@@ -590,7 +590,7 @@ static void _init_spells()
     objstat_spells.insert(NUM_SPELLS);
 }
 
-// Initialize field data that needs non-default intialization (i.e. to
+// Initialize field data that needs non-default initialization (i.e. to
 // something other than zero). Handling this in one pass creates a lot of
 // potentially unused entries, but it's better than trying to guard against
 // default initialization everywhere. For the rest of the fields, it's fine to
@@ -799,7 +799,7 @@ void objstat_record_item(const item_def &item)
     const objstat_item objs_item(item);
 
     // Just in case, don't count mimics as items; these are converted
-    // explicitely in mg_do_build_level().
+    // explicitly in mg_do_build_level().
     if (item.flags & ISFLAG_MIMIC || objs_item.base_type == ITEM_IGNORE)
         return;
 

--- a/crawl-ref/source/debian/changelog
+++ b/crawl-ref/source/debian/changelog
@@ -542,7 +542,7 @@ crawl (2:0.5.2-1) unstable; urgency=low
   * Appease lintian:
     * debhelper-but-no-misc-depends;
     * extra-license-file;
-    * spelling-error-in-binary: persistant.
+    * spelling-error-in-binary: persistent.
   * Add a watch file for uscan(1).
   * Drop Debian.README; it should be clear to everyone by now that DCSS is
     the actively developed Crawl codebase.

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -5931,7 +5931,7 @@ int describe_monsters(const monster_info &mi, const string& /*footer*/)
 
 #ifdef USE_TILE_WEB
     // the spell list is delimited so that we can later replace this substring
-    // with a placeholder marker; remove the delimeters for console display
+    // with a placeholder marker; remove the delimiters for console display
     desc = formatted_string::parse_string(
         replace_all(
             replace_all(raw_desc, SPELL_LIST_BEGIN, ""),

--- a/crawl-ref/source/dgn-irregular-box.cc
+++ b/crawl-ref/source/dgn-irregular-box.cc
@@ -130,7 +130,7 @@ static vector<int> _calculate_random_values(int min_value, int max_value,
 //  values. The first and last elements are set to the
 //  specified values. After this, one value at random is
 //  set to 0. If count <= 1, this function returns a vector
-//  containg the single value 0.
+//  contain the single value 0.
 static vector<int> _calculate_random_wall_distances(int first_value,
                                                     int last_value,
                                                     int max_value,

--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -1210,7 +1210,7 @@ void do_annotate()
             annotate_level(lid);
             return;
         case ID_UP:
-            // level_id() is the error vallue of find_up_level(lid)
+            // level_id() is the error value of find_up_level(lid)
             if (find_up_level(lid) == level_id())
                 mpr("There is no level above you.");
             else

--- a/crawl-ref/source/dgn-proclayouts.cc
+++ b/crawl-ref/source/dgn-proclayouts.cc
@@ -391,7 +391,7 @@ UnderworldLayout::operator()(const coord_def &p, const uint32_t offset) const
     //  * Wet cities have
     //  * City + water areas have lateral bridges
     //  * Borrow some easing functions from somewhere to better
-    //    control how features vary across bounaries
+    //    control how features vary across boundaries
     //  * Look at surrounding squares to determine gradients - will help
     //    with lateral features and also e.g. growing plants on sunlit mountainsides...
     //  * Use some lateral wetness to try and join mountain streams up to rivers...

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1097,7 +1097,7 @@ bool direction_chooser::find_default_monster_target(coord_def& result) const
         result = mons_target->pos();
         return true;
     }
-    // If the previous targetted position is at all useful, use it.
+    // If the previous targeted position is at all useful, use it.
     if (!Options.simple_targeting && hitfunc && !prefer_farthest
         && _find_monster_expl(you.prev_grd_targ, mode, needs_path,
                               range, hitfunc, AFF_YES, AFF_MULTIPLE))
@@ -1135,7 +1135,7 @@ bool direction_chooser::find_default_monster_target(coord_def& result) const
     }
 
     // This is used for three things:
-    // * For all LRD targetting
+    // * For all LRD targeting
     // * To aim explosions so they try to miss you
     // * To hit monsters in LOS that are outside of normal range, but
     //   inside explosion/cloud range

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -113,7 +113,7 @@ static void _pick_float_exits(vault_placement &place,
                               vector<coord_def> &targets);
 static bool _feat_is_wall_floor_liquid(dungeon_feature_type);
 static bool _connect_spotty(const coord_def& from,
-                            bool (*overwriteable)(dungeon_feature_type) = nullptr);
+                            bool (*overwritable)(dungeon_feature_type) = nullptr);
 static bool _connect_vault_exit(const coord_def& exit);
 
 // VAULT FUNCTIONS
@@ -5733,10 +5733,10 @@ vector<coord_def> dgn_join_the_dots_pathfind(const coord_def &from,
 
 bool join_the_dots(const coord_def &from, const coord_def &to,
                    uint32_t mapmask,
-                   bool (*overwriteable)(dungeon_feature_type))
+                   bool (*overwritable)(dungeon_feature_type))
 {
-    if (!overwriteable)
-        overwriteable = _feat_is_wall_floor_liquid;
+    if (!overwritable)
+        overwritable = _feat_is_wall_floor_liquid;
 
     const vector<coord_def> path =
         dgn_join_the_dots_pathfind(from, to, mapmask);
@@ -5744,7 +5744,7 @@ bool join_the_dots(const coord_def &from, const coord_def &to,
     for (auto c : path)
     {
         auto feat = env.grid(c);
-        if (!map_masked(c, mapmask) && overwriteable(feat))
+        if (!map_masked(c, mapmask) && overwritable(feat))
         {
             env.grid(c) = DNGN_FLOOR;
             dgn_height_set_at(c);
@@ -6203,14 +6203,14 @@ static bool _feat_is_wall_floor_liquid(dungeon_feature_type feat)
 // It might be better to aim for a more open connection -- currently
 // it stops pretty much as soon as connectivity is attained.
 static set<coord_def> _dgn_spotty_connect_path(const coord_def& from,
-            bool (*overwriteable)(dungeon_feature_type))
+            bool (*overwritable)(dungeon_feature_type))
 {
     set<coord_def> flatten;
     set<coord_def> border;
     bool success = false;
 
-    if (!overwriteable)
-        overwriteable = _feat_is_wall_floor_liquid;
+    if (!overwritable)
+        overwritable = _feat_is_wall_floor_liquid;
 
     for (adjacent_iterator ai(from); ai; ++ai)
         if (!map_masked(*ai, MMT_VAULT) && _spotty_seed_ok(*ai))
@@ -6232,7 +6232,7 @@ static set<coord_def> _dgn_spotty_connect_path(const coord_def& from,
             if (env.grid(*ai) == DNGN_FLOOR)
                 success = true; // Through, but let's remove the others, too.
 
-            if (!overwriteable(env.grid(*ai)) || flatten.count(*ai))
+            if (!overwritable(env.grid(*ai)) || flatten.count(*ai))
                 continue;
 
             flatten.insert(*ai);
@@ -6255,10 +6255,10 @@ static set<coord_def> _dgn_spotty_connect_path(const coord_def& from,
 }
 
 static bool _connect_spotty(const coord_def& from,
-                            bool (*overwriteable)(dungeon_feature_type))
+                            bool (*overwritable)(dungeon_feature_type))
 {
     const set<coord_def> spotty_path =
-        _dgn_spotty_connect_path(from, overwriteable);
+        _dgn_spotty_connect_path(from, overwritable);
 
     if (!spotty_path.empty())
     {

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1140,7 +1140,7 @@ static int _process_disconnected_zones(int x1, int y1, int x2, int y2,
                 && (fill_small_zones <= 0 || zone_size <= fill_small_zones))
             {
                 // Don't fill in areas connected to vaults.
-                // We want vaults to be accessible; if the area is disconneted
+                // We want vaults to be accessible; if the area is disconnected
                 // from the rest of the level, this will cause the level to be
                 // vetoed later on.
                 bool veto = false;
@@ -1216,7 +1216,7 @@ static void _fill_small_disconnected_zones()
 {
     // debugging tip: change the feature to something like lava that will be
     // very noticeable.
-    // TODO: make even more agressive, up to ~25?
+    // TODO: make even more aggressive, up to ~25?
     _process_disconnected_zones(0, 0, GXM-1, GYM-1, true, DNGN_ROCK_WALL,
                                        _dgn_square_is_passable,
                                        _dgn_square_is_boring,

--- a/crawl-ref/source/dungeon.h
+++ b/crawl-ref/source/dungeon.h
@@ -296,7 +296,7 @@ vector<coord_def> dgn_join_the_dots_pathfind(const coord_def &from,
 
 bool join_the_dots(const coord_def &from, const coord_def &to,
                    unsigned mmask,
-                   bool (*overwriteable)(dungeon_feature_type) = nullptr);
+                   bool (*overwritable)(dungeon_feature_type) = nullptr);
 int count_feature_in_box(int x0, int y0, int x1, int y1,
                          dungeon_feature_type feat);
 bool door_vetoed(const coord_def pos);

--- a/crawl-ref/source/exercise.h
+++ b/crawl-ref/source/exercise.h
@@ -1,7 +1,7 @@
 /**
  * @file
  * @brief Collects all calls to skills.cc:exercise for
- *            easier changes to the training modell.
+ *            easier changes to the training model.
 **/
 
 #pragma once

--- a/crawl-ref/source/externs.h
+++ b/crawl-ref/source/externs.h
@@ -133,7 +133,7 @@ typedef uint32_t mid_t;
  * This macro produces several inline function definitions; use it only at
  * file/namespace scope. It requires a trailing semicolon.
  *
- * @param T A type expression naming the enum type to augument. Evaluated
+ * @param T A type expression naming the enum type to augment. Evaluated
  *          several times.
  */
 #define DEF_ENUM_INC(T) \

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -236,7 +236,7 @@ static bool _autoswitch_to_melee()
 
 static bool _can_shoot_with(const item_def *weapon)
 {
-    // TOOD: dedup elsewhere.
+    // TODO: dedup elsewhere.
     return weapon
         && is_range_weapon(*weapon)
         && !you.attribute[ATTR_HELD]

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1515,7 +1515,7 @@ static const string VISITED_LEVELS_KEY = "visited_levels";
 // needs to happen.
 // before pregeneration, whether the level had been visited was synonymous with
 // whether it had been visited, but after, we need to track this information
-// more directly. It is also inferrable from turns_on_level, but you can't get
+// more directly. It is also inferable from turns_on_level, but you can't get
 // at that very easily without fully loading the level.
 // no need for a minor version here, though there will be a brief window of
 // offline pregen games that this doesn't handle right -- they will get things

--- a/crawl-ref/source/geom2d.h
+++ b/crawl-ref/source/geom2d.h
@@ -15,7 +15,7 @@ struct vector
 
     const vector& operator+=(const vector &v);
 
-    // TODO Figure out MSVC compatability with
+    // TODO Figure out MSVC compatibility with
     // PURE definitions in this and hash.h
 
     vector operator+(const vector &v) const PURE;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1864,10 +1864,10 @@ static int _slouch_damage(monster *mon)
                          : mon->type == MONS_JIANGSHI ? 90
                                                       : 1;
 
-    const int player_numer = BASELINE_DELAY * BASELINE_DELAY * BASELINE_DELAY;
+    const int player_number = BASELINE_DELAY * BASELINE_DELAY * BASELINE_DELAY;
     return 4 * (mon->speed * BASELINE_DELAY * jerk_num
                            / mon->action_energy(EUT_MOVE) / jerk_denom
-                - player_numer / player_movement_speed() / player_speed());
+                - player_number / player_movement_speed() / player_speed());
 }
 
 static bool _slouchable(coord_def where)

--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -120,7 +120,7 @@ static void _handle_piety_penance(int piety_change, int piety_denom,
 }
 
 /**
- * Whether good gods that you folow are offended by you attacking a specific
+ * Whether good gods that you follow are offended by you attacking a specific
  * holy monster.
  *
  * @param victim    The holy in question. (May be nullptr.)
@@ -564,7 +564,7 @@ static int _piety_bonus_for_holiness(mon_holy_type holiness)
  * @param god_is_good   Whether this is a good god.
  *                      (They don't scale piety with XL in the same way...?)
  * @param special       A special-case function.
- * @return              An appropropriate like_response.
+ * @return              An appropriate like_response.
  */
 static like_response _on_kill(const char* desc, mon_holy_type holiness,
                               bool god_is_good = false,

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1244,7 +1244,7 @@ void dithmenos_shadow_spell(bolt* orig_beam, spell_type spell)
     beem.target = target;
     beem.aimed_at_spot = orig_beam->aimed_at_spot;
 
-    mprf(MSGCH_FRIEND_SPELL, "%s mimicks your spell!",
+    mprf(MSGCH_FRIEND_SPELL, "%s mimics your spell!",
          mon->name(DESC_THE).c_str());
     mons_cast(mon, beem, shadow_spell, MON_SPELL_WIZARD, false);
 

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -1267,7 +1267,7 @@ static void _jiyva_transform()
         you.transform_uncancellable = true;
 }
 /**
- * Make Jiyva contaminate tha player.
+ * Make Jiyva contaminate that player.
  */
 static void _jiyva_contaminate()
 {

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -70,7 +70,7 @@ using namespace ui;
 // enough memory allocated to snarf in the scorefile entries
 static unique_ptr<scorefile_entry> hs_list[SCORE_FILE_ENTRIES];
 static int hs_list_size = 0;
-static bool hs_list_initalized = false;
+static bool hs_list_initialized = false;
 
 static FILE *_hs_open(const char *mode, const string &filename);
 static void  _hs_close(FILE *handle);
@@ -158,7 +158,7 @@ int hiscores_new_entry(const scorefile_entry &ne)
     }
 
     hs_list_size = i;
-    hs_list_initalized = true;
+    hs_list_initialized = true;
 
     // If we've still not inserted it, it's not a highscore.
     if (!inserted)
@@ -253,7 +253,7 @@ void hiscores_read_to_memory()
     }
 
     hs_list_size = i;
-    hs_list_initalized = true;
+    hs_list_initialized = true;
 
     //close off
     _hs_close(scores);
@@ -295,7 +295,7 @@ string hiscores_print_list(int display_count, int format, int newest_entry, int&
     string ret;
 
     // Additional check to preserve previous functionality
-    if (!hs_list_initalized)
+    if (!hs_list_initialized)
         hiscores_read_to_memory();
 
     int i, total_entries;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -4429,7 +4429,7 @@ void get_system_environment()
     // The player's name
     SysEnv.crawl_name = check_string(getenv("CRAWL_NAME"));
 
-    // The directory which contians init.txt, macro.txt, morgue.txt
+    // The directory which contains init.txt, macro.txt, morgue.txt
     // This should end with the appropriate path delimiter.
     SysEnv.crawl_dir = check_string(getenv("CRAWL_DIR"));
 
@@ -4973,7 +4973,7 @@ static void _bones_ls(const string &filename, const string name_match,
         count++;
         if (long_output)
         {
-            // TOOD: line wrapping, some elements of this aren't meaningful at
+            // TODO: line wrapping, some elements of this aren't meaningful at
             // the command line
             describe_info inf;
             m.set_ghost(g);

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -1611,7 +1611,7 @@ int wand_charge_value(int type, int item_level)
 /**
  * Is the given item a wand which is empty? Wands are normally destroyed when
  * their charges are exhausted, but empty wands can still happen through
- * transfered games.
+ * transferred games.
  *
  * @param item  The item in question.
  * @return      Whether the wand is empty.

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1149,7 +1149,7 @@ bool use_an_item(operation_types oper, item_def *target)
  * This function generates a menu containing type_expect items based on the
  * object_class_type to be acted on by another function. First it will list
  * items in inventory, then items on the floor. If the prompt is cancelled,
- * false is returned. If something is successfully choosen, then true is
+ * false is returned. If something is successfully chosen, then true is
  * returned, and at function exit the parameter target points to the object the
  * player chose or to nullptr if the player chose to wield bare hands (this is
  * only possible if oper is OPER_WIELD).
@@ -2080,7 +2080,7 @@ static bool _can_takeoff_armour(int item)
 bool takeoff_armour(int item, bool noask)
 {
     ASSERT_RANGE(item, 0, ENDOFPACK);
-    // We want to check non-item depedent stuff before prompting for the actual item
+    // We want to check non-item dependent stuff before prompting for the actual item
     if (!_can_generically_use_armour(false))
         return false;
 

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -1687,7 +1687,7 @@ LUAFN(_crawl_unavailable_god)
 /*** Divine voices.
  * @within dlua
  * @tparam string Name of a current crawl god.
- * @tparam string Speach
+ * @tparam string Speech
  * @function god_speaks
  */
 LUAFN(_crawl_god_speaks)

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -929,11 +929,11 @@ static int crawl_split(lua_State *ls)
 
 /*** Compare two strings in a locale-independent way.
  * Lua's built in comparison operations for strings are dependent on locale,
- * which isn't always desireable. This is just a wrapper on
+ * which isn't always desirable. This is just a wrapper on
  * std::basic_string::compare.
  *
  * @tparam string s1 the first string.
- * @tparam string s2 the second sring.
+ * @tparam string s2 the second string.
  * @treturn number -1 if s1 < s2, 1 if s2 < s1, 0 if s1 == s2.
  * @function string_compare
  */

--- a/crawl-ref/source/l-dgnbld.cc
+++ b/crawl-ref/source/l-dgnbld.cc
@@ -124,7 +124,7 @@ static bool _coords(lua_State *ls, map_lines &lines,
     return x1 + border <= x2 - border && y1 + border <= y2 - border;
 }
 
-// Check if a given coordiante is valid for lines.
+// Check if a given coordinate is valid for lines.
 static bool _valid_coord(lua_State *ls, map_lines &lines, int x, int y, bool error = true)
 {
     if (x < 0 || x >= lines.width())

--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -146,7 +146,7 @@ static int l_item_do_wield(lua_State *ls)
 }
 
 /*** Wield this item.
- * @treturn boolean successfuly wielded
+ * @treturn boolean successfully wielded
  * @function wield
  */
 IDEFN(wield, do_wield)
@@ -167,7 +167,7 @@ static int l_item_do_wear(lua_State *ls)
 }
 
 /*** Wear this item (as armour).
- * @treturn boolean successfuly worn
+ * @treturn boolean successfully worn
  * @function wear
  */
 IDEFN(wear, do_wear)
@@ -187,7 +187,7 @@ static int l_item_do_puton(lua_State *ls)
 }
 
 /*** Put this item on (as jewellry).
- * @treturn boolean successfuly put on
+ * @treturn boolean successfully put on
  * @function puton
  */
 IDEFN(puton, do_puton)
@@ -1329,7 +1329,7 @@ static int l_item_pickup(lua_State *ls)
 /*** Get the Item in a given equipment slot.
  * Takes either a slot name or a slot number.
  * @tparam string|int where
- * @treturn Item|nil returns nil for nothing equiped or invalid slot
+ * @treturn Item|nil returns nil for nothing equipped or invalid slot
  * @function equipped_at
  */
 static int l_item_equipped_at(lua_State *ls)

--- a/crawl-ref/source/los.cc
+++ b/crawl-ref/source/los.cc
@@ -72,7 +72,7 @@ static vector<coord_def> ray_coords;
 
 // These store all unique minimal cellrays. For each i,
 // cellray i ends in cellray_ends[i] and passes through
-// thoses cells p that have blockrays(p)[i] set. In other
+// those cells p that have blockrays(p)[i] set. In other
 // words, blockrays(p)[i] is set iff an opaque cell p blocks
 // the cellray with index i.
 static vector<coord_def> cellray_ends;

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -572,7 +572,7 @@ static void _show_commandline_options_help()
     puts("      Defaults to entire dungeon; same level syntax as -mapstat.");
     puts("  -iters <num>        For -mapstat and -objstat, set the number of "
          "iterations");
-    puts("  -force-map <map>    For -mapstat and -objstat, alway choose the "
+    puts("  -force-map <map>    For -mapstat and -objstat, always choose the "
          "      given map on every level.");
 #endif
     puts("");

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -894,7 +894,7 @@ static int _armour_plus_threshold(equipment_type armour_type)
 static armour_type _get_random_armour_type(int item_level)
 {
 
-    // Dummy value for initilization, always changed by the conditional
+    // Dummy value for initialization, always changed by the conditional
     // (and not changing it would trigger an ASSERT)
     armour_type armtype = NUM_ARMOURS;
 
@@ -1643,7 +1643,7 @@ static void _generate_misc_item(item_def& item, int force_type, int item_level)
 }
 
 /**
- * Alter the inputed item to have no "plusses" (mostly weapon/armour enchantment)
+ * Alter the inputted item to have no "plusses" (mostly weapon/armour enchantment)
  *
  * @param[in,out] item_slot The item slot of the item to remove "plusses" from.
  */

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -4452,7 +4452,7 @@ mons_spec mons_list::get_slime_spec(const string &name) const
 
 /**
  * Build a monster specification for a specified pillar of salt. The pillar of
- * salt won't crumble over time, since that seems unuseful for any version of
+ * salt won't crumble over time, since that seems useful for any version of
  * this function.
  *
  * @param name      The description of the pillar of salt; e.g.
@@ -4484,7 +4484,7 @@ mons_spec mons_list::get_salt_spec(const string &name) const
 //    yellow draconian or draconian knight - the monster specified.
 //
 // Others:
-//    any draconian => any random draconain
+//    any draconian => any random draconian
 //    any base draconian => any unspecialised coloured draconian.
 //    any nonbase draconian => any specialised coloured draconian.
 //    any <colour> draconian => any draconian of the colour.

--- a/crawl-ref/source/maybe-bool.h
+++ b/crawl-ref/source/maybe-bool.h
@@ -2,7 +2,7 @@
 
 #include <string>
 
-// inspired by boost's logic::tribool, but with a much simpler implementaiton
+// inspired by boost's logic::tribool, but with a much simpler implementation
 //    (https://github.com/boostorg/logic/blob/develop/include/boost/logic/tribool.hpp)
 // This essentially is a Kleene strong three-valued boolean, that requires an
 // explicit cast to use as a bool.

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -797,7 +797,7 @@ public:
             //
             // However, it should only print one message at a time when it really
             // needs to, i.e. an sound that interrupts the game. Otherwise it is
-            // more efficent to print text together.
+            // more efficient to print text together.
 #ifdef USE_SOUND
             play_sound(check_sound_patterns(orig_full_text));
 #endif

--- a/crawl-ref/source/misc/valgrind-suppress.txt
+++ b/crawl-ref/source/misc/valgrind-suppress.txt
@@ -13,7 +13,7 @@
    fun:*end*
 }
 
-# An SDL "conditional jump or move" error, with the unitialized value
+# An SDL "conditional jump or move" error, with the initialized value
 # being supplied by Nvidia's OpenGL library.
 {
    tiles_SDL_Nvida_GL_cond

--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -997,7 +997,7 @@ bool mon_special_ability(monster* mons)
             actor *foe = mons->get_foe();
             if (foe && mons->can_see(*foe))
             {
-                bolt beem = setup_targetting_beam(*mons);
+                bolt beem = setup_targeting_beam(*mons);
                 beem.target = foe->pos();
                 setup_mons_cast(mons, beem, SPELL_THORN_VOLLEY);
 

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1426,7 +1426,7 @@ static bool _mons_take_special_action(monster &mons, int old_energy)
 
     if (friendly_or_near)
     {
-        bolt beem = setup_targetting_beam(mons);
+        bolt beem = setup_targeting_beam(mons);
         if (handle_throw(&mons, beem, false, false))
         {
             DEBUG_ENERGY_USE_REF("_handle_throw()");

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -780,7 +780,7 @@ static void _setup_heal_other(bolt &beam, const monster &caster, int)
  *
  * @param targeter     A function that finds a target for the given spell.
  *                      Expected to return an out-of-bounds coord on failure.
- * @return              A function that initializes a fake targetting beam.
+ * @return              A function that initializes a fake targeting beam.
  */
 static function<void(bolt&, const monster&, int)>
     _target_beam_setup(function<coord_def(const monster&)> targeter)
@@ -788,7 +788,7 @@ static function<void(bolt&, const monster&, int)>
     return [targeter](bolt& beam, const monster& caster, int)
     {
         _setup_fake_beam(beam, caster);
-        // Your shadow keeps your targetting.
+        // Your shadow keeps your targeting.
         if (mons_is_player_shadow(caster))
             return;
         beam.target = targeter(caster);
@@ -3565,7 +3565,7 @@ static void _setup_ghostly_sacrifice_beam(bolt& beam, const monster& caster,
                                           int power)
 {
     _setup_ghostly_beam(beam, power, 5);
-    // Future-proofing: your shadow keeps your targetting.
+    // Future-proofing: your shadow keeps your targeting.
     if (mons_is_player_shadow(caster))
         return;
 
@@ -3932,8 +3932,8 @@ static monster_spells _find_usable_spells(monster &mons)
  *
  * @param mons            The monster casting the spell. XXX: should be const
  * @param beem[in,out]    A targeting beam. Has a very few params already set.
- *                        (from setup_targetting_beam())
- * @param spell           The spell to be targetted and cast.
+ *                        (from setup_targeting_beam())
+ * @param spell           The spell to be targeted and cast.
  * @param ignore_good_idea  Whether to ignore most targeting constraints (ru)
  */
 static bool _target_and_justify_spell(monster &mons,
@@ -3983,7 +3983,7 @@ static bool _target_and_justify_spell(monster &mons,
  *                      TODO: should be const (requires _ms_low_hitpoint_cast
                         param to be const)
  * @param orig_beem[in,out]     A beam. Has a very few params already set.
- *                              (from setup_targetting_beam())
+ *                              (from setup_targeting_beam())
  *                              TODO: split out targeting into another func
  * @param hspell_pass   A list of valid spells to consider casting.
  * @param ignore_good_idea      Whether to be almost completely indiscriminate
@@ -4053,7 +4053,7 @@ static mon_spell_slot _choose_spell_to_cast(monster &mons,
         }
 
         // if we didn't roll a spell, don't make another attempt; bail.
-        // (only give multiple attempts for targetting issues.)
+        // (only give multiple attempts for targeting issues.)
         if (chosen_slot.spell == SPELL_NO_SPELL)
             return chosen_slot;
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -4102,7 +4102,7 @@ bool handle_mon_spell(monster* mons)
     if (!hspell_pass.size())
         return false;
 
-    bolt beem = setup_targetting_beam(*mons);
+    bolt beem = setup_targeting_beam(*mons);
 
     bool ignore_good_idea = false;
     if (does_ru_wanna_redirect(*mons))

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1844,7 +1844,7 @@ item_def* monster_die(monster& mons, killer_type killer,
     }
     else if (mons.type == MONS_FOXFIRE)
     {
-        // Foxfires are unkillable, they either dissapate by timing out
+        // Foxfires are unkillable, they either dissipate by timing out
         // or hit something.
         silent = true;
     }

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -274,7 +274,7 @@ void monster::add_enchantment_effect(const mon_enchant &ench, bool quiet)
 
         if (type == MONS_FLAYED_GHOST)
         {
-            // temporarly change our attitude back (XXX: scary code...)
+            // temporarily change our attitude back (XXX: scary code...)
             unwind_var<mon_enchant_list> enchants(enchantments, mon_enchant_list{});
             unwind_var<FixedBitVector<NUM_ENCHANTMENTS>> ecache(ench_cache, {});
             end_flayed_effect(this);

--- a/crawl-ref/source/mon-movetarget.cc
+++ b/crawl-ref/source/mon-movetarget.cc
@@ -431,7 +431,7 @@ bool find_merfolk_avatar_water_target(monster* mon)
     return false;
 }
 
-// Returns true if further handling neeeded.
+// Returns true if further handling needed.
 static bool _handle_monster_travelling(monster* mon)
 {
 #ifdef DEBUG_PATHFIND
@@ -654,7 +654,7 @@ static bool _choose_random_patrol_target_grid(monster* mon)
     }
 
     return count_grids;
-}// Returns true if further handling neeeded.
+}// Returns true if further handling needed.
 static bool _handle_monster_patrolling(monster* mon)
 {
     if (!_choose_random_patrol_target_grid(mon))

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -2078,7 +2078,7 @@ static band_type _choose_band(monster_type mon_type, int *band_size_p,
 }
 
 /// a weighted list of possible monsters for a given band slot.
-typedef vector<pair<monster_type, int>> member_possibilites;
+typedef vector<pair<monster_type, int>> member_possibilities;
 
 /**
  * For each band type, a list of weighted lists of monsters that can appear
@@ -2097,7 +2097,7 @@ typedef vector<pair<monster_type, int>> member_possibilites;
  * the third, fourth, etc monsters will either be MONS_C or MONS_D with equal
  * likelihood.
  */
-static const map<band_type, vector<member_possibilites>> band_membership = {
+static const map<band_type, vector<member_possibilities>> band_membership = {
     { BAND_HOGS,                {{{MONS_HOG, 1}}}},
     { BAND_YAKS,                {{{MONS_YAK, 1}}}},
     { BAND_FAUNS,               {{{MONS_FAUN, 1}}}},

--- a/crawl-ref/source/mon-speak.cc
+++ b/crawl-ref/source/mon-speak.cc
@@ -682,7 +682,7 @@ bool mons_speaks(monster* mons)
     {
         string key = "'";
 
-        // Database keys are case-insensitve.
+        // Database keys are case-insensitive.
         if (isaupper(mons_base_char(mons->type)))
             key += "cap-";
 

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1622,7 +1622,7 @@ static int _handle_conflicting_mutations(mutation_type mutation,
                     }
 
                 default:
-                    die("bad mutation conflict resulution");
+                    die("bad mutation conflict resolution");
                 }
             }
         }

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2555,7 +2555,7 @@ const char* category_mutation_name(mutation_type mut)
  *                          with the partial match results (e.g. show them to the user). If this is `nullptr`,
  *                          will accept only exact matches.
  *
- * @return the mutation type if succesful, otherwise NUM_MUTATIONS if it can't find a single match.
+ * @return the mutation type if successful, otherwise NUM_MUTATIONS if it can't find a single match.
  */
 mutation_type mutation_from_name(string name, bool allow_category, vector<mutation_type> *partial_matches)
 {

--- a/crawl-ref/source/nearby-danger.cc
+++ b/crawl-ref/source/nearby-danger.cc
@@ -44,7 +44,7 @@ static bool _mons_has_path_to_player(const monster* mon)
         return true;
 
     // Non-adjacent non-tentacle stationary monsters are only threatening
-    // because of any ranged attack they might posess, which is handled
+    // because of any ranged attack they might possess, which is handled
     // elsewhere in the safety checks. Presently all stationary monsters
     // have a ranged attack, but if a melee stationary monster is introduced
     // this will fail. Don't add a melee stationary monster it's not a good

--- a/crawl-ref/source/ng-init.cc
+++ b/crawl-ref/source/ng-init.cc
@@ -115,7 +115,7 @@ void initialise_temples()
     else
     {
         // distribution of altar count has a mean at 13.5, with the extremes
-        // occuring approximately 2.5% of the time each (a much thicker tail
+        // occurring approximately 2.5% of the time each (a much thicker tail
         // than using 6 + random2avg(16,2)).
         if (coinflip())
             altar_count = max(6, 5 + random2max(9, 2));

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -968,7 +968,7 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
             drain_mp(mp);
 
             // Wake players who took fatal damage exactly equal to current HP,
-            // but had it reduced below fatal threshhold by spirit shield.
+            // but had it reduced below fatal threshold by spirit shield.
             if (dam < you.hp)
                 you.check_awaken(500);
 

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -837,7 +837,7 @@ static void _print_stats_noise(int x, int y)
     // intentional non-reset: after it has started drawing, we always redraw
     // noise. There's not a lot of cost to this, and the logic for detecting
     // if/when silenced status has changed is extremely annoying. So
-    // you.redraw_noise is esentially only used to keep the noise bar from
+    // you.redraw_noise is essentially only used to keep the noise bar from
     // drawing while the game is starting up. (If someone can figure out how
     // to correctly detect all the silence special cases, feel free to add that
     // in and I will see if you succeeded -advil.)

--- a/crawl-ref/source/package.cc
+++ b/crawl-ref/source/package.cc
@@ -199,7 +199,7 @@ void package::load_traces()
         trace_chunk(entry.second);
 
 #ifdef COSTLY_ASSERTS
-    // any inconsitency in the save is guaranteed to be already found
+    // any inconsistency in the save is guaranteed to be already found
     // by this time -- this checks only for internal bugs
     fsck();
 #endif

--- a/crawl-ref/source/pcg.cc
+++ b/crawl-ref/source/pcg.cc
@@ -14,7 +14,7 @@
  * Original source is (c) 2014 Melissa O'Neill <oneill@pcg-random.org>
  * Licensed under Apache License 2.0
  *
- * get_bounded_uint32 is derived/modified from an implemention by Melissa
+ * get_bounded_uint32 is derived/modified from an implementation by Melissa
  * O'Neill of an algorithm by Daniel Lemire as part of a comparison of bounded
  * random functions:
  *    http://www.pcg-random.org/posts/bounded-rands.html

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1934,7 +1934,7 @@ void update_acrobat_status()
         return;
 
     // Acrobat duration goes slightly into the next turn, giving the
-    // player visual feedback of the EV bonus recieved.
+    // player visual feedback of the EV bonus received.
     // This is assignment and not increment as acrobat duration depends
     // on player action.
     you.duration[DUR_ACROBAT] = you.time_taken+1;

--- a/crawl-ref/source/precision-menu.cc
+++ b/crawl-ref/source/precision-menu.cc
@@ -1313,7 +1313,7 @@ void MenuFreeform::render()
 }
 
 /**
- * Handle all the dirtyness here that the MenuItems themselves do not handle
+ * Handle all the dirtiness here that the MenuItems themselves do not handle
  */
 void MenuFreeform::_place_items()
 {

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -1773,7 +1773,7 @@ namespace quiver
             }
         }
 
-        // TOOD: uses_mp for wand mp mutation? Because this mut no longer forces
+        // TODO: uses_mp for wand mp mutation? Because this mut no longer forces
         // mp use, the result is somewhat weird
 
         void trigger(dist &t) override
@@ -2436,7 +2436,7 @@ namespace quiver
     /**
      * Return an action corresponding to an ability.
      *
-     * @abil the abilty to use
+     * @abil the ability to use
      * @return the resulting action. May be invalid.
      */
     shared_ptr<action> ability_to_action(ability_type abil)

--- a/crawl-ref/source/randbook.cc
+++ b/crawl-ref/source/randbook.cc
@@ -897,7 +897,7 @@ static bool _completely_random_books(int agent)
     return agent == GOD_XOM || agent == GOD_NO_GOD;
 }
 
-/// How desireable is the given spell for inclusion in an acquired randbook?
+/// How desirable is the given spell for inclusion in an acquired randbook?
 static int _randbook_spell_weight(spell_type spell, int agent)
 {
     if (_completely_random_books(agent))

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -983,11 +983,11 @@ static void _inc_gift_timeout(int val)
 }
 
 // These are sorted in order of power.
-// monsteres here come from genera: n, z, V and W
+// monsters here come from genera: n, z, V and W
 // - Vampire mages are excluded because they worship scholarly Kiku
 // - M genus is all Kiku's domain
 // - Curse *, putrid mouths, and bloated husks left out as they might
-//   do too much collatoral damage
+//   do too much collateral damage
 static monster_type _yred_servants[] =
 {
     MONS_WIGHT, MONS_NECROPHAGE, MONS_SHADOW, MONS_PHANTOM, MONS_WRAITH,

--- a/crawl-ref/source/scripts/placement.lua
+++ b/crawl-ref/source/scripts/placement.lua
@@ -119,7 +119,7 @@ end
 
 local maps_to_test = args_init
 
--- Which des file is the map in? Only neeed if if the des file isn't specificed
+-- Which des file is the map in? Only need if if the des file isn't specified
 -- in dat/dlua/loadmaps.lua
 local des_file = one_arg(args, "-des", "")
 local need_to_load_des = des_file ~= ""

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1232,7 +1232,7 @@ bool ShopMenu::examine_index(int i)
     ASSERT(i < static_cast<int>(items.size()));
     // A hack to make the description more useful.
     // The default copy constructor is non-const for item_def,
-    // so we need this violation of const hygene to tweak the flags
+    // so we need this violation of const hygiene to tweak the flags
     // to make the description more useful. The flags are copied by
     // value by the default copy constructor so this is safe.
     item_def& item(*const_cast<item_def*>(dynamic_cast<ShopEntry*>(
@@ -2063,7 +2063,7 @@ void ShoppingList::move_things(const coord_def &_src, const coord_def &_dst)
         || crawl_state.obj_stat_gen
         || crawl_state.test)
     {
-        return; // Shopping list is unitialized and uneeded.
+        return; // Shopping list is initialized and unneeded.
     }
 
     const level_pos src(level_id::current(), _src);

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -41,7 +41,7 @@ static void _actor_apply_noise(actor *act,
                                const coord_def &apparent_source,
                                int noise_intensity_millis);
 
-/// By default, what databse lookup key corresponds to each shout type?
+/// By default, what database lookup key corresponds to each shout type?
 static const map<shout_type, string> default_msg_keys = {
     { S_SILENT,         "" },
     { S_SHOUT,          "__SHOUT" },
@@ -178,7 +178,7 @@ void monster_shout(monster* mons, int shout)
         // same glyph/symbol
         string glyph_key = "'";
 
-        // Database keys are case-insensitve.
+        // Database keys are case-insensitive.
         if (isaupper(mchar))
             glyph_key += "cap-";
 
@@ -565,7 +565,7 @@ static bool _allies_can_see(const monster &mon)
  * Issue the order specified by the given key.
  *
  * @param keyn              The key the player just pressed.
- * @param mons_targd[out]   Who the player's allies should be targetting as a
+ * @param mons_targd[out]   Who the player's allies should be targeting as a
  *                          result of this command.
  * @return                  Whether a command actually executed (and the value
  *                          of mons_targd should be used).

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -586,7 +586,7 @@ private:
                 "   [<w>?</w>] help"; // XX hardcoded for this menu
 
         if (search_text.size())
-            return pad_more_with(desc.str(), "[<w>Esc</w>] clear"); // esc is harcoded for this case
+            return pad_more_with(desc.str(), "[<w>Esc</w>] clear"); // esc is barcoded for this case
         else
             return pad_more_with_esc(desc.str());
     }

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -250,7 +250,7 @@ int get_spell_slot_by_letter(char letter)
 static int _get_spell_slot(spell_type spell)
 {
     // you.spells is a FixedVector of spells in some arbitrary order. It
-    // doesn't corespond to letters.
+    // doesn't correspond to letters.
     auto i = find(begin(you.spells), end(you.spells), spell);
     return i == end(you.spells) ? -1 : i - begin(you.spells);
 }
@@ -1650,7 +1650,7 @@ bool spell_no_hostile_in_range(spell_type spell)
     if (testbits(flags, spflag::helpful))
         return false;
 
-    // For chosing default targets and prompting we don't treat Inner Flame as
+    // For choosing default targets and prompting we don't treat Inner Flame as
     // neutral, since the seeping flames trigger conducts and harm the monster
     // before it explodes.
     const bool allow_friends = testbits(flags, spflag::neutral)

--- a/crawl-ref/source/store.h
+++ b/crawl-ref/source/store.h
@@ -161,7 +161,7 @@ public:
     // default before the operation is done.
 
     // If the value is a hash table or vector, the container's values
-    // can be accessed with the [] operator with the approriate key
+    // can be accessed with the [] operator with the appropriate key
     // type (strings for hashes, longs for vectors).
     CrawlStoreValue &operator [] (const string &key);
     CrawlStoreValue &operator [] (const char *key);

--- a/crawl-ref/source/stringutil.cc
+++ b/crawl-ref/source/stringutil.cc
@@ -237,7 +237,7 @@ string wordwrap_line(string &s, int width, bool tags, bool indent, int force_ind
 #endif
     s.erase(0, cp - cp0);
 
-    // if we had to break a line, reinsert the indendation
+    // if we had to break a line, reinsert the indentation
     if (indent && c != '\n')
         s = indentation + s;
 

--- a/crawl-ref/source/stringutil.h
+++ b/crawl-ref/source/stringutil.h
@@ -125,7 +125,7 @@ Enum find_earliest_match(const string &spec, Enum begin, Enum end,
  * @tparam F A callable type that takes whatever Z points to, and
  *     returns a string or null-terminated char *.
  * @tparam G A callable type that takes whatever Z points to, and
- *     returns some type that is explicitly convertable to bool
+ *     returns some type that is explicitly convertible to bool
  *
  * @param start An iterator to the beginning of the range of elements to
  *     consider.
@@ -143,7 +143,7 @@ Enum find_earliest_match(const string &spec, Enum begin, Enum end,
  *     of elements in the range.
  *
  * @return A string containing the stringifications of all the elements
- *     for which filter returns true, with andc separating the last two
+ *     for which filter returns true, with and separating the last two
  *     elements and comma separating the other elements. If the range is
  *     empty, returns the empty string.
  */

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -86,7 +86,7 @@ enum tag_minor_version
     TAG_MINOR_ABIL_GOD_FIXUP,      // Movement of some non-god-specific abils.
     TAG_MINOR_NEMELEX_DUNGEONS,    // Make nemelex not give/track decks of dungeons.
     TAG_MINOR_DEMONSPAWN,          // Save compat wrt demonspawn enemies.
-    TAG_MINOR_EVENT_TIMERS,        // "Every 20 turn" effects are less determinstic.
+    TAG_MINOR_EVENT_TIMERS,        // "Every 20 turn" effects are less deterministic.
     TAG_MINOR_EVENT_TIMER_FIX,     // Correct event timers in transferred games
     TAG_MINOR_MONINFO_ENERGY,      // Energy usage in monster_info
     TAG_MINOR_BOOK_ID,             // Track spellbooks you've identified

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -3189,7 +3189,7 @@ static void _tag_read_you(reader &th)
                 && th.getMinorVersion() < TAG_MINOR_SPIT_POISON_AGAIN_AGAIN
                 && j == MUT_SPIT_POISON)
             {
-                // this special case needs to be handled diferently or
+                // this special case needs to be handled differently or
                 // the level will be set too high; innate is what's corrupted.
                 you.mutation[j] = you.innate_mutation[j] = 1;
                 you.temp_mutation[j] = 0;
@@ -4502,7 +4502,7 @@ static void _tag_read_you_items(reader &th)
     if (th.getMinorVersion() < TAG_MINOR_REMOVE_DECKS)
         reclaim_decks();
 
-    // Reset training arrays for transfered gnolls that didn't train all skills.
+    // Reset training arrays for transferred gnolls that didn't train all skills.
     if (th.getMinorVersion() < TAG_MINOR_GNOLLS_REDUX)
         reset_training();
 

--- a/crawl-ref/source/tilebuf.cc
+++ b/crawl-ref/source/tilebuf.cc
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Vertex buffer implementaions
+ * @brief Vertex buffer implementations
 **/
 
 #include "AppHdr.h"

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -136,7 +136,7 @@ bool TilesFramework::fonts_initialized()
 static void _init_consoles()
 {
 #ifdef TARGET_OS_WINDOWS
-    // Windows has an annoying habbit of disconnecting GUI apps from
+    // Windows has an annoying habit of disconnecting GUI apps from
     // consoles at startup, and insisting that console apps start with
     // consoles.
     //

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -510,7 +510,7 @@ wint_t TilesFramework::_handle_control_message(sockaddr_un addr, string data)
 
         mprf(MSGCH_DGL_MESSAGE, "%s", m.c_str());
         // The following two lines are a magic incantation to get this mprf
-        // to actually render without waiting on player inout
+        // to actually render without waiting on player input
         flush_prev_message();
         c = CK_REDRAW;
     }

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -435,7 +435,7 @@ static void _catchup_monster_moves(monster* mon, int turns)
     if (!mon->alive())
         return;
 
-    // Ball lightning dissapates harmlessly out of LOS
+    // Ball lightning dissipates harmlessly out of LOS
     if (mon->type == MONS_BALL_LIGHTNING && mon->summoner == MID_PLAYER)
     {
         monster_die(*mon, KILL_RESET, NON_MONSTER);
@@ -471,7 +471,7 @@ static void _catchup_monster_moves(monster* mon, int turns)
         else
         {
             // handle expiration messages if the player was quick
-            // doing it this way so the mesages are kept consistent with
+            // doing it this way so the messages are kept consistent with
             // corresponding non-yred derived undead
             mon_enchant abj(ENCH_FAKE_ABJURATION, 0, 0, 1);
             mon->add_ench(abj);

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1558,7 +1558,7 @@ static int _transform_duration(transformation which_trans, int pow)
  * All undead can enter shadow form; vampires also can enter batform, and, when
  * full, other forms (excepting lichform).
  *
- * @param which_trans   The tranformation which the player is undergoing
+ * @param which_trans   The transformation which the player is undergoing
  *                      (default you.form).
  * @param involuntary   Whether the transformation is involuntary or not.
  * @param temp                   Whether to factor in temporary limits, e.g. wrong blood level.

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -1108,7 +1108,7 @@ sub read_data
         # Strip comments.
         s/#.*//;
 
-        # Strip trailing whitspace; leading whitespace indicates the
+        # Strip trailing whitespace; leading whitespace indicates the
         # continuation of a string field.
         s/\s*$//;
 

--- a/crawl-ref/source/util/txc
+++ b/crawl-ref/source/util/txc
@@ -692,7 +692,7 @@ class ResourceFile():
             call([EDITOR, tmp.name])
         except OSError:
             print >> sys.stderr, "Cannot start text editor." \
-                                 "Set the EDITOR environement variable."
+                                 "Set the EDITOR environment variable."
             return False
         tmp_res = self.__class__(self.language, self.resource)
         tmp_res.path = tmp.name

--- a/crawl-ref/source/util/unbrace
+++ b/crawl-ref/source/util/unbrace
@@ -134,7 +134,7 @@ for my $f (@files)
     /rebrace($1,$2,$3)/egsmx if $add_braces;
 
     # return is not a function, eliminate totally enclosing parentheses.
-    # This part handles parenthese-less payloads.
+    # This part handles parentheses-less payloads.
     while (/^( *)return \(([^()]+)\);/sm)
     {
         # Done this roundabout way to properly unindent multiline blocks.

--- a/crawl-ref/source/util/what_is_left.sh
+++ b/crawl-ref/source/util/what_is_left.sh
@@ -51,7 +51,7 @@ jewel_ring=`process_cmd $item_file | grep " RING_"  | grep -v -e RING_FIRST | wc
 jewel_amu=`process_cmd $item_file | grep " AMU_" | grep -v -e AMU_FIRST | wc -l`
 echo jewellery: $(expr $jewel_ring + $jewel_amu)
 
-# need to be strict about this one because there is some repitition here. n.b. this enum looks a bit inaccurate currently:
+# need to be strict about this one because there is some repetition here. n.b. this enum looks a bit inaccurate currently:
 evoc_misc=`process_cmd $item_file | grep "^    MISC_[A-Z_]*,\$" | grep -v -e DECK_UNKNOWN -e QUAD_DAMAGE | sort | uniq | wc -l`
 # TODO: in 0.10 and before, rods were staves, and this doesn't handle that correctly.
 evoc_rod=`process_cmd $item_file | grep "  ROD_" | wc -l` # the "  " here filters out a bunch of junk in enum.h
@@ -70,7 +70,7 @@ if [ -e art-data.txt ]; then
     #echo randarts: `gcc $cpp_args -E art-enum.h | grep UNRAND_ | grep -v -e UNRAND_DUMMY -e UNRAND_START | wc -l`
 else
     # unrands and fixedarts are collapsed with brands in this version, e.g. SPWPN_SINGING_SWORD
-    # in principle one could extrac this from unrand.h
+    # in principle one could extract this from unrand.h
     echo unrands: NA
 fi
 

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1053,7 +1053,7 @@ static update_flags player_view_update_at(const coord_def &gc)
     maybe_remove_autoexclusion(gc);
     update_flags ret;
 
-    // Set excludes in a radius of 1 around harmful clouds genereated
+    // Set excludes in a radius of 1 around harmful clouds generated
     // by neither monsters nor the player.
     const cloud_struct* cloud = cloud_at(gc);
     if (cloud && !crawl_state.game_is_arena())

--- a/crawl-ref/source/webserver/CHANGELOG.md
+++ b/crawl-ref/source/webserver/CHANGELOG.md
@@ -201,8 +201,8 @@ New features:
 - Save information can be shown to players in the webtiles lobby, for crawl
   versions that support it. Configurable on a version-by-version basis.
 - Add a tool for admins to send messages to all players on the server, via
-  a collapsable admin panel in the lobby visible to admin users.
+  a collapsible admin panel in the lobby visible to admin users.
 
 Fixes, improvements, changes:
-- Various fixes to loggin and error handling
+- Various fixes to login and error handling
 - stuck processes are now killed with SIGABRT, rather than SIGTERM

--- a/crawl-ref/source/webserver/config.py
+++ b/crawl-ref/source/webserver/config.py
@@ -113,7 +113,7 @@ game_data_no_cache = True
 # Recursive templating is supported. If a template named `default` is defined,
 # it will be used as the template for any game definitions that specify no
 # template at all (see example below). If `default` is defined, it can be
-# explicitly overriden by using the template name `base` (which cannot be
+# explicitly overridden by using the template name `base` (which cannot be
 # redefined).
 
 # Templating string values:
@@ -276,7 +276,7 @@ ssl_port = 8081
 #
 # 2. `nick_check_fun` if defined, is a function that returns true on valid
 # nicknames. You can use this for arbitrary custom nick checks in a server
-# config. You will need to do case management manually in this funciton.
+# config. You will need to do case management manually in this function.
 # def nick_check_fun(s):
 #     return s.lower() != "plog" and s.lower() != "muggle"
 #

--- a/crawl-ref/source/webserver/game_data/static/action_panel.js
+++ b/crawl-ref/source/webserver/game_data/static/action_panel.js
@@ -219,7 +219,7 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
             hide_settings();
         });
 
-        // Triggering this function on keyup might be too agressive,
+        // Triggering this function on keyup might be too aggressive,
         // but at least the player doesn't have to press Enter to confirm changes
         $("#action-panel-settings input[type=radio],input[type=number]")
             .on("change keyup", function (e) {

--- a/crawl-ref/source/webserver/static/scripts/key_conversion.js
+++ b/crawl-ref/source/webserver/static/scripts/key_conversion.js
@@ -141,7 +141,7 @@ define(function() {
             // The keycode mappings for function keys here were wrong for a very
             // long time. They should start with -265 to match ncurses keycodes,
             // but the code used numpad internal dcss keycodes for years and
-            // no one noticed. In fact, various incorrect changes happend to
+            // no one noticed. In fact, various incorrect changes happened to
             // the crawl binary to accommodate. For this reason, we still need
             // to use these keycodes for old versions. Overridden in 0.27+.
             112: -1011, // F1

--- a/crawl-ref/source/webserver/webtiles/config.py
+++ b/crawl-ref/source/webserver/webtiles/config.py
@@ -291,7 +291,7 @@ class GameConfig(MutableMapping):
         t = self.get_defaults()
         while isinstance(t, GameConfig) and t.template:
             if t.id in seen:
-                logging.error("Loop in tempate dependencies from game %s: %s", self.id, t.id)
+                logging.error("Loop in template dependencies from game %s: %s", self.id, t.id)
                 return False
             seen.add(t.id)
             t = t.get_defaults()

--- a/crawl-ref/source/webserver/webtiles/terminal.py
+++ b/crawl-ref/source/webserver/webtiles/terminal.py
@@ -28,7 +28,7 @@ class TerminalRecorder(object):
         Args:
             command: argv of command to run, eg [cmd, args, ...]
             env_vars: dictionary of environment variables to set. The variables
-                COLUMNS, LINES, and TERM cannot be overriden.
+                COLUMNS, LINES, and TERM cannot be overridden.
         """
         self.command = command
         self.ttyrec = None

--- a/crawl-ref/source/webserver/webtiles/userdb.py
+++ b/crawl-ref/source/webserver/webtiles/userdb.py
@@ -219,7 +219,7 @@ def flag_description(flags):
     if (flags & DGLACCT_ACCOUNT_HOLD):
         s.append("hold")
     else:
-        # account is in a wierd state if it has these set...
+        # account is in a weird state if it has these set...
         if (flags & DGLACCT_PASSWD_LOCK):
             s.append("passwd lock")
         if (flags & DGLACCT_EMAIL_LOCK):

--- a/crawl-ref/source/windowmanager-sdl.cc
+++ b/crawl-ref/source/windowmanager-sdl.cc
@@ -264,7 +264,7 @@ static int _translate_keysym(SDL_Keysym &keysym)
 
 #ifdef TARGET_OS_WINDOWS
     // AltGr looks like right alt + left ctrl on Windows. Let the input
-    // method geneate a TextInput event rather than trying to handle it
+    // method generate a TextInput event rather than trying to handle it
     // as a KeyDown.
     if (testbits(keysym.mod, KMOD_RALT | KMOD_LCTRL))
         return 0;

--- a/crawl-ref/source/wiz-fsim.cc
+++ b/crawl-ref/source/wiz-fsim.cc
@@ -1,6 +1,6 @@
 /**
  * @file
- * @brief Fight simualtion wizard functions.
+ * @brief Fight simulation wizard functions.
 **/
 
 #include "AppHdr.h"
@@ -434,7 +434,7 @@ static void _do_one_fsim_round(monster &mon, fight_data &fd, bool defend)
         fd.player.time_taken += time_taken;
         if (did_hit)
             fd.monster.hits++;
-        // did player succesfully do some kind of retaliatory damage?
+        // did player successfully do some kind of retaliatory damage?
         // TODO check for damage-less hits
         if (mon.max_hit_points > mon.hit_points)
             fd.player.hits++;

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -534,7 +534,7 @@ void wizard_value_item()
 /**
  * Generate every unrand (including removed ones).
  *
- * @param override_unique if true, will generate unrands that have alread
+ * @param override_unique if true, will generate unrands that have already
  * placed in the game. If false, will generate fallback randarts for any
  * unrands that have already placed.
  */

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -465,7 +465,7 @@ void debug_stethoscope(int mon)
                 continue;
 
             // this is arguably redundant with mons_list::parse_mons_spells
-            // specificially the bit that turns names into flags
+            // specifically the bit that turns names into flags
             static const map<mon_spell_slot_flag, string> flagnames = {
                 { MON_SPELL_EMERGENCY,  "E" },
                 { MON_SPELL_NATURAL,    "N" },
@@ -1078,7 +1078,7 @@ void debug_miscast(int target_index)
     }
 
     // Handle repeats ourselves since miscasts are likely to interrupt
-    // command repetions, especially if the player is the target.
+    // command repetitions, especially if the player is the target.
     int repeats = prompt_for_int("Number of repetitions? ", true);
     if (repeats < 1)
     {

--- a/crawl-ref/source/worley.cc
+++ b/crawl-ref/source/worley.cc
@@ -244,9 +244,9 @@ large deltas in your distance function, so our 3D search can find
 them! [Alternatively, change the search algorithm for your special
 cases.]
 */
-            d2=dx*dx+dy*dy+dz*dz; /* Euclidian distance, squared */
+            d2=dx*dx+dy*dy+dz*dz; /* Euclidean distance, squared */
 
-            if (d2<F[max_order-1]) /* Is this point close enough to rememember? */
+            if (d2<F[max_order-1]) /* Is this point close enough to remember? */
             {
                 /* Insert the information into the output arrays if it's close enough.
                    We use an insertion sort. No need for a binary search to find

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -3488,7 +3488,7 @@ static const map<xom_event_type, xom_event> xom_events = {
     { XOM_BAD_TORMENT, { "torment", _xom_torment, 23}},
     { XOM_BAD_CHAOS_CLOUD, { "chaos cloud", _xom_chaos_cloud, 20}},
     { XOM_BAD_BANISHMENT, { "banishment", _xom_banishment, 50}},
-    { XOM_BAD_PSEUDO_BANISHMENT, {"psuedo-banishment", _xom_pseudo_banishment,
+    { XOM_BAD_PSEUDO_BANISHMENT, {"pseudo-banishment", _xom_pseudo_banishment,
                                   10}},
 };
 


### PR DESCRIPTION
These changes ignore all the typos in contrib, and the typo list was generated using https://github.com/crate-ci/typos