### PR TITLE
Rollpage heal

### DIFF
--- a/crawl-ref/source/dat/descript/passives.txt
+++ b/crawl-ref/source/dat/descript/passives.txt
@@ -58,7 +58,8 @@ You take an additional free step when moving towards enemies.
 %%%%
 roll passive
 
-<rampage passive>
+You take an additional free step when moving towards enemies, and heal while
+doing so.
 %%%%
 faith passive
 

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -869,6 +869,7 @@ void move_player_action(coord_def move)
 
             case spret::success:
                 rampaged = true;
+                apply_rampage_heal();
                 // If we've rampaged, reset initial_position for the second
                 // move.
                 initial_position = you.pos();
@@ -1096,6 +1097,8 @@ void move_player_action(coord_def move)
             _clear_constriction_data();
             _mark_potential_pursuers(targ);
             move_player_to_grid(targ, true);
+            if(rampaged)
+                apply_rampage_heal();
             apply_barbs_damage();
             remove_ice_movement();
             you.clear_far_engulf(false, true);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3753,6 +3753,16 @@ bool enough_mp(int minimum, bool suppress_msg, bool abort_macros)
     return true;
 }
 
+void apply_rampage_heal()
+{
+    //only armataurs heal on rampage
+    if(you.get_mutation_level(MUT_ROLLPAGE) == 0)
+        return;
+
+    int hp_gain = div_round_up(you.hp_max, 20); 
+    inc_hp(hp_gain);
+}
+
 void inc_mp(int mp_gain, bool silent)
 {
     ASSERT(!crawl_state.game_is_arena());

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1095,6 +1095,7 @@ void drain_mp(int mp_loss);
 void pay_hp(int cost);
 void pay_mp(int cost);
 
+void apply_rampage_heal();
 void inc_mp(int mp_gain, bool silent = false);
 void inc_hp(int hp_gain, bool silent = false);
 void refund_mp(int cost);


### PR DESCRIPTION
Grants armataurs 5% mhp healing for each tile they roll while rampaging.

Minimal effort has been done in descriptions, and absolutely no effort was given towards balance.