### PR TITLE
Remove unneeded quotes from YAML files.

### DIFF
--- a/crawl-ref/source/dat/species/armataur.yaml
+++ b/crawl-ref/source/dat/species/armataur.yaml
@@ -1,7 +1,7 @@
 enum: SP_ARMATAUR
 monster: MONS_ARMATAUR
-name: "Armataur"
-short_name: "At"
+name: Armataur
+short_name: At
 difficulty: Simple
 difficulty_priority: 30
 species_flags:

--- a/crawl-ref/source/dat/species/barachi.yaml
+++ b/crawl-ref/source/dat/species/barachi.yaml
@@ -1,8 +1,8 @@
 enum: SP_BARACHI
 monster: MONS_BARACHI
-name: "Barachi"
-adjective: "Barachian"
-genus: "Frog"
+name: Barachi
+adjective: Barachian
+genus: Frog
 difficulty: Advanced
 difficulty_priority: 100
 species_flags:

--- a/crawl-ref/source/dat/species/deep-elf.yaml
+++ b/crawl-ref/source/dat/species/deep-elf.yaml
@@ -1,9 +1,9 @@
 enum: SP_DEEP_ELF
 monster: MONS_ELF
-name: "Deep Elf"
-short_name: "DE"
-adjective: "Elven"
-genus: "Elf"
+name: Deep Elf
+short_name: DE
+adjective: Elven
+genus: Elf
 difficulty: Simple
 difficulty_priority: 40
 aptitudes:

--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -1,8 +1,8 @@
 enum: SP_DEMIGOD
 monster: MONS_DEMIGOD
-name: "Demigod"
-short_name: "Dg"
-adjective: "Divine"
+name: Demigod
+short_name: Dg
+adjective: Divine
 difficulty: Advanced
 difficulty_priority: 80
 aptitudes:

--- a/crawl-ref/source/dat/species/demonspawn.yaml
+++ b/crawl-ref/source/dat/species/demonspawn.yaml
@@ -1,8 +1,8 @@
 enum: SP_DEMONSPAWN
 monster: MONS_DEMONSPAWN
-name: "Demonspawn"
-short_name: "Ds"
-adjective: "Demonic"
+name: Demonspawn
+short_name: Ds
+adjective: Demonic
 difficulty: Intermediate
 difficulty_priority: 80
 aptitudes:

--- a/crawl-ref/source/dat/species/deprecated-centaur.yaml
+++ b/crawl-ref/source/dat/species/deprecated-centaur.yaml
@@ -1,7 +1,7 @@
 TAG_MAJOR_VERSION: 34
 enum: SP_CENTAUR
 monster: MONS_CENTAUR
-name: "Centaur"
+name: Centaur
 difficulty: False
 species_flags:
   - SPF_SMALL_TORSO

--- a/crawl-ref/source/dat/species/deprecated-deep-dwarf.yaml
+++ b/crawl-ref/source/dat/species/deprecated-deep-dwarf.yaml
@@ -1,10 +1,10 @@
 TAG_MAJOR_VERSION: 34
 enum: SP_DEEP_DWARF
 monster: MONS_DEEP_DWARF
-name: "Deep Dwarf"
-short_name: "DD"
-adjective: "Dwarven"
-genus: "Dwarf"
+name: Deep Dwarf
+short_name: DD
+adjective: Dwarven
+genus: Dwarf
 difficulty: False
 aptitudes:
   xp: -1

--- a/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
+++ b/crawl-ref/source/dat/species/deprecated-draconian-mottled.yaml
@@ -1,10 +1,10 @@
 TAG_MAJOR_VERSION: 34
 enum: SP_MOTTLED_DRACONIAN
 monster: MONS_MOTTLED_DRACONIAN
-name: "Mottled Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Mottled Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/deprecated-mayflytaur.yaml
+++ b/crawl-ref/source/dat/species/deprecated-mayflytaur.yaml
@@ -1,8 +1,8 @@
 TAG_MAJOR_VERSION: 34
 enum: SP_MAYFLYTAUR
 monster: MONS_BUTTERFLY
-name: "Mayflytaur"
-short_name: "My"
+name: Mayflytaur
+short_name: My
 difficulty: False
 aptitudes:
   xp: 0

--- a/crawl-ref/source/dat/species/deprecated-meteoran.yaml
+++ b/crawl-ref/source/dat/species/deprecated-meteoran.yaml
@@ -1,9 +1,9 @@
 TAG_MAJOR_VERSION: 34
 enum: SP_METEORAN
 monster: MONS_METEORAN
-name: "Meteoran"
-short_name: "Me"
-adjective: "Meteoric"
+name: Meteoran
+short_name: Me
+adjective: Meteoric
 difficulty: False
 aptitudes:
   xp: 2

--- a/crawl-ref/source/dat/species/draconian-base.yaml
+++ b/crawl-ref/source/dat/species/draconian-base.yaml
@@ -1,6 +1,6 @@
 enum: SP_BASE_DRACONIAN
 monster: MONS_DRACONIAN
-name: "Draconian"
+name: Draconian
 difficulty: Simple
 difficulty_priority: 60
 species_flags:

