### PR TITLE
feat: option to make autoexplore wait while listed durations are active

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -51,7 +51,9 @@ The contents of this text are:
                 tc_forbidden, runrest_ignore_message, runrest_stop_message,
                 interrupt_<delay>, delay_safe_poison, runrest_ignore_monster,
                 rest_wait_both, rest_wait_ancestor, rest_wait_percent,
-                explore_auto_rest, auto_exclude, travel_open_doors, fear_zot
+                explore_auto_rest, 
+                explore_auto_rest_status, explore_auto_rest_status_set, 
+                auto_exclude, travel_open_doors, fear_zot
 3-g     Command Enhancements.
                 auto_switch, easy_unequip, equip_unequip, jewellery_prompt,
                 easy_confirm, simple_targeting, force_spell_targeter,
@@ -1088,6 +1090,20 @@ rest_wait_percent = 100
 explore_auto_rest = true
         If true, auto-explore waits until your HP and MP are both at
         rest_wait_percent before moving. This is always disabled for Meteorans.
+
+explore_auto_rest_status_set = (none | all_neg_status | all_cooldowns | all)
+        Set explore_auto_rest to all statuses of that type. If anything else 
+        is given, defaults to none.
+                none            =   
+                all_neg_status  =   all temporary negative statuses
+                all_cooldowns   =   all temporary cooldowns
+                all             =   both all_neg_status and all_cooldowns
+        
+
+explore_auto_rest_status += <status name>, <cooldown name>, <duration name>...
+        (List option)
+        Auto-explore waits until all statuses, durations, and cooldowns in list 
+        are finished before moving. 
 
 fear_zot = false
         If true, Meteorans will be prompted before resting or auto-exploring

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -9,6 +9,7 @@
 #include "activity-interrupt-type.h"
 #include "char-set-type.h"
 #include "confirm-prompt-type.h"
+#include "duration-type.h"
 #include "easy-confirm-type.h"
 #include "explore-greedy-options.h"
 #include "feature.h"
@@ -672,6 +673,13 @@ public:
     // Wait for rest wait percent HP and MP before exploring.
     bool        explore_auto_rest;
 
+    // Sets explore_auto_rest_status for all durations with associated type.
+    string explore_auto_rest_status_set;
+
+    // explore_auto_rest_status is for which temporary statuses and cooldowns
+    // to wait for before exploring
+    vector<duration_type> explore_auto_rest_status;
+
     // Prompt Meteorans before exploring or resting.
     bool        fear_zot;
 
@@ -933,6 +941,7 @@ private:
 
     void update_explore_stop_conditions();
     void update_explore_greedy_visit_conditions();
+    void set_explore_auto_rest_status(const string &field);
     void update_use_animations();
     void update_travel_terrain();
 

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -2,30 +2,21 @@
 
 #include "status.h"
 
-#include "areas.h"
 #include "art-enum.h" // bearserk
 #include "artefact.h"
 #include "branch.h"
-#include "cloud.h"
 #include "duration-type.h"
 #include "env.h"
 #include "evoke.h"
 #include "fight.h" // weapon_cleaves
-#include "god-abil.h"
-#include "god-passive.h"
 #include "item-prop.h"
 #include "level-state-type.h"
-#include "mon-transit.h" // untag_followers() in duration-data
 #include "mutation.h"
 #include "options.h"
 #include "orb.h" // orb_limits_translocation in fill_status_info
 #include "player-stats.h"
-#include "random.h" // for midpoint_msg.offset() in duration-data
 #include "religion.h"
 #include "spl-damage.h" // COUPLING_TIME_KEY
-#include "spl-summoning.h" // NEXT_DOOM_HOUND_KEY in duration-data
-#include "spl-transloc.h" // for you_teleport_now() in duration-data
-#include "stairs.h" // rise_through_ceiling
 #include "stringutil.h"
 #include "throw.h"
 #include "transform.h"
@@ -64,6 +55,45 @@ static const duration_def* _lookup_duration(duration_type dur)
 const char *duration_name(duration_type dur)
 {
     return _lookup_duration(dur)->name();
+}
+
+duration_type duration_by_name(const string &name) {
+    for (int i = 0; i < NUM_DURATIONS; i++)
+    {
+        duration_def def = duration_data[duration_index[i]];
+
+        string short_text = def.short_text;
+        string name_text  = def.name_text;
+
+        lowercase(short_text);
+        lowercase(name_text);
+
+        if (name == short_text || name == name_text
+        || short_text.find(name) != string::npos
+        || name_text.find(name) != string::npos)
+        {
+            return (duration_type) def.dur;
+        }
+    }
+    return NUM_DURATIONS;
+}
+
+/**
+ * Vector of all durations with flag
+ *
+ */
+vector<duration_type> all_duration_with_flag(uint64_t flag)
+{
+    vector<duration_type> durations_with_flag = {};
+    for (int i = 0; i < NUM_DURATIONS; i++)
+    {
+        duration_type type = (duration_type) duration_index[i];
+        const duration_def* def = _lookup_duration(type);
+        if (def && def->duration_has_flag(flag)) {
+            durations_with_flag.push_back(type);
+        }
+    }
+    return durations_with_flag;
 }
 
 bool duration_dispellable(duration_type dur)

--- a/crawl-ref/source/status.h
+++ b/crawl-ref/source/status.h
@@ -71,6 +71,8 @@ struct status_info
 bool fill_status_info(int status, status_info& info);
 
 const char *duration_name(duration_type dur);
+duration_type duration_by_name(const string &name);
+vector<duration_type> all_duration_with_flag(uint64_t flag);
 bool duration_dispellable(duration_type dur);
 void init_duration_index();
 

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -53,6 +53,7 @@
 #include "religion.h"
 #include "stairs.h"
 #include "state.h"
+#include "status.h"
 #include "stringutil.h"
 #include "tag-version.h"
 #include "terrain.h"
@@ -1087,6 +1088,20 @@ command_type travel()
     {
         if (Options.explore_auto_rest && !you.is_sufficiently_rested())
             return CMD_WAIT;
+
+        for (unsigned int i = 0; i < Options.explore_auto_rest_status.size(); ++i)
+        {
+            duration_type type = Options.explore_auto_rest_status[i];
+
+            // Cant check DUR_TRANSFORMATION because it can be infinite
+            // If it is swiftness, check if it is antiswift before returning CMD_WAIT
+            if (you.duration[type] > 0
+                && type != DUR_TRANSFORMATION
+                && (type != DUR_SWIFTNESS || you.attribute[ATTR_SWIFTNESS] < 0))
+            {
+                return CMD_WAIT;
+            }
+        }
 
         // Exploring.
         if (env.grid(you.pos()) == DNGN_ENTER_SHOP


### PR DESCRIPTION
Resolves #3210 from (laserbat)

Added two new rc options

- explore_auto_rest_status (LIST)
  - Checks list and converts to known durations based on short_text and name_text.
- explore_auto_rest_status_set (STRING) 
  - Sets explore_auto_rest_status based on all statuses of selected type. Current options are none, all_neg_status, all_cooldowns, and all.

Added two new duration_flags that signify negative effects and cooldowns that affect the explore_auto_rest_status_set option

Options are default off right now. 

Further improvements on functionality could be:
- [ ] adding glow-level
- [ ] optimizing travel check to be based on callbacks
- [ ] more robust checking of waits that are too long (durations that are set manually to be on infinitely like transformations will not be caught typically, I think?)

Naming for the both option title and settings could be improved.