### PR TITLE
Remove Upheaval friendly fire

### DIFF
--- a/crawl-ref/source/beam-type.h
+++ b/crawl-ref/source/beam-type.h
@@ -35,6 +35,7 @@ enum beam_type                  // bolt::flavour
     BEAM_CHAOS,
     BEAM_UNRAVELLED_MAGIC,
     BEAM_LIGHT,
+    BEAM_QAZLAL,
 
     // Enchantments
     BEAM_SLOW,

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3046,6 +3046,9 @@ bool bolt::harmless_to_player() const
     case BEAM_ROOTS:
         return mons_att_wont_attack(attitude) || !agent()->can_constrict(you, CONSTRICT_ROOTS);
 
+    case BEAM_QAZLAL:
+        return true;
+
     default:
         return false;
     }
@@ -4126,6 +4129,9 @@ bool bolt::ignores_player() const
     if (flavour == BEAM_DIGGING)
         return true;
 
+    if (flavour == BEAM_QAZLAL)
+        return true;
+
     if (agent() && agent()->is_monster()
         && mons_is_hepliaklqana_ancestor(agent()->as_monster()->type))
     {
@@ -5147,6 +5153,11 @@ bool bolt::ignores_monster(const monster* mon) const
         return true;
 
     if (flavour == BEAM_WATER && mon->type == MONS_WATER_ELEMENTAL)
+        return true;
+
+    int summon_type = 0;
+    mon->is_summoned(nullptr, &summon_type);
+    if (flavour == BEAM_QAZLAL && summon_type == MON_SUMM_AID)
         return true;
 
     return false;
@@ -6759,7 +6770,7 @@ static string _beam_type_name(beam_type type)
     case BEAM_ENFEEBLE:              return "enfeeble";
     case BEAM_NECROTISE:             return "necrotise";
     case BEAM_ROOTS:                 return "roots";
-
+    case BEAM_QAZLAL:                return "upheaval targetter";
     case NUM_BEAMS:                  die("invalid beam type");
     }
     die("unknown beam type");

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3165,7 +3165,6 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
         args.mode = TARG_HOSTILE;
         args.needs_path = false;
         args.top_prompt = "Aiming: <white>Upheaval</white>";
-        args.self = confirm_prompt_type::cancel;
         args.hitfunc = &tgt;
         if (!spell_direction(*player_target, beam, &args))
             return spret::abort;
@@ -3180,7 +3179,7 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
         bolt tempbeam;
         tempbeam.source    = beam.target;
         tempbeam.target    = beam.target;
-        tempbeam.flavour   = BEAM_MISSILE;
+        tempbeam.flavour   = BEAM_QAZLAL;
         tempbeam.ex_size   = max_radius;
         tempbeam.hit       = AUTOMATIC_HIT;
         tempbeam.damage    = dice_def(AUTOMATIC_HIT, 1);
@@ -3233,8 +3232,16 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
     for (radius_iterator ri(beam.target, max_radius, C_SQUARE, LOS_SOLID, true);
          ri; ++ri)
     {
-        if (!in_bounds(*ri) || cell_is_solid(*ri))
+        if (!in_bounds(*ri) || cell_is_solid(*ri) || you.pos() == *ri)
             continue;
+
+        const monster *mon = monster_at(*ri);
+        int summon_type = 0;
+        if (mon && mon->is_summoned(nullptr, &summon_type)
+            && summon_type == MON_SUMM_AID)
+        {
+            continue;
+        }
 
         int chance = pow;
 
@@ -3387,24 +3394,28 @@ spret qazlal_disaster_area(bool fail)
     vector<coord_def> targets;
     vector<int> weights;
     const int pow = you.skill(SK_INVOCATIONS, 6);
-    const int upheaval_radius = _upheaval_radius(pow);
     for (radius_iterator ri(you.pos(), LOS_RADIUS, C_SQUARE, LOS_NO_TRANS, true);
          ri; ++ri)
     {
         if (!in_bounds(*ri) || cell_is_solid(*ri))
             continue;
 
-        const monster_info* m = env.map_knowledge(*ri).monsterinfo();
-        if (m && mons_att_wont_attack(m->attitude)
-            && !mons_is_projectile(m->type))
+        const monster *mon = monster_at(*ri);
+        int summon_type = 0;
+        //Never fire at elemental forces
+        if (mon && mon->is_summoned(nullptr, &summon_type)
+            && summon_type == MON_SUMM_AID)
+        {
+            continue;
+        }
+
+        if (mon && mons_att_wont_attack(mon->attitude)
+            && !mons_is_projectile(mon->type))
         {
             friendlies = true;
         }
 
-        const int range = you.pos().distance_from(*ri);
         const int dist = grid_distance(you.pos(), *ri);
-        if (range <= upheaval_radius)
-            continue;
 
         targets.push_back(*ri);
         // We weight using the square of grid distance, so monsters fewer tiles


### PR DESCRIPTION
Makes Upheaval (and consequently Disaster area) do no damage to Elemental Forces. Other allies are still affected, for thematic and consistency reasons.

This change has two benefits; firstly, it removes the incentive to remain at 16.66 invocations (the level at which Upheaval AoE is consistently 1, allowing reliable upheavals against adjacent enemies), and secondly it removes the awkwardness of using elemental force and disaster area in conjunction. 