### PR TITLE
Adjust increase duration, and adjust jinxbite will/2 duration

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7644,6 +7644,10 @@ void player::increase_duration(duration_type dur, int turns, int cap,
         mpr(msg);
     cap *= BASELINE_DELAY;
 
+    //If we are already over the cap, do not increase or decrease duration.
+    if (cap && duration[dur] > cap)
+        return;
+
     duration[dur] += turns * BASELINE_DELAY;
     if (cap && duration[dur] > cap)
         duration[dur] = cap;

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -253,10 +253,12 @@ spret cast_jinxbite(int pow, bool fail)
          you.duration[DUR_JINXBITE] ? "more" : "some");
 
     int dur = random_range(9, 15) + div_rand_round(pow, 4);
-    int max = 15 + div_rand_round(pow, 4);
+    int willdur = random_range(dur, 15) +
+                  div_rand_round(spell_power_cap(SPELL_JINXBITE), 4);
 
     you.increase_duration(DUR_JINXBITE, dur);
-    you.increase_duration(DUR_LOWERED_WL, dur * 2, max * 2, "You feel your willpower being sapped.");
+    you.increase_duration(DUR_LOWERED_WL, willdur, willdur,
+                          "You feel your willpower being sapped.");
 
     return spret::success;
 }

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -253,9 +253,10 @@ spret cast_jinxbite(int pow, bool fail)
          you.duration[DUR_JINXBITE] ? "more" : "some");
 
     int dur = random_range(9, 15) + div_rand_round(pow, 4);
+    int max = 15 + div_rand_round(pow, 4);
 
     you.increase_duration(DUR_JINXBITE, dur);
-    you.increase_duration(DUR_LOWERED_WL, dur * 2, 0, "You feel your willpower being sapped.");
+    you.increase_duration(DUR_LOWERED_WL, dur * 2, max * 2, "You feel your willpower being sapped.");
 
     return spret::success;
 }


### PR DESCRIPTION
Currently, casting Jinxbite, especially multiple times, results in an irritatingly long period of Will/2 to rest off. This rarely has practical impact, but is poor for quality of life. This PR reduces the duration of Will/2 to closely match the maximum possible jinxbite duration, and makes the Will/2 duration not stack by applying a cap. 

Applying the cap with no other changes causes issues.
Previously, when increase_duration was called with a nonzero cap on a duration already over said cap, it would decrease the duration down to the cap.

Currently, this can occur if reading a scroll of vuln, then getting hit with an AF_VULN attack or a will stripping zot trap- potentially shortening the duration from 50 turns to 40 or 20. Granting a reasonable cap to Jinxbite would have been considerably worse; potentially allowing players to remove AF_VULN at will.

This commit also changes increase_duration so that if a cap is passed, and the duration already surpasses the passed cap, the duration is not changed.

To the best of my knowledge, the only example besides AF_VULN where this change has impact is that blueberry klown pies could clear silence by applying shorter silence; this is almost certainly unintended, and if not good riddance anyways.