### PR TITLE
Tell the player about MF_SECONDARY_SCROLL in menus.

### DIFF
--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -891,10 +891,14 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
         if (!inv_class[i])
             continue;
 
-        string subtitle = item_class_name(i);
+        string subtitle = item_class_name(i), select_all;
 
         // Mention the class selection shortcuts.
-        if (is_set(MF_MULTISELECT))
+        if (is_set(MF_SECONDARY_SCROLL))
+            select_all = "go to first";
+        else if (is_set(MF_MULTISELECT))
+            select_all = "select all";
+        if (!select_all.empty())
         {
             vector<char> glyphs;
             get_class_hotkeys(i, glyphs);
@@ -904,7 +908,7 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
                 const string str = "Magical Staves ";
                 subtitle += string(strwidth(str) - strwidth(subtitle),
                                    ' ');
-                subtitle += "(select all with <w>";
+                subtitle += "("+select_all+" with <w>";
                 for (char gly : glyphs)
                     subtitle += gly;
                 subtitle += "</w><blue>)";

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -863,18 +863,20 @@ FixedVector<int, NUM_OBJECT_CLASSES> inv_order(
 
 menu_letter InvMenu::load_items(const vector<item_def>& mitems,
                                 function<MenuEntry* (MenuEntry*)> procfn,
-                                menu_letter ckey, bool sort)
+                                menu_letter ckey, bool sort, bool subkeys)
 {
     vector<const item_def*> xlatitems;
     for (const item_def &item : mitems)
         xlatitems.push_back(&item);
-    return load_items(xlatitems, procfn, ckey, sort);
+    return load_items(xlatitems, procfn, ckey, sort, subkeys);
 }
 
 menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
                                 function<MenuEntry* (MenuEntry*)> procfn,
-                                menu_letter ckey, bool sort)
+                                menu_letter ckey, bool sort, bool subkeys)
 {
+    subkeys |= is_set(MF_MULTISELECT); // XXX Can the caller do this?
+
     FixedVector< int, NUM_OBJECT_CLASSES > inv_class(0);
     for (const item_def * const mitem : mitems)
         inv_class[mitem->base_type]++;
@@ -884,6 +886,18 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
     if (sort)
         cond = find_menu_sort_condition();
 
+    string select_all;
+    if (subkeys)
+    {
+        // Mention the class selection shortcuts.
+        if (is_set(MF_SECONDARY_SCROLL))
+            select_all = "go to first";
+        else if (is_set(MF_MULTISELECT))
+            select_all = "select all";
+        else
+            select_all = "select first";
+    }
+
     for (int obj = 0; obj < NUM_OBJECT_CLASSES; ++obj)
     {
         int i = inv_order[obj];
@@ -891,14 +905,9 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
         if (!inv_class[i])
             continue;
 
-        string subtitle = item_class_name(i), select_all;
+        string subtitle = item_class_name(i);
 
-        // Mention the class selection shortcuts.
-        if (is_set(MF_SECONDARY_SCROLL))
-            select_all = "go to first";
-        else if (is_set(MF_MULTISELECT))
-            select_all = "select all";
-        if (!select_all.empty())
+        if (subkeys)
         {
             vector<char> glyphs;
             get_class_hotkeys(i, glyphs);
@@ -925,6 +934,8 @@ menu_letter InvMenu::load_items(const vector<const item_def*> &mitems,
                 continue;
 
             InvEntry * const ie = new InvEntry(*mitem);
+            if (!subkeys)
+                ie->hotkeys.resize(1);
             if (mitem->sub_type == get_max_subtype(mitem->base_type))
                 forced_first = ie;
             else

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -570,7 +570,7 @@ void InvMenu::load_inv_items(int item_selector, int excluded_slot,
     vector<const item_def *> tobeshown;
     _get_inv_items_to_show(tobeshown, item_selector, excluded_slot);
 
-    load_items(tobeshown, procfn);
+    load_items(tobeshown, procfn, 'a', true, true);
 
     if (!item_count())
         set_title(no_selectables_message(item_selector));

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -144,12 +144,14 @@ public:
     // NOTE: Does not set menu title, ever! You *must* set the title explicitly
     menu_letter load_items(const vector<const item_def*> &items,
                            function<MenuEntry* (MenuEntry*)> procfn = nullptr,
-                           menu_letter ckey = 'a', bool sort = true);
+                           menu_letter ckey = 'a', bool sort = true,
+                           bool subkeys = false);
 
     // Make sure this menu does not outlive items, or mayhem will ensue!
     menu_letter load_items(const vector<item_def>& items,
                            function<MenuEntry* (MenuEntry*)> procfn = nullptr,
-                           menu_letter ckey = 'a', bool sort = true);
+                           menu_letter ckey = 'a', bool sort = true,
+                           bool subkeys = false);
 
     // Loads items from the player's inventory into the menu, and sets the
     // title to the stock title. If "procfn" is provided, it'll be called for

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -486,6 +486,11 @@ static void _note_tele_cancel(MenuEntry* entry)
 
 void UseItemMenu::populate_menu()
 {
+    const bool use_category_selection = item_type_filter == OSEL_UNIDENT
+                                        || _equip_oper(oper);
+    if (use_category_selection)
+        set_flags(get_flags() | MF_SECONDARY_SCROLL);
+
     if (item_inv.empty())
         is_inventory = false;
     else if (item_floor.empty())
@@ -526,7 +531,7 @@ void UseItemMenu::populate_menu()
                     {
                         // hacky: remove the class hotkey for cases where it
                         // is counterintuitive/useless
-                        if (item_type_filter != OSEL_UNIDENT)
+                        if (!use_category_selection)
                             entry->hotkeys.pop_back();
                         if (item_type_filter == OBJ_SCROLLS)
                             _note_tele_cancel(entry);

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -488,7 +488,7 @@ void UseItemMenu::populate_menu()
 {
     const bool use_category_selection = item_type_filter == OSEL_UNIDENT
                                         || _equip_oper(oper);
-    if (use_category_selection)
+    if (_equip_oper(oper))
         set_flags(get_flags() | MF_SECONDARY_SCROLL);
 
     if (item_inv.empty())
@@ -529,14 +529,10 @@ void UseItemMenu::populate_menu()
         load_items(item_inv,
                     [&](MenuEntry* entry) -> MenuEntry*
                     {
-                        // hacky: remove the class hotkey for cases where it
-                        // is counterintuitive/useless
-                        if (!use_category_selection)
-                            entry->hotkeys.pop_back();
                         if (item_type_filter == OBJ_SCROLLS)
                             _note_tele_cancel(entry);
                         return entry;
-                    });
+                    }, 'a', true, use_category_selection);
     }
     last_inv_pos = items.size() - 1;
 
@@ -556,12 +552,10 @@ void UseItemMenu::populate_menu()
         load_items(item_floor,
                     [&](MenuEntry* entry) -> MenuEntry*
                     {
-                        // hacky: remove the class hotkey
-                        entry->hotkeys.pop_back();
                         if (item_type_filter == OBJ_SCROLLS)
                             _note_tele_cancel(entry);
                         return entry;
-                    });
+                    }, 'a', true, false);
     }
     update_sections();
 


### PR DESCRIPTION
If `MF_SECONDARY_SCROLL` is set, state in any menu "subtitles" that object class keys (such as ? or /) move to an item in its section. This was not previously communicated.

Add `MF_SECONDARY_SCROLL` to equip/unequip and identify menus.

The previous situation was:
The wield command showed weapons and staffs, but there was no one-key way to go to the staves.
The menu displayed if you read a scroll of identify showed scrolls and potions. If you typed `!` in that menu it would identify the first unidentified potion.

With this change:
Pressing `|` in the wield menu moves the cursor to the first staff.
Pressing `!` in the identify menu moves the cursor to the first potion.
Both keys are displayed within the menu.