### PR TITLE
Buff Norris cast rates

### DIFF
--- a/crawl-ref/source/mon-spell.h
+++ b/crawl-ref/source/mon-spell.h
@@ -2249,8 +2249,8 @@ static const mon_spellbook mspell_list[] =
 
     {  MST_NORRIS,
       {
-       { SPELL_DRAINING_GAZE, 20, MON_SPELL_PRIEST },
-       { SPELL_PRIMAL_WAVE, 24, MON_SPELL_PRIEST },
+       { SPELL_DRAINING_GAZE, 36, MON_SPELL_PRIEST },
+       { SPELL_PRIMAL_WAVE, 30, MON_SPELL_PRIEST },
       }
     },
 


### PR DESCRIPTION
Even after his previous buffs, Norris's killratio remains below 1%. In an actual game, he shows up at a time when you're already steamrolling most enemies, and then gets steamrolled.

Raise his draining gaze frequency dramatically so it can actually outdrain your mp regen and also increase primal wave's cast frequency slightly.