### PR TITLE
Make rCorr halve corrosion stacks on the player instead of a coinflip chance to prevent

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1096,7 +1096,7 @@ int attack::player_apply_slaying_bonuses(int damage, bool aux)
                         || (weapon && is_range_weapon(*weapon)
                                    && using_weapon());
     damage_plus += slaying_bonus(throwing);
-    damage_plus -= 4 * you.corrosion_amount();
+    damage_plus -= you.corrosion_amount();
 
     // XXX: should this also trigger on auxes?
     if (!aux && !ranged)

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1115,7 +1115,7 @@ static void _print_stats_wp(int y)
         item_def wpn = *you.weapon(); // copy
 
         if (you.corrosion_amount() && wpn.base_type == OBJ_WEAPONS)
-            wpn.plus -= 4 * you.corrosion_amount();
+            wpn.plus -= you.corrosion_amount();
 
         text = wpn.name(DESC_PLAIN, true, false, true);
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6304,7 +6304,7 @@ int player::corrosion_amount() const
         corrosion += slime_wall_corrosion(&you);
 
     if (player_in_branch(BRANCH_DIS))
-        corrosion += 2;
+        corrosion += 8;
 
     return corrosion;
 }
@@ -6348,7 +6348,7 @@ int player::armour_class_with_specific_items(vector<const item_def *> items) con
     if (you.props.exists(PASSWALL_ARMOUR_KEY))
         AC += you.props[PASSWALL_ARMOUR_KEY].get_int() * scale;
 
-    AC -= 400 * corrosion_amount();
+    AC -= 100 * corrosion_amount();
 
     AC += sanguine_armour_bonus();
 
@@ -6924,16 +6924,6 @@ bool player::resists_dislodge(string event) const
 
 bool player::corrode_equipment(const char* corrosion_source, int degree)
 {
-    // rCorr protects against 50% of corrosion.
-    if (res_corr())
-    {
-        degree = binomial(degree, 50);
-        if (!degree)
-        {
-            dprf("rCorr protects.");
-            return false;
-        }
-    }
     // always increase duration, but...
     increase_duration(DUR_CORROSION, 10 + roll_dice(2, 4), 50,
                       make_stringf("%s corrodes you!",
@@ -6941,12 +6931,13 @@ bool player::corrode_equipment(const char* corrosion_source, int degree)
 
     // the more corrosion you already have, the lower the odds of more
     // Static environmental corrosion doesn't factor in
+    // Reduce corrosion amount by 50% if you have resistance
     int prev_corr = props[CORROSION_KEY].get_int();
     bool did_corrode = false;
     for (int i = 0; i < degree; i++)
-        if (!x_chance_in_y(prev_corr, prev_corr + 7))
+        if (!x_chance_in_y(prev_corr, prev_corr + 28))
         {
-            props[CORROSION_KEY].get_int()++;
+            props[CORROSION_KEY].get_int() += res_corr() ? 2 : 4;
             prev_corr++;
             did_corrode = true;
         }

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -201,7 +201,7 @@ bool fill_status_info(int status, status_info& inf)
         // Intentional fallthrough
     case DUR_CORROSION:
         inf.light_text = make_stringf("Corr (%d)",
-                          (-4 * you.corrosion_amount()));
+                          (-1 * you.corrosion_amount()));
         break;
 
     case DUR_FLAYED:

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -886,7 +886,7 @@ int slime_wall_corrosion(actor* act)
     if (actor_slime_wall_immune(act))
         return 0;
 
-    return count_adjacent_slime_walls(act->pos());
+    return count_adjacent_slime_walls(act->pos()) * 4;
 }
 
 // slime wall damage under Jiyva's oozemancy; this should only affect monsters


### PR DESCRIPTION
Protecting yourself against corrosion with rCorr has feelsbad moments where you get corroded for the full amount. It's not noticeable when it prevents corrosion because some sources of corrosion aren't guaranteed to begin with.

Each stack of corrosion on the players reduces AC and slay by 1. Quadrupled most sources of corrosion to compensate. Having corrosion resistance will halve the number of stacks applied to the player instead of a coinflip chance to prevent the status entirely. This should hopefully make it feel more consistent. 

Corrosion from slime walls and Dis are not affected by this change, though this change makes it easier to halve the corrosion from slime walls if need be. Corrosion against monsters is not touched as well.