### PR TITLE
Improve Gell's Gravitas + show collision damage for spells

### DIFF
--- a/crawl-ref/source/actor.cc
+++ b/crawl-ref/source/actor.cc
@@ -22,6 +22,7 @@
 #include "mon-behv.h"
 #include "mon-death.h"
 #include "religion.h"
+#include "spl-damage.h"
 #include "stepdown.h"
 #include "stringutil.h"
 #include "terrain.h"
@@ -1003,7 +1004,7 @@ void actor::collide(coord_def newpos, const actor *agent, int pow)
     if (is_monster() && !god_prot)
         behaviour_event(as_monster(), ME_WHACK, agent);
 
-    dice_def damage(2, 1 + div_rand_round(pow, 10));
+    const dice_def damage = collision_damage(pow, true);
     const int dam = apply_ac(damage.roll());
 
     if (other && other->alive())

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2744,8 +2744,8 @@ bool bolt::can_affect_wall(const coord_def& p, bool map_knowledge) const
     if (can_burn_trees())
         return feat_is_flammable(wall);
 
-    // Lee's Rapid Deconstruction
-    if (flavour == BEAM_FRAG)
+    // Lee's Rapid Deconstruction / Gravitas
+    if (flavour == BEAM_FRAG || origin_spell == SPELL_GRAVITAS)
         return true; // smite targeting, we don't care
 
     return false;

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -681,6 +681,7 @@ Gell's Gravitas spell
 Briefly redirects gravity around a target point, causing 'down' to be towards
 that point. All nearby creatures, save the caster, fall helplessly toward that
 point – typically colliding with each other, or with a victim standing there.
+Spellpower increases attraction distance and collision damage.
 %%%%
 Ghostly Fireball spell
 
@@ -847,6 +848,7 @@ Iskenderun's Mystic Blast spell
 
 Detonates a crackling sphere of destructive energy. The explosion will hit all
 nearby monsters with physical force, knocking them back if damage is done.
+Spellpower increases damage and knockback distance.
 %%%%
 Jinxbite spell
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1216,7 +1216,7 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     case SPELL_GLACIATE:
         return make_unique<targeter_cone>(&you, range);
     case SPELL_GRAVITAS:
-        return make_unique<targeter_gravitas>(&you, range, gravitas_range(pow));
+        return make_unique<targeter_gravitas>(&you, range);
     case SPELL_VIOLENT_UNRAVELLING:
         return make_unique<targeter_unravelling>();
     case SPELL_INFESTATION:

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1216,12 +1216,7 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     case SPELL_GLACIATE:
         return make_unique<targeter_cone>(&you, range);
     case SPELL_GRAVITAS:
-        return make_unique<targeter_smite>(&you, range,
-                                           gravitas_range(pow),
-                                           gravitas_range(pow),
-                                           false,
-                                           [](const coord_def& p) -> bool {
-                                              return you.pos() != p; });
+        return make_unique<targeter_gravitas>(&you, range, gravitas_range(pow));
     case SPELL_VIOLENT_UNRAVELLING:
         return make_unique<targeter_unravelling>();
     case SPELL_INFESTATION:

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2882,6 +2882,8 @@ string spell_damage_string(spell_type spell, bool evoked, int pow)
         }
         case SPELL_AIRSTRIKE:
             return describe_airstrike_dam(base_airstrike_damage(pow));
+        case SPELL_GRAVITAS:
+            return describe_collision_dam(collision_damage(pow, false));
         default:
             break;
     }
@@ -2906,6 +2908,13 @@ string spell_damage_string(spell_type spell, bool evoked, int pow)
     }
     const string dam_str = make_stringf("%s%dd%d", mult.c_str(), dam.num,
             dam.size);
