### PR TITLE
Zin's Imprison improve

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -391,13 +391,13 @@ static vector<ability_def> &_get_ability_list()
 
         // INVOCATIONS:
         // Zin
-        { ABIL_ZIN_RECITE, "Recite",
-            0, 0, 0, -1, {fail_basis::invo, 30, 6, 20}, abflag::none },
+        { ABIL_ZIN_IMPRISON, "Imprison",
+            4, 0, 2, LOS_MAX_RANGE, {fail_basis::invo, 30, 6, 20},
+            abflag::target | abflag::not_self },
         { ABIL_ZIN_VITALISATION, "Vitalisation",
             2, 0, 1, -1, {fail_basis::invo, 40, 5, 20}, abflag::none },
-        { ABIL_ZIN_IMPRISON, "Imprison",
-            5, 0, 4, LOS_MAX_RANGE, {fail_basis::invo, 60, 5, 20},
-            abflag::target | abflag::not_self },
+        { ABIL_ZIN_RECITE, "Recite",
+            0, 0, 0, -1, {fail_basis::invo, 60, 5, 20}, abflag::none },
         { ABIL_ZIN_SANCTUARY, "Sanctuary",
             7, 0, 15, -1, {fail_basis::invo, 80, 4, 25}, abflag::none },
         { ABIL_ZIN_DONATE_GOLD, "Donate Gold",

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1279,7 +1279,7 @@ spret zin_imprison(const coord_def& target, bool fail)
         return spret::abort;
     }
 
-    int power = 3 + (roll_dice(5, you.skill(SK_INVOCATIONS, 5) + 12) / 26);
+    int power = 6 + (roll_dice(5, you.skill(SK_INVOCATIONS, 5) + 12) / 26);
 
     return cast_tomb(power, mons, -GOD_ZIN, fail);
 }

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -98,9 +98,9 @@ const vector<vector<god_power>> & get_all_god_powers()
         { },
 
         // Zin
-        {   { 1, ABIL_ZIN_RECITE, "recite Zin's Axioms of Law" },
+        {   { 1, ABIL_ZIN_IMPRISON, "call upon Zin to imprison the lawless" },
             { 2, ABIL_ZIN_VITALISATION, "call upon Zin for vitalisation" },
-            { 3, ABIL_ZIN_IMPRISON, "call upon Zin to imprison the lawless" },
+            { 3, ABIL_ZIN_RECITE, "recite Zin's Axioms of Law" },
             { 5, ABIL_ZIN_SANCTUARY, "call upon Zin to create a sanctuary" },
             { 6, "Zin will now cleanse your potions of mutation.",
                  "Zin will no longer cleanse your potions of mutation.",


### PR DESCRIPTION
Recite relies heavily on skill level and has no effect on beasts. In the early game, the player's skill level is very low, and half of the monsters that appear are beasts. Therefore, I think Recite is a poor choice for a first power. So I want to bump Recite to 3*, which doesn't help me right away, and I'm eyeing Imprison as an alternative (1* power). This is because while there are a lot of different powers in DCSS - damage, healing, buffs, debuffs, allies, etc. - the concept of "temporarily removing an enemy from the battlefield" is very rare. I think Zin's focus on Imprison rather than Recite could open up a new playstyle, so I'm going to experiment with reducing the cost of Imprison and increasing its duration to see what it would look like to actively use this power.