### PR TITLE
Reallow gozag title for excessive spenders

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -59,7 +59,8 @@ static int _gold_level()
            (you.gold >=  5000) ? 5 :
            (you.gold >=  1000) ? 4 :
            (you.gold >=   500) ? 3 :
-           (you.gold >=   100) ? 2
+           (you.gold >=   100) ? 2 :
+           (you.props.exists(DESCENT_DEBT_KEY)) ? 0
                                : 1;
 }
 


### PR DESCRIPTION
While it's not technically penance, Descent's debt mechanic is close enough to justify giving out Gozag's penance title.