### PR TITLE
Use a PromptMenu for various selections in wizard mode.

### DIFF
--- a/crawl-ref/source/prompt.cc
+++ b/crawl-ref/source/prompt.cc
@@ -545,3 +545,63 @@ vector<MenuEntry *> PromptMenu::show_in_msgpane()
     get_selected(&sel);
     return sel;
 }
+
+#ifdef WIZARD
+
+WizardMenu::WizardMenu(string _title, vector<WizardEntry> &_options,
+                       int _default)
+    : PromptMenu(MF_SINGLESELECT | MF_ARROWS_SELECT | MF_INIT_HOVER
+                 | MF_GRID_LAYOUT | MF_ANYPRINTABLE), default_value(_default)
+{
+    set_title(new MenuEntry(_title, MEL_TITLE));
+    for (auto &o : _options)
+    {
+        auto p = new WizardEntry(o); // Menu expects new pointers.
+        if (!p->hotkeys_count())
+            p->add_hotkey(next_unused_symbol()); // Give everything a hotkey.
+        add_entry(p);
+    }
+}
+
+int WizardMenu::run(bool to_bool)
+{
+    run_aux();
+    return to_bool ? last_success : last_result;
+}
+
+// Display the menu. If something is selected, set success and return the
+// selected thing. If not, clear success and return default_value.
+void WizardMenu::run_aux()
+{
+    show();
+    last_success = !sel.empty();
+    if (last_success)
+        last_result = (dynamic_cast<WizardEntry*>(sel[0]))->output;
+    else
+    {
+        canned_msg(MSG_OK);
+        last_result = default_value;
+    }
+}
+
+int WizardMenu::index_to_symbol(int index) const
+{
+    if (index < 52)
+        return index_to_letter(index);
+    else if (last_symbol_index < 69)
+        return '0'+last_symbol_index-52;
+    else
+        return 0; // 0 no hotkey, cursor keys only.
+}
+
+int WizardMenu::next_unused_symbol()
+{
+    while (true)
+    {
+        int sym = index_to_symbol(last_symbol_index++);
+        if (!sym || -1 == hotkey_to_index(sym, true))
+            return sym;
+    }
+}
+
+#endif // defined(WIZARD)

--- a/crawl-ref/source/prompt.h
+++ b/crawl-ref/source/prompt.h
@@ -82,7 +82,7 @@ public:
     WizardEntry(string _text, int _output) // Find a symbol later.
     : WizardEntry(0, _text, _output) { }
 
-    const int output;
+    int output;
 };
 
 class WizardMenu : private PromptMenu

--- a/crawl-ref/source/prompt.h
+++ b/crawl-ref/source/prompt.h
@@ -67,3 +67,47 @@ protected:
     bool in_prompt_mode;
 
 };
+
+#ifdef WIZARD
+// If _symbol is 0, a copy in a WizardMenu will be given the next unused symbol.
+// symbol in the menu's copy.
+class WizardEntry : public MenuEntry
+{
+public:
+    WizardEntry(int _symbol, string _text, int _output)
+    : MenuEntry(_text, MEL_ITEM, 1, _symbol), output(_output)
+    { indent_no_hotkeys = true; }
+    WizardEntry(int _symbol, string _text) // Return the symbol from run().
+    : WizardEntry(_symbol, _text, _symbol) { }
+    WizardEntry(string _text, int _output) // Find a symbol later.
+    : WizardEntry(0, _text, _output) { }
+
+    const int output;
+};
+
+class WizardMenu : private PromptMenu
+{
+public:
+    WizardMenu(string _title, vector<WizardEntry> &_options, int _default=127);
+    int run(bool to_bool = false);
+
+    int result() const
+    {
+        return last_result;
+    }
+    bool success() const
+    {
+        return last_success;
+    }
+protected:
+    void run_aux();
+    int index_to_symbol(int index) const;
+    int next_unused_symbol();
+
+    unsigned last_symbol_index = 0;
+    int last_result = 0;
+    bool last_success = false;
+
+    int default_value;
+};
+#endif

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1643,13 +1643,6 @@ const char *shoptype_to_str(shop_type type)
     return shop_types[type];
 }
 
