### PR TITLE
teach the player to [Q]uiver in tutorial2

### DIFF
--- a/crawl-ref/source/dat/descript/tutorial.txt
+++ b/crawl-ref/source/dat/descript/tutorial.txt
@@ -215,15 +215,18 @@ tutorial2 boomerangs
 
 Now, for ranged combat! Pick up these boomerangs with
 <input>$cmd[CMD_PICKUP]</input> or <input>g</input><localtiles>, or by
-<input>mouseclick</input>,</localtiles> and continue.
+<input>mouseclick</input></localtiles>.
+Then, quiver them with <input>$cmd[CMD_QUIVER_ITEM]</input>.
 %%%%
 tutorial2 throwing
 
-You can fire your boomerangs at a monster with <input>$cmd[CMD_FIRE]</input>
+You can fire your boomerangs at a monster with <input>$cmd[CMD_FIRE_ITEM_NO_QUIVER]</input>
 <localtiles> or by <input>clicking</input> on them in the inventory
-panel</localtiles>. To confirm the auto-targeted monster, press
-<input>$cmd[CMD_TARGET_SELECT]</input> or <input>Enter</input>. You can skip
-this and fire at the closest monster with <input>shift-tab</input> or <input>p</input>.
+panel</localtiles>.
+To confirm the auto-targeted monster, press <input>$cmd[CMD_TARGET_SELECT]</input> or <input>Enter</input>.
+If quivered, you can skip item selection with <input>$cmd[CMD_FIRE]</input>
+and you can also skip target selection and fire at the closest monster with
+<input>shift-tab</input> or <input>p</input>.
 %%%%
 tutorial2 wield_bow
 


### PR DESCRIPTION
The tutorial asked the player to [f]ire or auto-[p]hire boomerangs. Neither of these commands work unless the player already has an item quivered.

Teach the player about [Q] first and also mention [F]ire-no-quiver.

Wording is admittedly a bit awkward.

It looks like this in console
![image](https://github.com/crawl/crawl/assets/7819240/b9204d12-4ead-4071-af89-b16aa1167e52)

like this in local tiles (the awkward new line after "If quivered, you" is only present in the ctrl+p message log. Other tutorial messages have this issue too)
![image](https://github.com/crawl/crawl/assets/7819240/f0d7bf00-6763-4251-8ee9-fad886bed85c)

