### PR TITLE
Make abyss exit spawning interrupt travel

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1047,10 +1047,11 @@ interrupt_<delay> += <activity_interrupt_type>, <activity_interrupt_type>, ...
         run, shaft_self, travel. (These are derived from the `name()`
         functions in delay.h.)
 
-        Possible interrupt types are: ancestor_hp, force, full_hp, full_mp,
-        hp_loss, hit_monster, keypress, message, mimic, monster,
-        monster_attack, stat, sense_monster, teleport. (These are derived
-        from the `activity_interrupt_names` array in delay.cc.)
+        Possible interrupt types are: abyss_exit_spawned, ally_attacked,
+        ancestor_hp, force, full_hp, full_mp, hp_loss, hit_monster, keypress,
+        message, mimic, monster, monster_attack, stat, sense_monster, teleport.
+        (These are derived from the `activity_interrupt_names` array in
+        delay.cc.)
 
 
 delay_safe_poison = <% of hp>:<% of mhp>

--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -2385,4 +2385,5 @@ void abyss_maybe_spawn_xp_exit()
 
     you.props[ABYSS_STAIR_XP_KEY] = EXIT_XP_COST;
     you.props[ABYSS_SPAWNED_XP_EXIT_KEY] = true;
+    interrupt_activity(activity_interrupt::abyss_exit_spawned);
 }

--- a/crawl-ref/source/activity-interrupt-type.h
+++ b/crawl-ref/source/activity-interrupt-type.h
@@ -24,6 +24,7 @@ enum class activity_interrupt
     mimic,
     ally_attacked,      // A permanent player ally was attacked by something
                         // out of the player's LoS
+    abyss_exit_spawned, // Abyss exit spawned
 
     // Always the last.
     COUNT

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -1417,7 +1417,7 @@ static const char *activity_interrupt_names[] =
 {
     "force", "keypress", "full_hp", "full_mp", "ancestor_hp", "message",
     "hp_loss", "stat", "monster", "monster_attack", "teleport", "hit_monster",
-    "sense_monster", MIMIC_KEY, "ally_attacked"
+    "sense_monster", MIMIC_KEY, "ally_attacked", "abyss_exit_spawned"
 };
 
 static const char *_activity_interrupt_name(activity_interrupt ai)

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -1369,7 +1369,7 @@ void game_options::set_default_activity_interrupts()
         "interrupt_revivify = interrupt_butcher",
         "interrupt_multidrop = hp_loss, monster_attack, teleport, stat",
         "interrupt_macro = interrupt_multidrop",
-        "interrupt_travel = interrupt_butcher, hit_monster, sense_monster, ally_attacked",
+        "interrupt_travel = interrupt_butcher, hit_monster, sense_monster, ally_attacked, abyss_exit_spawned",
         "interrupt_run = interrupt_travel, message",
         "interrupt_rest = interrupt_run, full_hp, full_mp, ancestor_hp",
 


### PR DESCRIPTION
At least in local tiles, an abyss exit spawning does not interrupt autoexplore so you could press o and immediately find yourself 50 steps away from an exit that just spawned even with a force more for the message. This commit makes it that having an abyss exit or downstairs spawn interrupts autoexplore.

Also updated options_guide to include interrupt types for abyss_exit_spawned and ally_attacked.