### PR TITLE
Make Ozo's Fridge ignore firewood for huddling

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -668,11 +668,13 @@ static int _count_adj_actors(coord_def pos)
     for (adjacent_iterator ai(pos); ai; ++ai)
     {
         const actor* act = actor_at(*ai);
-        if(!act)
+        if (!act)
             continue;
+
         const monster* mon = act->as_monster();
-        if(mon && mons_is_firewood(*mon))
+        if (mon && mons_is_firewood(*mon))
             continue;
+
         if (!mons_is_conjured(act->type))
             ++adj_count;
     }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -808,10 +808,8 @@ static spret _cast_los_attack_spell(spell_type spell, int pow,
             continue;
         if (!(*vulnerable)(agent, *ai))
             continue;
-
         if ((*vulnerable)(agent, *ai))
             affected_actors.push_back(*ai);
-
         // For perf, don't count when running tracers.
         if (spell == SPELL_OZOCUBUS_REFRIGERATION)
             ozo_adj_count[*ai] = actual ? _count_adj_actors(ai->pos()) : 0;

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -662,7 +662,7 @@ static int _los_spell_damage_actor(const actor* agent, actor &target,
 }
 
 //Counts adjacent non-firewood actors
-static int _count_adj_actors(coord_def pos)
+int count_adj_actors(coord_def pos)
 {
     int adj_count = 0;
     for (adjacent_iterator ai(pos); ai; ++ai)
@@ -814,7 +814,7 @@ static spret _cast_los_attack_spell(spell_type spell, int pow,
 
         // For perf, don't count when running tracers.
         if (spell == SPELL_OZOCUBUS_REFRIGERATION)
-            ozo_adj_count[*ai] = actual ? _count_adj_actors(ai->pos()) : 0;
+            ozo_adj_count[*ai] = actual ? count_adj_actors(ai->pos()) : 0;
     }
 
     const int avg_damage = (1 + beam.damage.num * beam.damage.size) / 2;

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -662,7 +662,7 @@ static int _los_spell_damage_actor(const actor* agent, actor &target,
 }
 
 //Counts adjacent non-firewood actors
-int count_adj_actors(coord_def pos)
+static int _count_adj_actors(coord_def pos)
 {
     int adj_count = 0;
     for (adjacent_iterator ai(pos); ai; ++ai)
@@ -814,7 +814,7 @@ static spret _cast_los_attack_spell(spell_type spell, int pow,
 
         // For perf, don't count when running tracers.
         if (spell == SPELL_OZOCUBUS_REFRIGERATION)
-            ozo_adj_count[*ai] = actual ? count_adj_actors(ai->pos()) : 0;
+            ozo_adj_count[*ai] = actual ? _count_adj_actors(ai->pos()) : 0;
     }
 
     const int avg_damage = (1 + beam.damage.num * beam.damage.size) / 2;

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -670,11 +670,9 @@ static int _count_adj_actors(coord_def pos)
         const actor* act = actor_at(*ai);
         if(!act)
             continue;
-
         const monster* mon = act->as_monster();
         if(mon && mons_is_firewood(*mon))
             continue;
-
         if (!mons_is_conjured(act->type))
             ++adj_count;
     }
@@ -808,8 +806,10 @@ static spret _cast_los_attack_spell(spell_type spell, int pow,
             continue;
         if (!(*vulnerable)(agent, *ai))
             continue;
+
         if ((*vulnerable)(agent, *ai))
             affected_actors.push_back(*ai);
+
         // For perf, don't count when running tracers.
         if (spell == SPELL_OZOCUBUS_REFRIGERATION)
             ozo_adj_count[*ai] = actual ? _count_adj_actors(ai->pos()) : 0;

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -661,13 +661,21 @@ static int _los_spell_damage_actor(const actor* agent, actor &target,
     return hurted;
 }
 
+//Counts adjacent non-firewood actors
 static int _count_adj_actors(coord_def pos)
 {
     int adj_count = 0;
     for (adjacent_iterator ai(pos); ai; ++ai)
     {
         const actor* act = actor_at(*ai);
-        if (act && !mons_is_conjured(act->type))
+        if(!act)
+            continue;
+
+        const monster* mon = act->as_monster();
+        if(mon && mons_is_firewood(*mon))
+            continue;
+
+        if (!mons_is_conjured(act->type))
             ++adj_count;
     }
     return adj_count;

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -98,7 +98,6 @@ spret cast_toxic_radiance(actor *caster, int pow, bool fail = false,
                                bool mon_tracer = false);
 void toxic_radiance_effect(actor* agent, int mult, bool on_cast = false);
 
-int count_adj_actors(coord_def pos);
 dice_def glaciate_damage(int pow, int eff_range);
 spret cast_glaciate(actor *caster, int pow, coord_def aim,
                          bool fail = false);

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -98,6 +98,7 @@ spret cast_toxic_radiance(actor *caster, int pow, bool fail = false,
                                bool mon_tracer = false);
 void toxic_radiance_effect(actor* agent, int mult, bool on_cast = false);
 
+int count_adj_actors(coord_def pos);
 dice_def glaciate_damage(int pow, int eff_range);
 spret cast_glaciate(actor *caster, int pow, coord_def aim,
                          bool fail = false);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1609,8 +1609,14 @@ aff_type targeter_refrig::is_affected(coord_def loc)
     for (adjacent_iterator ai(loc); ai; ++ai)
     {
         const actor* adj_act = actor_at(*ai);
-        if (adj_act
-            && agent->can_see(*adj_act)
+        if (!adj_act)
+            continue;
+
+        const monster* mon = adj_act->as_monster();
+        if (mon && mons_is_firewood(*mon))
+            continue;
+
+        if (agent->can_see(*adj_act)
             && !mons_is_conjured(adj_act->type))
         {
             ++adj;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1605,17 +1605,7 @@ aff_type targeter_refrig::is_affected(coord_def loc)
     if (god_protects(agent, act->as_monster(), true))
         return AFF_NO;
 
-    int adj = 0;
-    for (adjacent_iterator ai(loc); ai; ++ai)
-    {
-        const actor* adj_act = actor_at(*ai);
-        if (adj_act
-            && agent->can_see(*adj_act)
-            && !mons_is_conjured(adj_act->type))
-        {
-            ++adj;
-        }
-    }
+    int adj = count_adj_actors(loc);
     switch (adj)
     {
     case 0:

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1605,7 +1605,17 @@ aff_type targeter_refrig::is_affected(coord_def loc)
     if (god_protects(agent, act->as_monster(), true))
         return AFF_NO;
 
-    int adj = count_adj_actors(loc);
+    int adj = 0;
+    for (adjacent_iterator ai(loc); ai; ++ai)
+    {
+        const actor* adj_act = actor_at(*ai);
+        if (adj_act
+            && agent->can_see(*adj_act)
+            && !mons_is_conjured(adj_act->type))
+        {
+            ++adj;
+        }
+    }
     switch (adj)
     {
     case 0:


### PR DESCRIPTION
Ozocubu's Refridgeration deals reduced damage to actors that are adjacent to another actor. This previously included firewood.

If fridge is your primary damage source (by a sufficiently large margin), you are encouraged to shoot firewood with a sling then wait for it to die when it comes into LOS, so that monsters could not huddle against it. This is an extremely unfun play pattern.

While this issue occurs to some degree with plant blocked missiles, it is not as severe in those cases, nor as easily fixable. In the case of missiles, retreating until an enemy enters line of fire is sufficient. In the case of Ozocubu's, you must retreat until the enemy is a full tile beyond the plant, which may be several turns where the enemy has LOF but can still huddle.