### PR TITLE
Stop monsters applying Flux enchant to each other (fix issue 3241)

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/crawl.iml" filepath="$PROJECT_DIR$/.idea/crawl.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/crawl.iml" filepath="$PROJECT_DIR$/.idea/crawl.iml" />
-    </modules>
-  </component>
-</project>

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -587,7 +587,7 @@ bool melee_attack::handle_phase_hit()
     apply_damage_brand();
 
     // Apply flux form's sfx.
-    if (you.form == transformation::flux && defender->alive() && defender->is_monster())
+    if (attacker->is_player() && you.form == transformation::flux && defender->alive() && defender->is_monster())
         _apply_flux_contam(*(defender->as_monster()));
 
     // Fireworks when using Serpent's Lash to kill.


### PR DESCRIPTION
It should now only apply if the player is the attacker. Even though it was really funny.