### PR TITLE
Cheapen of rings of slaying

### DIFF
--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -2070,7 +2070,7 @@ jewellery_type get_random_amulet_type()
     return *random_iterator(valid_types);
 }
 
-static jewellery_type _get_raw_random_ring_type()
+jewellery_type get_random_ring_type()
 {
     static vector<jewellery_type> valid_types;
     if (valid_types.empty())
@@ -2078,16 +2078,6 @@ static jewellery_type _get_raw_random_ring_type()
             if (!item_type_removed(OBJ_JEWELLERY, (jewellery_type)i))
                 valid_types.push_back((jewellery_type)i);
     return *random_iterator(valid_types);
-}
-
-jewellery_type get_random_ring_type()
-{
-    const jewellery_type j = _get_raw_random_ring_type();
-    // Adjusted distribution here. - bwr
-    if (j == RING_SLAYING && !one_chance_in(3))
-        return _get_raw_random_ring_type();
-
-    return j;
 }
 
 // Sets item appearance to match brands, if any.

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -2070,7 +2070,7 @@ jewellery_type get_random_amulet_type()
     return *random_iterator(valid_types);
 }
 
-jewellery_type get_random_ring_type()
+static jewellery_type _get_raw_random_ring_type()
 {
     static vector<jewellery_type> valid_types;
     if (valid_types.empty())
@@ -2078,6 +2078,16 @@ jewellery_type get_random_ring_type()
             if (!item_type_removed(OBJ_JEWELLERY, (jewellery_type)i))
                 valid_types.push_back((jewellery_type)i);
     return *random_iterator(valid_types);
+}
+
+jewellery_type get_random_ring_type()
+{
+    const jewellery_type j = _get_raw_random_ring_type();
+    // Adjusted distribution here. - bwr
+    if (j == RING_SLAYING && !one_chance_in(3))
+        return _get_raw_random_ring_type();
+
+    return j;
 }
 
 // Sets item appearance to match brands, if any.

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -541,15 +541,13 @@ unsigned int item_value(item_def item, bool ident)
             // Variable-strength rings.
             if (jewellery_type_has_plusses(item.sub_type))
             {
-                // Formula: price = kn(n+1) / 2, where k is 40,
-                // n is the power. (The base variable is equal to 2n.)
+                // Formula: price = 5n(n+1)
+                // n is the power. (The base variable is equal to n.)
                 int base = 0;
 
                 switch (item.sub_type)
                 {
                 case RING_SLAYING:
-                    base = 3 * item.plus;
-                    break;
                 case RING_PROTECTION:
                     base = 2 * item.plus;
                     break;


### PR DESCRIPTION
Rings of slaying are more than twice as expensive as other variable strength rings despite being arguably not that much better. Tone down its price to match other rings so it isn't often more expensive than good randart rings that generate in stores.

Slay rings are great in the early game and with short blades in the late game, but can end up being outclassed by stat rings which can provide more damage + ev. Using them also means forgoing potentially important defenses.

Closes #3279