### PR TITLE
Fix !cancellation contamination (The Unspeakable)

### DIFF
--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -394,7 +394,7 @@ public:
         debuff_player();
         mpr("You feel magically purged.");
         const int old_contam_level = get_contamination_level();
-        contaminate_player(-1 * 1000 + random2(4000));
+        contaminate_player(-1 * (1000 + random2(4000)));
         if (old_contam_level && old_contam_level == get_contamination_level())
             mpr("You feel slightly less contaminated with magical energies.");
         return true;


### PR DESCRIPTION
Missing parenthesis meant potion of cancellation was accidentally giving you contamination most of the time.