-void list_shop_types()
-{
-    mpr_nojoin(MSGCH_PLAIN, "Available shop types: ");
-    for (const char *type : shop_types)
-        mprf_nocap("%s", type);
-}
-
 ////////////////////////////////////////////////////////////////////////
 
 // TODO:

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -44,7 +44,6 @@ bool shop_item_unknown(const item_def &item);
 
 shop_type str_to_shoptype(const string &s);
 const char *shoptype_to_str(shop_type type);
-void list_shop_types();
 
 /////////////////////////////////////////////////////////////////////
 

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -443,68 +443,28 @@ void wizard_map_level()
 
 bool debug_make_trap(const coord_def& pos)
 {
-    char requested_trap[80];
-    trap_type trap = TRAP_UNASSIGNED;
-    int gridch     = env.grid(pos);
-
-    if (gridch != DNGN_FLOOR)
+    if (env.grid(pos) != DNGN_FLOOR)
     {
         mpr("You need to be on a floor square to make a trap.");
         return false;
     }
 
-    msgwin_get_line("What kind of trap? ",
-                    requested_trap, sizeof(requested_trap));
-    if (!*requested_trap)
+    vector<WizardEntry> options;
+    for (int i = TRAP_FIRST_TRAP; i < NUM_TRAPS; ++i)
     {
-        canned_msg(MSG_OK);
+        auto name = trap_name(static_cast<trap_type>(i));
+        options.emplace_back(WizardEntry(name, i));
+    }
+    sort(options.begin(), options.end());
+    options.emplace_back(WizardEntry('*', "any", TRAP_RANDOM));
+
+    auto menu = WizardMenu("Make which kind of trap?", options);
+    if (!menu.run(true))
         return false;
-    }
 
-    string spec = lowercase_string(requested_trap);
-    vector<trap_type> matches;
-    vector<string>    match_names;
-
-    if (spec == "random" || spec == "any")
-        trap = TRAP_RANDOM;
-
-    for (int t = TRAP_FIRST_TRAP; t < NUM_TRAPS; ++t)
-    {
-        const trap_type tr = static_cast<trap_type>(t);
-        string tname       = lowercase_string(trap_name(tr));
-        if (spec.find(tname) != spec.npos)
-        {
-            trap = tr;
-            break;
-        }
-        else if (tname.find(spec) != tname.npos)
-        {
-            matches.push_back(tr);
-            match_names.push_back(tname);
-        }
-    }
-
-    if (trap == TRAP_UNASSIGNED)
-    {
-        if (matches.empty())
-        {
-            mprf("I know no traps named \"%s\".", spec.c_str());
-            return false;
-        }
-        // Only one match, use that
-        else if (matches.size() == 1)
-            trap = matches[0];
-        else
-        {
-            string prefix = "No exact match for trap '";
-            prefix += spec;
-            prefix += "', possible matches are: ";
-            mpr_comma_separated_list(prefix, match_names);
-            return false;
-        }
-    }
-
+    auto trap = static_cast<trap_type>(menu.result());
     place_specific_trap(you.pos(), trap);
+
     mprf("Created %s.",
          (trap == TRAP_RANDOM)
             ? "a random trap"
@@ -524,25 +484,21 @@ bool debug_make_shop(const coord_def& pos)
         return false;
     }
 
-    char requested_shop[80];
-    msgwin_get_line("What kind of shop? ",
-                    requested_shop, sizeof(requested_shop));
-    if (!*requested_shop)
+    vector<WizardEntry> options;
+    for (int i = 0; i < NUM_SHOPS; ++i)
     {
-        canned_msg(MSG_OK);
-        return false;
+        auto name = shoptype_to_str(static_cast<shop_type>(i));
+        if (str_to_shoptype(name) == i) // Don't offer to make "removed" shops.
+            options.emplace_back(WizardEntry(name, i));
     }
+    sort(options.begin(), options.end());
+    options.emplace_back(WizardEntry('*', "any", SHOP_RANDOM));
 
-    const shop_type new_shop_type = str_to_shoptype(requested_shop);
-
-    if (new_shop_type == SHOP_UNASSIGNED)
-    {
-        mprf("Bad shop type: \"%s\"", requested_shop);
-        list_shop_types();
+    auto menu = WizardMenu("Make which kind of shop?", options);
+    if (!menu.run(true))
         return false;
-    }
 
