### PR TITLE
New option use_terminal_default_colours

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -160,7 +160,8 @@ The contents of this text are:
                 blink_brightens_background, bold_brightens_foreground,
                 best_effort_brighten_background,
                 best_effort_brighten_foreground, allow_extended_colours,
-                background_colour, foreground_colour, use_fake_cursor
+                background_colour, foreground_colour,
+                use_default_terminal_colours, use_fake_cursor
 
 6-  Lua.
 6-a     Including lua files.
@@ -3119,6 +3120,10 @@ foreground_colour = lightgrey
 
         This option comes with the same baggage as the background_colour option.
         See its documentation for more details.
+
+use_terminal_default_colours = false
+        Use the terminal's default foreground and background colors. This can
+        be used to enable a transparent background.
 
 use_fake_cursor = true
         If true, Crawl draws the cursor explicitly on the level-map and

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -575,6 +575,7 @@ const vector<GameOption*> game_options::build_options_list()
         new ColourGameOption(SIMPLE_NAME(status_caption_colour), BROWN),
         new ColourGameOption(SIMPLE_NAME(background_colour), BLACK),
         new ColourGameOption(SIMPLE_NAME(foreground_colour), LIGHTGREY),
+        new BoolGameOption(SIMPLE_NAME(use_terminal_default_colours), false),
         new StringGameOption(enemy_hp_colour_option,
             {"enemy_hp_colour", "enemy_hp_color"}, "default", false,
             [this]() { update_enemy_hp_colour(); }),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -504,6 +504,7 @@ public:
     int         colour[16];      // macro fg colours to other colours
     unsigned    background_colour; // select default background colour
     unsigned    foreground_colour; // select default foreground colour
+    bool        use_terminal_default_colours; // inherit default colors from terminal
     msg_colour_type channels[NUM_MESSAGE_CHANNELS];  // msg channel colouring
     vector<string> use_animations_option;
     use_animations_type use_animations; // which animations to show


### PR DESCRIPTION
Use the terminal's default foreground and background colors. This can be used to enable a transparent background.

![Captura de pantalla -2023-08-10 22-38-18](https://github.com/crawl/crawl/assets/9676118/eb3b0488-c9fa-41af-ae27-1df175b263fe)

Closes #2534