### PR TITLE
Add a nostalgic hats-only shop

### DIFF
--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1982,38 +1982,43 @@ ENDMAP
 NAME:   mainiacjoe_wiglaf_hat_shop
 TAGS:   transparent float no_monster_gen no_item_gen no_trap_gen
 KFEAT:  O = altar_okawaru
-FTILE:  .@ = floor_cobble_blood
+FTILE:  .@O = floor_cobble_blood
 {{
-local shopname = util.random_from({"type:Millinery",
-    "type:Haberdashery", "type:Hat suffix:Hut"})
+local shopname = util.random_from({"type:Magnificent suffix:Millinery",
+    "type:Humble suffix:Haberdashery", "type:Hat suffix:Hut"})
 local kstr = "S = armour shop name:Wiglaf " .. shopname ..
-    " count:8 use_all no_mimic ; " ..
-    " hat any | hat any | hat any" ..
-    " | hat good_item tile:that_wizard_hat" ..
-    " | hat good_item tile:telven_leather_helm" ..
-    " | hat good_item tile:that_explorer_2" ..
-    " | hat randart tile:tcap_jester | "
+    " count:5 use_all no_mimic ; " ..
+    " | hat randart tile:thelm_cap_jester" ..
+    " | hat randart tile:thelm_hat_art_last"
+possible_ego_hats = {
+    " | hat ego:intelligence tile:thelm_cap" ..
+        " | hat ego:see_invisible tile:thelm_hat_explorer2",
+    " | hat ego:see_invisible tile:thelm_cap" ..
+        " | hat ego:willpower tile:thelm_hat_explorer2",
+    " | hat ego:willpower tile:thelm_cap" ..
+        " | hat ego:intelligence tile:thelm_hat_explorer2"}
+kstr = kstr .. util.random_from(possible_ego_hats)
 possible_unrands = {}
 if not you.unrands("hat of the Bear Spirit") then
-    table.insert(possible_unrands, "hat of the Bear Spirit")
+    table.insert(possible_unrands, " | hat of the Bear Spirit")
 end
 if not you.unrands("crown of Dyrovepreva") then
-    table.insert(possible_unrands, "crown of Dyrovepreva")
+    table.insert(possible_unrands, " | crown of Dyrovepreva")
 end
 if not you.unrands("mask of the Dragon") then
-    table.insert(possible_unrands, "mask of the Dragon")
+    table.insert(possible_unrands, " | mask of the Dragon")
 end
 if not you.unrands("hat of the Alchemist") then
-    table.insert(possible_unrands, "hat of the Alchemist")
+    table.insert(possible_unrands, " | hat of the Alchemist")
 end
 if not you.unrands("hat of Pondering") then
-    table.insert(possible_unrands, "hat of Pondering")
+    table.insert(possible_unrands, " | hat of Pondering")
 end
 if not you.unrands("hood of the Assassin") then
-    table.insert(possible_unrands, "hood of the Assassin")
+    table.insert(possible_unrands, " | hood of the Assassin")
 end
 if next(possible_unrands) == nil then
-    kstr = kstr .. "hat randart tile:tsanta_hat"
+    kstr = kstr .. " | hat randart tile:thelm_hat_santa"
 else
     kstr = kstr .. util.random_from(possible_unrands)
 end

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1981,7 +1981,7 @@ ENDMAP
 # Wiglaf has retired from adventuring and sells off his hat collection
 NAME:   mainiacjoe_wiglaf_hat_shop
 TAGS:   transparent float no_monster_gen no_item_gen no_trap_gen
-DEPTH:  Vaults, Crypt, Depths   
+DEPTH:  Vaults, Crypt, Depths, Snake:$, Shoals:$, Spider:$, Swamp:$   
 KFEAT:  O = altar_okawaru
 FTILE:  .@O = floor_cobble_blood
 {{

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1981,6 +1981,7 @@ ENDMAP
 # Wiglaf has retired from adventuring and sells off his hat collection
 NAME:   mainiacjoe_wiglaf_hat_shop
 TAGS:   transparent float no_monster_gen no_item_gen no_trap_gen
+DEPTH:  Vaults, Crypt, Depths   
 KFEAT:  O = altar_okawaru
 FTILE:  .@O = floor_cobble_blood
 {{

--- a/crawl-ref/source/dat/des/builder/shops.des
+++ b/crawl-ref/source/dat/des/builder/shops.des
@@ -1978,6 +1978,59 @@ m..S..m
 ...m...
 ENDMAP
 
+# Wiglaf has retired from adventuring and sells off his hat collection
+NAME:   mainiacjoe_wiglaf_hat_shop
+TAGS:   transparent float no_monster_gen no_item_gen no_trap_gen
+KFEAT:  O = altar_okawaru
+FTILE:  .@ = floor_cobble_blood
+{{
+local shopname = util.random_from({"type:Millinery",
+    "type:Haberdashery", "type:Hat suffix:Hut"})
+local kstr = "S = armour shop name:Wiglaf " .. shopname ..
+    " count:8 use_all no_mimic ; " ..
+    " hat any | hat any | hat any" ..
+    " | hat good_item tile:that_wizard_hat" ..
+    " | hat good_item tile:telven_leather_helm" ..
+    " | hat good_item tile:that_explorer_2" ..
+    " | hat randart tile:tcap_jester | "
+possible_unrands = {}
+if not you.unrands("hat of the Bear Spirit") then
+    table.insert(possible_unrands, "hat of the Bear Spirit")
+end
+if not you.unrands("crown of Dyrovepreva") then
+    table.insert(possible_unrands, "crown of Dyrovepreva")
+end
+if not you.unrands("mask of the Dragon") then
+    table.insert(possible_unrands, "mask of the Dragon")
+end
+if not you.unrands("hat of the Alchemist") then
+    table.insert(possible_unrands, "hat of the Alchemist")
+end
+if not you.unrands("hat of Pondering") then
+    table.insert(possible_unrands, "hat of Pondering")
+end
+if not you.unrands("hood of the Assassin") then
+    table.insert(possible_unrands, "hood of the Assassin")
+end
+if next(possible_unrands) == nil then
+    kstr = kstr .. "hat randart tile:tsanta_hat"
+else
+    kstr = kstr .. util.random_from(possible_unrands)
+end
+kfeat(kstr)
+}}
+MAP
+    xxxxx
+  xxx...xxx
+ xx.......xx
+ x....O....x
+xx.........xx
+x...x...x...x
+@.xxx.S.xxx.@
+xxx x...x xxx
+    xxxxx
+ENDMAP
+
 ###############################################################################
 # <<3>> Multi
 #       Not tagged shop, and has no threats. Contain possibly multiple shops in


### PR DESCRIPTION
This is a themed shop that has only hats.  The nostalgia is that the shop owner is Wiglaf.  He has collected a few quite nice hats over the years but now that he isn't adventuring anymore he wants to sell these to fund his retirement.  The Lua code intends that there be two ego hats, two randart hats, and either a single unrand hat or third randart hat.  These hats use the rare hat tiles without duplication.  DEPTH is set deep because these are nice items, though a shallower placement and high greed would work too and maybe be more thematic.