### PR TITLE
Increase the inventory size to 104 stacks.

### DIFF
--- a/crawl-ref/docs/crawl_manual.rst
+++ b/crawl-ref/docs/crawl_manual.rst
@@ -472,7 +472,7 @@ auto-explore will usually save real time.
 Stashes and Searching
 ========================================
 
-Since you can only carry 52 items, you will occasionally want to stash things
+Since you can only carry 104 items, you will occasionally want to stash things
 away (by dropping them with the 'd' command). When you want to search for
 something in your stashes, you can do this with the Find command 'Ctrl-F'. The
 parser even accepts regular expressions, although you will mostly just need
@@ -756,7 +756,7 @@ unusual. When the inventory screen shows "-more-", to show you that there is
 another page of items, you can type the letter of the item you want, even if it
 is not visible, instead of pressing Space or Enter to see the next page.
 
-You can carry at most 52 items at once, and your item slot usage is printed at
+You can carry at most 104 items at once, and your item slot usage is printed at
 the top of the inventory screen.
 
 You can use the adjust command (the '=' key) to change the letters to which your

--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -206,9 +206,9 @@ void swap_inv_slots(int from_slot, int to_slot, bool verbose)
     you.inv[from_slot] = tmp;
 
     // Slot switching.
-    tmp.slot = you.inv[to_slot].slot;
-    you.inv[to_slot].slot  = index_to_letter(to_slot);//you.inv[from_slot].slot is 0 when 'from_slot' contains no item.
-    you.inv[from_slot].slot = tmp.slot;
+    // Not symmetrical as you.inv[to_slot] may have been empty beforehand.
+    you.inv[from_slot].slot = you.inv[to_slot].slot;
+    you.inv[to_slot].slot = to_slot;
 
     you.inv[from_slot].link = from_slot;
     you.inv[to_slot].link  = to_slot;

--- a/crawl-ref/source/dat/descript/hints.txt
+++ b/crawl-ref/source/dat/descript/hints.txt
@@ -567,7 +567,7 @@ selection with <w>Enter</w>.
 %%%%
 HINT_FULL_INVENTORY
 
-Sadly, your inventory is limited to 52 items, and it appears your knapsack is
+Sadly, your inventory is limited to 104 items, and it appears your knapsack is
 full. However, this is easy enough to rectify: simply <w>$cmd[CMD_DROP]</w>rop
 some of the stuff you don't need right now. In the drop menu you can then
 comfortably select which items to drop by pressing their inventory

--- a/crawl-ref/source/dbg-asrt.cc
+++ b/crawl-ref/source/dbg-asrt.cc
@@ -341,7 +341,7 @@ static void _dump_player(FILE *file)
                     i, name.c_str(), item.link);
         }
 
