### PR TITLE
Remove spurious sticky flame reference in _ugly_thing_resists().

### DIFF
--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -668,7 +668,6 @@ static resists_t _ugly_thing_resists(bool very_ugly, attack_flavour u_att_flav)
     switch (u_att_flav)
     {
     case AF_FIRE:
-    case AF_STICKY_FLAME:
         return MR_RES_FIRE * (very_ugly ? 2 : 1);
 
     case AF_ACID:


### PR DESCRIPTION
Since red very ugly things don't have sticky flame anymore, it shouldn't be referenced when giving them their resists, either.