### PR TITLE
Fix compiling with NOWIZARD.

### DIFF
--- a/crawl-ref/source/wizard-option-type.h
+++ b/crawl-ref/source/wizard-option-type.h
@@ -1,12 +1,8 @@
 #pragma once
 
-#ifdef WIZARD
-
 enum wizard_option_type
 {
     WIZ_NEVER,                         // protect player from accidental wiz
     WIZ_NO,                            // don't start character in wiz mode
     WIZ_YES,                           // start character in wiz mode
 };
-
-#endif


### PR DESCRIPTION
The wizard option is defined in NOWIZARD builds. Define an enum it relies on then.

Compiling with NOWIZARD on gcc highlights a few unused parameters and unused functions, but I've left those.