+
+    if (spell == SPELL_ISKENDERUNS_MYSTIC_BLAST)
+    {
+        return dam_str + make_stringf(" + %s",
+            describe_collision_dam(collision_damage(pow, false)).c_str());
+    }
+
     if (spell == SPELL_LRD
         || spell == SPELL_SHATTER
         || spell == SPELL_POLAR_VORTEX)

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -4891,5 +4891,5 @@ dice_def collision_damage(int pow, bool random)
 
 string describe_collision_dam(dice_def dice)
 {
-    return make_stringf("%dd%d/collision", dice.num, dice.size);
+    return make_stringf("%dd%d/slam", dice.num, dice.size);
 }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -4883,3 +4883,13 @@ int get_warp_space_chance(int pow)
 {
     return min(90, 35 + pow);
 }
+
+dice_def collision_damage(int pow, bool random)
+{
+    return dice_def(2, random ? 1 + div_rand_round(pow, 10) : 1 + pow / 10);
+}
+
+string describe_collision_dam(dice_def dice)
+{
+    return make_stringf("%dd%d/collision", dice.num, dice.size);
+}

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -163,3 +163,6 @@ void do_boulder_impact(monster& boulder, actor& victim);
 dice_def electrolunge_damage(int pow);
 
 int get_warp_space_chance(int pow);
+
+dice_def collision_damage(int pow, bool random);
+string describe_collision_dam(dice_def dice);

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1746,6 +1746,10 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
         const int strength = ((pow + 100) / 20) / (range*range);
 
         _attract_actor(agent, ai, pos, pow, strength);
+
+        monster* mon = ai->as_monster();
+        if (!invalid_monster(mon) && coinflip())
+            mon->lose_energy(EUT_SPECIAL);
     }
 
     return true;
@@ -1753,12 +1757,6 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
 
 spret cast_gravitas(int pow, const coord_def& where, bool fail)
 {
-    if (cell_is_solid(where))
-    {
-        canned_msg(MSG_UNTHINKING_ACT);
-        return spret::abort;
-    }
-
     fail_check();
 
     monster* mons = monster_at(where);

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1639,12 +1639,6 @@ spret cast_dispersal(int pow, bool fail)
     return spret::success;
 }
 
-int gravitas_range(int pow)
-{
-    return pow >= 60 ? 3 : 2;
-}
-
-
 #define GRAVITY "by gravitational forces"
 
 static void _attract_actor(const actor* agent, actor* victim,
@@ -1728,7 +1722,7 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
             continue;
 
         const int range = (pos - ai->pos()).rdist();
-        if (range > gravitas_range(pow))
+        if (range > GRAVITAS_RANGE)
             continue;
 
         victims.push_back(*ai);

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1641,7 +1641,7 @@ spret cast_dispersal(int pow, bool fail)
 
 int gravitas_range(int pow)
 {
-    return pow >= 80 ? 3 : 2;
+    return pow >= 60 ? 3 : 2;
 }
 
 
@@ -1742,8 +1742,7 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
 
     for (actor * ai : victims)
     {
-        const int range = (pos - ai->pos()).rdist();
-        const int strength = ((pow + 100) / 20) / (range*range);
+        const int strength = div_rand_round(pow + 100, 80);
 
         _attract_actor(agent, ai, pos, pow, strength);
 

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1748,8 +1748,8 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
         _attract_actor(agent, ai, pos, pow, strength);
 
         monster* mon = ai->as_monster();
-        if (!invalid_monster(mon) && coinflip())
-            mon->lose_energy(EUT_SPECIAL);
+        if (!invalid_monster(mon))
+            mon->speed_increment -= random2(6) + 4;
     }
 
     return true;

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1737,7 +1737,7 @@ bool fatal_attraction(const coord_def& pos, const actor *agent, int pow)
     if (victims.empty())
         return false;
 
-    near_to_far_sorter sorter = {you.pos()};
+    near_to_far_sorter sorter = {pos};
     sort(victims.begin(), victims.end(), sorter);
 
     for (actor * ai : victims)

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -52,7 +52,7 @@ spret cast_golubrias_passage(int pow, const coord_def& where, bool fail);
 
 spret cast_dispersal(int pow, bool fail);
 
-int gravitas_range(int pow);
+constexpr int GRAVITAS_RANGE = 3;
 bool fatal_attraction(const coord_def& pos, const actor *agent, int pow);
 spret cast_gravitas(int pow, const coord_def& where, bool fail);
 

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -791,8 +791,8 @@ bool targeter_unravelling::set_aim(coord_def a)
     return true;
 }
 
