### PR TITLE
Add talisman acquirement.

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -779,6 +779,7 @@ void dgn_flush_map_memory()
     you.seen_weapon.init(0);
     you.seen_armour.init(0);
     you.seen_misc.reset();
+    you.seen_talisman.reset();
 }
 
 static void _dgn_load_colour_grid()

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -1163,6 +1163,8 @@ void set_ident_flags(item_def &item, iflags_t flags)
     {
         if (item.base_type == OBJ_MISCELLANY)
             you.seen_misc.set(item.sub_type);
+        if (item.base_type == OBJ_TALISMANS)
+            you.seen_talisman.set(item.sub_type);
     }
 }
 
@@ -3203,6 +3205,8 @@ void seen_item(item_def &item)
             you.seen_armour[item.sub_type] = 1U;
         if (item.base_type == OBJ_MISCELLANY)
             you.seen_misc.set(item.sub_type);
+        if (item.base_type == OBJ_TALISMANS)
+            you.seen_talisman.set(item.sub_type);
     }
 
     _maybe_note_found_unrand(item);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5488,6 +5488,7 @@ player::player()
     seen_weapon.init(0);
     seen_armour.init(0);
     seen_misc.reset();
+    seen_talisman.reset();
 
     generated_misc.clear();
     octopus_king_rings = 0x00;

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -298,6 +298,7 @@ public:
     FixedVector<uint32_t, NUM_WEAPONS> seen_weapon;
     FixedVector<uint32_t, NUM_ARMOURS> seen_armour;
     FixedBitVector<NUM_MISCELLANY>     seen_misc;
+    FixedBitVector<NUM_TALISMANS>      seen_talisman;
 
     uint8_t normal_vision;        // how far the species gets to see
     uint8_t current_vision;       // current sight radius (cells)

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -302,6 +302,7 @@ enum tag_minor_version
     TAG_MINOR_NO_CONSTRICTION_DUR, // Remove duration parameter from constriction tracking
     TAG_MINOR_NEW_DRACONIAN_BREATH, // Add charges to draconian breaths, revamp effects
     TAG_MINOR_COGLIN_NO_JEWELLERY, // Remove all jewellery from Coglins
+    TAG_MINOR_TALISMANS_SEEN,      // Keep track of seen talismans
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1838,6 +1838,7 @@ static void _tag_construct_you_items(writer &th)
         marshallInt(th,you.seen_armour[j]);
 
     _marshallFixedBitVector<NUM_MISCELLANY>(th, you.seen_misc);
+    _marshallFixedBitVector<NUM_TALISMANS>(th, you.seen_talisman);
 
     for (int i = 0; i < NUM_OBJECT_CLASSES; i++)
         for (int j = 0; j < MAX_SUBTYPES; j++)
@@ -4556,6 +4557,10 @@ static void _tag_read_you_items(reader &th)
     for (int j = NUM_ARMOURS; j < count; ++j)
         unmarshallInt(th);
     _unmarshallFixedBitVector<NUM_MISCELLANY>(th, you.seen_misc);
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_TALISMANS_SEEN)
+#endif
+    _unmarshallFixedBitVector<NUM_TALISMANS>(th, you.seen_talisman);
 
     for (int i = 0; i < iclasses; i++)
         for (int j = 0; j < count2; j++)

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -779,7 +779,7 @@ static void _debug_acquirement_stats()
     object_class_type list[] =
     {
         OBJ_WEAPONS, OBJ_ARMOUR, OBJ_JEWELLERY, OBJ_BOOKS, OBJ_STAVES,
-        OBJ_MISCELLANY
+        OBJ_MISCELLANY, OBJ_TALISMANS
     };
     char c = 'a';
     for (auto typ : list)

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -635,9 +635,9 @@ static void _xom_acquirement(int /*sever*/)
 
     const object_class_type types[] =
     {
-        OBJ_WEAPONS, OBJ_ARMOUR, OBJ_JEWELLERY,  OBJ_BOOKS,
-        OBJ_STAVES,  OBJ_WANDS,  OBJ_MISCELLANY, OBJ_GOLD,
-        OBJ_MISSILES
+        OBJ_WEAPONS,  OBJ_ARMOUR,   OBJ_JEWELLERY,  OBJ_BOOKS,
+        OBJ_STAVES,   OBJ_WANDS,    OBJ_MISCELLANY, OBJ_GOLD,
+        OBJ_MISSILES, OBJ_TALISMANS
     };
     const object_class_type force_class = RANDOM_ELEMENT(types);
 


### PR DESCRIPTION
Modeled after staff acquirement, in that it's accessible via the scroll, but only commonly so with enough shapeshifting skill. It's biased in favour of talismans you haven't seen, and more biased in favour of shapeshifting skill. However, no talismans are entirely ruled out; it's still possible, although rare, to acquire a talisman with no shapeshifting skill.

Accordingly, start keeping track of what talismans we've seen, as is already done with misc items.

Xom can also give talismans as gifts now, chosen entirely randomly.

(A lot of the seen-talisman tracking code is modeled after the seen-misc-item tracking code, some parts of which are rather confusing. It seems to work in my perfunctory testing, though.)