### PR TITLE
Check for flight item removal safety on swap

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2546,6 +2546,8 @@ static afsz _abort_for_stat_zero(const item_def &item, int prop_str,
 static bool _safe_to_remove_or_wear(const item_def &item, const item_def
                                     *old_item, bool remove, bool quiet)
 {
+    // Check that removing item will not cauase a dangerous loss of
+    // flight.
     if (remove && !safe_to_remove(item, quiet))
         return false;
 
@@ -2553,6 +2555,11 @@ static bool _safe_to_remove_or_wear(const item_def &item, const item_def
     afsz asked = afsz::noask;
     if (!remove && old_item)
     {
+        // Check that removing old item will not cause a dangerous
+        // loss of flight.
+        if (!safe_to_remove(*old_item, quiet))
+            return false;
+
         _item_stat_bonus(*old_item, str1, dex1, int1, true);
         asked = _abort_for_stat_zero(item, str1, dex1, int1, true, quiet);
         if (afsz::stop == asked)


### PR DESCRIPTION
When removing an item, `_safe_to_remove_or_wear` checked for the safety of removing the item if it provided flight and the player was above lava or deep water. However when swapping two items, `remove` is false and the removal of the old item is implicit. The function to check the safety of flight removal `safe_to_remove` is not called in this case.

This commit adds a flight removal safety check in the branch of `_safe_to_remove_or_wear` that has determined that we're swapping out an old item, echoing the check that was already happening for non-swap removal.

I added comments to both `safe_to_remove` checks, because it is not immediately clear that only flight removal safety is checked by that function. `_safe_to_remove_or_wear` has a comment stating that it checks for stat zero and does not mention flight, so I wanted to make sure the code doing something other than what that comment says was clearly signaled.

Resolves #3502 

Notes:
- This is a two-line fix, and I think it's fairly clean, considering the surrounding code.
- This needs to get merged to 0.31 as well.
- One issue remains: trying to swap an item that gives flight for _another_ item that gives flight is not possible. I think that's a less frustrating edge case than surprise emergency flight, so I wanted to PR this with the quick, simple fix first. It also kind of makes sense if momentarily taking off your ring of flight for another ring of flight would be dangerous, so I'm not sure if this is a feature or a bug.
- This code is pretty confusing. I think it might be fun to clean things up and rework/refactor how these checks are implemented. I can't _commit_ to that, but I'd like to mess around and see how far I can get. Would it be something the devs were open to? (I wouldn't want to refactor something that's getting heavy work right now with the all the Coglin equipment stuff?) Even a couple of function renames could really help.