### PR TITLE
Finish removing CMD_TOGGLE_TRAVEL_SPEED

### DIFF
--- a/crawl-ref/docs/keybind.txt
+++ b/crawl-ref/docs/keybind.txt
@@ -94,7 +94,6 @@ O         CMD_OPEN_DOOR
 >         CMD_GO_DOWNSTAIRS
 ;         CMD_INSPECT_FLOOR
 !         CMD_ANNOTATE_LEVEL
-^T        CMD_TOGGLE_TRAVEL_SPEED
 
 Player status
 -------------

--- a/crawl-ref/settings/colemak_command_keys.txt
+++ b/crawl-ref/settings/colemak_command_keys.txt
@@ -59,7 +59,6 @@ bindkey = [u] CMD_TARGET_EXCLUDE
 bindkey = [u] CMD_MAP_EXCLUDE_AREA
 bindkey = [U] CMD_EXPERIENCE_CHECK
 bindkey = [U] CMD_MAP_FIND_EXCLUDED
-bindkey = [^U] CMD_TOGGLE_TRAVEL_SPEED
 bindkey = [^U] CMD_MAP_CLEAR_EXCLUDES
 
 # fix overwrite on ^U


### PR DESCRIPTION
This removes the leftover CMD_TOGGLE_TRAVEL_SPEED from colemak keybindings and keybind help.