### PR TITLE
Trove: stop asking for dragon armour toll from draconian

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -120,7 +120,11 @@ function trove.get_trove_item(e, value, base_item)
        {base="armour", type="fire dragon scales", quant=d(3)+d(3)},
        {base="armour", type="ice dragon scales", quant=d(3)+d(3)} }
 
-  if you.race() ~= "Felid" and you.race() ~= "Octopode" then
+  local is_armour_user = you.race() ~= "Felid"
+      and you.race() ~= "Octopode"
+      and you.genus() ~= "draconian"
+
+  if is_armour_user then
     for _, toll in ipairs(arm) do
       table.insert(prices, toll)
     end


### PR DESCRIPTION
As draconians do not use dragon armour, it is not a big deal for them to pay such small price to enter trove