### PR TITLE
Gozag shouldn't offer jewellery shops to Coglin

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3295,6 +3295,10 @@ bool gozag_call_merchant()
         {
             continue;
         }
+        if (type == SHOP_JEWELLERY && you.has_mutation(MUT_NO_JEWELLERY))
+        {
+            continue;
+        }
         valid_shops.push_back(type);
     }
 


### PR DESCRIPTION
Jewellery shops have a 10% chance per item of generating a talisman, but it's highly unlikely you'd buy one for that reason when general stores can include them anyway.