### PR TITLE
Give EEs Conjurations instead of Alchemy (#3444).

### DIFF
--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -140,7 +140,7 @@ static const map<job_type, job_def> job_data =
     },
     { "robe", "potion of magic", },
     WCHOICE_NONE,
-    { { SK_ALCHEMY, 1 }, { SK_EARTH_MAGIC, 3 }, { SK_SPELLCASTING, 2 },
+    { { SK_CONJURATIONS, 1 }, { SK_EARTH_MAGIC, 3 }, { SK_SPELLCASTING, 2 },
       { SK_DODGING, 2 }, { SK_STEALTH, 2 }, }
 } },
 


### PR DESCRIPTION
Since Passwall (now level 3) no longer uses the latter, and Stone Arrow (level 3) uses the former.