### PR TITLE
Make Jiyva protect jellies from harm

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5206,7 +5206,7 @@ void bolt::affect_monster(monster* mon)
     hit_count[mon->mid]++;
 
     // Jiyva absorbs attacks on slimes.
-    if (!is_tracer && agent()->is_player()
+    if (!is_tracer && agent() && agent()->is_player()
         && flavour != BEAM_VILE_CLUTCH
         && have_passive(passive_t::neutral_slimes)
         && god_protects(agent(), mon, true))

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -1241,7 +1241,8 @@ void bolt::do_fire()
                    && mons_is_firewood(*monster_at(pos()))
             // or visible jelly with Jiyva
                    || have_passive(passive_t::neutral_slimes)
-                   && god_protects(agent(), monster_at(pos()), true)))
+                   && god_protects(agent(), monster_at(pos()), true)
+                   && flavour != BEAM_VILE_CLUTCH))
             // and it's a player tracer...
             // (!is_targeting so you don't get prompted while adjusting the aim)
             && is_tracer && !is_targeting && YOU_KILL(thrower)
@@ -5206,6 +5207,7 @@ void bolt::affect_monster(monster* mon)
 
     // Jiyva absorbs attacks on slimes.
     if (!is_tracer && agent()->is_player()
+        && flavour != BEAM_VILE_CLUTCH
         && have_passive(passive_t::neutral_slimes)
         && god_protects(agent(), mon, true))
     {

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -3832,7 +3832,8 @@ static bool _is_cancellable_scroll(scroll_type scroll)
  */
 static bool _scroll_will_harm(const scroll_type scr, const actor &m)
 {
-    return m.alive() && scr == SCR_TORMENT && !m.res_torment();
+    return m.alive() && scr == SCR_TORMENT
+        && !m.res_torment() && !god_protects(&you, m.as_monster(), true);
 }
 
 static vector<string> _desc_finite_wl(const monster_info& mi)
@@ -4282,6 +4283,10 @@ bool read(item_def* scroll, dist *target)
         for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
         {
             if (mons_invuln_will(**mi))
+                continue;
+
+            // Jiyva stops you from using jellies as bombs
+            if (have_passive(passive_t::neutral_slimes) && god_protects(*mi))
                 continue;
 
             if (mi->add_ench(mon_enchant(ENCH_INNER_FLAME, 0, &you)))

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2712,6 +2712,19 @@ bool god_protects(const actor *agent, const monster *target, bool quiet)
             mprf("%s avoids your attack.", target->name(DESC_THE).c_str());
         return true;
     }
+
+    if (aligned && agent->is_player() && have_passive(passive_t::neutral_slimes)
+        && mons_is_slime(*target))
+    {
+        if (!quiet && you.can_see(*target))
+        {
+            simple_god_message(
+                    make_stringf(" protects %s slime from harm.",
+                        target->friendly() ? "your" : "a").c_str(),
+                        GOD_JIYVA);
+        }
+        return true;
+    }
     return false;
 }
 

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1203,6 +1203,7 @@ void torment_cell(coord_def where, actor *attacker, torment_source_type taux)
     if (!mons
         || !mons->alive()
         || mons->res_torment()
+        || attacker && god_protects(attacker, mons, false)
         // Monsters can't currently use the sceptre, but just in case.
         || attacker
            && mons == attacker->as_monster()


### PR DESCRIPTION
Jiyva's mpregen and mp/wild magic/int mutations support casters well, but the random jelly spawns are especially annoying for casters. You can't firestorm when a jelly decides to hug your target. You can't shatter if there are jellies on the floor because there's a chance you damage a jelly behind a rock wall and incur penance. You can't even immolate at any time because a jelly could spawn and throw itself into the flames. This is no fun and I'm changing that.

Jiyva now protects slimes from harm similarly to Fedhas with the difference that you can't fire through slimes and they'll absorb projectiles if you try to do so.

Jiyva also prevents immolation scrolls from affecting jellies because using jellies as bombs is not cool (at least from Jiyva's perspective).

Additionally, all god protection will protect from torment. Previously this wouldn't have had an effect because plants and ancestors already resist torment.

Based on 75f1ca80bcda43d3fbc33714f3299d0209dd9cc1 with changes.