-targeter_gravitas::targeter_gravitas(const actor *act, int ran, int radius) :
-    targeter_smite(act, ran, radius, radius, true,
+targeter_gravitas::targeter_gravitas(const actor *act, int ran) :
+    targeter_smite(act, ran, GRAVITAS_RANGE, GRAVITAS_RANGE, true,
                    [](const coord_def& p) -> bool {
                       return you.pos() != p; })
 {

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -791,6 +791,39 @@ bool targeter_unravelling::set_aim(coord_def a)
     return true;
 }
 
+targeter_gravitas::targeter_gravitas(const actor *act, int ran, int radius) :
+    targeter_smite(act, ran, radius, radius, true,
+                   [](const coord_def& p) -> bool {
+                      return you.pos() != p; })
+{
+}
+
+bool targeter_gravitas::set_aim(coord_def a)
+{
+    if (!targeter::set_aim(a))
+        return false;
+
+    if (exp_range_max > 0)
+    {
+        bolt beam;
+        beam.target = a;
+        beam.use_target_as_pos = true;
+        beam.origin_spell = SPELL_GRAVITAS;
+        exp_map_min.init(INT_MAX);
+        beam.determine_affected_cells(exp_map_min, coord_def(), 0,
+                                      exp_range_min, true, true);
+        if (exp_range_min == exp_range_max)
+            exp_map_max = exp_map_min;
+        else
+        {
+            exp_map_max.init(INT_MAX);
+            beam.determine_affected_cells(exp_map_max, coord_def(), 0,
+                    exp_range_max, true, true);
+        }
+    }
+    return true;
+}
+
 targeter_airstrike::targeter_airstrike()
 {
     agent = &you;

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -174,6 +174,13 @@ private:
     int pow;
 };
 
+class targeter_gravitas : public targeter_smite
+{
+public:
+    targeter_gravitas(const actor *act, int ran, int radius);
+    bool set_aim(coord_def a) override;
+};
+
 class targeter_airstrike : public targeter
 {
 public:

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -177,7 +177,7 @@ private:
 class targeter_gravitas : public targeter_smite
 {
 public:
-    targeter_gravitas(const actor *act, int ran, int radius);
+    targeter_gravitas(const actor *act, int ran);
     bool set_aim(coord_def a) override;
 };
 


### PR DESCRIPTION
It's weird that we have a telekinesis spell that doesn't allow the common demonstration of telekinetic might by slamming dudes into walls, so allow casting Gell's Gravitas on walls.

Give Gell's IMB's ministun. This is intended to make it feel more effective by making monsters not always immediately move away from where you're chucking them at.

Rework Gell's attraction distance. As far as I can tell with the old formula, the attraction distance for Gell's would be always be 1 at radius 1 and 3, 1 at radius 2 below 60 spellpower and 2 otherwise which is pretty unintuitive and has a weird breakpoint. I don't care if gravity realistically weakens with distance, it isn't well communicated to players that the radius 3 pull which only happens when your power is above 80% would be weaker and it doesn't feel good in practice. Change the distance to 1.25 scaling to 2.5 at max spellpower with random rounding and remove distance from the center of attraction from the formula. This does not affect collision damage.

Increase Gell's radius to always be 3 to remove another weird breakpoint. No random radius because we already have collision damage and pull distance scale with power and don't need a third factor to complicate things.

Sort gravitas targets by distance from attraction center rather than distance from you which I assume was a mistake. This makes attracting targets towards a point more reliable.

Using Gell's now counts as an attack for penance. This fixes being able to attack under sanctuary with Gell's.

Show collision damage for Gell's and IMB in description. Describe spellpower effects for these spells.