### PR TITLE
Fix typo: "It isextremely good for stabbing"

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1695,7 +1695,7 @@ static string _category_string(const item_def &item)
         {
             description += make_stringf(
                 "It is%s good for stabbing helpless or unaware enemies. ",
-                (item.sub_type == WPN_DAGGER) ? "extremely" : "");
+                (item.sub_type == WPN_DAGGER) ? " extremely" : "");
 
         }
         break;


### PR DESCRIPTION
An in-game description was saying "It isextremely good for stabbing". Fix the typo.