### PR TITLE
Remove the "Eos" unrand, along with its halo.

### DIFF
--- a/crawl-ref/source/areas.cc
+++ b/crawl-ref/source/areas.cc
@@ -595,11 +595,8 @@ int player::halo_radius() const
                                                     / piety_breakpoint(5);
     }
 
-    if (player_equip_unrand(UNRAND_EOS)
-        || player_equip_unrand(UNRAND_BRILLIANCE))
-    {
+    if (player_equip_unrand(UNRAND_BRILLIANCE))
         size = max(size, 3);
-    }
     else if (wearing_ego(EQ_ALL_ARMOUR, SPARM_LIGHT))
         size = max(size, 3);
     else if (you.props.exists(WU_JIAN_HEAVENLY_STORM_KEY))
@@ -639,11 +636,8 @@ int monster::halo_radius() const
     item_def* weap = mslot_item(MSLOT_WEAPON);
     int size = -1;
 
-    if (weap && (is_unrandom_artefact(*weap, UNRAND_EOS)
-                 || is_unrandom_artefact(*weap, UNRAND_BRILLIANCE)))
-    {
+    if (weap && is_unrandom_artefact(*weap, UNRAND_BRILLIANCE))
         size = 3;
-    }
 
     if (wearing_ego(EQ_ALL_ARMOUR, SPARM_LIGHT))
         size = 3;

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -561,6 +561,7 @@ WILL:    1
 BOOL:    nospell, nogen
 # end TAG_MAJOR_VERSION
 
+# start TAG_MAJOR_VERSION == 34
 NAME:    morningstar "Eos"
 OBJ:     OBJ_WEAPONS/WPN_MORNINGSTAR
 PLUS:    +10
@@ -569,9 +570,8 @@ COLOUR:  ETC_JEWEL
 TILE:    urand_eos
 TILE_EQ: eos
 BRAND:   SPWPN_ELECTROCUTION
-BOOL:    elec
-DESCRIP: Halo:      It grants its wielder a halo, revealing invisible creatures
- and increasing accuracy against all within it other than the wielder.
+BOOL:    elec, nogen
+# end TAG_MAJOR_VERSION
 
 # start TAG_MAJOR_VERSION == 34
 # Was "spear of Voo-Doo". In the African origin, there is a distinction

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -718,17 +718,6 @@ static void _UNDEADHUNTER_melee_effects(item_def* /*item*/, actor* attacker,
 }
 
 ///////////////////////////////////////////////////
-static void _EOS_equip(item_def */*item*/, bool */*show_msgs*/, bool /*unmeld*/)
-{
-    invalidate_agrid(true);
-}
-
-static void _EOS_unequip(item_def */*item*/, bool */*show_msgs*/)
-{
-    invalidate_agrid(true);
-}
-
-///////////////////////////////////////////////////
 static void _BRILLIANCE_equip(item_def */*item*/, bool */*show_msgs*/, bool /*unmeld*/)
 {
     invalidate_agrid(true);

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -196,6 +196,7 @@ who eschewed the use of magic in combat, preferring to destroy her enemies with
 brute force. Unfortunately for her, not all of her opponents shared her
 limitations.
 %%%%
+# TAG_MAJOR_VERSION == 34
 morningstar "Eos"
 
 A jewelled morningstar, glowing brightly with the light of the dawn. It

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4979,11 +4979,8 @@ bool invis_allowed(bool quiet, string *fail_reason, bool temp)
     {
         vector<string> sources;
 
-        if (temp && (player_equip_unrand(UNRAND_EOS)
-                     || player_equip_unrand(UNRAND_BRILLIANCE)))
-        {
+        if (temp && player_equip_unrand(UNRAND_BRILLIANCE))
             sources.push_back("weapon");
-        }
 
         if (temp && you.wearing_ego(EQ_ALL_ARMOUR, SPARM_LIGHT))
             sources.push_back("orb");


### PR DESCRIPTION
The halo overlaps with the recently revived "Brilliance", and, without it, "Eos" is just a +10 morningstar of electrocution. It's also not placed by any vaults.