### PR TITLE
Increased *Rage ego Trigger Chance

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -277,7 +277,7 @@ int actor::angry(bool items) const
     if (!items)
         return anger;
 
-    return anger + 20 * wearing_ego(EQ_ALL_ARMOUR, SPARM_RAGE)
+    return anger + 25 * wearing_ego(EQ_ALL_ARMOUR, SPARM_RAGE)
                  + scan_artefacts(ARTP_ANGRY);
 }
 

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -852,7 +852,7 @@ TILE:     urand_bear
 TILE_EQ:  bear
 # TODO: why isn't this brand working on the fallback?
 BRAND:    SPARM_SPIRIT_SHIELD
-ANGRY:    20
+ANGRY:    25
 WILL:     2
 DBRAND:   Bear:      Going berserk makes the wearer exceptionally tough, and
  they are slowed for a shorter time afterward.

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2137,7 +2137,7 @@ static const char* _item_ego_desc(special_armour_type ego)
                "invisible creatures, increasing accuracy against all within "
                "it other than the wearer, and reducing the wearer's stealth.";
     case SPARM_RAGE:
-        return "it berserks the wearer when making melee attacks (20% chance).";
+        return "it berserks the wearer when making melee attacks (25% chance).";
     case SPARM_MAYHEM:
         return "it causes witnesses of the wearer's kills to go into a frenzy,"
                " attacking everything nearby with great strength and speed.";


### PR DESCRIPTION
*Rage items currently have a 20% trigger chance (like the Bear Hat and Orb of Wrath). This chance seems pretty ambiguous, especially in situations where the player gives up their shield and equips the Orb of Wrath. The player has to swing the weapon 4-5 times at the beginning of every fight to get berserk, so the 1-3 times before that are unreliable compared to shields. I like to slightly increase the trigger chance (20%->25%) so that players can enjoy the *Rage effect more reliably.