### PR TITLE
Explicitly qualify std::move and std::forward

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1563,7 +1563,7 @@ void AcquireMenu::init_entries()
         auto newentry = make_unique<AcquireEntry>(item);
         newentry->hotkeys.clear();
         newentry->add_hotkey(ckey++);
-        add_entry(move(newentry));
+        add_entry(std::move(newentry));
     }
 
     on_single_selection = [this](const MenuEntry& item)

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -1481,9 +1481,9 @@ static void _choose_arena_teams(newgame_def& choice,
     prompt.cprintf("  Sigmund v Jessica\n");
     prompt.cprintf("  99 orc v the Royal Jelly\n");
     prompt.cprintf("  20-headed hydra v 10 kobold ; scimitar ego:flaming");
-    vbox->add_child(make_shared<Text>(move(prompt)));
+    vbox->add_child(make_shared<Text>(std::move(prompt)));
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     bool done = false, cancel = false;
     popup->on_hotkey_event([&](const KeyEvent& ev) {
@@ -1494,7 +1494,7 @@ static void _choose_arena_teams(newgame_def& choice,
         return done;
     });
 
-    ui::run_layout(move(popup), done, teams_input);
+    ui::run_layout(std::move(popup), done, teams_input);
 
     if (cancel || crawl_state.seen_hups)
     {

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -229,23 +229,23 @@ static void _print_version()
 #ifdef USE_TILE
     auto icon = make_shared<Image>();
     icon->set_tile(tile_def(TILEG_STARTUP_STONESOUP));
-    title_hbox->add_child(move(icon));
+    title_hbox->add_child(std::move(icon));
 #endif
 
     auto title = make_shared<Text>(formatted_string::parse_string(info));
     title->set_margin_for_sdl(0, 0, 0, 10);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_cross_alignment(Widget::CENTER);
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
     title_hbox->set_margin_for_sdl(0, 0, 20, 0);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     auto scroller = make_shared<Scroller>();
     auto content = formatted_string::parse_string(feats + "\n\n" + changes);
-    auto text = make_shared<Text>(move(content));
+    auto text = make_shared<Text>(std::move(content));
     text->set_wrap_text(true);
-    scroller->set_child(move(text));
+    scroller->set_child(std::move(text));
     vbox->add_child(scroller);
 
     auto popup = make_shared<ui::Popup>(vbox);
@@ -265,7 +265,7 @@ static void _print_version()
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 }
 
 void list_armour()

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -420,19 +420,19 @@ static void _describe_cards(CrawlVector& cards)
 #ifdef USE_TILE
         auto icon = make_shared<Image>();
         icon->set_tile(tile_def(TILEG_NEMELEX_CARD));
-        title_hbox->add_child(move(icon));
+        title_hbox->add_child(std::move(icon));
 #endif
         auto title = make_shared<Text>(formatted_string(name, WHITE));
         title->set_margin_for_sdl(0, 0, 0, 10);
-        title_hbox->add_child(move(title));
+        title_hbox->add_child(std::move(title));
         title_hbox->set_cross_alignment(Widget::CENTER);
         title_hbox->set_margin_for_crt(first ? 0 : 1, 0);
         title_hbox->set_margin_for_sdl(first ? 0 : 20, 0);
-        vbox->add_child(move(title_hbox));
+        vbox->add_child(std::move(title_hbox));
 
         auto text = make_shared<Text>(desc);
         text->set_wrap_text(true);
-        vbox->add_child(move(text));
+        vbox->add_child(std::move(text));
 
 #ifdef USE_TILE_WEB
         tiles.json_open_object();
@@ -447,7 +447,7 @@ static void _describe_cards(CrawlVector& cards)
     vbox->max_size().width = tiles.get_crt_font()->char_width()*80;
 #endif
 
-    scroller->set_child(move(vbox));
+    scroller->set_child(std::move(vbox));
     auto popup = make_shared<ui::Popup>(scroller);
 
     bool done = false;
@@ -462,7 +462,7 @@ static void _describe_cards(CrawlVector& cards)
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 }
 
 string deck_status(deck_type deck)

--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -730,7 +730,7 @@ void push_delay(shared_ptr<Delay> delay);
 template<typename T, typename... Args>
 shared_ptr<Delay> start_delay(Args&&... args)
 {
-    auto delay = make_shared<T>(forward<Args>(args)...);
+    auto delay = make_shared<T>(std::forward<Args>(args)...);
     push_delay(delay);
     return delay;
 }

--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -1061,16 +1061,16 @@ static void build_partial_god_ui(god_type which_god, shared_ptr<ui::Popup>& popu
     auto icon = make_shared<Image>();
     const tileidx_t idx = tileidx_feature_base(altar_for_god(which_god));
     icon->set_tile(tile_def(idx));
-    title_hbox->add_child(move(icon));
+    title_hbox->add_child(std::move(icon));
 #endif
 
     auto title = make_shared<Text>(topline.trim());
     title->set_margin_for_sdl(0, 0, 0, 16);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_main_alignment(Widget::CENTER);
     title_hbox->set_cross_alignment(Widget::CENTER);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     desc_sw = make_shared<Switcher>();
     more_sw = make_shared<Switcher>();
@@ -1111,7 +1111,7 @@ static void build_partial_god_ui(god_type which_god, shared_ptr<ui::Popup>& popu
         auto text = make_shared<Text>(desc.trim());
         text->set_wrap_text(true);
         scroller->set_child(text);
-        desc_sw->add_child(move(scroller));
+        desc_sw->add_child(std::move(scroller));
 
         more_sw->add_child(make_shared<Text>(
                 formatted_string::parse_string(mores[mores_index][i])));

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -128,19 +128,19 @@ int show_description(const describe_info &inf, const tile_def *tile)
             auto icon = make_shared<Image>();
             icon->set_tile(*tile);
             icon->set_margin_for_sdl(0, 10, 0, 0);
-            title_hbox->add_child(move(icon));
+            title_hbox->add_child(std::move(icon));
         }
 #else
         UNUSED(tile);
 #endif
 
         auto title = make_shared<Text>(inf.title);
-        title_hbox->add_child(move(title));
+        title_hbox->add_child(std::move(title));
 
         title_hbox->set_cross_alignment(Widget::CENTER);
         title_hbox->set_margin_for_sdl(0, 0, 20, 0);
         title_hbox->set_margin_for_crt(0, 0, 1, 0);
-        vbox->add_child(move(title_hbox));
+        vbox->add_child(std::move(title_hbox));
     }
 
     auto desc_sw = make_shared<Switcher>();
@@ -167,7 +167,7 @@ int show_description(const describe_info &inf, const tile_def *tile)
         auto text = make_shared<Text>(fs);
         text->set_wrap_text(true);
         scroller->set_child(text);
-        desc_sw->add_child(move(scroller));
+        desc_sw->add_child(std::move(scroller));
         more_sw->add_child(make_shared<Text>(
                 formatted_string::parse_string(mores[i])));
     }
@@ -218,7 +218,7 @@ int show_description(const describe_info &inf, const tile_def *tile)
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     return lastch;
 }
@@ -3426,11 +3426,11 @@ bool describe_feature_wide(const coord_def& pos, bool do_actions)
 #ifdef USE_TILE
         auto icon = make_shared<Image>();
         icon->set_tile(feat.tile);
