### PR TITLE
buff ice-themed ziggurat floors

### DIFF
--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -345,8 +345,9 @@ end), { weight = 2 }))
 mset(with_props(spec_fn(function ()
   local d = 10 + you.zigs_completed() * 2
   local e = 10 + you.zigs_completed() * 3
-  return "ice beast / ice devil / simulacrum / rime drake / " ..
-         "ice dragon w:" .. d .. " / frost giant w:" .. d .. " / " ..
+  return "ice devil w:5 / rime drake w:5 / simulacrum place:Depths:4 / " ..
+         "juggernaut simulacrum / 20-headed hydra simulacrum / " ..
+         "wendigo w:" .. d .. " / frost giant w:" .. d .. " / " ..
          "blizzard demon w:" .. d .. " / white draconian knight w:" .. e .. " / " ..
          "shard shrike w:" .. e .. " / ice fiend w:" .. e
 end), { weight = 2 }))


### PR DESCRIPTION
ice zig floors are quite pathetic just by virtue of having to go up against ignition, but their monster sets could still be a little better:

- removed ice beasts from the set
- halved the spawn chances of ice devils and rime drakes; while rime drakes do have an interesting gimmick of unavoidably hitting you with a projectile that slows your movement for a few turns, they still fold instantly to any zig-capable character
- random simulacra generate based on depths:4 spawns now (i dont know where it pulled from before this), and juggernaut/20 headed hydra (maybe a bit too many heads?) simulacra have their own seperate spawn chances
- replaced ice dragons with wendigo (i thought about also removing frost giants to match b0162a2 , but i think they're okay because they are one of the only monsters in the set that arent weak to fire). hopefully this doesnt make the set too indistinguishable from cocytus