### PR TITLE
Enable a confirmation prompt for "bump" attacks with ranged weapons.

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -307,19 +307,19 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
         ASSERT(!crawl_state.game_is_arena());
         // Can't damage orbs this way.
         if (mons_is_projectile(defender->type) && !you.confused())
-        {
-            you.turn_is_over = false;
             return false;
-        }
 
         if (!simu && you.weapon() && !you.confused())
         {
             if (Options.auto_switch && _autoswitch_to_melee())
                 return true; // Is this right? We did take time, but we didn't melee
         }
+        // Will this "melee" attack really fire a missile weapon?
         bool asked = false, fire = !simu && !you.confused()
                                    && !you.duration[DUR_CONFUSING_TOUCH]
                                    && _can_shoot_with(you.weapon());
+
+        // Has the player marked this missile weapon as "not to be fired"?
         bool no_fire = fire && !check_warning_inscriptions(*you.weapon(),
                                                            OPER_FIRE, &asked);
 
@@ -328,11 +328,10 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
                            defender->as_monster());
 
         // Check if the player is fighting with something unsuitable,
-        // or someone unsuitable.
+        // or someone unsuitable. Don't ask the player if we did this above.
         if (no_fire || !asked && !simu && you.can_see(*defender)
                        && !wielded_weapon_check(you.weapon()))
         {
-            you.turn_is_over = false;
             return false;
         }
         else if (fire)

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -320,7 +320,8 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
                                    && _can_shoot_with(you.weapon());
 
         // Has the player marked this missile weapon as "not to be fired"?
-        bool no_fire = fire && !check_warning_inscriptions(*you.weapon(),
+        bool no_fire = fire && you.can_see(*defender)
+                            && !check_warning_inscriptions(*you.weapon(),
                                                            OPER_FIRE, &asked);
 
         // We're trying to hit a monster, break out of travel/explore now.

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1697,8 +1697,9 @@ bool needs_handle_warning(const item_def &item, operation_types oper,
 // If there are warning inscriptions associated with performing this operation
 // on this item, prompt the user for confirmation. Return true if all prompts
 // are OK'd.
+// Sets *asked (if provided) if a prompt is used.
 bool check_warning_inscriptions(const item_def& item,
-                                 operation_types oper)
+                                 operation_types oper, bool *asked)
 {
     bool penance = false;
     if (item.defined()
@@ -1759,6 +1760,9 @@ bool check_warning_inscriptions(const item_def& item,
             if (item.cursed())
                 return true;
         }
+
+        if (asked)
+            *asked = true;
 
         // XXX: duplicates a check in delay.cc:_finish_delay()
         string prompt = "Really " + _operation_verb(oper) + " ";

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -221,7 +221,8 @@ bool get_tiles_for_item(const item_def &item, vector<tile_def>& tileset, bool sh
 
 bool check_old_item_warning(const item_def& item, operation_types oper,
                             bool check_melded = false);
-bool check_warning_inscriptions(const item_def& item, operation_types oper);
+bool check_warning_inscriptions(const item_def& item, operation_types oper,
+                                bool *asked = nullptr);
 
 void init_item_sort_comparators(item_sort_comparators &list,
                                 const string &set);


### PR DESCRIPTION
If the user attacks by moving towards a monster holding a ranged weapon, this change causes the player to be asked to confirm the attack in some situations.

A "!a" inscription might prompt a "Really attack ...?" message, which is temporarily suppressed after a "yes" response. A "!f" inscription might prompt a "Really fire ...?" message which appears for each attack. This mirrors how the "attack with wielded item" command works.

This should fix #3052.