-        title_hbox->add_child(move(icon));
+        title_hbox->add_child(std::move(icon));
 #endif
         auto title = make_shared<Text>(feat.title);
         title->set_margin_for_sdl(0, 0, 0, 10);
-        title_hbox->add_child(move(title));
+        title_hbox->add_child(std::move(title));
         title_hbox->set_cross_alignment(Widget::CENTER);
 
         const bool has_desc = feat.body != feat.title && feat.body != "";
@@ -3440,7 +3440,7 @@ bool describe_feature_wide(const coord_def& pos, bool do_actions)
             title_hbox->set_margin_for_crt(0, 0, 1, 0);
             title_hbox->set_margin_for_sdl(0, 0, 20, 0);
         }
-        vbox->add_child(move(title_hbox));
+        vbox->add_child(std::move(title_hbox));
 
         if (has_desc)
         {
@@ -3473,13 +3473,13 @@ bool describe_feature_wide(const coord_def& pos, bool do_actions)
         footer->set_text(footer_text);
         footer->set_margin_for_crt(1, 0, 0, 0);
         footer->set_margin_for_sdl(20, 0, 0, 0);
-        vbox->add_child(move(footer));
+        vbox->add_child(std::move(footer));
     }
 
 #ifdef USE_TILE_LOCAL
     vbox->max_size().width = tiles.get_crt_font()->char_width()*80;
 #endif
-    scroller->set_child(move(vbox));
+    scroller->set_child(std::move(vbox));
 
     auto popup = make_shared<ui::Popup>(scroller);
 
@@ -3517,7 +3517,7 @@ bool describe_feature_wide(const coord_def& pos, bool do_actions)
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
     return _do_feat_action(pos, action);
 }
 
@@ -3917,20 +3917,20 @@ command_type describe_item_popup(const item_def &item,
         {
             auto icon = make_shared<Image>();
             icon->set_tile(tile);
-            tiles_stack->add_child(move(icon));
+            tiles_stack->add_child(std::move(icon));
         }
-        title_hbox->add_child(move(tiles_stack));
+        title_hbox->add_child(std::move(tiles_stack));
     }
 #endif
 
     auto title = make_shared<Text>(name);
     title->set_margin_for_sdl(0, 0, 0, 10);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_cross_alignment(Widget::CENTER);
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
     title_hbox->set_margin_for_sdl(0, 0, 20, 0);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     auto scroller = make_shared<Scroller>();
     auto text = make_shared<Text>(fs_desc.trim());
@@ -3948,14 +3948,14 @@ command_type describe_item_popup(const item_def &item,
         footer->set_text(footer_text);
         footer->set_margin_for_crt(1, 0, 0, 0);
         footer->set_margin_for_sdl(20, 0, 0, 0);
-        vbox->add_child(move(footer));
+        vbox->add_child(std::move(footer));
     }
 
 #ifdef USE_TILE_LOCAL
     vbox->max_size().width = tiles.get_crt_font()->char_width()*80;
 #endif
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     bool done = false;
     command_type action = CMD_NO_CMD;
@@ -4003,7 +4003,7 @@ command_type describe_item_popup(const item_def &item,
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     return action;
 }
@@ -4498,7 +4498,7 @@ void describe_spell(spell_type spell, const monster_info *mon_owner,
 #ifdef USE_TILE
     auto spell_icon = make_shared<Image>();
     spell_icon->set_tile(tile_def(tileidx_spell(spell)));
-    title_hbox->add_child(move(spell_icon));
+    title_hbox->add_child(std::move(spell_icon));
 #endif
 
     string spl_title = spell_title(spell);
@@ -4507,21 +4507,21 @@ void describe_spell(spell_type spell, const monster_info *mon_owner,
     auto title = make_shared<Text>();
     title->set_text(spl_title);
     title->set_margin_for_sdl(0, 0, 0, 10);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_cross_alignment(Widget::CENTER);
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
     title_hbox->set_margin_for_sdl(0, 0, 20, 0);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     auto scroller = make_shared<Scroller>();
     auto text = make_shared<Text>();
     text->set_text(formatted_string::parse_string(desc));
     text->set_wrap_text(true);
-    scroller->set_child(move(text));
+    scroller->set_child(std::move(text));
     vbox->add_child(scroller);
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     bool done = false;
     int lastch;
@@ -4548,7 +4548,7 @@ void describe_spell(spell_type spell, const monster_info *mon_owner,
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 }
 
 /**
@@ -6112,18 +6112,18 @@ int describe_monsters(const monster_info &mi, const string& /*footer*/)
     auto dgn = make_shared<Dungeon>();
     dgn->width = dgn->height = 1;
     dgn->buf().add_monster(mi, 0, 0);
-    title_hbox->add_child(move(dgn));
+    title_hbox->add_child(std::move(dgn));
 #endif
 
     auto title = make_shared<Text>();
     title->set_text(inf.title);
     title->set_margin_for_sdl(0, 0, 0, 10);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_cross_alignment(Widget::CENTER);
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
     title_hbox->set_margin_for_sdl(0, 0, 20, 0);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     desc += inf.body.str();
     if (crawl_state.game_is_hints())
@@ -6161,7 +6161,7 @@ int describe_monsters(const monster_info &mi, const string& /*footer*/)
         auto text = make_shared<Text>(content[i]->trim());
         text->set_wrap_text(true);
         scroller->set_child(text);
-        desc_sw->add_child(move(scroller));
+        desc_sw->add_child(std::move(scroller));
 
         more_sw->add_child(make_shared<Text>(
                 formatted_string::parse_string(mores[i])));
@@ -6179,7 +6179,7 @@ int describe_monsters(const monster_info &mi, const string& /*footer*/)
     vbox->max_size().width = tiles.get_crt_font()->char_width()*80;
 #endif
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     bool done = false;
     int lastch;
@@ -6269,7 +6269,7 @@ int describe_monsters(const monster_info &mi, const string& /*footer*/)
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     return lastch;
 }

--- a/crawl-ref/source/dgn-event.cc
+++ b/crawl-ref/source/dgn-event.cc
@@ -32,7 +32,7 @@ void dgn_event_dispatcher::move_listeners(
     const coord_def &from, const coord_def &to)
 {
     // Any existing listeners at to will be discarded. YHBW.
-    grid_triggers[to.x][to.y] = move(grid_triggers[from.x][from.y]);
+    grid_triggers[to.x][to.y] = std::move(grid_triggers[from.x][from.y]);
 }
 
 bool dgn_event_dispatcher::has_listeners_at(const coord_def &pos) const

--- a/crawl-ref/source/end.cc
+++ b/crawl-ref/source/end.cc
@@ -348,7 +348,7 @@ NORETURN void end_game(scorefile_entry &se)
 
     auto tile = make_shared<Image>(death_tile);
     tile->set_margin_for_sdl(0, 10, 0, 0);
-    title_hbox->add_child(move(tile));
+    title_hbox->add_child(std::move(tile));
 #endif
     string goodbye_title = make_stringf("Goodbye, %s.", you.your_name.c_str());
     title_hbox->add_child(make_shared<Text>(goodbye_title));
