### PR TITLE
Let players win the game with Rising Flame

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -1485,6 +1485,10 @@ static bool _can_rising_flame(bool quiet)
             mpr("You're already rising!");
         return false;
     }
+    if (you.where_are_you == BRANCH_DUNGEON && you.depth == 1 && player_has_orb())
+    {
+        return true;
+    }
     if (!level_above().is_valid())
     {
         if (!quiet)

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -706,6 +706,11 @@ level_id level_above()
 void rise_through_ceiling()
 {
     const level_id whither = level_above();
+    if (you.where_are_you == BRANCH_DUNGEON && you.depth == 1 && player_has_orb())
+    {
+        mpr("With a burst of heat and light, you rocket upward!");
+        floor_transition(DNGN_EXIT_DUNGEON, DNGN_EXIT_DUNGEON, level_id(BRANCH_DUNGEON, 0), true, true, false, false);
+    }
     if (!whither.is_valid())
     {
         mpr("In a burst of heat and light, you rocket briefly upward... "


### PR DESCRIPTION
Ignis's Rising Flame ability allows the player to travel rapidly to the floor above them, if that floor is a valid destination (next higher floor of the current branch, branch entry if they're at the top floor of a connected branch).  It does not, at present, work on D1...but if they player has the orb, they SHOULD be able to Rising Flame their way out of the dungeon to glorious victory.  This pull request implements this EXTREMELY IMPORTANT feature, the absence of which has no doubt caused untold suffering.

I have tested and confirmed this works in local tiles on Windows.