### PR TITLE
Add option to remove dropped items from autopickup

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -27,7 +27,7 @@ The contents of this text are:
 3-a     Dropping and Picking up.
                 autopickup, autopickup_exceptions, default_autopickup,
                 pickup_thrown, assign_item_slot, pickup_menu_limit,
-                drop_filter
+                drop_filter, drop_disables_autopickup
 3-b     Passive Sightings (detected and remembered entities).
                 detected_monster_colour, detected_item_colour,
                 remembered_monster_colour
@@ -675,6 +675,10 @@ drop_filter += <regex>, <regex>, ...
         When a drop_filter is set, using the select/deselect keys will
         set/clear selection of items that match the filter
         expression(s).
+
+drop_disables_autopickup = false
+        drop_disables_autopickup = true automatically removes dropped items
+        from autopickup.
 
 3-b     Passive Sightings (detected or remembered entities).
 ------------------------------------------------------------

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -496,6 +496,7 @@ const vector<GameOption*> game_options::build_options_list()
 #endif
         new BoolGameOption(SIMPLE_NAME(small_more), false),
         new BoolGameOption(SIMPLE_NAME(pickup_thrown), true),
+        new BoolGameOption(SIMPLE_NAME(drop_disables_autopickup), false),
         new MaybeBoolGameOption(SIMPLE_NAME(show_god_gift), maybe_bool::maybe,
             {"unid", "unident", "unidentified"}),
         new BoolGameOption(SIMPLE_NAME(show_travel_trail), USING_DGL),

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2636,6 +2636,9 @@ bool drop_item(int item_dropped, int quant_drop)
 
     ASSERT(item.defined());
 
+    if (Options.drop_disables_autopickup)
+        set_item_autopickup(item, AP_FORCE_OFF);
+
     if (copy_item_to_grid(item, you.pos(), quant_drop, true, true) == NON_ITEM)
     {
         mpr("Too many items on this level, not dropping the item.");

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -511,6 +511,7 @@ public:
     bool        darken_beyond_range; // whether to darken squares out of range
     bool        show_blood; // whether to show blood or not
     bool        reduce_animations;   // if true, don't show interim steps for animations
+    bool        drop_disables_autopickup;   // if true, automatically remove drops from autopickup
 
     vector<text_pattern> unusual_monster_items; // which monster items to
                                                 // highlight as unusual


### PR DESCRIPTION
Adds a new option: drop_disables_autopickup which removes all dropped items from autopickup automatically. A QoL thing that allows you to drop items (especially from local tiles inventory panel) without needing additional keypresses to enter the autopickup menu and disable autopickup manually. Defaults to off.