-        if (item.slot < 0 || item.slot > 127)
+        if (item.slot != -1 && item.slot != i)
         {
             fprintf(file, "    slot #%d: item '%s' has invalid slot %d\n",
                     i, name.c_str(), item.slot);

--- a/crawl-ref/source/defines.h
+++ b/crawl-ref/source/defines.h
@@ -38,7 +38,7 @@
 #endif
 
 // max size of inventory array {dlb}:
-#define ENDOFPACK 52
+#define ENDOFPACK 104
 
 // Max ghosts in a bones file.
 const int MAX_GHOSTS = 127;

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -2020,7 +2020,7 @@ static string _hints_throw_stuff(const item_def &item)
     string result;
 
     result  = "To do this, press <w>%</w> to fire, then ";
-    if (item.slot >= 0)
+    if (item.slot >= 0 && item.slot < 52)
     {
         result += "<w>";
         result += index_to_letter(item.slot);

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -33,6 +33,7 @@
 #include "nearby-danger.h"
 #include "options.h"
 #include "output.h"
+#include "prompt.h"
 #include "religion.h"
 #include "shopping.h"
 #include "showsymb.h"
@@ -2019,11 +2020,11 @@ static string _hints_throw_stuff(const item_def &item)
     string result;
 
     result  = "To do this, press <w>%</w> to fire, then ";
-    if (item.slot)
+    if (item.slot >= 0)
     {
         result += "<w>";
-        result += item.slot;
-        result += "</w> for";
+        result += index_to_letter(item.slot);
+        result += "</w> for ";
     }
     else
     {

--- a/crawl-ref/source/item-def.h
+++ b/crawl-ref/source/item-def.h
@@ -84,7 +84,7 @@ struct item_def
 public:
     item_def() : base_type(OBJ_UNASSIGNED), sub_type(0), plus(0), plus2(0),
                  special(0), rnd(0), quantity(0), flags(0),
-                 pos(), link(NON_ITEM), slot(0), orig_place(),
+                 pos(), link(NON_ITEM), slot(-1), orig_place(),
                  orig_monnum(0), inscription()
     {
     }

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -154,7 +154,7 @@ string item_def::name(description_level_type descrip, bool terse, bool ident,
     {
         if (in_inventory(*this)) // actually in inventory
         {
-            buff << index_to_letter(link);
+            buff << index_to_char(link);
             if (terse)
                 buff << ") ";
             else

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2147,7 +2147,7 @@ static int _prompt_ring_to_remove()
     {
         rings.push_back(you.slot_item(eq, true));
         ASSERT(rings.back());
-        slot_chars.push_back(index_to_letter(rings.back()->link));
+        slot_chars.push_back(index_to_char(rings.back()->link));
     }
 
     if (slot_chars.size() + 2 > msgwin_lines() || ui::has_layout())
@@ -2170,7 +2170,10 @@ static int _prompt_ring_to_remove()
         if (key == '<')
             m += '<';
 
-        m += "</w> or " + rings[i]->name(DESC_INVENTORY);
+        if ('&' == slot_chars[i])
+            m += "</w> " + rings[i]->name(DESC_PLAIN);
+        else
+            m += "</w> or " + rings[i]->name(DESC_INVENTORY);
         mprf_nocap("%s", m.c_str());
     }
     flush_prev_message();
@@ -2185,6 +2188,8 @@ static int _prompt_ring_to_remove()
     do
     {
         c = getchm();
+        if ('&' == c) // Never a valid response.
+            continue;
         for (size_t i = 0; i < slot_chars.size(); i++)
         {
             if (c == slot_chars[i]
@@ -2508,8 +2513,8 @@ static equipment_type _choose_ring_slot()
 {
     clear_messages();
 
-    mprf(MSGCH_PROMPT,
-         "Put ring on which %s? (<w>Esc</w> to cancel)", you.hand_name(false).c_str());
+    mprf(MSGCH_PROMPT, "Put ring on which %s? (<w>Esc</w> to cancel)",
+         you.hand_name(false).c_str());
 
     const vector<equipment_type> slots = _current_ring_types();
     for (auto eq : slots)
@@ -2545,8 +2550,8 @@ static equipment_type _choose_ring_slot()
         for (auto eq : slots)
         {
             if (c == _ring_slot_key(eq)
-                || (you.slot_item(eq, true)
-                    && c == index_to_letter(you.slot_item(eq, true)->link)))
+                || (c != '&' && you.slot_item(eq, true)
+                    && c == index_to_char(you.slot_item(eq, true)->link)))
             {
                 eqslot = eq;
                 c = ' ';

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1629,11 +1629,8 @@ int find_free_slot(const item_def &i)
 
     // See if the item remembers where it's been. Lua code can play with
     // this field so be extra careful.
-    if (isaalpha(i.slot))
-        slot = letter_to_index(i.slot);
-
-    if (slotisfree(slot))
-        return slot;
+    if (slotisfree(i.slot))
+        return i.slot;
 
     FixedBitVector<ENDOFPACK> disliked;
     if (i.base_type == OBJ_POTIONS)
@@ -2121,7 +2118,7 @@ static int _place_item_in_free_slot(item_def &it, int quant_got,
     item          = it;
     item.link     = freeslot;
     item.quantity = quant_got;
-    item.slot     = index_to_letter(item.link);
+    item.slot     = item.link;
     item.pos = ITEM_IN_INVENTORY;
     // Remove "unobtainable" as it was just proven false.
     item.flags &= ~ISFLAG_UNOBTAINABLE;
@@ -2422,7 +2419,7 @@ bool copy_item_to_grid(item_def &item, const coord_def& p,
                     // If the items on the floor already have a nonzero slot,
                     // leave it as such, otherwise set the slot.
                     if (!si->slot)
-                        si->slot = index_to_letter(item.link);
+                        si->slot = item.link;
 
                     si->flags |= ISFLAG_DROPPED;
                     si->flags &= ~ISFLAG_THROWN;
@@ -2448,7 +2445,7 @@ bool copy_item_to_grid(item_def &item, const coord_def& p,
 
     if (mark_dropped)
     {
-        new_item.slot   = index_to_letter(item.link);
+        new_item.slot   = item.link;
         new_item.flags |= ISFLAG_DROPPED;
         new_item.flags &= ~ISFLAG_THROWN;
         origin_set_unknown(new_item);

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1627,9 +1627,9 @@ int find_free_slot(const item_def &i)
     if (slotisfree(slot))
         return slot;
 
-    // See if the item remembers where it's been. Lua code can play with
-    // this field so be extra careful.
-    if (slotisfree(i.slot))
+    // See if the item remembers where it's been (letter slots only).
+    // Lua code can play with this field so be extra careful.
+    if (52 > i.slot && slotisfree(i.slot))
         return i.slot;
 
     FixedBitVector<ENDOFPACK> disliked;
@@ -2085,6 +2085,19 @@ item_def *auto_assign_item_slot(item_def& item)
                     newslot = index;
                     break;
                 }
+            }
+            else if (i == '&') // Move to a non-letter slot; don't care which.
+            {
+                for (int j = 52; j < ENDOFPACK; ++j)
+                {
+                    if (!you.inv[j].defined())
+                    {
+                        newslot = j;
+                        break;
+                    }
+                }
+                if (overwrite && newslot == -1)
+                    newslot = ENDOFPACK-1;
             }
         }
         if (newslot != -1 && newslot != item.link)

--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -1260,7 +1260,7 @@ static int l_item_inventory(lua_State *ls)
     return 1;
 }
 
-/*** Get the inventory letter of a slot number.
+/*** Get the inventory character of a slot number.
  * @tparam int idx
  * @treturn string
  * @function index_to_letter
@@ -1270,7 +1270,7 @@ static int l_item_index_to_letter(lua_State *ls)
     int index = luaL_safe_checkint(ls, 1);
     char sletter[2] = "?";
     if (index >= 0 && index <= ENDOFPACK)
-        *sletter = index_to_letter(index);
+        *sletter = index_to_char(index);
     lua_pushstring(ls, sletter);
     return 1;
 }
@@ -1469,7 +1469,7 @@ static int l_item_fired_item(lua_State *ls)
 static int l_item_inslot(lua_State *ls)
 {
     int index = luaL_safe_checkint(ls, 1);
-    if (index >= 0 && index < 52 && you.inv[index].defined())
+    if (index >= 0 && index < ENDOFPACK && you.inv[index].defined())
         clua_push_item(ls, &you.inv[index]);
     else
         lua_pushnil(ls);

--- a/crawl-ref/source/menu.h
+++ b/crawl-ref/source/menu.h
@@ -106,6 +106,7 @@ public:
     bool indent_no_hotkeys;
     string preface_format;
     void *data;
+    int data_n; // Used by InvMenu as "next non-letter".
     function<bool(const MenuEntry&)> on_select;
 
 #ifdef USE_TILE
@@ -120,7 +121,7 @@ public:
         text(txt), quantity(qty), selected_qty(0), colour(-1),
         hotkeys(), level(lev),
         indent_no_hotkeys(false),
-        data(nullptr),
+        data(nullptr), data_n(-1),
         on_select(nullptr),
         m_enabled(true)
     {

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -519,7 +519,7 @@ static void _setup_generic(const newgame_def& ng,
             continue;
         item.pos = ITEM_IN_INVENTORY;
         item.link = i;
-        item.slot = index_to_letter(item.link);
+        item.slot = i;
         item_colour(item);  // set correct special and colour
     }
 

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1123,7 +1123,7 @@ static void _print_stats_wp(int y)
         text = you.unarmed_attack_name();
 
     textcolour(HUD_CAPTION_COLOUR);
-    const char slot_letter = you.weapon() ? index_to_letter(you.weapon()->link)
+    const char slot_letter = you.weapon() ? index_to_char(you.weapon()->link)
                                           : '-';
     const string slot_name = make_stringf("%c) ", slot_letter);
     CPRINTF("%s", slot_name.c_str());
@@ -2066,7 +2066,7 @@ static void _print_overview_screen_equip(column_composer& cols,
             string colname = melded ? "darkgrey" : colour_to_str(col);
 
             const int item_idx   = you.equip[eqslot];
-            const char equip_char = index_to_letter(item_idx);
+            const char equip_char = index_to_char(item_idx);
 
             str = make_stringf(
                      "<w>%c</w> - <%s>%s%s</%s>",
@@ -2536,7 +2536,8 @@ public:
 private:
     maybe_bool process_key(int ch) override
     {
-        if (find(equip_chars.begin(), equip_chars.end(), ch) != equip_chars.end())
+        if (isaalpha(ch) && equip_chars.end() !=
+                            find(equip_chars.begin(), equip_chars.end(), ch))
         {
             item_def& item = you.inv[letter_to_index(ch)];
             return describe_item(item);

--- a/crawl-ref/source/prompt.cc
+++ b/crawl-ref/source/prompt.cc
@@ -363,13 +363,27 @@ double prompt_for_float(const char* prompt)
     return ret;
 }
 
-
-char index_to_letter(int the_index)
+// Allow ENDOFPACK indices.
+char index_to_char(int the_index)
 {
     ASSERT_RANGE(the_index, 0, ENDOFPACK);
-    return the_index + ((the_index < 26) ? 'a' : ('A' - 26));
+    if (the_index > 51)
+        return '&';
+    else if (the_index > 25)
+        return the_index+'A'-26;
+    else
+        return the_index+'a';
 }
 
+// Allow 52 indices.
+char index_to_letter(int the_index)
+{
+    char rtn = index_to_char(the_index);
+    ASSERT(rtn != '&');
+    return rtn;
+}
+
+// Allow 52 letters. "&" does not represent a specific index.
 int letter_to_index(int the_letter)
 {
     if (the_letter >= 'a' && the_letter <= 'z')

--- a/crawl-ref/source/prompt.h
+++ b/crawl-ref/source/prompt.h
@@ -28,6 +28,7 @@ int prompt_for_quantity(const char *prompt);
 int prompt_for_int(const char *prompt, bool nonneg, const string &prefill = "");
 double prompt_for_float(const char* prompt);
 
+char index_to_char(int the_index);
 char index_to_letter(int the_index);
 
 int letter_to_index(int the_letter);

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -209,7 +209,7 @@ namespace quiver
     int action::source_hotkey() const
     {
         if (get_item() >= 0 && is_valid())
-            return index_to_letter(get_item());
+            return index_to_char(get_item());
         return 0;
     }
 
@@ -395,7 +395,7 @@ namespace quiver
                 string verb = you.confused() ? "confused " : "";
                 verb += quiver_verb();
                 qdesc.cprintf("%s: %c) ", uppercase_first(verb).c_str(),
-                                index_to_letter(weapon.link));
+                                index_to_char(weapon.link));
             }
 
             const string prefix = item_prefix(weapon);
@@ -499,7 +499,7 @@ namespace quiver
 
                 verb += quiver_verb();
                 qdesc.cprintf("%s: %c) ", uppercase_first(verb).c_str(),
-                                weapon ? index_to_letter(weapon->link) : '-');
+                                weapon ? index_to_char(weapon->link) : '-');
             }
 
             const string prefix = weapon ? item_prefix(*weapon) : "";

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -293,6 +293,7 @@ enum tag_minor_version
     TAG_MINOR_RAMPAGE_HEAL,        // Adjust Armataur mutations for healpage.
     TAG_MINOR_GEMS,                // Add gems.
     TAG_MINOR_NUMERIC_ITEM_SLOT,   // item_def.slot is the index, not a letter.
+    TAG_MINOR_104_INVENTORY,       // you.inv[] has 104 elements (was 52).
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -292,6 +292,7 @@ enum tag_minor_version
     TAG_MINOR_MON_SH_INFO,         // Store SH in mon-info.
     TAG_MINOR_RAMPAGE_HEAL,        // Adjust Armataur mutations for healpage.
     TAG_MINOR_GEMS,                // Add gems.
+    TAG_MINOR_NUMERIC_ITEM_SLOT,   // item_def.slot is the index, not a letter.
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -4269,7 +4269,7 @@ static void _tag_read_you_items(reader &th)
 
     // how many inventory slots?
     count = unmarshallByte(th);
-    ASSERT(count == ENDOFPACK); // not supposed to change
+    ASSERT(count <= ENDOFPACK);
 #if TAG_MAJOR_VERSION == 34
     string bad_slots;
 #endif
@@ -4285,7 +4285,7 @@ static void _tag_read_you_items(reader &th)
             // search would change the position of items in inventory.
             if (it.pos != ITEM_IN_INVENTORY)
             {
-                bad_slots += index_to_letter(i);
+                bad_slots += index_to_char(i);
                 it.pos = ITEM_IN_INVENTORY;
             }
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -5151,6 +5151,14 @@ void unmarshallItem(reader &th, item_def &item)
     item.slot        = unmarshallByte(th);
 
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() < TAG_MINOR_NUMERIC_ITEM_SLOT)
+    {
+        if (!item.slot)
+            item.slot = -1;
+        else
+            item.slot = letter_to_index(item.slot);
+    }
+
     if (th.getMinorVersion() < TAG_MINOR_PLACE_UNPACK)
     {
         unsigned short packed = unmarshallShort(th);

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -663,7 +663,7 @@ void throw_it(quiver::action &a)
     item_def item = thrown;
     item.quantity = 1;
     if (ammo_slot != -1)
-        item.slot     = index_to_letter(item.link);
+        item.slot     = item.link;
 
     _setup_missile_beam(&you, pbolt, item);
 

--- a/crawl-ref/source/webserver/game_data/static/action_panel.js
+++ b/crawl-ref/source/webserver/game_data/static/action_panel.js
@@ -399,7 +399,7 @@ function ($, comm, client, cr, enums, options, player, icons, gui, main,
             return;
 
         // Have we received the inventory yet?
-        // Note: an empty inventory will still have 52 empty slots.
+        // Note: an empty inventory will still have 104 empty slots.
         var inventory_initialized = Object.values(player.inv).length;
         if (!inventory_initialized)
         {

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -156,8 +156,10 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
             return "-"
         else if (index < 26)
             return String.fromCharCode("a".charCodeAt(0) + index);
-        else
+        else if (index < 52)
             return String.fromCharCode("A".charCodeAt(0) + index - 26);
+        else
+            return '&';
     }
     player.index_to_letter = index_to_letter;
 


### PR DESCRIPTION
The player accesses the first 52 items in the same way as now. The last 52 (all denoted by a "letter" of `&`) can be accessed by scrolling through. Pressing `&` goes to the next one on the list.

This is intended mainly to give an idea of what effect expanding the inventory would have on gameplay. The UI may not be the best possible one (it would involve fewer keypresses if you could type `&a` or `&Z`, for instance), but it should show how it plays.

There are a couple of things I can think of which I haven't explained within the game.

- What the `&` key does in an inventory list is not explained.
- The game reassigns `&` items by default if you drop them and pick them up again. This is intentional, but doing that with the entire inventory could lead to other items also being reassigned.