### PR TITLE
Fix Anaconda status description, remove unused variable

### DIFF
--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -480,7 +480,7 @@ and reducing the effectiveness of body armour.
 Any equipped weapons, shields, and gloves are melded, and your success rate
 with spells is somewhat reduced.
 %%%%
-Snake status
+Anaconda status
 
 You have been transformed into a giant, cold-blooded anaconda, ready to wind
 your coils around foes and crush them to death.

--- a/crawl-ref/source/dat/descript/zh/status.txt
+++ b/crawl-ref/source/dat/descript/zh/status.txt
@@ -429,7 +429,7 @@ Blade status
 
 装备的武器、盾牌和手套都会被融合，你的施法成功率也有所降低。
 %%%%
-Snake status
+Anaconda status
 
 你变成了一只巨大的、决意将敌人缠绕、挤压至死的冷血森蚺。
 

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1669,7 +1669,6 @@ vector<string> monster_info::get_unusual_items() const
 
         const item_def* item = inv[i].get();
         const string name = item->name(DESC_A, false, false, true, false);
-        const brand_type brand = get_weapon_brand(*item);
 
         if (any_of(begin(patterns), end(patterns),
                    [&](const text_pattern &p) -> bool


### PR DESCRIPTION
Mousing-over Anaconda status would show "No description found" on WebTiles as it had the wrong name in the db (could still be found via ?/t as it would match the contents).

Also remove an unused variable in `get_unusual_items()` after commit 128b3467.