### PR TITLE
prevent a Grand Finale crash

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5222,7 +5222,8 @@ spret uskayaw_grand_finale(bool fail)
     if (mons->alive())
         monster_die(*mons, KILL_YOU, NON_MONSTER, false);
 
-    if (!mons->alive())
+    // a lost soul may sneak in here
+    if (!mons->alive() && !monster_at(beam.target))
         move_player_to_grid(beam.target, false);
     else
         mpr("You spring back to your original position.");


### PR DESCRIPTION
If there are lost souls in LOS when Grand Finale is used, one may create a new monster where the exploded one had been, causing a crash. Catch this and take the fallback path.