### PR TITLE
Make Krakens scary again

### DIFF
--- a/crawl-ref/source/dat/mons/kraken-tentacle-segment.yaml
+++ b/crawl-ref/source/dat/mons/kraken-tentacle-segment.yaml
@@ -6,7 +6,7 @@ genus: kraken
 will: invuln
 attacks:
 hd: 12
-hp_10x: 480
+hp_10x: 240
 ac: 5
 ev: 7
 intelligence: animal

--- a/crawl-ref/source/dat/mons/kraken-tentacle.yaml
+++ b/crawl-ref/source/dat/mons/kraken-tentacle.yaml
@@ -7,12 +7,13 @@ will: invuln
 attacks:
  - {type: tentacle_slap, damage: 29}
 hd: 12
-hp_10x: 480
+hp_10x: 240
 ac: 5
 ev: 7
 intelligence: animal
 habitat: amphibious
-speed: 17
+speed: 10
+energy: {attack: 25}
 size: large
 shape: snake
 tile: program_bug

--- a/crawl-ref/source/dat/mons/kraken.yaml
+++ b/crawl-ref/source/dat/mons/kraken.yaml
@@ -1,13 +1,13 @@
 name: "kraken"
 glyph: {char: "X", colour: lightmagenta}
-flags: [cold_blood, no_skeleton]
+flags: [cold_blood, no_skeleton, fast_regen]
 xp_mult: 6
 will: 60
 attacks:
- - {type: bite, damage: 50}
+ - {type: bite, damage: 35}
 hd: 16
 hp_10x: 2080