-    place_spec_shop(pos, new_shop_type);
+    place_spec_shop(pos, static_cast<shop_type>(menu.result()));
     mpr("Done.");
     return true;
 }

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -95,33 +95,18 @@ void wizard_create_spec_object_by_name()
 
 void wizard_create_spec_object()
 {
-    char specs[80];
-    char32_t keyin;
-    object_class_type class_wanted;
-
-    do
+    string title = "Which item class (ESC to exit)?";
+    vector<WizardEntry> options =
     {
-        mprf(MSGCH_PROMPT, ") - weapons     ( - missiles  [ - armour  / - wands    ?  - scrolls");
-        mprf(MSGCH_PROMPT, "= - jewellery   ! - potions   : - books   | - staves   }  - miscellany");
-        mprf(MSGCH_PROMPT, "%% - talismans   X - corpses   $ - gold    0  - the Orb");
-        mprf(MSGCH_PROMPT, "ESC - exit");
-
-        msgwin_prompt("What class of item? ");
-
-        keyin = towupper(get_ch());
-
-        class_wanted = item_class_by_sym(keyin);
-        if (key_is_escape(keyin) || keyin == ' '
-                || keyin == '\r' || keyin == '\n')
-        {
-            msgwin_reply("");
-            canned_msg(MSG_OK);
-            return;
-        }
-    } while (class_wanted == NUM_OBJECT_CLASSES);
-
-    // XXX: hope item_class_by_sym never returns a real class for non-ascii.
-    msgwin_reply(string(1, (char) keyin));
+        {')', "weapons"}, {'(', "missiles"}, {'[', "armour"}, {'/', "wands"},
+        {'?', "scrolls"}, {'=', "jewellery"}, {'!', "potions"}, {':', "books"},
+        {'|', "staves"}, {'}', "miscellany"}, {'X', "corpses"}, {'$', "gold"},
+        {'0', "the Orb"}
+    };
+    auto menu = WizardMenu(title, options);
+    object_class_type class_wanted = item_class_by_sym(menu.run());
+    if (NUM_OBJECT_CLASSES == class_wanted)
+        return;
 
     // Allocate an item to play with.
     int thing_created = get_mitm_slot();
