### PR TITLE
Improve how search handles artefacts.

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -399,8 +399,10 @@ vector<stash_search_result> Stash::matches_search(
     {
         const string s   = stash_item_name(item);
         const string ann = stash_annotate_item(STASH_LUA_SEARCH_ANNOTATE, &item);
-        if (search.matches(prefix + " " + ann + " " + s)
-            || is_dumpable_artefact(item) && search.matches(chardump_desc(item)))
+        string haystack = prefix + " " + ann + " " + s;
+        if (is_dumpable_artefact(item))
+            haystack += " " + chardump_desc(item);
+        if (search.matches(haystack))
         {
             stash_search_result res;
             res.match_type = MATCH_ITEM;
@@ -661,9 +663,9 @@ vector<stash_search_result> ShopInfo::matches_search(
         const string ann   = stash_annotate_item(STASH_LUA_SEARCH_ANNOTATE,
                                                  &item);
 
-        if (search.matches(prefix + " " + ann + " " + sname +
-                                                    " {" + shoptitle + "}")
-            || search.matches(shop_item_desc(item)))
+        string text = prefix + " " + ann + " " + sname + " {" + shoptitle + "}"
+                      + shop_item_desc(item);
+        if (search.matches(text))
         {
             stash_search_result res;
             res.match_type = MATCH_ITEM;
@@ -1288,9 +1290,10 @@ static vector<stash_search_result> _inventory_search(const base_pattern &search)
 
         const string s   = Stash::stash_item_name(item);
         const string ann = stash_annotate_item(STASH_LUA_SEARCH_ANNOTATE, &item);
-        if (search.matches(ann + " " + s)
-            || is_dumpable_artefact(item)
-               && search.matches(chardump_desc(item)))
+        string haystack = ann + " " + s;
+        if (is_dumpable_artefact(item))
+            haystack += " " + chardump_desc(item);
+        if (search.matches(haystack))
         {
             stash_search_result res;
             res.match = s;


### PR DESCRIPTION
Instead of returning artefacts where the name & prefixes match, or where the artefact description matches, return artefacts (from inventory, floor or shops) which match with all three things combined.

Should fix #3350.