### PR TITLE
Fix typos and spelling.

### DIFF
--- a/crawl-ref/docs/changelog.txt
+++ b/crawl-ref/docs/changelog.txt
@@ -188,7 +188,7 @@ Tiles and Other Art
 * New art for Volatile Blastmotes (spell icon and clouds).
 * New art for short sword and eveningstar artefacts.
 * New art for the Orb of Zot.
-* New art for blink frogs, ancient lichen, rakshashas, and shrike simulacrae.
+* New art for blink frogs, ancient lichen, rakshashas, and shrike simulacra.
 * New art for Dithmenos's altar.
 * New Dragon Form and dragon monster art.
 * Icons added for many mutations.
@@ -2962,11 +2962,11 @@ Monsters
   - Nergalle can no longer enter Death's Door.
   - Gloorx Vloq can no longer cast Black Mark.
   - Various uniques have had their genders changed.
-* Zombies, skeletons, and simulacrula no longer hide damage taken, and display
+* Zombies, skeletons, and simulacra no longer hide damage taken, and display
   the full names of the monster they were created from.
 * Battlecry has been simplified, affecting all monsters of the same genus.
 * Blood Saints's Legendary Destruction now casts two spells at a time.
-* Necromancers gain Bind Soul, reviving slain monsters as simulacrula.
+* Necromancers gain Bind Soul, reviving slain monsters as simulacra.
 * Ghostly Fireball is now completely resistible by rN and causes draining.
 * Obsidian statues can Mesmerise.
 * Wizards and Ogre Mages have split up and re-arranged their many spell sets

--- a/crawl-ref/docs/changelog.txt
+++ b/crawl-ref/docs/changelog.txt
@@ -188,7 +188,7 @@ Tiles and Other Art
 * New art for Volatile Blastmotes (spell icon and clouds).
 * New art for short sword and eveningstar artefacts.
 * New art for the Orb of Zot.
-* New art for blink frogs, ancient lichen, rakshashas, and shrike simulacra.
+* New art for blink frogs, ancient lichen, rakshasas, and shrike simulacra.
 * New art for Dithmenos's altar.
 * New Dragon Form and dragon monster art.
 * Icons added for many mutations.

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1217,7 +1217,7 @@ burned away for a short time.
 %%%%
 Sculpt Simulacrum spell
 
-Forms icy simulacrula of an adjacent living, demonic, or holy creature. These
+Forms icy simulacra of an adjacent living, demonic, or holy creature. These
 fragile doppelgangers will take shape over a short period of time, eventually
 gaining the ability to move and attack the caster's enemies.
 

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -1222,7 +1222,7 @@ fragile doppelgangers will take shape over a short period of time, eventually
 gaining the ability to move and attack the caster's enemies.
 
 The good gods frown on this spell, as it works blood and ichor into unnatural
-fascimiles.
+facsimiles.
 
 You can maintain up to 5 simulacra simultaneously.
 %%%%


### PR DESCRIPTION
The spelling changes consistently make the plural of "simulacrum" "simulacra".

"Simulacrula" is used in a few places, but "simulacra" is most commonly used, and matches what's used in-game (cf. english.cc:pluralise()).