### PR TITLE
Add SH preview to item descriptions

### DIFF
--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -866,9 +866,11 @@ public:
     int adjusted_body_armour_penalty(int scale = 1) const;
     int adjusted_shield_penalty(int scale = 1) const;
 
-    // Calculates total permanent EV if the player was/wasn't wearing a given item
-    int evasion_with_specific_item(int scale, const item_def& new_item) const;
-    int evasion_without_specific_item(int scale, const item_def& item_to_remove) const;
+    // Calculates total permanent EV/SH if the player was/wasn't wearing a given item
+    void ac_ev_sh_with_specific_item(int scale, const item_def& new_item,
+                                     int *ac, int *ev, int *sh);
+    void ac_ev_sh_without_specific_item(int scale, const item_def& item_to_remove,
+                                        int *ac, int *ev, int *sh);
 
     bool wearing_light_armour(bool with_skill = false) const;
     int  skill(skill_type skill, int scale = 1, bool real = false,
@@ -945,10 +947,6 @@ public:
     bool clear_far_engulf(bool force = false, bool moved = false) override;
 
     int armour_class_scaled(int scale) const;
-
-    int armour_class_with_one_sub(int scale, item_def sub) const;
-
-    int armour_class_with_one_removal(int scale, item_def sub) const;
 
     int ac_changes_from_mutations() const;
     vector<const item_def *> get_armour_items() const;
@@ -1061,8 +1059,9 @@ int player_res_poison(bool allow_random = true, bool temp = true,
                       bool items = true);
 int player_willpower(bool temp = true);
 
-int player_shield_class(int scale = 1, bool random = true);
-int player_displayed_shield_class();
+int player_shield_class(int scale = 1, bool random = true,
+                        bool ignore_temporary = false);
+int player_displayed_shield_class(int scale = 1, bool ignore_temporary = false);
 bool player_omnireflects();
 
 int player_spec_air();


### PR DESCRIPTION
Similarly to how item descriptions show the effect equipping that item would have on your AC/EV, make it also show the effect it would have on your SH, if relevant.

For consistency, make AC/EV/SH previews in descriptions not include temporary effects (previously these were included for AC and excluded for EV). If you prefer the alternative, we can do that too; the most important thing is that it's consistent.

Also make AC/EV/SH previews use the same function to compute them, instead of using entirely separate functions with entirely separate logic.

AC/EV/SH preview will now show on all items that have a non-zero effect on them, except non-artefact rings of protection/evasion and amulets of reflection (as for these items, it is not useful). AC preview will always show on body armour and aux armour; EV preview will always show on body armour, aux armour and true shields; and SH preview will always show on true shields, even if there is no effect. Debatably EV shouldn't always appear on aux armour, but I note this was something considered in https://github.com/crawl/crawl/commit/64bcc3171f6afe03e50909bde2252f2c2c0d74ea just last week so I haven't touched this behaviour.