### PR TITLE
Rework and bring back sword of the doom knight

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -549,17 +549,18 @@ BOOL:    evil
 DBRAND:  Damnation: Any ammunition fired from it explodes in a burst of
  damnation on striking a foe, dealing damage which bypasses armour.
 
-# start TAG_MAJOR_VERSION == 34
 NAME:    sword of the Doom Knight
 OBJ:     OBJ_WEAPONS/WPN_GREAT_SWORD
 PLUS:    +13
+INSCRIP: doom
 COLOUR:  BLUE
 TILE:    urand_doom_knight
 TILE_EQ: doom_knight
-BRAND:   SPWPN_PAIN
+FB_BRAND: SPWPN_PAIN
 WILL:    1
-BOOL:    nospell, nogen
-# end TAG_MAJOR_VERSION
+BOOL:    nospell, evil, drain
+DBRAND:  Doom: It inflicts additional damage proportional to its victim's
+ maximum health.
 
 NAME:    morningstar "Eos"
 OBJ:     OBJ_WEAPONS/WPN_MORNINGSTAR

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1806,3 +1806,18 @@ static void _ASMODEUS_melee_effects(item_def* /*weapon*/, actor* attacker,
         }
     }
 }
+
+////////////////////////////////////////////////////
+
+static void _DOOM_KNIGHT_melee_effects(item_def* /*item*/, actor* attacker,
+                                        actor* defender, bool mondied, int /*dam*/)
+{
+    if (!mondied)
+    {
+        int bonus_dam = random2avg((1 + defender->stat_maxhp() / 10), 3);
+        mprf("%s convulses%s",
+              defender->name(DESC_THE).c_str(),
+              attack_strength_punctuation(bonus_dam).c_str());
+        defender->hurt(attacker, bonus_dam);
+    }
+}

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1815,9 +1815,10 @@ static void _DOOM_KNIGHT_melee_effects(item_def* /*item*/, actor* attacker,
     if (!mondied)
     {
         int bonus_dam = random2avg((1 + defender->stat_maxhp() / 10), 3);
-        mprf("%s convulses%s",
-              defender->name(DESC_THE).c_str(),
-              attack_strength_punctuation(bonus_dam).c_str());
+        mprf("%s %s%s",
+            defender->name(DESC_THE).c_str(),
+            defender->conj_verb("convulse").c_str(),
+            attack_strength_punctuation(bonus_dam).c_str());
         defender->hurt(attacker, bonus_dam);
     }
 }

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -196,7 +196,7 @@ who eschewed the use of magic in combat, preferring to destroy her enemies with
 brute force. Unfortunately for her, not all of her opponents shared her
 limitations.
 
-It has felled countless great warriors under her grip, and the souls of those 
+It has felled countless great warriors under her grip, and the souls of those
 who had their lives taken beckon it to take even more under its new owner.
 %%%%
 morningstar "Eos"

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -189,13 +189,15 @@ An unholy crossbow, forged in the fires of Gehenna. It imbues the bolts it
 fires with the raw power of its namesake. Thankfully, the blasts this weapon
 produces never harm the one firing.
 %%%%
-# TAG_MINOR_VERSION == 34
 sword of the Doom Knight
 
 An adamantine great sword. Its first wielder was a worshipper of Yredelemnul
 who eschewed the use of magic in combat, preferring to destroy her enemies with
 brute force. Unfortunately for her, not all of her opponents shared her
 limitations.
+
+It has felled countless great warriors under her grip, and the souls of those 
+who had their lives taken beckon it to take even more under its new owner.
 %%%%
 morningstar "Eos"
 


### PR DESCRIPTION
Replace pain brand with the doom brand which causes it to inflict bonus damage up to 10% of its victim's maximum health on hit. This does the opposite of the sword of power, dealing more damage the tougher the foe you face and avoids making you train necromancy for bonus damage when the weapon has -cast.

Give it ^Drain to discourage swapping it in and out to use spells because of -cast or only when you face a tough enemy like a unique panlord.

Also make it evil because doom sounds evil and it was used by a yred worshipper.