### PR TITLE
Fix crash in the Android port

### DIFF
--- a/crawl-ref/source/known-items.cc
+++ b/crawl-ref/source/known-items.cc
@@ -468,7 +468,7 @@ void check_item_knowledge(bool unknown_items)
             { OBJ_GOLD, 1 },
             { OBJ_BOOKS, 0 },
             { OBJ_RUNES, NUM_RUNE_TYPES },
-            { OBJ_GEMS, NUM_GEM_TYPES },
+            { OBJ_GEMS, 0 },
         };
         for (auto e : misc_list)
             _add_fake_item(e.first, e.second, selected_items, items_other);


### PR DESCRIPTION
The Android port, when compiled for release, crashes when opening the item knowledge menu. The crash occurs when creating the related InvEntry, at invent.cc:89

```
81  if (in_inventory(i) && i.base_type != OBJ_GOLD) 82  {
83      // We need to do this in order to get the 'wielded' annotation
84      // We then toss out the first four characters, which look
85      // like this: "a - ". Ow. FIXME.
86      text = i.name(DESC_INVENTORY_EQUIP, false).substr(4);
87  }
88  else
89      text = i.name(DESC_A, false);
```

Closes #3490