### PR TITLE
Give wjc lunges a bonus with polearms, edit text

### DIFF
--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -687,12 +687,10 @@ Wu Jian extra
   ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O..  140% damage if you're using a polearm, and 120%
   .......       .......  otherwise.
 
-
   .......       ...<lightred>@</lightred>...  (*) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to an
-  ...<lightred>@</lightred>O..  -->  ....O..  enemy to strike them lightly dealing 80% damage.
-  .......       .......  Multiple adjacent foes can be attacked simultaneously
-                         this way.
-
+  ...<lightred>@</lightred>O..  -->  ....O..  enemy to strike them dealing 80% damage. Multiple
+  .......       .......  adjacent foes can be attacked simultaneously this way.
+                    
   ..#....       ..#....  (**) <lightred>Wall Jump</lightred>: Vault off a nearby wall and strike
   ..#<lightred>@</lightred>O..  -->  ..#.O<lightred>@</lightred>.  enemies adjacent to the landing spot. Vaulting takes
   ..#....       ..#....  two turns and strikes twice as many times. Activated

--- a/crawl-ref/source/dat/descript/gods.txt
+++ b/crawl-ref/source/dat/descript/gods.txt
@@ -684,16 +684,19 @@ Wu Jian extra
 # any god extra screens need :nowrap
 :nowrap
   .......       .......  (.) <lightred>Lunge</lightred>: Move directly towards an enemy to deal
-  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O..  extra damage.
-  .......       .......
+  ..<lightred>@</lightred>.O..  -->  ...<lightred>@</lightred>O..  140% damage if you're using a polearm, and 120%
+  .......       .......  otherwise.
 
-  .......       ...<lightred>@</lightred>...  (*) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to
-  ...<lightred>@</lightred>O..  -->  ....O..  an enemy to strike them lightly. Multiple adjacent
-  .......       .......  foes can be attacked simultaneously this way.
+
+  .......       ...<lightred>@</lightred>...  (*) <lightred>Whirlwind</lightred>: Move between two tiles adjacent to an
+  ...<lightred>@</lightred>O..  -->  ....O..  enemy to strike them lightly dealing 80% damage.
+  .......       .......  Multiple adjacent foes can be attacked simultaneously
+                         this way.
 
   ..#....       ..#....  (**) <lightred>Wall Jump</lightred>: Vault off a nearby wall and strike
   ..#<lightred>@</lightred>O..  -->  ..#.O<lightred>@</lightred>.  enemies adjacent to the landing spot. Vaulting takes
-  ..#....       ..#....  two turns. Activated via the (a)bility menu.
+  ..#....       ..#....  two turns and strikes twice as many times. Activated
+                         via the (a)bility menu.
 
 These prevent enemies from getting free attacks on you while you move away.
 You cannot launch martial attacks while digging.

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3963,11 +3963,13 @@ int melee_attack::cleave_damage_mod(int dam)
 // Martial strikes get modified by momentum and maneuver specific damage mods.
 int melee_attack::martial_damage_mod(int dam)
 {
+    const bool reaching = weapon && weapon_reach(*weapon) > REACH_NONE;
+
     if (wu_jian_has_momentum(wu_jian_attack))
         dam = div_rand_round(dam * 14, 10);
 
     if (wu_jian_attack == WU_JIAN_ATTACK_LUNGE)
-        dam = div_rand_round(dam * 12, 10);
+        dam = div_rand_round(dam * (reaching ? 14 : 12), 10);
 
     if (wu_jian_attack == WU_JIAN_ATTACK_WHIRLWIND)
         dam = div_rand_round(dam * 8, 10);


### PR DESCRIPTION
Polearms gain no special bonus with WJC martial attacks but lose their ability to do reach attacks when lunging. The optimal action when using polearms with WJC is to reach attack when there is a space between you and your enemy for an extra turn and that means you're not making use of lunge, which makes WJC polearm users a little sadder (emotionally) than others.

Fix this by giving lunge a 140% damage multiplier instead of 120% when used with reaching attacks.

Edited some descriptions to give more information about what the different martial attacks do.