### PR TITLE
Rework lightning rod damage

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3025,7 +3025,7 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
 
     int arc = hitfunc.arclen;
     
-    //ASSERT(arc > 0);
+    ASSERT(arc > 0);
     dprf("arc length is %d", arc);
 
     for (const auto &entry : hitfunc.zapped)
@@ -3046,7 +3046,8 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
 
     noisy(spell_effect_noise(SPELL_THUNDERBOLT), caster->pos());
 
-    _set_thunderbolt_last_aim(caster, aim);
+    //we use hitfunc aim bc set_aim has adjusted the target coord to be 5 away
+    _set_thunderbolt_last_aim(caster, hitfunc.aim);
 
     if (charges < LIGHTNING_MAX_CHARGE)
         charges++;

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3031,7 +3031,7 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
         if (!actor_at(entry.first))
             continue;
 
-        int arc = hitfunc.arc_length[entry.first.distance_from(hitfunc.origin)];
+        int arc = hitfunc.arclen;
         ASSERT(arc > 0);
         dprf("at distance %d, arc length is %d",
              entry.first.distance_from(hitfunc.origin), arc);

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3022,6 +3022,12 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
 
     beam.glyph = 0; // FIXME: a hack to avoid "appears out of thin air"
 
+
+    int arc = hitfunc.arclen;
+    
+    //ASSERT(arc > 0);
+    dprf("arc length is %d", arc);
+
     for (const auto &entry : hitfunc.zapped)
     {
         if (entry.second <= 0)
@@ -3031,10 +3037,6 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
         if (!actor_at(entry.first))
             continue;
 
-        int arc = hitfunc.arclen;
-        ASSERT(arc > 0);
-        dprf("at distance %d, arc length is %d",
-             entry.first.distance_from(hitfunc.origin), arc);
         beam.source = beam.target = entry.first;
         beam.source.x -= sgn(beam.source.x - hitfunc.origin.x);
         beam.source.y -= sgn(beam.source.y - hitfunc.origin.y);

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3024,7 +3024,7 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
 
 
     int arc = hitfunc.arclen;
-    
+
     ASSERT(arc > 0);
     dprf("arc length is %d", arc);
 

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1333,19 +1333,26 @@ static bool left_of(coord_def a, coord_def b)
     return a.x * b.y > a.y * b.x;
 }
 
-//FIXME: ensure rounding is sensible
+//Project a coordinate to 'range' tiles away from the origin
+//FIXME: rounding is incorrect.
 static coord_def _project_coord(coord_def coord, int range)
 {
-    if(coord.x > coord.y)
-        return coord * range / coord.x;
-    return coord * range / coord.y;
+    if(abs(coord.x) > abs(coord.y))
+        return coord * range / abs(coord.x);
+    return coord * range / abs(coord.y);
 }
 
 //returns the arc distance from a to b when projected to range away from center
 static int _get_arclen(coord_def a, coord_def b, coord_def center, int range)
 {
+    ASSERT(a != center);
+    ASSERT(b != center);
+
     coord_def a_off = _project_coord(a - center, range); 
     coord_def b_off = _project_coord(b - center, range);
+
+    ASSERT(a_off.rdist() == range);
+    ASSERT(b_off.rdist() == range);
 
     int arclen = abs(a_off.x - b_off.x) + abs(a_off.y - b_off.y) + 1;
 

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1351,7 +1351,7 @@ static int _get_arclen(coord_def a, coord_def b, coord_def center)
     int arclen = abs(a_off.x - b_off.x) + abs(a_off.y - b_off.y) + 1;
 
     //A and b on opposite vertical sides
-    if(abs(a_off.x) == range && abs(b_off.x) == range && a_off.x != b_off.x)
+    if (abs(a_off.x) == range && abs(b_off.x) == range && a_off.x != b_off.x)
     {
         const int a_to_side = range - abs(a_off.y);
         const int b_to_side = range - abs(b_off.y);
@@ -1359,7 +1359,7 @@ static int _get_arclen(coord_def a, coord_def b, coord_def center)
     }
 
     //Opposite horizontal sides
-    if(abs(a_off.y) == range && abs(b_off.y) == range && a_off.y != b_off.y)
+    if (abs(a_off.y) == range && abs(b_off.y) == range && a_off.y != b_off.y)
     {
         const int a_to_side = range - abs(a_off.x);
         const int b_to_side = range - abs(b_off.x);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1374,7 +1374,7 @@ bool targeter_thunderbolt::set_aim(coord_def a)
     zapped.clear();
 
     if (a == origin)
-        return false; 
+        return false;
 
     ray_def ray;
     coord_def p; // ray.pos() does lots of processing, cache it

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -289,7 +289,7 @@ public:
     bool set_aim(coord_def a) override;
     aff_type is_affected(coord_def loc) override;
     map<coord_def, aff_type> zapped;
-    int arclen;
+    int arclen = 1;
 private:
     coord_def prev;
     int range;

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -289,7 +289,7 @@ public:
     bool set_aim(coord_def a) override;
     aff_type is_affected(coord_def loc) override;
     map<coord_def, aff_type> zapped;
-    FixedVector<int, LOS_RADIUS + 1> arc_length;
+    int arclen;
 private:
     coord_def prev;
     int range;


### PR DESCRIPTION
Lightning rod damage was previously divided by the arclength+2 at a particular distance; e.g. if your cone hit two squares at range two, the damage for enemies at range 2 was divided by 4.

This had several issues: it was extremely unintuitive, it was not communicated sufficiently by the description, and it was very difficult to reason about in terms of effectiveness.

This PR changes lightning rod damage to be divided by arclength + 2 where arclength is computed at range 5, rather than computing a distinct arclength for each range from 1 to 5. 