@@ -194,7 +179,9 @@ void wizard_create_spec_object()
     }
     else
     {
-        string prompt = "What type of item? ";
+        char specs[80];
+        string prompt = make_stringf("What type of %s? ",
+                                     base_type_string(class_wanted));
         if (class_wanted == OBJ_BOOKS)
             prompt += "(\"all\" for all) ";
         msgwin_get_line_autohist(prompt, specs, sizeof(specs));
@@ -258,68 +245,30 @@ static void _tweak_randart(item_def &item)
 
     string prompt = "";
 
-    vector<unsigned int> choice_to_prop;
-    for (unsigned int i = 0, choice_num = 0; i < ARTP_NUM_PROPERTIES; ++i)
+    vector<WizardEntry> choices;
+    for (unsigned int i = 0, choice = 'a'; i < ARTP_NUM_PROPERTIES; ++i)
     {
 #if TAG_MAJOR_VERSION == 34
         if (i == ARTP_METABOLISM || i == ARTP_ACCURACY || i == ARTP_TWISTER)
             continue;
 #endif
-        choice_to_prop.push_back(i);
-        if (choice_num % 8 == 0 && choice_num != 0)
-            prompt.back() = '\n'; // Replace the space
+        auto prop = (artefact_prop_type)i;
+        choices.emplace_back(WizardEntry(choice, artp_name(prop), i));
 
-        char choice;
-        char buf[80];
-
-        if (choice_num < 26)
-            choice = 'a' + choice_num;
-        else if (choice_num < 52)
-            choice = 'A' + choice_num - 26;
-        else if (choice_num < 'A' - '0' + 52)
-        {
-            // 0-9 then :;<=>?@ . Any higher would collide with letters.
-            choice = '0' + choice_num - 52;
-        }
+        if (choice == 'z')
+            choice = 'A';
+        else if (choice == 'Z')
+            choice = '0';
+        else if (choice == '@' || !choice)
+            choice = 0;
         else
-            choice = '-'; // Too many choices!
-
-        snprintf(buf, sizeof(buf), "%s) %s%-6s%s ",
-                choice == '<' ? "<<" : string(1, choice).c_str(),
-                 props[i] ? "<w>" : "",
-                 artp_name((artefact_prop_type)choice_to_prop[choice_num]),
-                 props[i] ? "</w>" : "");
-
-        prompt += buf;
-
-        choice_num++;
+            ++choice;
     }
-    mprf_nocap(MSGCH_PROMPT, "%s", prompt.c_str());
-
-    mprf(MSGCH_PROMPT, "Change which field? ");
-
-    int keyin = get_ch();
-    unsigned int  choice;
-
-    if (isaalpha(keyin) && islower(keyin))
-        choice = keyin - 'a';
-    else if (isaalpha(keyin) && isupper(keyin))
-        choice = keyin - 'A' + 26;
-    else if (keyin >= '0' && keyin < 'A')
-        choice = keyin - '0' + 52;
-    else
-    {
-        canned_msg(MSG_OK);
+    auto menu = WizardMenu("Change which field (ESC to exit)?", choices);
+    if (!menu.run(true))
         return;
-    }
+    auto prop = static_cast<artefact_prop_type>(menu.result());
 
-    if (choice >= choice_to_prop.size())
-    {
-        canned_msg(MSG_HUH);
-        return;
-    }
-
-    const artefact_prop_type prop = (artefact_prop_type)choice_to_prop[choice];
     switch (artp_potential_value_types(prop))
     {
     case ARTP_VAL_BOOL:
@@ -407,39 +356,29 @@ void wizard_tweak_object()
     while (true)
     {
         int64_t old_val = 0; // flags are uint64_t, but they don't care
-
-        while (true)
+        string c_prop = is_art ? "art props" : "special";
+        vector<WizardEntry> options =
         {
-            mprf_nocap("%s", you.inv[item].name(DESC_INVENTORY_EQUIP).c_str());
+            {'a', "plus"}, {'b', "plus2"}, {'c', c_prop}, {'d', "quantity"},
+            {'e', "flags"}
+        };
+        mprf_nocap("%s", you.inv[item].name(DESC_INVENTORY_EQUIP).c_str());
+        auto menu = WizardMenu("Which field (Esc to exit)?", options);
+        keyin = menu.run();
 
-            mprf_nocap(MSGCH_PROMPT, "a - plus  b - plus2  c - %s  "
-                                     "d - quantity  e - flags  ESC - exit",
-                                     is_art ? "art props" : "special");
+        if (keyin == 'a')
+            old_val = you.inv[item].plus;
+        else if (keyin == 'b')
+            old_val = you.inv[item].plus2;
+        else if (keyin == 'c')
+            old_val = you.inv[item].special;
+        else if (keyin == 'd')
+            old_val = you.inv[item].quantity;
+        else if (keyin == 'e')
+            old_val = you.inv[item].flags;
+        else if (!menu.success())
+            return;
 
-            mprf(MSGCH_PROMPT, "Which field? ");
-
-            keyin = toalower(get_ch());
-
-            if (keyin == 'a')
-                old_val = you.inv[item].plus;
-            else if (keyin == 'b')
-                old_val = you.inv[item].plus2;
-            else if (keyin == 'c')
-                old_val = you.inv[item].special;
-            else if (keyin == 'd')
-                old_val = you.inv[item].quantity;
-            else if (keyin == 'e')
-                old_val = you.inv[item].flags;
-            else if (key_is_escape(keyin) || keyin == ' '
-                    || keyin == '\r' || keyin == '\n')
-            {
-                canned_msg(MSG_OK);
-                return;
-            }
-
-            if (keyin >= 'a' && keyin <= 'e')
-                break;
-        }
 
         if (is_art && keyin == 'c')
         {
@@ -834,24 +773,21 @@ static void _debug_acquirement_stats(FILE *ostat)
     env.item[p].base_type = OBJ_UNASSIGNED;
 
     clear_messages();
-    mpr("[a] Weapons [b] Armours   [c] Jewellery [d] Books");
-    mpr("[e] Staves  [f] Evocables");
-    mprf(MSGCH_PROMPT, "What kind of item would you like to get acquirement stats on? ");
 
-    object_class_type type;
-    const int keyin = toalower(get_ch());
-    switch (keyin)
+    vector<WizardEntry> choices;
+    object_class_type list[] =
     {
-    case 'a': type = OBJ_WEAPONS;    break;
-    case 'b': type = OBJ_ARMOUR;     break;
-    case 'c': type = OBJ_JEWELLERY;  break;
-    case 'd': type = OBJ_BOOKS;      break;
-    case 'e': type = OBJ_STAVES;     break;
-    case 'f': type = OBJ_MISCELLANY; break;
-    default:
-        canned_msg(MSG_OK);
+        OBJ_WEAPONS, OBJ_ARMOUR, OBJ_JEWELLERY, OBJ_BOOKS, OBJ_STAVES,
+        OBJ_MISCELLANY
+    };
+    char c = 'a';
+    for (auto typ : list)
+        choices.emplace_back(WizardEntry(c++, item_class_name(typ), typ));
+    auto menu = WizardMenu("What kind of item would you like to get acquirement"
+                           " stats on (ESC to exit)?", choices, OBJ_UNASSIGNED);
+    if (!menu.run(true))
         return;
-    }
+    auto type = static_cast<object_class_type>(menu.result());
 
     const int num_itrs = prompt_for_int("How many iterations? ", true);
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -784,60 +784,41 @@ void wizard_make_monster_summoned(monster* mon)
         return;
     }
 
-    mprf(MSGCH_PROMPT, "[a] clone [b] animated [c] chaos [d] miscast [e] zot");
-    mprf(MSGCH_PROMPT, "[f] wrath [h] aid   [m] misc    [s] spell");
-
-    mprf(MSGCH_PROMPT, "Which summon type? ");
-
-    char choice = toalower(getchm());
-
-    if (!(choice >= 'a' && choice <= 'h') && choice != 'm' && choice != 's')
+    vector<WizardEntry> choices =
     {
-        canned_msg(MSG_OK);
+        {'a', "clone", MON_SUMM_CLONE}, {'b', "animated", MON_SUMM_ANIMATE},
+        {'c', "chaos", MON_SUMM_CHAOS}, {'d', "miscast", MON_SUMM_MISCAST},
+        {'e', "zot", MON_SUMM_ZOT}, {'f', "wrath", MON_SUMM_WRATH},
+        {'h', "aid", MON_SUMM_AID}, {'m', "misc", 0},
+        {'s', "spell", 's'},
+    };
+
+    auto menu = WizardMenu("Which summon type (ESC to exit)?", choices);
+    if (!menu.run(true))
         return;
-    }
 
