### PR TITLE
Updated tileidx_feature to prevent override of DNGN_UNKNOWN_PORTAL

### DIFF
--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -558,7 +558,8 @@ tileidx_t tileidx_feature(const coord_def &gc)
                         && feat != DNGN_FLOOR
                         && feat != DNGN_UNSEEN
                         && feat != DNGN_PASSAGE_OF_GOLUBRIA
-                        && feat != DNGN_MALIGN_GATEWAY;
+                        && feat != DNGN_MALIGN_GATEWAY
+                        && feat != DNGN_UNKNOWN_PORTAL;
     if (override && can_override)
         return override;
 


### PR DESCRIPTION
In depth write-up of the cause of #3225:

Gauntlet portal would be leaked by magic mapping via a scroll of magic mapping/revelations and then examining shop/portal tiles. The bug can be reproduced by setting PLACE: D:2 on the gauntlet entrance vault, and then descending to the second level of the dungeon. Simply placing the gauntlet entrance tile in wizard mode, and then clearing map knowledge does not repro the bug; the custom lua script in gauntlet.des is what causes the leak.

gauntlet.des uses the dgn.til lua function, which leads to tile_env.flv(pos).feat being set when laying out the gauntlet entrance vault in a level. tile_env.flv(pos).feat can override env.map_knowledge(pos) in tileidx_feature, which is used by the describe popup to select the appropriate tile.

This commit prevents the leak by adding DNGN_UNKNOWN_PORTAL as a tile exempt from being overriden. Removing the dng.tile call on the lua side seems to work as well, but I'm unsure which side effects that could have. Additionally, it makes sense to generally prevent DNGN_UNKNOWN_PORTAL from being overridden.

Refs: 3225