### PR TITLE
CLEANUP: Binding sigils.

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -320,6 +320,7 @@ public:
 
     virtual bool is_banished() const = 0;
     virtual bool is_web_immune() const = 0;
+    virtual bool is_binding_sigil_immune() const = 0;
     virtual bool airborne() const = 0;
     virtual bool ground_level() const;
 

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1734,8 +1734,8 @@ COLOUR:  ETC_DITHMENOS
 EV:      4
 VALUE:   270
 INSCRIP: slick, slippery,
-DBRAND:  Slick:     Its wearer cannot be constricted, engulfed, netted or
- webbed.
+DBRAND:  Slick:     Its wearer cannot be constricted, engulfed, netted,
+ webbed, or stopped by binding sigils.
 +Slippery:  Its wearer slips away from damaging melee attacks, pulling the
  attacker onward.
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -6206,6 +6206,16 @@ bool monster::is_web_immune() const
             || is_insubstantial();
 }
 
+/**
+ * Checks if the monster can pass over binding sigils freely.
+ *
+ * @return Whether the monster is immune to binding sigils.
+ */
+bool monster::is_binding_sigil_immune() const
+{
+    return has_ench(ENCH_SWIFT);
+}
+
 // Monsters with an innate umbra don't have their accuracy reduced by it, and
 // nor do followers of Yredelemnul and Dithmenos.
 bool monster::nightvision() const

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -405,6 +405,7 @@ public:
     bool airborne() const override;
     bool is_banished() const override;
     bool is_web_immune() const override;
+    bool is_binding_sigil_immune() const override;
     bool invisible() const override;
     bool can_see_invisible() const override;
     bool visible_to(const actor *looker) const override;

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -909,7 +909,7 @@ bool player::is_web_immune() const
 
 bool player::is_binding_sigil_immune() const
 {
-    return false;
+    return player_equip_unrand(UNRAND_SLICK_SLIPPERS);
 }
 
 bool player::shove(const char* feat_name)

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -907,6 +907,11 @@ bool player::is_web_immune() const
         || player_equip_unrand(UNRAND_SLICK_SLIPPERS);
 }
 
+bool player::is_binding_sigil_immune() const
+{
+    return false;
+}
+
 bool player::shove(const char* feat_name)
 {
     for (distance_iterator di(pos()); di; ++di)

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -259,7 +259,7 @@ bool check_moveto_terrain(const coord_def& p, const string &move_verb,
 
     if (!_check_moveto_dangerous(p, msg))
         return false;
-    if (env.grid(p) == DNGN_BINDING_SIGIL)
+    if (env.grid(p) == DNGN_BINDING_SIGIL && !you.is_binding_sigil_immune())
     {
         string prompt;
         if (prompted)

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -516,6 +516,7 @@ public:
     bool is_banished() const override;
     bool is_sufficiently_rested(bool starting=false) const; // Up to rest_wait_percent HP and MP.
     bool is_web_immune() const override;
+    bool is_binding_sigil_immune() const override;
     bool cannot_speak() const;
     bool invisible() const override;
     bool can_see_invisible() const override;

--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -588,22 +588,22 @@ spret cast_sigil_of_binding(int pow, bool fail, bool tracer)
 
 void trigger_binding_sigil(actor& actor)
 {
+    if (actor.is_binding_sigil_immune())
+    {
+        mprf("%s cannot be bound by the sigil due to %s high momentum!",
+             actor.name(DESC_THE).c_str(), actor.pronoun(PRONOUN_POSSESSIVE).c_str());
+        return;
+    }
+
     if (actor.is_player())
     {
-        mprf(MSGCH_WARN, "You move over your own binding sigil and are bound in place!");
+        mprf(MSGCH_WARN, "You move over the binding sigil and are bound in place!");
         you.increase_duration(DUR_NO_MOMENTUM, random_range(3, 6));
         revert_terrain_change(you.pos(), TERRAIN_CHANGE_BINDING_SIGIL);
         return;
     }
 
     monster* m = actor.as_monster();
-    if (m->has_ench(ENCH_SWIFT))
-    {
-        mprf("%s has too much momentum for your sigil to bind %s!",
-             m->name(DESC_THE).c_str(), m->pronoun(PRONOUN_OBJECTIVE).c_str());
-        return;
-    }
-
     const int pow = calc_spell_power(SPELL_SIGIL_OF_BINDING);
     const int dur = max(2, random_range(4 + div_rand_round(pow, 12),
                                         7 + div_rand_round(pow, 8))
@@ -613,7 +613,7 @@ void trigger_binding_sigil(actor& actor)
     if (m->add_ench(mon_enchant(ENCH_BOUND, 0, &you, dur)))
     {
         simple_monster_message(*m,
-            " moves over your binding sigil and is bound in place!",
+            " moves over the binding sigil and is bound in place!",
             MSGCH_FRIEND_SPELL);
 
         // The enemy will gain swift for twice as long as it was bound


### PR DESCRIPTION
Immunity to binding sigils is now in its own actor-level function, the sigil messages are adjusted to not be player-specific, and the slick slippers now grant immunity to binding sigils on the player side.