-    int type = 0;
-
-    switch (choice)
+    int type = menu.result();
+    if ('s' == type)
     {
-        case 'a': type = MON_SUMM_CLONE; break;
-        case 'b': type = MON_SUMM_ANIMATE; break;
-        case 'c': type = MON_SUMM_CHAOS; break;
-        case 'd': type = MON_SUMM_MISCAST; break;
-        case 'e': type = MON_SUMM_ZOT; break;
-        case 'f': type = MON_SUMM_WRATH; break;
-        case 'h': type = MON_SUMM_AID; break;
-        case 'm': type = 0; break;
+        char specs[80];
 
-        case 's':
+        msgwin_get_line("Cast which spell by name? ",
+                        specs, sizeof(specs));
+
+        if (specs[0] == '\0')
         {
-            char specs[80];
-
-            msgwin_get_line("Cast which spell by name? ",
-                            specs, sizeof(specs));
-
-            if (specs[0] == '\0')
-            {
-                canned_msg(MSG_OK);
-                return;
-            }
-
-            spell_type spell = spell_by_name(specs, true);
-            if (spell == SPELL_NO_SPELL)
-            {
-                mprf(MSGCH_PROMPT, "No such spell.");
-                return;
-            }
-            type = (int) spell;
-            break;
+            canned_msg(MSG_OK);
+            return;
         }
 
-        default:
-            die("Invalid summon type choice.");
-            break;
+        spell_type spell = spell_by_name(specs, true);
+        if (spell == SPELL_NO_SPELL)
+        {
+            mprf(MSGCH_PROMPT, "No such spell.");
+            return;
+        }
+        type = (int) spell;
     }
