### PR TITLE
Fix jinxbite doing extra attacks

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -84,8 +84,6 @@ bool attack::handle_phase_blocked()
     if (attacker->is_player())
         behaviour_event(defender->as_monster(), ME_WHACK, attacker);
 
-    maybe_trigger_jinxbite();
-
     return true;
 }
 

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -255,6 +255,16 @@ bool melee_attack::handle_phase_attempted()
     return true;
 }
 
+bool melee_attack::handle_phase_blocked()
+{
+    //We need to handle jinxbite here instead of in
+    //attack::handle_phase_blocked as some attacks
+    //such as darts don't trigger it
+    maybe_trigger_jinxbite();
+
+    return attack::handle_phase_blocked();
+}
+
 bool melee_attack::handle_phase_dodged()
 {
     did_hit = false;

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -67,6 +67,7 @@ public:
 private:
     /* Attack phases */
     bool handle_phase_attempted() override;
+    bool handle_phase_blocked() override;
     bool handle_phase_dodged() override;
     bool handle_phase_hit() override;
     bool handle_phase_damaged() override;

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -196,7 +196,11 @@ bool ranged_attack::handle_phase_blocked()
              punctuation.c_str());
     }
 
-    maybe_trigger_jinxbite();
+    if (!projectile->is_type(OBJ_MISSILES, MI_DART)
+        && !projectile->is_type(OBJ_MISSILES, MI_THROWING_NET))
+    {
+        maybe_trigger_jinxbite();
+    }
 
     return attack::handle_phase_blocked();
 }
@@ -228,7 +232,11 @@ bool ranged_attack::handle_phase_dodged()
              attack_strength_punctuation(damage_done).c_str());
     }
 
-    maybe_trigger_jinxbite();
+    if (!projectile->is_type(OBJ_MISSILES, MI_DART)
+        && !projectile->is_type(OBJ_MISSILES, MI_THROWING_NET))
+    {
+        maybe_trigger_jinxbite();
+    }
 
     maybe_trigger_autodazzler();
 


### PR DESCRIPTION
Fix jinxbite doing two attacks when shooting a ranged weapon that is blocked. Also, remove jinxbite attacks when blocking and dodging darts and nets (they never did attacks on hit).

Should fix #3581