--- a/crawl-ref/source/dat/species/draconian-black.yaml
+++ b/crawl-ref/source/dat/species/draconian-black.yaml
@@ -1,9 +1,9 @@
 enum: SP_BLACK_DRACONIAN
 monster: MONS_BLACK_DRACONIAN
-name: "Black Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Black Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-green.yaml
+++ b/crawl-ref/source/dat/species/draconian-green.yaml
@@ -1,9 +1,9 @@
 enum: SP_GREEN_DRACONIAN
 monster: MONS_GREEN_DRACONIAN
-name: "Green Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Green Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-grey.yaml
+++ b/crawl-ref/source/dat/species/draconian-grey.yaml
@@ -1,9 +1,9 @@
 enum: SP_GREY_DRACONIAN
 monster: MONS_GREY_DRACONIAN
-name: "Grey Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Grey Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-pale.yaml
+++ b/crawl-ref/source/dat/species/draconian-pale.yaml
@@ -1,9 +1,9 @@
 enum: SP_PALE_DRACONIAN
 monster: MONS_PALE_DRACONIAN
-name: "Pale Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Pale Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-purple.yaml
+++ b/crawl-ref/source/dat/species/draconian-purple.yaml
@@ -1,9 +1,9 @@
 enum: SP_PURPLE_DRACONIAN
 monster: MONS_PURPLE_DRACONIAN
-name: "Purple Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Purple Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-red.yaml
+++ b/crawl-ref/source/dat/species/draconian-red.yaml
@@ -1,9 +1,9 @@
 enum: SP_RED_DRACONIAN
 monster: MONS_RED_DRACONIAN
-name: "Red Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Red Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-white.yaml
+++ b/crawl-ref/source/dat/species/draconian-white.yaml
@@ -1,9 +1,9 @@
 enum: SP_WHITE_DRACONIAN
 monster: MONS_WHITE_DRACONIAN
-name: "White Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: White Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/draconian-yellow.yaml
+++ b/crawl-ref/source/dat/species/draconian-yellow.yaml
@@ -1,9 +1,9 @@
 enum: SP_YELLOW_DRACONIAN
 monster: MONS_YELLOW_DRACONIAN
-name: "Yellow Draconian"
-short_name: "Dr"
-adjective: "Draconian"
-genus: "Draconian"
+name: Yellow Draconian
+short_name: Dr
+adjective: Draconian
+genus: Draconian
 difficulty: False
 species_flags:
   - SPF_DRACONIAN

--- a/crawl-ref/source/dat/species/felid.yaml
+++ b/crawl-ref/source/dat/species/felid.yaml
@@ -1,8 +1,8 @@
 enum: SP_FELID
 monster: MONS_FELID
-name: "Felid"
-adjective: "Feline"
-genus: "Cat"
+name: Felid
+adjective: Feline
+genus: Cat
 difficulty: Advanced
 difficulty_priority: 40
 aptitudes:

--- a/crawl-ref/source/dat/species/formicid.yaml
+++ b/crawl-ref/source/dat/species/formicid.yaml
@@ -1,7 +1,7 @@
 enum: SP_FORMICID
 monster: MONS_FORMICID
-name: "Formicid"
-genus: "Ant"
+name: Formicid
+genus: Ant
 difficulty: Advanced
 difficulty_priority: 70
 species_flags: # n.b. ants have hair

--- a/crawl-ref/source/dat/species/gargoyle.yaml
+++ b/crawl-ref/source/dat/species/gargoyle.yaml
@@ -1,7 +1,7 @@
 enum: SP_GARGOYLE
 monster: MONS_GARGOYLE
-name: "Gargoyle"
-short_name: "Gr"
+name: Gargoyle
+short_name: Gr
 difficulty: Simple
 difficulty_priority: 70
 species_flags:

--- a/crawl-ref/source/dat/species/gnoll.yaml
+++ b/crawl-ref/source/dat/species/gnoll.yaml
@@ -1,6 +1,6 @@
 enum: SP_GNOLL
 monster: MONS_GNOLL
-name: "Gnoll"
+name: Gnoll
 difficulty: Simple
 difficulty_priority: 10
 aptitudes:

--- a/crawl-ref/source/dat/species/mountain-dwarf.yaml
+++ b/crawl-ref/source/dat/species/mountain-dwarf.yaml
@@ -2,8 +2,8 @@ enum: SP_MOUNTAIN_DWARF
 monster: MONS_DWARF
 name: Mountain Dwarf
 short_name: MD
-adjective: "Dwarven"
-genus: "Dwarf"
+adjective: Dwarven
+genus: Dwarf
 difficulty: Simple
 difficulty_priority: 100
 aptitudes:

--- a/crawl-ref/source/dat/species/octopode.yaml
+++ b/crawl-ref/source/dat/species/octopode.yaml
@@ -1,9 +1,9 @@
 enum: SP_OCTOPODE
 monster: MONS_OCTOPODE
-name: "Octopode"
-short_name: "Op"
-adjective: "Octopoid"
-genus: "Octopus"
+name: Octopode
+short_name: Op
+adjective: Octopoid
+genus: Octopus
 difficulty: Advanced
 difficulty_priority: 50
 aptitudes:


### PR DESCRIPTION
Some have them around species name, abbreviation, short name, adjective, and/or genus; and some don't. (Mountain Dwarf has them around some things and not others.) They're read properly either way, so the quotes aren't necessary.