### PR TITLE
Add some self-published spell books

### DIFF
--- a/crawl-ref/source/dat/des/builder/custombooks.des
+++ b/crawl-ref/source/dat/des/builder/custombooks.des
@@ -32,6 +32,7 @@ local books = {
 "Basic_Undead_Handling numspells:2 spells:animate_dead&dispel_undead",
 "Beguiling owner:Ashenzari numspells:5 spells:momentum_strike&dazzling_flash&"
   .. "portal_projectile&fulminant_prism&iskenderun's_mystic_blast",
+"Closer_Than_Before numspells:3 spells:agony&confusing_touch&dispel_undead",
 "Crowd_Control numspells:3 spells:gell's_gravitas&arcjolt&ignition",
 "Curse_Words numspells:5 spells:slow&anguish&silence&enfeeble&discord",
 "Earth_from_Core_to_Peak numspells:8 spells:sandblast&passwall&stone_arrow&"

--- a/crawl-ref/source/dat/des/builder/custombooks.des
+++ b/crawl-ref/source/dat/des/builder/custombooks.des
@@ -22,6 +22,8 @@ DEPTH:  D:4-, Depths, Elf, Snake
 -- The "randbook title:" part of the item def is left out here to help shorten
 -- the lines below 80 characters.
 local books = {
+"Amateur_Aromatherapy numspells:4 spells:mephitic_cloud&eringya's_noxious_bog&"
+  .. "cigotuvi's_dreadful_rot&poisonous_cloud",
 "Aperture_Sorcery numspells:4 spells:portal_projectile&passage_of_golubria&"
   .. "malign_gateway&death's_door",
 "Apprentice_Sorcery owner:Jessica numspells:4 spells:necrotise&slow&blink&"

--- a/crawl-ref/source/dat/des/builder/custombooks.des
+++ b/crawl-ref/source/dat/des/builder/custombooks.des
@@ -113,6 +113,8 @@ local books = {
 "Self-Indulgence owner:Encalio numspells:7 spells:necrotise&ignite_poison&"
   .. "chain_lightning&ozocubu's_armour&lehudib's_crystal_spear&animate_dead&"
   .. "enfeeble",
+"Servitor_Owner's_Manual numspells:6 spells:plasma_beam&fireball&arcjolt&"
+  .. "ledas's_unmaking&orb_of_destruction&lehudib's_crystal_spear",
 "Standing_By numspells:8 spells:freeze&kiss_of_death&static_discharge&"
   .. "vampiric_draining&dispel_undead&sticky_flame&agony&irradiate",
 "Terraforming numspells:7 spells:frozen_ramparts&leda's_liquefaction&"

--- a/crawl-ref/source/dat/des/builder/custombooks.des
+++ b/crawl-ref/source/dat/des/builder/custombooks.des
@@ -51,6 +51,8 @@ local books = {
 "Feline_Knowledge owner:Natasha numspells:3 spells:magic_dart&slow&call_imp",
 "Gerundive_Groundings numspells:5 spells:lesser_beckoning&vampiric_draining&"
   .. "yara's_violent_unravelling&leda's_unmaking&maxwell's_capacitive_coupling",
+"Guide_to_Peace_and_Solitude numspells:4 spells:dispersal&disjunction&"
+  .. "silence&teleport_other",
 "Hitting_the_Bricks numspells:4 spells:blink&passwall&swiftness&"
   .. "passage_of_golubria",
 "Honourable_Companions owner:Okawaru numspells:5 spells:foxfire&"

--- a/crawl-ref/source/dat/des/builder/custombooks.des
+++ b/crawl-ref/source/dat/des/builder/custombooks.des
@@ -41,6 +41,8 @@ local books = {
   .. "chain_lightning",
 "Elementary_Elements numspells:8 spells:foxfire&freeze&sandblast&shock&"
   .. "ensorcelled_hibernation&passwall&scorch&static_discharge",
+"Elemental_Confusion numspells:2 polar_vortex&
+  .. "maxwell's_capacitive_coupling",
 "Enchanting_Elements numspells:4 spells:inner_flame&leda's_liquefaction&"
  .. "metabolic_englaciation&silence",
 "Endless_Yammering numspells:1 spells:discord",


### PR DESCRIPTION
- "Amateur Aromatherapy" has stinky clouds.
- "Elemental Confusion" is about how Tornado and Absolute Zero swapped spell schools.
- "Closer Than Before" has spells that used to be ranged but are now range 1.
- "Servitor Owner's Manual" has the highest spells that Spellforged Servitor can cast.
- "Guide to Peace and Solitude" has spells that get rid of annoyances.