### PR TITLE
feat(webserver): Add game_id to rcfile_contents

### DIFF
--- a/crawl-ref/source/webserver/webtiles/ws_handler.py
+++ b/crawl-ref/source/webserver/webtiles/ws_handler.py
@@ -1242,7 +1242,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
         # Handle RC file not existing. IOError for py2, OSError for py3
         except (OSError, IOError):
             contents = ''
-        self.send_message("rcfile_contents", contents = contents)
+        self.send_message("rcfile_contents", game_id = game_id, contents = contents)
 
     def set_rc(self, game_id, contents):
         rcfile_path = self.rcfile_path(game_id)


### PR DESCRIPTION
When webtiles clients request an rc file's contents,
 they send a
`get_rc` message with a `game_id` property. The webt iles sever responds
with a `rcfile_contents` message that has a `content s` property.

Because the response doesn't include `game_id`, the client has to treat this as a stateful request. It has to remember what was recently
requested and can't pipeline multiple requests.

The current webtiles client stores this state in the
 UI and will ignore
the additional property. But its existence will simp lify design of
future webtiles clients.