### PR TITLE
Unbug throwing nets

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2660,10 +2660,12 @@ void bolt::drop_object()
     {
         monster* m = monster_at(pos());
         // Player or monster at position is caught in net.
-        if (you.pos() == pos() && you.attribute[ATTR_HELD]
-            || m && m->caught())
+        // Don't catch anything if the creature was already caught.
+        if (get_trapping_net(pos(), true) == NON_ITEM
+            && (you.pos() == pos() && you.attribute[ATTR_HELD]
+            || m && m->caught()))
         {
-            set_net_stationary(env.item[idx]);
+            maybe_split_nets(env.item[idx], pos());
         }
     }
 }

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4974,3 +4974,30 @@ void say_farewell_to_weapon(const item_def &item)
     // TODO: variant messages? (in the database?)
     mprf("You whisper farewell to %s.", name.c_str());
 }
+
+// If there are more than one net on this square
+// split off one of them for checking/setting values.
+void maybe_split_nets(item_def &item, const coord_def& where)
+{
+    if (item.quantity == 1)
+    {
+        set_net_stationary(item);
+        return;
+    }
+
+    item_def it;
+
+    it.base_type = item.base_type;
+    it.sub_type  = item.sub_type;
+    it.net_durability      = item.net_durability;
+    it.net_placed  = item.net_placed;
+    it.flags     = item.flags;
+    it.special   = item.special;
+    it.quantity  = --item.quantity;
+    item_colour(it);
+
+    item.quantity = 1;
+    set_net_stationary(item);
+
+    copy_item_to_grid(it, where);
+}

--- a/crawl-ref/source/items.h
+++ b/crawl-ref/source/items.h
@@ -187,6 +187,8 @@ void say_farewell_to_weapon(const item_def &item);
 
 bool valid_item_index(int i);
 
+void maybe_split_nets(item_def &item, const coord_def& where);
+
 // stack_iterator guarantees validity so long as you don't manually
 // mess with item_def.link: i.e., you can kill the item you're
 // examining but you can't kill the item linked to it.

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -210,33 +210,6 @@ const char* held_status(actor *act)
         return "caught in a web";
 }
 
-// If there are more than one net on this square
-// split off one of them for checking/setting values.
-static void _maybe_split_nets(item_def &item, const coord_def& where)
-{
-    if (item.quantity == 1)
-    {
-        set_net_stationary(item);
-        return;
-    }
-
-    item_def it;
-
-    it.base_type = item.base_type;
-    it.sub_type  = item.sub_type;
-    it.net_durability      = item.net_durability;
-    it.net_placed  = item.net_placed;
-    it.flags     = item.flags;
-    it.special   = item.special;
-    it.quantity  = --item.quantity;
-    item_colour(it);
-
-    item.quantity = 1;
-    set_net_stationary(item);
-
-    copy_item_to_grid(it, where);
-}
-
 static void _mark_net_trapping(const coord_def& where)
 {
     int net = get_trapping_net(where);
@@ -244,7 +217,7 @@ static void _mark_net_trapping(const coord_def& where)
     {
         net = get_trapping_net(where, false);
         if (net != NON_ITEM)
-            _maybe_split_nets(env.item[net], where);
+            maybe_split_nets(env.item[net], where);
     }
 }
 


### PR DESCRIPTION
Once upon a time there lived two bugs in a cottage.

The first bug caused a third throwing net that nets a target that's been netted and then netted again with a second net to get stuck on the target without increasing the net duration but remain stuck after the target breaks free, leaving behind a net that catches nobody but yet cannot be picked up.

The second bug caused netting a target that's standing on top of a net to merge the nets together, breaking both nets once the target breaks free.

Now the cottage is on fire and both bugs are dead. Throwing nets that hit a netted target will not net the target and nets that successfully net a target will not merge with any nets on the floor.

There is a third bug that causes a net that drops from killing a netted monster to not merge with any nets on the ground, but that one is harmless enough so I let it go. Hopefully it won't come back to take revenge for its friends' deaths.

Closes #3472