-ac: 20
+ac: 5
 ev: 0
 spells: kraken
 has_corpse: true

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1427,7 +1427,7 @@ static void _confused_move_dir(monster *mons)
 static int _tentacle_move_speed(monster_type type)
 {
     if (type == MONS_KRAKEN)
-        return 10;
+        return 20;
     else if (type == MONS_TENTACLED_STARSPAWN)
         return 18;
     else

--- a/crawl-ref/source/mon-spell.h
+++ b/crawl-ref/source/mon-spell.h
@@ -1379,7 +1379,7 @@ static const mon_spellbook mspell_list[] =
     // ('X') Greater horrors and tentacled things.
     {  MST_KRAKEN,
       {
-       { SPELL_CREATE_TENTACLES, 44, MON_SPELL_NATURAL },
+       { SPELL_CREATE_TENTACLES, 88, MON_SPELL_NATURAL },
        { SPELL_INK_CLOUD, 22, MON_SPELL_NATURAL | MON_SPELL_EMERGENCY },
       }
     },

--- a/crawl-ref/source/mon-tentacle.cc
+++ b/crawl-ref/source/mon-tentacle.cc
@@ -15,6 +15,7 @@
 #include "env.h"
 #include "fprop.h"
 #include "libutil.h" // map_find
+#include "los.h"
 #include "losglobal.h"
 #include "mgen-data.h"
 #include "mon-death.h"
@@ -208,7 +209,7 @@ const monster& get_tentacle_head(const monster& mon)
 }
 
 static void _establish_connection(monster* tentacle,
-                                  monster* head,
+                                  const monster* head,
                                   set<position_node>::iterator path,
                                   monster_type connector_type)
 {
@@ -546,7 +547,7 @@ static bool _tentacle_pathfind(monster* tentacle,
 static bool _try_tentacle_connect(const coord_def & new_pos,
                                   const coord_def & base_position,
                                   monster* tentacle,
-                                  monster* head,
+                                  const monster* head,
                                   tentacle_connect_constraints & connect_costs,
                                   monster_type connect_type)
 {
@@ -618,13 +619,13 @@ static void _purge_connectors(monster* tentacle)
     ASSERT(tentacle->alive());
 }
 
-static void _collect_foe_positions(monster *mons,
+static void _collect_foe_positions(const monster *mons,
                                    vector<coord_def> &foe_positions,
-                                   function<bool(const actor *)> sight_check)
+                                   function<bool(const actor *)> valid_check)
 {
     coord_def foe_pos(-1, -1);
     actor * foe = mons->get_foe();
-    if (foe && sight_check(foe))
+    if (foe && valid_check(foe))
     {
         foe_positions.push_back(mons->get_foe()->pos());
         foe_pos = foe_positions.back();
@@ -636,7 +637,7 @@ static void _collect_foe_positions(monster *mons,
         if (!mons_is_firewood(*test)
             && !mons_aligned(test, mons)
             && test->pos() != foe_pos
-            && sight_check(test))
+            && valid_check(test))
         {
             foe_positions.push_back(test->pos());
         }
@@ -919,6 +920,21 @@ void move_solo_tentacle(monster* tentacle)
     tentacle->apply_location_effects(old_pos);
 }
 
+//How far past the edge of LOS a particular tentacle can reach
+int _tentacle_reach(const monster_type type)
+{
+    if (type == MONS_KRAKEN)
+        return 2;
+    else
+        return 0;
+}
+
+bool _tentacle_in_range(const monster* mons, const actor* test)
+{
+    return grid_distance(mons->pos(), test->pos())
+                <= get_los_radius() + _tentacle_reach(mons->type);
+}
+
 void move_child_tentacles(monster* mons)
 {
     ASSERT(mons);
@@ -932,11 +948,11 @@ void move_child_tentacles(monster* mons)
     bool no_foe = false;
 
     vector<coord_def> foe_positions;
-    _collect_foe_positions(mons, foe_positions,
-                           [mons](const actor *test) -> bool
-                           {
-                               return mons->can_see(*test);
-                           });
+    _collect_foe_positions(mons, foe_positions, 
+                            [mons] (const actor *test) -> bool
+                            {
+                                return _tentacle_in_range(mons, test);
+                            });
 
     if (foe_positions.empty()
         || mons->behaviour == BEH_FLEE

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5703,7 +5703,7 @@ void monster::react_to_damage(const actor *oppressor, int damage,
         {
             int &hits = headmaster->props[TENTACLE_LORD_HITS].get_int();
             // Reduce damage taken by the parent when blasting many tentacles.
-            const int master_damage = damage >> hits;
+            const int master_damage = damage >> 4; 
             deferred_damage_fineff::schedule(oppressor, headmaster,
                                              master_damage, false);
             ++hits;


### PR DESCRIPTION
Old Krakens functioned as a quasi-stationary enemy, being easy but nontrivial to run from, difficult to kill safely, and dangerous enough that having run from a kraken warped the rest of the floor.

However, modern Krakens are easily trivialized. Scrolls of poison will deplete most of a kraken's health before it reaches you, aoe spells or axes enable you to cut down tentacles as fast as they spawn, and if all else fails you can stand at the edge of LOS with a ranged weapon and repeatedly step out of LOS if the tentacles reach far enough.

This branch seeks to change anti-Kraken tactics from solely applying AoE to instead encourage hitting the head- ideally, a more interesting risk-reward decision. Additionally, it seeks to mitigate or remove some of the degenerate tactics for fighting krakens.

The main changes in this commit are:
1: Quarter the damage the head takes when tentacles are hurt. This both makes AoE do less to trivialize Krakens, and helps disincentivize sitting at the edge of tentacle range and killing one tentacle at a time

2: Make tentacles not require LoS, and reach out to 2 past it This strongly disincentivizes strategies where the player repeatedly leaves and re-enters LoS.

3: Make the head more frail and less dangerous
This seems necessary to make krakens feasible to fight for melee characters.

4: Give Krakens fast regen
This is necessary for much the same reason why it's needed on stationary monsters- to make repeated disengagement a losing proposition

Less central to the goal is the change to tentacle stats, making them more frequent, fast moving, and frail. Frequent and fast moving were chosen to lower the window in which a character with a bow can shoot a kraken head unopposed and increase the danger of repeated attempts; frail both limits the effectiveness of single high aoe hits, and allows melee characters to more effectively fight their way to the kraken's head with tentacles in the way.