### PR TITLE
Give lesser beckoning a ministun

### DIFF
--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1830,7 +1830,11 @@ bool beckon(actor &beckoned, const bolt &path)
 
     beckoned.apply_location_effects(old_pos); // traps, etc.
     if (beckoned.is_monster())
+    {
         mons_relocated(beckoned.as_monster()); // cleanup tentacle segments
+        // Ministun
+        beckoned.as_monster()->speed_increment -= random2(6) + 4;
+    }
 
     return true;
 }


### PR DESCRIPTION
This makes using lesser beckoning on melee monsters less bad compared to just waiting for them to walk next to as you no longer spend 2 MP just to give them a free turn.

This also makes it consistent with IMB and buffed Gell's ministunning monsters.

It's fine for spells to be situational and this doesn't change that.