### PR TITLE
make regen/regenMP gizmos attune

### DIFF
--- a/crawl-ref/source/equipment-type.h
+++ b/crawl-ref/source/equipment-type.h
@@ -33,7 +33,7 @@ enum equipment_type
 
     EQ_MIN_ARMOUR = EQ_CLOAK,
     EQ_MAX_ARMOUR = EQ_BODY_ARMOUR,
-    EQ_MAX_WORN   = EQ_RING_AMULET,
+    EQ_MAX_WORN   = EQ_GIZMO,
     // these aren't actual equipment slots, they're categories for functions
     EQ_STAFF            = 100,         // weapon with base_type OBJ_STAVES
     EQ_RINGS,                          // check both rings


### PR DESCRIPTION
previously, if tinkered up while not at full hp/mp, would never attune.