### PR TITLE
Add punctuation to collisions, remove from misses

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -267,11 +267,10 @@ bool melee_attack::handle_phase_dodged()
             player_warn_miss();
         else
         {
-            mprf("%s%s misses %s%s",
+            mprf("%s%s misses %s.",
                  atk_name(DESC_THE).c_str(),
                  evasion_margin_adverb().c_str(),
-                 defender_name(true).c_str(),
-                 attack_strength_punctuation(damage_done).c_str());
+                 defender_name(true).c_str());
         }
     }
 

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -221,11 +221,10 @@ bool ranged_attack::handle_phase_dodged()
 
     if (needs_message)
     {
-        mprf("%s%s misses %s%s",
+        mprf("%s%s misses %s.",
              projectile->name(DESC_THE).c_str(),
              evasion_margin_adverb().c_str(),
-             defender_name(false).c_str(),
-             attack_strength_punctuation(damage_done).c_str());
+             defender_name(false).c_str());
     }
 
     maybe_trigger_jinxbite();


### PR DESCRIPTION
It's unclear to me why misses call attack_strength_punctuation when the damage is always 0, so always use a period instead.

Make punctuation marks in collision messages vary with amount of damage dealt. This is averaged for collisions between creatures. Collisions can sometimes deal surprising amounts of damage and this better conveys that!!