### PR TITLE
Rework antimagic brand

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -209,6 +209,9 @@ int attack::calc_pre_roll_to_hit(bool random)
             }
             else if (weapon->base_type == OBJ_STAVES)
                 mhit += property(*weapon, PWPN_HIT);
+
+            if (get_weapon_brand(*weapon) == SPWPN_ANTIMAGIC)
+                mhit += 27;
         }
 
         // slaying bonus

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6299,7 +6299,7 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
             break;
 
         const int dur =
-            random2(div_rand_round(ench_power, mon->get_hit_dice()) + 1)
+            (1 + random2(div_rand_round(ench_power, mon->get_hit_dice()) + 1))
                     * BASELINE_DELAY;
         mon->add_ench(mon_enchant(ENCH_ANTIMAGIC, 0,
                                   agent(), // doesn't matter

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6298,9 +6298,16 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
         if (!mon->antimagic_susceptible())
             break;
 
-        const int dur =
-            (1 + random2(div_rand_round(ench_power, mon->get_hit_dice()) + 1))
+        int dur = random2(div_rand_round(ench_power, mon->get_hit_dice()) + 1)
                     * BASELINE_DELAY;
+
+        // Cap antimagic duration
+        constexpr int cap = 5 * BASELINE_DELAY;
+        if (mon->has_ench(ENCH_ANTIMAGIC))
+            dur = min(dur, cap - mon->get_ench(ENCH_ANTIMAGIC).duration);
+
+        // Apply minimum duration
+        dur = max(BASELINE_DELAY, dur);
         mon->add_ench(mon_enchant(ENCH_ANTIMAGIC, 0,
                                   agent(), // doesn't matter
                                   dur));

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1813,7 +1813,9 @@ static string _describe_weapon_brand(const item_def &item)
     case SPWPN_ANTIMAGIC:
         return "It reduces the magical energy of the wielder, and disrupts "
                "the spells and magical abilities of those it strikes. Natural "
-               "abilities and divine invocations are not affected.";
+               "abilities and divine invocations are not affected. Its "
+               "attraction to latent magical energy present in all beings "
+               "greatly increases its accuracy.";
     case SPWPN_SPECTRAL:
         return "When its wielder attacks, the weapon's spirit leaps out and "
                "launches a second, slightly weaker strike. The spirit shares "

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -472,13 +472,8 @@ static bool _mons_can_cast_dig(const monster* mons, bool random)
     }
 
     const bool antimagiced = mons->has_ench(ENCH_ANTIMAGIC)
-                      && (random
-                          && !x_chance_in_y(4 * BASELINE_DELAY,
-                                            4 * BASELINE_DELAY
-                                            + mons->get_ench(ENCH_ANTIMAGIC).duration)
-                      || (!random
-                          && mons->get_ench(ENCH_ANTIMAGIC).duration
-                             >= 4 * BASELINE_DELAY));
+                      && (random && x_chance_in_y(2, 3)
+                      || !random);
     const auto flags = mons->spell_slot_flags(SPELL_DIG);
     return !(antimagiced && flags & MON_SPELL_ANTIMAGIC_MASK)
             && !(mons->is_silenced() && flags & MON_SPELL_SILENCE_MASK);

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -4372,9 +4372,7 @@ bool handle_mon_spell(monster* mons)
 
     // Check for antimagic if casting a spell spell.
     if (mons->has_ench(ENCH_ANTIMAGIC) && flags & MON_SPELL_ANTIMAGIC_MASK
-        && !x_chance_in_y(4 * BASELINE_DELAY,
-                          4 * BASELINE_DELAY
-                          + mons->get_ench(ENCH_ANTIMAGIC).duration))
+        && x_chance_in_y(2, 3))
     {
         // This may be a bad idea -- if we decide monsters shouldn't
         // lose a turn like players do not, please make this just return.

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4183,7 +4183,7 @@ int get_real_mp(bool include_items)
     enp /= 100;
 
     if (include_items && you.wearing_ego(EQ_WEAPON, SPWPN_ANTIMAGIC))
-        enp /= 3;
+        enp /= 2;
 
     enp = max(enp, 0);
 


### PR DESCRIPTION
Simplify antimagic's chance to prevent a spellcast. It is now a flat 2/3 to fizzle a spell rather than 4/(4 + duration) to fail. Having its effect scale with duration means it is hard to evaluate its usefulness as a monster with antimagic could either have only 1 turn left and thus have an 80% chance to succeed casting or enough to never succeed. Since duration is tied to damage dealt, it also means severely antimagicked monsters are those who are 1-2 hits away from dying and will die before antimagic does much and those with high health have so little antimagic that they will succeed at casting anyway despite the little icon.

This number is equivalent to always having 8 turns of antimagic and could be adjusted if the brand ends up being too powerful, though this could affect other methods of applying antimagic (ru, enfeeble, etc).

Antimagic duration will be capped when applied via direct attacks so that it quickly wears off if not constantly reapplied in order to discourage swapping to another weapon after applying antimagic. It will also have a minimum of 10 auts when applied after the cap. This prevents situations where the "magic leaks into the air" message is printed but no antimagic is actually applied and slightly improves its performance with low damage weapons.

Antimagic halves your mp rather than reducing it by 2/3. This is still debilitating enough to casters that they would never want to use it, but allows non-casters a bit more mp for using god abilities.

Antimagic-branded weapons also gain a huge bonus to accuracy. This is flavored as antimagic being attracted to latent magic present in all beings the same way antimatter is attracted to matter.

Since antimagic only works against a small proportion of monsters you face, and even then likely not a monster with a spell you would care to disable or one that would survive being hit for more than a couple of turns, it is only valuable as a swap brand. Players with an antimagic weapon would either need to swap it frequently with a main weapon to get value out of it or get so annoyed that they just stick to their main weapon or rebrand the antimagic weapon. It is also arguable if disabling a single spellcaster is better than simply killing them faster when facing multiple enemies is common and antimagic only disables the enemy you are currently damaging.

Frequent weapon swapping is definitely something we need to move away from encouraging, so I'm giving antimagic an effect that enhances its overall effectiveness. This also makes applying antimagic more consistent and reduces situations where antimagic wears off despite you making constant attacks against an enemy.

The numbers could use some tweaking but this represents a 5-20% damage increase in most situations depending on your target's ev.