### PR TITLE
Fix torpor snail slow

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4611,9 +4611,9 @@ void dec_slow_player(int delay)
             ? haste_mul(delay) : delay;
     }
 
-    if (you.torpor_slowed() && you.duration[DUR_SLOW] <= 1)
+    if (you.torpor_slowed())
     {
-        you.duration[DUR_SLOW] = 1;
+        you.duration[DUR_SLOW] = max(1, you.duration[DUR_SLOW]);
         return;
     }
     if (you.props.exists(TORPOR_SLOWED_KEY))

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4611,7 +4611,7 @@ void dec_slow_player(int delay)
             ? haste_mul(delay) : delay;
     }
 
-    if (you.torpor_slowed())
+    if (you.torpor_slowed() && you.duration[DUR_SLOW] <= 1)
     {
         you.duration[DUR_SLOW] = 1;
         return;


### PR DESCRIPTION
Torpor snails currently allows you to clear any other slow, by walking into the snail's LOS then leaving it.

This fixes that.