### PR TITLE
Improve colours of spells in spellbooks

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -264,13 +264,10 @@ static int _spell_colour(spell_type spell, const item_def* const source_item)
     if (!source_item)
         return spell_highlight_by_utility(spell, COL_UNKNOWN);
 
-    if (you.has_spell(spell))
-        return COL_MEMORIZED;
-
-    // this is kind of ugly.
-    if (!you_can_memorise(spell)
-        || you.experience_level < spell_difficulty(spell)
-        || player_spell_levels() < spell_levels_required(spell))
+    // note: Vehumet's gifts mean having a spell memorised does not imply that
+    // said spell is in your library
+    if (you.spell_library[spell] || you.has_spell(spell)
+        || !you_can_memorise(spell))
     {
         return COL_USELESS;
     }
@@ -278,10 +275,13 @@ static int _spell_colour(spell_type spell, const item_def* const source_item)
     if (god_hates_spell(spell, you.religion))
         return COL_FORBIDDEN;
 
-    if (!you.has_spell(spell))
-        return COL_UNMEMORIZED;
+    if (you.experience_level < spell_difficulty(spell)
+        || player_spell_levels() < spell_levels_required(spell))
+    {
+        return COL_USEFUL_IN_FUTURE;
+    }
 
-    return spell_highlight_by_utility(spell, COL_UNKNOWN);
+    return COL_USEFUL_NOW;
 }
 
 /**

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -43,9 +43,9 @@ struct direction_chooser_args;
 enum spell_highlight_colours
 {
     COL_UNKNOWN      = LIGHTGRAY,   // spells for which no known brand applies.
-    COL_UNMEMORIZED  = LIGHTBLUE,   // spell hasn't been memorised (used reading spellbooks)
-    COL_MEMORIZED    = LIGHTGRAY,   // spell has been memorised
-    COL_USELESS      = DARKGRAY,    // ability would have no useful effect
+    COL_USEFUL_NOW   = LIGHTBLUE,   // spell not in library which you could use now
+    COL_USEFUL_IN_FUTURE = LIGHTGRAY,   // spell not in library, can't use now
+    COL_USELESS      = DARKGRAY,    // ability would have no useful effect / spell already in library
     COL_INAPPLICABLE = COL_USELESS, // ability cannot be meaningfully applied (e.g., no targets)
     COL_FORBIDDEN    = LIGHTRED,    // The player's god hates this ability
     COL_DANGEROUS    = LIGHTRED,    // ability/spell use could be dangerous


### PR DESCRIPTION
Currently, in WebTiles, the colours of spells in spellbooks are far from useful. The most important question when x-v-ing a book (e.g. in a gauntlet, or a ghost vault) and seeing its spells is "do I already have this spell in my library?". There was previously no way to check this without leaving the x-v menu and manually checking.

With this PR, all spells will be greyed out in book descriptions if you already have them in your library (or if they are useless, or if you have memorised them via Vehumet), lightred if forbidden, lightgrey if eventually useful, and lightblue if you could memorise it immediately, in that order of priority.

Better suggestions for colouring are welcome. I had wondered whether it would be better to change WebTiles to use the local tiles (and I presume console) formatting for spellbook descriptions, but I figure there's a reason why WebTiles and local tiles have different formatting in the first place. On the other hand, doing so would bring spell tiles to local tiles' spellbook descriptions, and it would bring the "already known" column to WebTiles, which would also solve this problem.