### PR TITLE
If an orc is marked for vengeance, it can only be converted via deathbed conversion.

### DIFF
--- a/crawl-ref/source/attitude-change.h
+++ b/crawl-ref/source/attitude-change.h
@@ -13,6 +13,8 @@ enum class conv_t
     sight,
     deathbed,
     deathbed_follower,
+    vengeance,
+    vengeance_follower,
     resurrection,
 };
 void beogh_convert_orc(monster* orc, conv_t conv);

--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -8202,6 +8202,14 @@ beogh_converted_orc_speech_battle
 
 @Subjective@ yells, "I follow Beogh's word, I swear it!"
 %%%%
+beogh_converted_orc_speech_vengeance
+
+@Subjective@ shouts, "You have your revenge! Let me go!"
+
+@Subjective@ shouts, "Spare me, and you'll never see me again!"
+
+@Subjective@ says, "I deserve death, but Beogh is merciful!"
+%%%%
 # these are actually used even if the orc previously was allied
 beogh_converted_orc_resurrection
 
@@ -8225,6 +8233,10 @@ beogh_converted_orc_reaction_battle_follower
 beogh_converted_orc_speech_battle_follower
 
 @beogh_converted_orc_speech_battle@
+%%%%
+beogh_converted_orc_speech_vengeance_follower
+
+@beogh_converted_orc_speech_vengeance@
 %%%%
 #######################################################
 # Or if they weren't converted because you did this already.

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -745,8 +745,16 @@ static bool _beogh_forcibly_convert_orc(monster &mons, killer_type killer)
         // Bias beaten-up-conversion towards the stronger orcs.
         && random2(mons.get_experience_level()) > 2)
     {
-        beogh_convert_orc(&mons, MON_KILL(killer) ? conv_t::deathbed_follower :
-                                                    conv_t::deathbed);
+        const bool follower = MON_KILL(killer);
+        conv_t ctype = follower ? conv_t::deathbed_follower
+                                : conv_t::deathbed;
+        if (mons.has_ench(ENCH_VENGEANCE_TARGET))
+        {
+            ctype = follower ? conv_t::vengeance_follower
+                             : conv_t::vengeance;
+        }
+
+        beogh_convert_orc(&mons, ctype);
         return true;
     }
 


### PR DESCRIPTION
And such deathbed conversion will count as vengeance. This matches orc apostles, who, if they're marked for vengeance, only have it cleared by being defeated, although sneak attacks will also work on ordinary orcs.

This should fix #3576.