-
     mon->mark_summoned(dur, true, type);
     mpr("Monster is now summoned.");
 }

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -592,109 +592,84 @@ void wizard_set_stats()
     notify_stat_change();
 }
 
-void wizard_edit_durations()
+// Let the user type in a duration name.
+// Return true and set "choice" if one match is found.
+// If none, or more than one, is found, return false.
+static bool _wizard_enter_duration_name(duration_type &choice)
 {
-    vector<duration_type> durs;
-    size_t max_len = 0;
+    char buf[80];
+    vector<string> match_names;
+
+    mprf(MSGCH_PROMPT, "Edit which duration (name)? ");
+
+    if (cancellable_get_line_autohist(buf, sizeof buf) || !*buf
+        || !strlcpy(buf, lowercase_string(trimmed_string(buf)).c_str(),
+                    sizeof(buf)))
+    {
+        canned_msg(MSG_OK);
+        return false;
+    }
 
     for (int i = 0; i < NUM_DURATIONS; ++i)
     {
-        const duration_type dur = static_cast<duration_type>(i);
+        const auto dur = static_cast<duration_type>(i);
+        if (strcmp(duration_name(dur), buf) == 0)
+        {
+            choice = dur;
+            return true;
+        }
+        if (strstr(duration_name(dur), buf) != nullptr)
+        {
+            choice = dur;
+            match_names.emplace_back(duration_name(dur));
+        }
+    }
+    if (match_names.size() == 1)
+        return true;
+    else if (match_names.empty())
+    {
+        mprf(MSGCH_PROMPT, "No durations matching '%s'.", buf);
+        return false;
+    }
+    else
+    {
+        string prefix = "No exact match for duration '";
+        prefix += buf;
+        prefix += "', possible matches are: ";
 
+        mpr_comma_separated_list(prefix, match_names, " and ", ", ",
+                                 MSGCH_DIAGNOSTICS);
+        return false;
+    }
+}
+
+void wizard_edit_durations()
+{
+    vector<WizardEntry> active;
+    duration_type choice;
+
+    for (int i = 0; i < NUM_DURATIONS; ++i)
+    {
+        const auto d = static_cast<duration_type>(i);
         if (!you.duration[i])
             continue;
-
-        max_len = max(strlen(duration_name(dur)), max_len);
-        durs.push_back(dur);
+        auto text = make_stringf("%s : %d", duration_name(d), you.duration[i]);
+        active.emplace_back(WizardEntry(text, i));
     }
-
-    if (!durs.empty())
+    if (!active.empty())
     {
-        for (size_t i = 0; i < durs.size(); ++i)
-        {
-            const duration_type dur = durs[i];
-            const char ch = i >= 26 ? ' ' : 'a' + i;
-            mprf_nocap(MSGCH_PROMPT, "%c%c %-*s : %d",
-                 ch, ch == ' ' ? ' ' : ')',
-                 (int)max_len, duration_name(dur), you.duration[dur]);
-        }
-        mprf(MSGCH_PROMPT, "\nEdit which duration (letter or name)? ");
+        active.emplace_back('*', "other durations", NUM_DURATIONS);
+        auto menu = WizardMenu("Edit which duration (ESC to exit)?", active);
+        if (!menu.run(true))
+            return;
+        choice = static_cast<duration_type>(menu.result());
+        if (NUM_DURATIONS == choice && !_wizard_enter_duration_name(choice))
+            return;
     }
-    else
-        mprf(MSGCH_PROMPT, "Edit which duration (name)? ");
+    else if (!_wizard_enter_duration_name(choice))
+        return;
 
     char buf[80];
-
-    if (cancellable_get_line_autohist(buf, sizeof buf) || !*buf)
-    {
-        canned_msg(MSG_OK);
-        return;
-    }
-
-    if (!strlcpy(buf, lowercase_string(trimmed_string(buf)).c_str(), sizeof(buf)))
-    {
-        canned_msg(MSG_OK);
-        return;
-    }
-
-    duration_type choice = NUM_DURATIONS;
-
-    if (strlen(buf) == 1 && isalower(buf[0]))
-    {
-        if (durs.empty())
-        {
-            mprf(MSGCH_PROMPT, "No existing durations to choose from.");
-            return;
-        }
-        const int dchoice = buf[0] - 'a';
-
-        if (dchoice < 0 || dchoice >= (int) durs.size())
-        {
-            mprf(MSGCH_PROMPT, "Invalid choice.");
-            return;
-        }
-        choice = durs[dchoice];
-    }
-    else
-    {
-        vector<duration_type> matches;
-        vector<string> match_names;
-
-        for (int i = 0; i < NUM_DURATIONS; ++i)
-        {
-            const duration_type dur = static_cast<duration_type>(i);
-            if (strcmp(duration_name(dur), buf) == 0)
-            {
-                choice = dur;
-                break;
-            }
-            if (strstr(duration_name(dur), buf) != nullptr)
-            {
-                matches.push_back(dur);
-                match_names.emplace_back(duration_name(dur));
-            }
-        }
-        if (choice != NUM_DURATIONS)
-            ;
-        else if (matches.size() == 1)
-            choice = matches[0];
-        else if (matches.empty())
-        {
-            mprf(MSGCH_PROMPT, "No durations matching '%s'.", buf);
-            return;
-        }
-        else
-        {
-            string prefix = "No exact match for duration '";
-            prefix += buf;
-            prefix += "', possible matches are: ";
-
-            mpr_comma_separated_list(prefix, match_names, " and ", ", ",
-                                     MSGCH_DIAGNOSTICS);
-            return;
-        }
-    }
-
     snprintf(buf, sizeof(buf), "Set '%s' to: ", duration_name(choice));
     int num = prompt_for_int(buf, false);
 
@@ -920,47 +895,20 @@ void wizard_god_mollify()
 
 void wizard_transform()
 {
-    transformation form;
-
-    while (true)
+    vector<WizardEntry> choices;
+    for (int i = 0; i < NUM_TRANSFORMS; ++i)
     {
-        string line;
-        for (int i = 0; i < NUM_TRANSFORMS; i++)
-        {
             const auto tr = static_cast<transformation>(i);
 #if TAG_MAJOR_VERSION == 34
             if (tr == transformation::jelly || tr == transformation::porcupine)
                 continue;
 #endif
-            line += make_stringf("[%c] %-10s ", i + 'a', transform_name(tr));
-            if (i % 5 == 4 || i == NUM_TRANSFORMS - 1)
-            {
-                mprf(MSGCH_PROMPT, "%s", line.c_str());
-                line.clear();
-            }
-        }
-        mprf(MSGCH_PROMPT, "Which form (ESC to exit)? ");
-
-        int keyin = toalower(get_ch());
-
-        if (key_is_escape(keyin) || keyin == ' '
-            || keyin == '\r' || keyin == '\n')
-        {
-            canned_msg(MSG_OK);
-            return;
-        }
-
-        if (keyin < 'a' || keyin > 'a' + NUM_TRANSFORMS - 1)
-            continue;
-
-        const auto k_tr = static_cast<transformation>(keyin - 'a');
-#if TAG_MAJOR_VERSION == 34
-        if (k_tr == transformation::jelly || k_tr == transformation::porcupine)
-            continue;
-#endif
-        form = k_tr;
-        break;
+        choices.emplace_back(WizardEntry(0, transform_name(tr), i));
     }
+    auto menu = WizardMenu("Which form (ESC to exit)?", choices);
+    if (!menu.run(true))
+        return;
+    auto form = static_cast<transformation>(menu.result());
 
     you.transform_uncancellable = false;
     if (you.default_form == you.form && you.form != transformation::none)


### PR DESCRIPTION
Various wizmode functions functions printed a menu in the message window, but didn't check if it would fit, and thereby hid some of the options.

Make some use PromptMenu instead. This displays the menu in a separate popup if it's larger than the message window, so doesn't share this issue.

There's nothing wizard-specific about the class I added; I only included the #ifdef because I haven't seen a similar issue anywhere else.