### PR TITLE
remove redundant "unblindable" tag from elementals

### DIFF
--- a/crawl-ref/source/dat/mons/air-elemental.yaml
+++ b/crawl-ref/source/dat/mons/air-elemental.yaml
@@ -1,6 +1,6 @@
 name: "air elemental"
 glyph: {char: "E", colour: etc_air}
-flags: [flies, see_invis, unblindable, insubstantial]
+flags: [flies, see_invis, insubstantial]
 resists: {elec: 3}
 xp_mult: 6
 genus: elemental

--- a/crawl-ref/source/dat/mons/earth-elemental.yaml
+++ b/crawl-ref/source/dat/mons/earth-elemental.yaml
@@ -1,6 +1,5 @@
 name: "earth elemental"
 glyph: {char: "E", colour: etc_earth}
-flags: [unblindable]
 resists: {elec: 3, fire: 3, cold: 3, petrify: 1}
 xp_mult: 13
 genus: elemental

--- a/crawl-ref/source/dat/mons/elemental-wellspring.yaml
+++ b/crawl-ref/source/dat/mons/elemental-wellspring.yaml
@@ -1,6 +1,5 @@
 name: "elemental wellspring"
 glyph: {char: "E", colour: lightcyan}
-flags: [unblindable]
 resists: {elec: 1}
 xp_mult: 13
 genus: elemental

--- a/crawl-ref/source/dat/mons/fire-elemental.yaml
+++ b/crawl-ref/source/dat/mons/fire-elemental.yaml
@@ -1,6 +1,6 @@
 name: "fire elemental"
 glyph: {char: "E", colour: etc_fire}
-flags: [unblindable, insubstantial]
+flags: [insubstantial]
 resists: {elec: 1, fire: 3, cold: -1}
 genus: elemental
 holiness: [nonliving]

--- a/crawl-ref/source/dat/mons/iron-elemental.yaml
+++ b/crawl-ref/source/dat/mons/iron-elemental.yaml
@@ -1,6 +1,5 @@
 name: "iron elemental"
 glyph: {char: "E", colour: etc_iron}
-flags: [unblindable]
 resists: {elec: 3, fire: 3, cold: 3}
 xp_mult: 13
 genus: elemental

--- a/crawl-ref/source/dat/mons/quicksilver-elemental.yaml
+++ b/crawl-ref/source/dat/mons/quicksilver-elemental.yaml
@@ -1,6 +1,6 @@
 name: "quicksilver elemental"
 glyph: {char: "E", colour: lightcyan}
-flags: [see_invis, unblindable, batty]
+flags: [see_invis, batty]
 resists: {elec: 3, fire: 3, cold: 3}
 genus: elemental
 holiness: [nonliving]

--- a/crawl-ref/source/dat/mons/water-elemental.yaml
+++ b/crawl-ref/source/dat/mons/water-elemental.yaml
@@ -1,6 +1,5 @@
 name: "water elemental"
 glyph: {char: "E", colour: etc_water}
-flags: [unblindable]
 resists: {elec: 1, fire: -1}
 xp_mult: 12
 genus: elemental


### PR DESCRIPTION
nonliving monsters have been immune to blindness since commit b856850