### PR TITLE
Allow cloning of uglies and dancing weapons.

### DIFF
--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -220,11 +220,12 @@ void mons_summon_illusion_from(monster* mons, actor *foe,
 
 bool mons_clonable(const monster* mon, bool needs_adjacent)
 {
-    // No uniques or ghost demon monsters. Also, figuring out the name
-    // for the clone of a named monster isn't worth it, and duplicate
-    // battlespheres with the same owner cause problems with the spell
+    // No uniques. Also, figuring out the name for the clone of a named
+    // monster isn't worth it, duplicate battlespheres with the same
+    // owner cause problems with the spell, and duplicate inugami don't
+    // give you the usual penalty if they die.
     if (mons_is_unique(mon->type)
-        || mons_is_ghost_demon(mon->type)
+        || mon->type == MONS_INUGAMI
         || mon->is_named()
         || mons_is_conjured(mon->type)
         || mons_is_tentacle_or_tentacle_segment(mon->type))


### PR DESCRIPTION
Ghost demon monsters can now be cloned. As for the others, named monsters still aren't clonable, which rules out Pandemonium lords, player ghosts, and player illusions; conjured monsters still aren't clonable, which rules out spectral weapons; and inugami are explicitly not clonable because you don't get the usual penalty if the inugami clone dies.

(I couldn't find a reason why ghost demons were barred from being cloned; git blame for that chunk of code goes back to 2010 when Mara's creating player illusions was added. Allowing clones of dancing weapons might be controversial, since a player could just cast Tukima's Dance and then use a phantom mirror on the resulting weapon, but I don't know if that's game-breaking.)