### PR TITLE
Fix inconsistencies in vitrify messages.

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5833,7 +5833,7 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
         {
             if (you.can_see(*mon))
             {
-                mprf("%s becomes as fragile as glass.",
+                mprf("%s becomes as fragile as glass!",
                      mon->name(DESC_THE).c_str());
                 obvious_effect = true;
             }
@@ -5856,7 +5856,7 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
                 }
                 else
                 {
-                    mprf("%s becomes as fragile as glass.",
+                    mprf("%s becomes as fragile as glass!",
                          mon->name(DESC_THE).c_str());
                 }
                 obvious_effect = true;

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3564,6 +3564,8 @@ void bolt::affect_player_enchantment(bool resistible)
     case BEAM_VITRIFY:
         if (!you.duration[DUR_VITRIFIED])
             mpr("Your body becomes as fragile as glass!");
+        else
+            mpr("You feel your fragility will last longer.");
         you.increase_duration(DUR_VITRIFIED, random_range(8, 18), 50);
         obvious_effect = true;
         break;


### PR DESCRIPTION
When the player is vitrified more by BEAM_VITRIFY_GAZE, there's a message for that. However, there isn't one for when the player is vitrified more by BEAM_VITRIFY. This fixes that.

Also, the monster messages for becoming as fragile as glass end in "!" in one place (Killer Klowns' clear moon pies), and "." in two others (the vitrify beam and the vitrifying gaze beam). This makes them all use "!", especially since vitrification does more damage now.