### PR TITLE
Make Lightning Rods use half AC

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2999,7 +2999,7 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
     beam.colour            = LIGHTCYAN;
     beam.range             = 1;
     beam.hit               = AUTOMATIC_HIT;
-    beam.ac_rule           = ac_type::proportional;
+    beam.ac_rule           = ac_type::half;
     beam.loudness          = spell_effect_noise(SPELL_THUNDERBOLT);
     beam.set_agent(caster);
 #ifdef USE_TILE


### PR DESCRIPTION
Makes lightning rod check against half AC rather than proportional AC. This change follows in a push to make lightning damage always ignore half AC, and also removes an inappropriate usage of proportional AC.

This is a buff, but it's unclear to me to what degree, as lightning rod damage code is fairly opaque.