### PR TITLE
Rework and bring back Crown of Eternal Torment

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1449,7 +1449,6 @@ BOOL:    mutate, elec, chaotic, nogen
 VALUE:   400
 # end TAG_MAJOR_VERSION
 
-# start TAG_MAJOR_VERSION == 34
 ENUM:    ETERNAL_TORMENT
 NAME:    crown of Eternal Torment
 OBJ:     OBJ_ARMOUR/ARM_HAT
@@ -1457,10 +1456,11 @@ PLUS:    +3
 COLOUR:  ETC_DARK
 TILE:    urand_eternal_torment
 TILE_EQ: eternal_torment
-INSCRIP: rTorment HP--
+INSCRIP: *Torment rTorment
 LIFE:    3
-BOOL:    evil, seeinv, nogen, drain
-# end TAG_MAJOR_VERSION
+BOOL:    evil, drain
+DBRAND:  *Torment:  It may torment nearby living creatures when you take damage.
++rTorment: It reduces the damage you take from torment.
 
 ENUM:    VINES
 NAME:    robe of Vines

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -634,7 +634,6 @@ contamination almost as effectively. Anyone reckless enough to place it on
 their head would find their magic regeneration dramatically increased, at the
 cost of multiplying any magical contamination received.
 %%%%
-
 crown of Eternal Torment
 
 A gold crown set with jet-black gems. It frequently afflicts its wearer and

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -634,12 +634,12 @@ contamination almost as effectively. Anyone reckless enough to place it on
 their head would find their magic regeneration dramatically increased, at the
 cost of multiplying any magical contamination received.
 %%%%
-# TAG_MAJOR_VERSION == 34
+
 crown of Eternal Torment
 
-A gold crown set with jet-black gems. It permanently afflicts its wearer with
-agonising pain, substantially reducing their resilience but rendering them
-immune to further torments.
+A gold crown set with jet-black gems. It frequently afflicts its wearer and
+surrounding living creatures with agonising pain. Over time, the wearer becomes
+numb to the pain, greatly reducing the effects of torment on them.
 %%%%
 robe of Vines
 

--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -666,7 +666,7 @@ static const char *kill_method_names[] =
     "beogh_smiting", "divine_wrath", "bounce", "reflect", "self_aimed",
     "falling_through_gate", "disintegration", "headbutt", "rolling",
     "mirror_damage", "spines", "frailty", "barbs", "being_thrown",
-    "collision", "zot", "constriction", "exploremode",
+    "collision", "zot", "constriction", "exploremode", "torment",
 };
 
 static const char *_kill_method_name(kill_method_type kmt)
@@ -2722,6 +2722,10 @@ string scorefile_entry::death_description(death_desc_verbosity verbosity) const
         else
             desc += "Constricted to death by " + death_source_desc();
         needs_damage = true;
+        break;
+
+    case KILLED_BY_TORMENT: // Should never happen
+        desc += terse? "torment" : "Tormented";
         break;
 
     default:

--- a/crawl-ref/source/kill-method-type.h
+++ b/crawl-ref/source/kill-method-type.h
@@ -57,5 +57,6 @@ enum kill_method_type
     KILLED_BY_ZOT,
     KILLED_BY_CONSTRICTION,
     KILLED_BY_EXPLORING,
+    KILLED_BY_TORMENT,
     NUM_KILLBY
 };

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -807,6 +807,7 @@ static void _maybe_torment()
     if (player_equip_unrand(UNRAND_ETERNAL_TORMENT)
         && x_chance_in_y(5, 100))
     {
+        flash_view_delay(UA_PLAYER, DARKGREY, 300);
         torment(&you, TORMENT_CROWN, you.pos());
     }
 }

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -799,6 +799,18 @@ static void _maybe_disable_potions()
     }
 }
 
+/**
+ * Maybe torment if the player is wearing a crown of eternal torment
+ **/
+static void _maybe_torment()
+{
+    if (player_equip_unrand(UNRAND_ETERNAL_TORMENT)
+        && x_chance_in_y(5, 100))
+    {
+        torment(&you, TORMENT_CROWN, you.pos());
+    }
+}
+
 static void _place_player_corpse(bool explode)
 {
     if (!in_bounds(you.pos()))
@@ -1165,6 +1177,8 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
                 _maybe_slow();
                 _maybe_disable_scrolls();
                 _maybe_disable_potions();
+                if (death_type != KILLED_BY_TORMENT)
+                    _maybe_torment();
             }
             if (drain_amount > 0)
                 drain_player(drain_amount, true, true);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6839,7 +6839,7 @@ bool player::res_torment() const
     // doesn't currently make you a plant, and I suspect changing that
     // would cause other bugs. (For example, being able to wield holy
     // weapons as a demonspawn & keep them while untransformed?)
