### PR TITLE
Hopefully deduplicate portals

### DIFF
--- a/crawl-ref/source/dat/dlua/lm_timed.lua
+++ b/crawl-ref/source/dat/dlua/lm_timed.lua
@@ -118,6 +118,7 @@ function TimedMarker:event(marker, ev)
       self.dur = 1
     else
       self.dur = self.dur - ev:ticks()
+    end
     self.msg:event(self, marker, ev)
     if self.dur <= 0 then
       self:timeout(marker, true)

--- a/crawl-ref/source/dat/dlua/lm_timed.lua
+++ b/crawl-ref/source/dat/dlua/lm_timed.lua
@@ -112,7 +112,12 @@ function TimedMarker:event(marker, ev)
   elseif ev:type() == dgn.dgn_event_type('player_los') then
     self:start_short(marker)
   elseif ev:type() == self.ticktype then
-    self.dur = self.dur - ev:ticks()
+    local x, y = marker:pos()
+    local yx, yy = you.pos()
+    if x == yx and y == yy and you.taking_stairs() and self.dur > 1 then
+      self.dur = 1
+    else
+      self.dur = self.dur - ev:ticks()
     self.msg:event(self, marker, ev)
     if self.dur <= 0 then
       self:timeout(marker, true)


### PR DESCRIPTION
grab some code from TimedMarker:timeout to set timeout to be faster, so portals
 can't be re-entered.

(Descent Mode Bug)