### PR TITLE
Fix warning if Beogh can't give an orc an orcbow.

### DIFF
--- a/crawl-ref/source/god-blessing.cc
+++ b/crawl-ref/source/god-blessing.cc
@@ -253,7 +253,7 @@ static string _beogh_bless_ranged_weapon(monster* mon)
     _gift_weapon_to_orc(mon, WPN_ORCBOW);
     if (mon->launcher() == nullptr)
     {
-        dprf("Couldn't give crossbow to follower!");
+        dprf("Couldn't give orcbow to follower!");
         return ""; // ?
     }
 


### PR DESCRIPTION
Now with a short-enough commit message, and without the breakage of the last attempt.