-           || you.form == transformation::tree ;
+           || you.form == transformation::tree;
 }
 
 bool player::res_polar_vortex() const

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6839,11 +6839,7 @@ bool player::res_torment() const
     // doesn't currently make you a plant, and I suspect changing that
     // would cause other bugs. (For example, being able to wield holy
     // weapons as a demonspawn & keep them while untransformed?)
-           || you.form == transformation::tree
-#if TAG_MAJOR_VERSION == 34
-           || player_equip_unrand(UNRAND_ETERNAL_TORMENT)
-#endif
-           ;
+           || you.form == transformation::tree ;
 }
 
 bool player::res_polar_vortex() const

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1099,6 +1099,8 @@ void torment_player(const actor *attacker, torment_source_type taux)
             hploss /= 2;
         if (you.has_mutation(MUT_TORMENT_RESISTANCE))
             hploss /= 2;
+        if (player_equip_unrand(UNRAND_ETERNAL_TORMENT))
+            hploss /= 2;
 #if TAG_MAJOR_VERSION == 34
         // Save compatibility for old demonspawn mutation -- now deterministic
         if (you.has_mutation(MUT_STOCHASTIC_TORMENT_RESISTANCE))
@@ -1136,12 +1138,6 @@ void torment_player(const actor *attacker, torment_source_type taux)
 
     mpr("Your body is wracked with pain!");
 
-    kill_method_type type = KILLED_BY_BEAM;
-    if (crawl_state.is_god_acting())
-        type = KILLED_BY_DIVINE_WRATH;
-    else if (taux == TORMENT_MISCAST)
-        type = KILLED_BY_WILD_MAGIC;
-
     const char *aux = "";
 
     switch (taux)
@@ -1165,7 +1161,6 @@ void torment_player(const actor *attacker, torment_source_type taux)
         break;
 
     case TORMENT_XOM:
-        type = KILLED_BY_XOM;
         aux = "Xom's torment";
         break;
 
@@ -1174,16 +1169,19 @@ void torment_player(const actor *attacker, torment_source_type taux)
         break;
 
     case TORMENT_LURKING_HORROR:
-        type = KILLED_BY_DEATH_EXPLOSION;
         aux = "an exploding lurking horror";
         break;
 
     case TORMENT_MISCAST:
         aux = "by torment";
         break;
+
+    case TORMENT_CROWN:
+        aux = "the Crown of Eternal Torment";
+        break;
     }
 
-    ouch(hploss, type, attacker ? attacker->mid : MID_NOBODY, aux);
+    ouch(hploss, KILLED_BY_TORMENT, attacker ? attacker->mid : MID_NOBODY, aux);
 
     return;
 }

--- a/crawl-ref/source/torment-source-type.h
+++ b/crawl-ref/source/torment-source-type.h
@@ -11,5 +11,6 @@ enum torment_source_type
     TORMENT_KIKUBAAQUDGHA = -7,   // Kikubaaqudgha effect
     TORMENT_MISCAST       = -8,
     TORMENT_AGONY         = -9,   // SPELL_AGONY
-    TORMENT_CARD_PAIN    = -10, // for pain card
+    TORMENT_CARD_PAIN    = -10,   // for pain card
+    TORMENT_CROWN        = -11,   // Crown of Eternal Torment
 };


### PR DESCRIPTION
Replace its mhp malus with *Torm which gives a 5% chance to torment you
and surrounding living creatures when you take non-torment damage. This
serves to give it a more interesting effect and drawback that also
works before extended.

Replace torment immunity with half torment damage so *Torm is an actual
drawback unless you're already undead.

Remove SInv because it doesn't quite fit thematically and we already
have a good number of hat unrands with that.

This commit also adds KILLED_BY_TORMENT as a kill type which is used to
prevent the crown from recursively triggering. It should never actually
kill anything.