@@ -357,7 +357,7 @@ NORETURN void end_game(scorefile_entry &se)
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
 
     auto vbox = make_shared<Box>(Box::VERT);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
 
     string goodbye_msg;
     goodbye_msg += "    "; // Space padding where # would go in list format
@@ -400,7 +400,7 @@ NORETURN void end_game(scorefile_entry &se)
     vbox->add_child(make_shared<Text>(formatted_string::parse_string(morgue_dir)));
 #endif
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
     bool done = false;
     popup->on_keydown_event([&](const KeyEvent&) { return done = true; });
 
@@ -419,7 +419,7 @@ NORETURN void end_game(scorefile_entry &se)
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-        ui::run_layout(move(popup), done);
+        ui::run_layout(std::move(popup), done);
     }
 
 #ifdef USE_TILE_WEB

--- a/crawl-ref/source/format.cc
+++ b/crawl-ref/source/format.cc
@@ -106,7 +106,7 @@ void formatted_string::parse_string_to_multiple(const string &s,
     vector<string> lines = split_string("\n", s, false, true);
     if (wrap_col > 0)
     {
-        vector<string> pre_split = move(lines);
+        vector<string> pre_split = std::move(lines);
         for (string &line : pre_split)
         {
             do

--- a/crawl-ref/source/format.h
+++ b/crawl-ref/source/format.h
@@ -114,7 +114,7 @@ template<typename R>
 formatted_string&& operator+(formatted_string&& lhs, const R&& rhs)
 {
     lhs += rhs;
-    return move(lhs);
+    return std::move(lhs);
 }
 
 inline formatted_string operator+(const formatted_string& lhs, const char* rhs)
@@ -127,7 +127,7 @@ inline formatted_string operator+(const formatted_string& lhs, const char* rhs)
 inline formatted_string&& operator+(formatted_string&& lhs, const char* rhs)
 {
     lhs += rhs;
-    return move(lhs);
+    return std::move(lhs);
 }
 
 int count_linebreaks(const formatted_string& fs);

--- a/crawl-ref/source/game-options.h
+++ b/crawl-ref/source/game-options.h
@@ -467,7 +467,7 @@ public:
             if (ltyp == RCFILE_LINE_MINUS)
                 remove_matching(value, element);
             else
-                new_entries.push_back(move(element));
+                new_entries.push_back(std::move(element));
         }
         merge_lists(value, new_entries, ltyp == RCFILE_LINE_CARET);
         return GameOption::loadFromString(field, ltyp);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -198,16 +198,16 @@ void pick_hints(newgame_def& choice)
         fill_doll_for_newgame(doll, tng);
         auto tile = make_shared<ui::PlayerDoll>(doll);
         tile->set_margin_for_sdl(0, 6, 0, 0);
-        hbox->add_child(move(tile));
+        hbox->add_child(std::move(tile));
         hbox->add_child(label);
 #endif
 
         auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE_LOCAL
         hbox->set_margin_for_sdl(4,8);
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
 #else
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
 #endif
         btn->id = i;
         btn->hotkey = 'a' + i;
@@ -241,7 +241,7 @@ void pick_hints(newgame_def& choice)
     {
         auto label = make_shared<Text>(formatted_string("Esc - Quit", BROWN));
         auto btn = make_shared<MenuButton>();
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
         btn->hotkey = CK_ESCAPE;
         btn->id = CK_ESCAPE;
         sub_items->add_button(btn, 0, 0);
@@ -249,7 +249,7 @@ void pick_hints(newgame_def& choice)
     {
         auto label = make_shared<Text>(formatted_string("  * - Random hints mode character", BROWN));
         auto btn = make_shared<MenuButton>();
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
         btn->hotkey = '*';
         btn->id = '*';
         sub_items->add_button(btn, 0, 1);
@@ -263,7 +263,7 @@ void pick_hints(newgame_def& choice)
         return false;
     });
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     if (cancelled)
     {
@@ -414,7 +414,7 @@ void hints_starting_screen()
     popup->on_keydown_event([&](const KeyEvent&) { return done = true; });
 
     mouse_control mc(MOUSE_MODE_MORE);
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 }
 
 // Called each turn from _input. Better name welcome.

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -139,7 +139,7 @@ int hiscores_new_entry(const scorefile_entry &ne)
             // Fixed a nasty overflow bug here -- Sharp
             if (i+1 < SCORE_FILE_ENTRIES)
             {
-                hs_list[i + 1] = move(hs_list[i]);
+                hs_list[i + 1] = std::move(hs_list[i]);
                 hs_list[i].reset(new scorefile_entry(ne));
                 i++;
             }
@@ -424,13 +424,13 @@ UIHiscoresMenu::UIHiscoresMenu()
 #ifdef USE_TILE
     auto tile = make_shared<Image>();
     tile->set_tile(tile_def(TILEG_STARTUP_HIGH_SCORES));
-    title_hbox->add_child(move(tile));
+    title_hbox->add_child(std::move(tile));
 #endif
 
     auto title = make_shared<Text>(formatted_string(
                 CRAWL ": High Scores", YELLOW));
     title->set_margin_for_sdl(0, 0, 0, 16);
-    title_hbox->add_child(move(title));
+    title_hbox->add_child(std::move(title));
 
     title_hbox->set_main_alignment(Widget::CENTER);
     title_hbox->set_cross_alignment(Widget::CENTER);
@@ -441,7 +441,7 @@ UIHiscoresMenu::UIHiscoresMenu()
     nhsr = 0;
     _construct_hiscore_table();
 
-    m_root->add_child(move(title_hbox));
+    m_root->add_child(std::move(title_hbox));
     if (initial_focus)
     {
         m_root->add_child(m_description);
@@ -488,7 +488,7 @@ void UIHiscoresMenu::_add_hiscore_row(scorefile_entry& se, int id)
     tmp->set_text(hiscores_format_single(se));
     auto btn = make_shared<MenuButton>();
     tmp->set_margin_for_sdl(2);
-    btn->set_child(move(tmp));
+    btn->set_child(std::move(tmp));
     btn->on_activate_event([id](const ActivateEvent&) {
         _show_morgue(*hs_list[id]);
         return true;
@@ -496,13 +496,13 @@ void UIHiscoresMenu::_add_hiscore_row(scorefile_entry& se, int id)
     btn->on_focusin_event([this, se](const FocusEvent&) {
         formatted_string desc(hiscores_format_single_long(se, true));
         desc.cprintf(string(max(0, 9-count_linebreaks(desc)), '\n'));
-        m_description->set_text(move(desc));
+        m_description->set_text(std::move(desc));
         return false;
     });
 
     if (!initial_focus)
         initial_focus = btn.get();
-    m_score_entries->add_button(move(btn), 0, nhsr++);
+    m_score_entries->add_button(std::move(btn), 0, nhsr++);
 }
 
 void UIHiscoresMenu::_render()
@@ -535,7 +535,7 @@ void show_hiscore_table()
     unwind_var<string> sprintmap(crawl_state.map, crawl_state.sprint_map);
     auto hiscore_ui = make_shared<UIHiscoresMenu>();
     auto popup = make_shared<ui::Popup>(hiscore_ui);
-    ui::run_layout(move(popup), hiscore_ui->done);
+    ui::run_layout(std::move(popup), hiscore_ui->done);
 }
 
 // Trying to supply an appropriate verb for the attack type. -- bwr

--- a/crawl-ref/source/libutil.cc
+++ b/crawl-ref/source/libutil.cc
@@ -520,7 +520,7 @@ string unwrap_desc(string&& desc)
         string tag = desc.substr(1, pos - 1);
         desc.erase(0, pos + 1);
         if (tag == "nowrap")
-            return move(desc);
+            return std::move(desc);
         else if (desc.empty())
             return "";
     }

--- a/crawl-ref/source/libutil.h
+++ b/crawl-ref/source/libutil.h
@@ -207,7 +207,7 @@ typename M::mapped_type lookup(M &map, const typename M::key_type &key,
 template<typename T, typename... Args>
 unique_ptr<T> make_unique(Args&&... args)
 {
-    return unique_ptr<T>(new T(forward<Args>(args)...));
+    return unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 #endif
 /** Remove from a container all elements matching a predicate.

--- a/crawl-ref/source/loading-screen.cc
+++ b/crawl-ref/source/loading-screen.cc
@@ -70,11 +70,11 @@ void loading_screen_open()
     loading_text->set_margin_for_sdl(15, 0, 0, 0);
     auto vbox = make_shared<Box>(Widget::VERT);
     vbox->set_cross_alignment(Widget::CENTER);
-    vbox->add_child(move(splash));
+    vbox->add_child(std::move(splash));
     vbox->add_child(loading_text);
     FontWrapper *font = tiles.get_crt_font();
     vbox->min_size().width = font->string_width(load_complete_msg.c_str());
-    popup = make_shared<ui::Popup>(move(vbox));
+    popup = make_shared<ui::Popup>(std::move(vbox));
     ui::push_layout(popup);
 }
 

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -1090,7 +1090,7 @@ void map_lines::extend(int min_width, int min_height, char fill)
             for (int x = 0; x < old_width; ++x)
                 (*new_overlay)(x, y) = (*overlay)(x, y);
 
-        overlay = move(new_overlay);
+        overlay = std::move(new_overlay);
     }
 }
 
@@ -1601,7 +1601,7 @@ void map_lines::rotate(bool clockwise)
         for (int i = xs, y = 0; i != xe; i += xi, ++y)
             for (int j = ys, x = 0; j != ye; j += yi, ++x)
                 (*new_overlay)(x, y) = (*overlay)(i, j);
-        overlay = move(new_overlay);
+        overlay = std::move(new_overlay);
     }
 
     map_width = lines.size();

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -1696,7 +1696,7 @@ int msgwin_get_line(string prompt, char *buf, int len,
         tiles.push_ui_layout("msgwin-get-line", 0);
         popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
-        ui::run_layout(move(popup), done, input);
+        ui::run_layout(std::move(popup), done, input);
 
         strncpy(buf, input->get_text().c_str(), len - 1);
         buf[len - 1] = '\0';

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -354,7 +354,7 @@ static bool _reroll_random(newgame_def& ng)
 #ifdef USE_TILE_LOCAL
     auto tile = make_shared<ui::PlayerDoll>(doll);
     tile->set_margin_for_sdl(0, 10, 0, 0);
-    title_hbox->add_child(move(tile));
+    title_hbox->add_child(std::move(tile));
 #endif
 #endif
     title_hbox->add_child(make_shared<Text>(prompt));
@@ -363,9 +363,9 @@ static bool _reroll_random(newgame_def& ng)
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
 
     auto vbox = make_shared<Box>(Box::VERT);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
     vbox->add_child(make_shared<Text>("Do you want to play this combination? [Y/n/q]"));
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     bool done = false;
     int c;
@@ -381,7 +381,7 @@ static bool _reroll_random(newgame_def& ng)
     tiles.push_ui_layout("newgame-random-combo", 0);
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     // XX mouse interface in local tiles for `y` -- right now right click does
     // `q` only
@@ -523,12 +523,12 @@ static void _add_menu_sub_item(shared_ptr<OuterMenu>& menu, int x, int y, const 
     tmp->set_margin_for_crt(0, 2, 0, 0);
 
     auto btn = make_shared<MenuButton>();
-    btn->set_child(move(tmp));
+    btn->set_child(std::move(tmp));
     btn->id = id;
     btn->description = description;
     btn->hotkey = letter;
     btn->highlight_colour = STARTUP_HIGHLIGHT_CONTROL;
-    menu->add_button(move(btn), x, y);
+    menu->add_button(std::move(btn), x, y);
 }
 
 #ifndef DGAMELAUNCH
@@ -577,7 +577,7 @@ static void _choose_name(newgame_def& ng, newgame_def& choice)
 #ifdef USE_TILE_LOCAL
     auto tile = make_shared<ui::PlayerDoll>(doll);
     tile->set_margin_for_sdl(0, 10, 0, 0);
-    title_hbox->add_child(move(tile));
+    title_hbox->add_child(std::move(tile));
 #endif
 #endif
     title_hbox->add_child(make_shared<Text>(title));
@@ -586,7 +586,7 @@ static void _choose_name(newgame_def& ng, newgame_def& choice)
     title_hbox->set_margin_for_crt(0, 0, 1, 0);
 
     auto vbox = make_shared<Box>(Box::VERT);
-    vbox->add_child(move(title_hbox));
+    vbox->add_child(std::move(title_hbox));
     auto prompt_ui = make_shared<Text>();
     vbox->add_child(prompt_ui);
 
@@ -622,7 +622,7 @@ static void _choose_name(newgame_def& ng, newgame_def& choice)
         });
         tmp->set_margin_for_sdl(4,8);
         tmp->set_margin_for_crt(0, 2, 0, 0);
-        btn->set_child(move(tmp));
+        btn->set_child(std::move(tmp));
         btn->id = CK_ENTER;
         btn->description = "";
         btn->hotkey = CK_ENTER;
@@ -640,7 +640,7 @@ static void _choose_name(newgame_def& ng, newgame_def& choice)
         sub_items->add_button(btn, 2, 0);
     }
 
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     sub_items->on_activate_event([&](const ActivateEvent& event) {
         const auto button = static_pointer_cast<MenuButton>(event.target());
@@ -680,7 +680,7 @@ static void _choose_name(newgame_def& ng, newgame_def& choice)
         return true;
     });
 
-    ui::push_layout(move(popup));
+    ui::push_layout(std::move(popup));
     while (!done && !crawl_state.seen_hups)
     {
         formatted_string prompt;
@@ -849,7 +849,7 @@ static void _choose_seed(newgame_def& ng, newgame_def& choice,
     clear_btn_label->set_margin_for_sdl(4, 4);
     clear_btn_label->set_margin_for_crt(0, 1, 0, 1);
     auto clear_btn = make_shared<MenuButton>();
-    clear_btn->set_child(move(clear_btn_label));
+    clear_btn->set_child(std::move(clear_btn_label));
     clear_btn->set_sync_id("btn-clear");
     clear_btn->hotkey = '-';
     clear_btn->set_margin_for_sdl(0,0,0,10);
@@ -859,7 +859,7 @@ static void _choose_seed(newgame_def& ng, newgame_def& choice,
         ui::set_focused_widget(seed_input.get());
         return true;
     });
-    seed_hbox->add_child(move(clear_btn));
+    seed_hbox->add_child(std::move(clear_btn));
 
     auto d_btn_label = make_shared<ui::Text>();
     d_btn_label->set_text(formatted_string("[d] Today's daily seed", BROWN));
@@ -867,7 +867,7 @@ static void _choose_seed(newgame_def& ng, newgame_def& choice,
     d_btn_label->set_margin_for_crt(0, 2, 0, 0);
 
     auto daily_seed_btn = make_shared<MenuButton>();
-    daily_seed_btn->set_child(move(d_btn_label));
+    daily_seed_btn->set_child(std::move(d_btn_label));
     daily_seed_btn->set_sync_id("btn-daily");
     daily_seed_btn->hotkey = 'd';
     daily_seed_btn->set_margin_for_sdl(0,0,0,10);
@@ -882,7 +882,7 @@ static void _choose_seed(newgame_def& ng, newgame_def& choice,
         ui::set_focused_widget(seed_input.get());
         return true;
     });
-    seed_hbox->add_child(move(daily_seed_btn));
+    seed_hbox->add_child(std::move(daily_seed_btn));
 
     const string footer_text =
 #ifdef USE_TILE_LOCAL
@@ -965,7 +965,7 @@ static void _choose_seed(newgame_def& ng, newgame_def& choice,
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), done, seed_input);
+    ui::run_layout(std::move(popup), done, seed_input);
 
     string result = seed_input->get_text();
     uint64_t tmp_seed = 0;
@@ -1267,7 +1267,7 @@ protected:
         tile->set_tile(item_tile);
         tile->set_margin_for_sdl(0, 6, 0, 0);
         tile->flex_grow = 0;
-        hbox->add_child(move(tile));
+        hbox->add_child(std::move(tile));
         hbox->add_child(label);
 #else
         UNUSED(item_tile);
@@ -1307,9 +1307,9 @@ protected:
         auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE
         hbox->set_margin_for_sdl(2, 10, 2, 2);
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
 #else
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
 #endif
         btn->id = id;
         btn->description = desc;
@@ -1327,7 +1327,7 @@ protected:
     {
         auto text = make_shared<Text>(formatted_string(name, LIGHTBLUE));
         text->set_margin_for_sdl(7, 0, 7, 32+2+6);
-        m_main_items->add_label(move(text), position.x, position.y);
+        m_main_items->add_label(std::move(text), position.x, position.y);
     }
 
     void _add_choice_menu_option(int x, int y, const string& text, char letter,
@@ -1638,7 +1638,7 @@ static void _prompt_choice(int choice_type, newgame_def& ng, newgame_def& ng_cho
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    ui::run_layout(move(popup), newgame_ui->done);
+    ui::run_layout(std::move(popup), newgame_ui->done);
 
     if (newgame_ui->end_game)
         end(0);
@@ -1670,9 +1670,9 @@ static void _construct_weapon_menu(const newgame_def& ng,
         string label;
         tileidx_t tile;
         weapon_menu_item(skill_type _skill, string _label, tileidx_t _tile)
-            : skill(move(_skill)), label(move(_label)), tile(move(_tile)) {};
+            : skill(std::move(_skill)), label(std::move(_label)), tile(std::move(_tile)) {};
         weapon_menu_item(skill_type _skill, string _label)
-            : skill(move(_skill)), label(move(_label)), tile(0) {};
+            : skill(std::move(_skill)), label(std::move(_label)), tile(0) {};
     };
     vector<weapon_menu_item> choices;
 
@@ -1753,7 +1753,7 @@ static void _construct_weapon_menu(const newgame_def& ng,
         hbox->add_child(suffix);
 
         auto btn = make_shared<MenuButton>();
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
         btn->id = wpn_type;
         btn->hotkey = letter;
         btn->highlight_colour = bg;
@@ -1761,7 +1761,7 @@ static void _construct_weapon_menu(const newgame_def& ng,
         // Is this item our default weapon?
         if (wpn_type == defweapon || (defweapon == WPN_UNKNOWN && i == 0))
             main_items->set_initial_focus(btn.get());
-        main_items->add_button(move(btn), 0, i);
+        main_items->add_button(std::move(btn), 0, i);
     }
 
     _add_menu_sub_item(sub_items, 0, 0, "+ - Recommended random choice",
@@ -1806,7 +1806,7 @@ static bool _prompt_weapon(const newgame_def& ng, newgame_def& ng_choice,
 #ifdef USE_TILE_LOCAL
     auto tile = make_shared<ui::PlayerDoll>(doll);
     tile->set_margin_for_sdl(0, 10, 0, 0);
-    title_hbox->add_child(move(tile));
+    title_hbox->add_child(std::move(tile));
 #endif
 #endif
     auto title = make_shared<Text>(formatted_string(_welcome(ng), BROWN));
@@ -1909,7 +1909,7 @@ static bool _prompt_weapon(const newgame_def& ng, newgame_def& ng_choice,
     tiles.push_ui_layout("newgame-choice", 1);
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     return ret;
 }
@@ -2103,7 +2103,7 @@ static void _construct_gamemode_map_menu(const mapref_vector& maps,
         auto tile = make_shared<Image>();
         tile->set_tile(tile_for_map_name(map_name));
         tile->set_margin_for_sdl(0, 6, 0, 0);
-        hbox->add_child(move(tile));
+        hbox->add_child(std::move(tile));
         hbox->add_child(label);
 #endif
 
@@ -2112,9 +2112,9 @@ static void _construct_gamemode_map_menu(const mapref_vector& maps,
         auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE
         hbox->set_margin_for_sdl(2, 10, 2, 2);
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
 #else
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
 #endif
         btn->id = i; // ID corresponds to location in vector
         btn->hotkey = letter;
@@ -2274,7 +2274,7 @@ static void _prompt_gamemode_map(newgame_def& ng, newgame_def& ng_choice,
     tiles.push_ui_layout("newgame-choice", 1);
     popup->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     if (cancel || crawl_state.seen_hups)
         game_ended(game_exit::abort);

--- a/crawl-ref/source/outer-menu.cc
+++ b/crawl-ref/source/outer-menu.cc
@@ -94,7 +94,7 @@ void MenuButton::recolour_descendants(const shared_ptr<Widget>& node)
         formatted_string new_contents;
         new_contents.textcolour(fg);
         new_contents.cprintf("%s", tw->get_text().tostring().c_str());
-        tw->set_text(move(new_contents));
+        tw->set_text(std::move(new_contents));
         tw->set_bg_colour(static_cast<COLOURS>(bg));
         return;
     }
@@ -215,7 +215,7 @@ OuterMenu::OuterMenu(bool can_shrink, int width, int height)
     {
         auto scroller = make_shared<Scroller>();
         scroller->set_child(m_grid);
-        m_root = move(scroller);
+        m_root = std::move(scroller);
     }
     else
         m_root = m_grid;
@@ -275,7 +275,7 @@ void OuterMenu::add_label(shared_ptr<Text> label, int x, int y)
     ASSERT(y >= 0 && y < m_height);
     ASSERT(m_buttons[y*m_width + x] == nullptr);
     m_labels.emplace_back(label->get_text(), coord_def(x, y));
-    m_grid->add_child(move(label), x, y);
+    m_grid->add_child(std::move(label), x, y);
 }
 
 void OuterMenu::add_button(shared_ptr<MenuButton> btn, int x, int y)
@@ -307,7 +307,7 @@ void OuterMenu::add_button(shared_ptr<MenuButton> btn, int x, int y)
     {
         auto desc_text = make_shared<Text>(formatted_string(btn->description, WHITE));
         desc_text->set_wrap_text(true);
-        descriptions->add_child(move(desc_text));
+        descriptions->add_child(std::move(desc_text));
         m_description_indexes[y*m_width + x] = descriptions->num_children()-1;
     }
 

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -991,7 +991,7 @@ namespace quiver
             {
                 auto a = make_shared<ammo_action>(i_inv);
                 if (a->is_valid() && (allow_disabled || a->is_enabled()))
-                    result.push_back(move(a));
+                    result.push_back(std::move(a));
             }
             return result;
         }
@@ -1011,7 +1011,7 @@ namespace quiver
             {
                 auto a = make_shared<ammo_action>(i);
                 if (a->is_valid() && (allow_disabled || a->is_enabled()))
-                    result.push_back(move(a));
+                    result.push_back(std::move(a));
                 // TODO: allow arbitrary items with +f to get added here? I
                 // have had some trouble getting this to work
             }
@@ -1318,7 +1318,7 @@ namespace quiver
                 auto a = make_shared<spell_action>(
                                 get_spell_by_letter(index_to_letter(i)));
                 if (a->in_fire_order(allow_disabled, menu))
-                    result.push_back(move(a));
+                    result.push_back(std::move(a));
             }
             return result;
         }
@@ -1606,7 +1606,7 @@ namespace quiver
                 }
                 auto a = make_shared<ability_action>(tal.which);
                 if (a->is_valid() && (allow_disabled || a->is_enabled()))
-                    result.push_back(move(a));
+                    result.push_back(std::move(a));
             }
             return result;
         }
@@ -1721,9 +1721,9 @@ namespace quiver
                     && (allow_disabled || w->is_enabled()))
                 {
                     if (you.inv[slot].base_type == OBJ_POTIONS)
-                        result.push_back(move(w));
+                        result.push_back(std::move(w));
                     else
-                        scrolls.push_back(move(w));
+                        scrolls.push_back(std::move(w));
                 }
             }
             result.insert(result.end(), scrolls.begin(), scrolls.end());
@@ -1829,7 +1829,7 @@ namespace quiver
                     // (Maybe do this with autoinscribe?)
                     && you.inv[slot].sub_type != WAND_DIGGING)
                 {
-                    result.push_back(move(w));
+                    result.push_back(std::move(w));
                 }
             }
             return result;
@@ -1930,7 +1930,7 @@ namespace quiver
                     // TODO: autoinscribe =f?
                     && you.inv[slot].sub_type != MISC_ZIGGURAT)
                 {
-                    result.push_back(move(w));
+                    result.push_back(std::move(w));
                 }
             }
             return result;
@@ -2060,7 +2060,7 @@ namespace quiver
         for (auto &val : history_vec)
         {
             auto a = _load_action(val.get_table());
-            history.push_back(move(a));
+            history.push_back(std::move(a));
         }
     }
 
@@ -2091,7 +2091,7 @@ namespace quiver
         auto n = new_act ? new_act : make_shared<action>();
 
         const bool diff = *n != *get();
-        current = move(n);
+        current = std::move(n);
         set_needs_redraw();
         return diff;
     }
@@ -2109,8 +2109,8 @@ namespace quiver
         auto n = new_act ? new_act : make_shared<action>();
 
         const bool diff = *n != *get();
-        auto old = move(current);
-        current = move(n);
+        auto old = std::move(current);
+        current = std::move(n);
 
         if (diff)
         {
@@ -2119,7 +2119,7 @@ namespace quiver
             history.erase(remove(history.begin(), history.end(), old), history.end());
             // this may push back an invalid action, which is useful for all
             // sorts of reasons
-            history.push_back(move(old));
+            history.push_back(std::move(old));
 
             if (history.size() > 6) // 6 chosen arbitrarily
                 history.erase(history.begin());

--- a/crawl-ref/source/randbook.cc
+++ b/crawl-ref/source/randbook.cc
@@ -653,7 +653,7 @@ void init_book_theme_randart(item_def &book, vector<spell_type> spells)
 {
     book.sub_type = BOOK_RANDART_THEME;
     _make_book_randart(book);
-    _set_book_spell_list(book, move(spells));
+    _set_book_spell_list(book, std::move(spells));
 }
 
 /**

--- a/crawl-ref/source/scroller.cc
+++ b/crawl-ref/source/scroller.cc
@@ -74,8 +74,8 @@ int formatted_scroller::show()
 #ifdef USE_TILE_LOCAL
         title_hbox->set_main_alignment(Widget::Align::CENTER);
 #endif
-        title_hbox->add_child(move(title));
-        vbox->add_child(move(title_hbox));
+        title_hbox->add_child(std::move(title));
+        vbox->add_child(std::move(title_hbox));
     }
 
 #ifdef USE_TILE_LOCAL
@@ -102,7 +102,7 @@ int formatted_scroller::show()
         more->set_text(m_more);
         more->set_margin_for_crt(1, 0, 0, 0);
         more->set_margin_for_sdl(20, 0, 0, 0);
-        vbox->add_child(move(more));
+        vbox->add_child(std::move(more));
     }
 
     auto popup = make_shared<ui::Popup>(vbox);
@@ -166,7 +166,7 @@ int formatted_scroller::show()
         m_scroller->set_scroll(m_scroll);
     }
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
     open_scrollers.pop_back();
 
     return m_lastch;

--- a/crawl-ref/source/scroller.h
+++ b/crawl-ref/source/scroller.h
@@ -36,10 +36,10 @@ public:
     void set_tag(const string& tag) { m_tag = tag; }
 
     void set_more() { m_more.clear(); }
-    void set_more(formatted_string more) { m_more = move(more); }
+    void set_more(formatted_string more) { m_more = std::move(more); }
 
     void set_title() { m_title.clear(); };
-    void set_title(formatted_string title) { m_title = move(title); };
+    void set_title(formatted_string title) { m_title = std::move(title); };
 
     void scroll_to_end();
     void set_scroll(int y);

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -957,7 +957,7 @@ void ShopMenu::init_entries()
         auto newentry = make_unique<ShopEntry>(item, *this);
         newentry->hotkeys.clear();
         newentry->add_hotkey(ckey++);
-        add_entry(move(newentry));
+        add_entry(std::move(newentry));
     }
 }
 

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -1872,7 +1872,7 @@ void skill_menu(int flag, int exp)
         return;
     }
 
-    ui::run_layout(move(popup), done);
+    ui::run_layout(std::move(popup), done);
 
     skm.clear();
 }

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -454,7 +454,7 @@ static void _construct_game_modes_menu(shared_ptr<OuterMenu>& container)
         auto tile = make_shared<Image>();
         tile->set_tile(tile_def(tileidx_gametype(entry.id)));
         tile->set_margin_for_sdl(0, 6, 0, 0);
-        hbox->add_child(move(tile));
+        hbox->add_child(std::move(tile));
         hbox->add_child(label);
 #endif
 
@@ -463,14 +463,14 @@ static void _construct_game_modes_menu(shared_ptr<OuterMenu>& container)
         auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE_LOCAL
         hbox->set_margin_for_sdl(2, 10, 2, 2);
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
 #else
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
 #endif
         btn->id = entry.id;
         btn->description = entry.description;
         btn->highlight_colour = LIGHTGREY;
-        container->add_button(move(btn), 0, i);
+        container->add_button(std::move(btn), 0, i);
     }
 }
 
@@ -488,9 +488,9 @@ static shared_ptr<MenuButton> _make_newgame_button(int num_chars)
 
     auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE_LOCAL
-    btn->set_child(move(hbox));
+    btn->set_child(std::move(hbox));
 #else
-    btn->set_child(move(label));
+    btn->set_child(std::move(label));
 #endif
     btn->get_child()->set_margin_for_sdl(2, 10, 2, 2);
     btn->id = NUM_GAME_TYPE + num_chars;
@@ -509,7 +509,7 @@ static void _construct_save_games_menu(shared_ptr<OuterMenu>& container,
 #ifdef USE_TILE_LOCAL
         auto tile = make_shared<ui::PlayerDoll>(chars.at(i).doll);
         tile->set_margin_for_sdl(0, 6, 0, 0);
-        hbox->add_child(move(tile));
+        hbox->add_child(std::move(tile));
 #endif
 
         const COLOURS fg = chars.at(i).save_loadable ? WHITE : RED;
@@ -533,20 +533,20 @@ static void _construct_save_games_menu(shared_ptr<OuterMenu>& container,
 
         auto btn = make_shared<MenuButton>();
 #ifdef USE_TILE_LOCAL
-        btn->set_child(move(hbox));
+        btn->set_child(std::move(hbox));
 #else
-        btn->set_child(move(label));
+        btn->set_child(std::move(label));
 #endif
         btn->get_child()->set_margin_for_sdl(2, 10, 2, 2);
         btn->id = NUM_GAME_TYPE + i;
         btn->highlight_colour = LIGHTGREY;
-        container->add_button(move(btn), 0, i);
+        container->add_button(std::move(btn), 0, i);
     }
 
     if (!chars.empty())
     {
         auto btn = _make_newgame_button(chars.size());
-        container->add_button(move(btn), 0, (int)chars.size());
+        container->add_button(std::move(btn), 0, (int)chars.size());
     }
 }
 
@@ -586,7 +586,7 @@ public:
         about->set_margin_for_crt(0, 0, 1, 0);
         about->set_margin_for_sdl(0, 0, 10, 0);
 
-        m_root->add_child(move(about));
+        m_root->add_child(std::move(about));
 
         auto grid = make_shared<Grid>();
         grid->set_margin_for_crt(0, 0, 1, 0);
@@ -602,7 +602,7 @@ public:
         input_text->set_margin_for_crt(0, 0, 1, 0);
         input_text->set_margin_for_sdl(0, 0, 10, 10);
 
-        grid->add_child(move(name_prompt), 0, 0);
+        grid->add_child(std::move(name_prompt), 0, 0);
         grid->add_child(input_text, 1, 0);
 
         descriptions = make_shared<Switcher>();
@@ -622,7 +622,7 @@ public:
         game_modes_menu->min_size().height = 2;
 #endif
 
-        grid->add_child(move(mode_prompt), 0, 1);
+        grid->add_child(std::move(mode_prompt), 0, 1);
         grid->add_child(game_modes_menu, 1, 1);
 
         save_games_menu = make_shared<OuterMenu>(num_saves > 1, 1, num_saves + 1);
@@ -641,7 +641,7 @@ public:
             save_games_menu->descriptions = descriptions;
 
             _construct_save_games_menu(save_games_menu, chars);
-            grid->add_child(move(save_prompt), 0, 2);
+            grid->add_child(std::move(save_prompt), 0, 2);
             grid->add_child(save_games_menu, 1, 2);
 
             game_modes_menu->linked_menus[2] = save_games_menu;
@@ -675,7 +675,7 @@ public:
         grid->column_flex_grow(0) = 1;
         grid->column_flex_grow(1) = 10;
 
-        m_root->add_child(move(grid));
+        m_root->add_child(std::move(grid));
 
         string instructions_text;
         // TODO: these can overflow on console 80x24 and won't line-wrap, is
@@ -979,7 +979,7 @@ static void _show_startup_menu(newgame_def& ng_choice,
     auto startup_ui = make_shared<UIStartupMenu>(ng_choice, defaults);
     auto popup = make_shared<ui::Popup>(startup_ui);
 
-    ui::run_layout(move(popup), startup_ui->done);
+    ui::run_layout(std::move(popup), startup_ui->done);
 
     if (startup_ui->end_game || crawl_state.seen_hups)
     {

--- a/crawl-ref/source/stringutil.cc
+++ b/crawl-ref/source/stringutil.cc
@@ -474,7 +474,7 @@ string deescape(string s, const set<size_t> &escapes)
 string deescape(string s)
 {
     set<size_t> escapes = find_escapes(s);
-    return deescape(move(s), escapes);
+    return deescape(std::move(s), escapes);
 }
 
 /**

--- a/crawl-ref/source/tilereg-doll.cc
+++ b/crawl-ref/source/tilereg-doll.cc
@@ -389,9 +389,9 @@ void DollEditRegion::run()
     vbox->set_cross_alignment(Widget::CENTER);
     auto title = make_shared<Text>(formatted_string("Doll Editor", YELLOW));
     title->set_margin_for_sdl(0, 0, 20, 0);
-    vbox->add_child(move(title));
+    vbox->add_child(std::move(title));
     vbox->add_child(doll_ui);
-    auto popup = make_shared<ui::Popup>(move(vbox));
+    auto popup = make_shared<ui::Popup>(std::move(vbox));
 
     popup->on_keydown_event([this, &done, &doll_ui, &update_part_idx](const KeyEvent& ev) {
         const auto key = ev.key();
@@ -500,7 +500,7 @@ void DollEditRegion::run()
         return true;
     });
 
-    ui::push_layout(move(popup), KMC_DOLL);
+    ui::push_layout(std::move(popup), KMC_DOLL);
     while (!done && !crawl_state.seen_hups)
     {
         if (update_part_idx)

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -440,7 +440,7 @@ public:
                 ts.safe_if_ignoring_hostile_terrain =
                     is_travelsafe_square(p, true);
             }
-            _travel_safe_grid = move(tsgrid);
+            _travel_safe_grid = std::move(tsgrid);
         }
     }
     ~precompute_travel_safety_grid()

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -265,7 +265,7 @@ shared_ptr<Widget> Bin::get_child_at_offset(int x, int y)
 void Bin::set_child(shared_ptr<Widget> child)
 {
     child->_set_parent(this);
-    m_child = move(child);
+    m_child = std::move(child);
     _invalidate_sizereq();
 }
 
@@ -424,7 +424,7 @@ void Widget::set_visible(bool visible)
 void Widget::add_internal_child(shared_ptr<Widget> child)
 {
     child->_set_parent(this);
-    m_internal_children.emplace_back(move(child));
+    m_internal_children.emplace_back(std::move(child));
 }
 
 void Widget::set_sync_id(string id)
@@ -463,7 +463,7 @@ void Widget::sync_state_changed()
 void Box::add_child(shared_ptr<Widget> child)
 {
     child->_set_parent(this);
-    m_children.push_back(move(child));
+    m_children.push_back(std::move(child));
     _invalidate_sizereq();
 }
 
@@ -1112,7 +1112,7 @@ SizeReq Image::_get_preferred_size(Direction dim, int /*prosp_width*/)
 void Stack::add_child(shared_ptr<Widget> child)
 {
     child->_set_parent(this);
-    m_children.push_back(move(child));
+    m_children.push_back(std::move(child));
     _invalidate_sizereq();
     _queue_allocation();
 }
@@ -1171,7 +1171,7 @@ void Switcher::add_child(shared_ptr<Widget> child)
     // - it must be in the current top child
     // - unfocus it before we
     child->_set_parent(this);
-    m_children.push_back(move(child));
+    m_children.push_back(std::move(child));
     _invalidate_sizereq();
     _queue_allocation();
 }
@@ -1296,7 +1296,7 @@ shared_ptr<Widget> Grid::get_child_at_offset(int x, int y)
 void Grid::add_child(shared_ptr<Widget> child, int x, int y, int w, int h)
 {
     child->_set_parent(this);
-    child_info ch = { {x, y}, {w, h}, move(child) };
+    child_info ch = { {x, y}, {w, h}, std::move(child) };
     m_child_info.push_back(ch);
     m_track_info_dirty = true;
     _invalidate_sizereq();
@@ -1641,7 +1641,7 @@ Layout::Layout(shared_ptr<Widget> child)
     m_depth = ui_root.num_children();
 #endif
     child->_set_parent(this);
-    m_child = move(child);
+    m_child = std::move(child);
     expand_h = expand_v = true;
 }
 
@@ -2488,7 +2488,7 @@ void UIRoot::push_child(shared_ptr<Widget> ch, KeymapContext km)
     state.default_focus = state.current_focus = focus;
     state.generation_id = next_generation_id++;
 
-    m_root.add_child(move(ch));
+    m_root.add_child(std::move(ch));
     m_needs_layout = true;
     m_changed_layout_since_click = true;
     update_focus_order();
@@ -2787,7 +2787,7 @@ void UIRoot::update_hover_path()
 
     send_mouse_enter_leave_events(hover_path, new_hover_path);
 
-    hover_path = move(new_hover_path);
+    hover_path = std::move(new_hover_path);
     hover_path.resize(new_hover_path_size);
 }
 
@@ -3150,7 +3150,7 @@ void pop_cutoff()
 
 void push_layout(shared_ptr<Widget> root, KeymapContext km)
 {
-    ui_root.push_child(move(root), km);
+    ui_root.push_child(std::move(root), km);
 #ifdef USE_TILE_WEB
     ui_root.sync_state();
 #endif
@@ -3506,7 +3506,7 @@ progress_popup::progress_popup(string title, int width)
     contents->on_layout_pop([](){ tiles.pop_ui_layout(); });
 #endif
 
-    push_layout(move(contents));
+    push_layout(std::move(contents));
     pump_events(0);
 }
 

--- a/crawl-ref/source/ui.h
+++ b/crawl-ref/source/ui.h
@@ -168,7 +168,7 @@ public:
 
     shared_ptr<Widget>& target() { return m_target; }
     shared_ptr<Widget> target() const { return m_target; }
-    void set_target(shared_ptr<Widget> _target) { m_target = move(_target); }
+    void set_target(shared_ptr<Widget> _target) { m_target = std::move(_target); }
 
 protected:
     Type m_type;
@@ -241,7 +241,7 @@ public:
             if (pred(it.first))
             {
                 HandlerSig func = it.second;
-                if (func(forward<Args>(args)...))
+                if (func(std::forward<Args>(args)...))
                     return true;
             }
         return false;
@@ -252,7 +252,7 @@ public:
         for (auto it = i.first; it != i.second; ++it)
         {
             HandlerSig func = it->second;
-            if (func(forward<Args>(args)...))
+            if (func(std::forward<Args>(args)...))
                 return true;
         }
         return false;
@@ -383,7 +383,7 @@ public:
     void set_margin_for_crt(Args&&... args)
     {
 #ifndef USE_TILE_LOCAL
-        margin = Margin(forward<Args>(args)...);
+        margin = Margin(std::forward<Args>(args)...);
         _invalidate_sizereq();
 #else
         UNUSED(args...);
@@ -394,7 +394,7 @@ public:
     void set_margin_for_sdl(Args&&... args)
     {
 #ifdef USE_TILE_LOCAL
-        margin = Margin(forward<Args>(args)...);
+        margin = Margin(std::forward<Args>(args)...);
         _invalidate_sizereq();
 #else
         UNUSED(args...);
@@ -406,7 +406,7 @@ public:
     template<class F>
     void on_any_event(F&& cb)
     {
-        slots.event.on(this, forward<F>(cb));
+        slots.event.on(this, std::forward<F>(cb));
     }
 
     template<class F>
@@ -484,8 +484,8 @@ protected:
     template<class F>
     void for_each_child_including_internal(F&& cb)
     {
-        for_each_internal_child(forward<F>(cb));
-        for_each_child(forward<F>(cb));
+        for_each_internal_child(std::forward<F>(cb));
+        for_each_child(std::forward<F>(cb));
     }
 
     /**
@@ -745,7 +745,7 @@ public:
     template<class... Args>
     explicit Text(Args&&... args) : Text()
     {
-        set_text(forward<Args>(args)...);
+        set_text(std::forward<Args>(args)...);
     }
 
     void set_text(const formatted_string &fs);
@@ -1023,7 +1023,7 @@ protected:
 class Popup : public Layout
 {
 public:
-    explicit Popup(shared_ptr<Widget> child) : Layout(move(child)) {}
+    explicit Popup(shared_ptr<Widget> child) : Layout(std::move(child)) {}
 
     void _render() override;
     SizeReq _get_preferred_size(Direction dim, int prosp_width) override;
@@ -1115,12 +1115,12 @@ public:
 
     template<typename T>
     void set_input_history(T&& fn) {
-        m_line_reader.set_input_history(forward<T>(fn));
+        m_line_reader.set_input_history(std::forward<T>(fn));
     }
 
     template<typename T>
     void set_keyproc(T&& fn) {
-        m_line_reader.set_keyproc(forward<T>(fn));
+        m_line_reader.set_keyproc(std::forward<T>(fn));
     }
 
 protected:

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -786,7 +786,7 @@ public:
         // happened, then it set m_state and we don't want to overwrite it.
         // TODO some refactoring to make this cleaner
         if (!check_and_reset_reentry())
-            m_state = move(ret);
+            m_state = std::move(ret);
 
         if (!m_state.map_alive)
             return;


### PR DESCRIPTION
Clang++-15 now warns about all unqualified uses of `std::move` and `std::forward`. According to https://reviews.llvm.org/D119670?id=408276 this is a new recommendation by the C++ standards committee, due to "concerns that this might be an usual anti pattern particularly britle worth warning about - both because move is a common name and because these functions accept any values".

I mostly did this because the noise was hiding a number of new unused-but-initialized variable warnings which I will address separately.