### PR TITLE
Give deep elves bonus mp regeneration

### DIFF
--- a/crawl-ref/source/dat/descript/species.txt
+++ b/crawl-ref/source/dat/descript/species.txt
@@ -17,6 +17,7 @@ wrapping slow-revving metal around their puny goblinoid frames.
 Deep Elf
 
 Deep Elves have a strong affinity for all kinds of magic, but are very fragile.
+They regenerate magic rapidly.
 %%%%
 Demigod
 

--- a/crawl-ref/source/dat/species/debugman.yaml
+++ b/crawl-ref/source/dat/species/debugman.yaml
@@ -1,0 +1,13 @@
+enum: SP_DEBUG_MAN
+monster: MONS_HUMAN
+name: Debug Man
+difficulty: False
+aptitudes:
+  xp: 0
+  hp: 0
+  mp_mod: 0
+  wl: 3
+str: 8
+int: 8
+dex: 8
+levelup_stat_frequency: 4

--- a/crawl-ref/source/dat/species/deep-elf.yaml
+++ b/crawl-ref/source/dat/species/deep-elf.yaml
@@ -42,8 +42,9 @@ dex: 10
 levelup_stat_frequency: 4
 levelup_stats:
   - int
-# if you add any mutations here: you'll need to fix test/mut_species.lua, which
-# relies on DE having none.
+mutations:
+  1:
+    MUT_MANA_REGENERATION: 1
 recommended_jobs:
   - JOB_HEDGE_WIZARD
   - JOB_CONJURER

--- a/crawl-ref/source/test/mut_species.lua
+++ b/crawl-ref/source/test/mut_species.lua
@@ -131,6 +131,6 @@ end
 
 -- the testbed doesn't really clean up much of anything.
 you.delete_all_mutations("Species mutation test")
-assert(you.change_species("deep elf")) -- should clean up any innate mutations
+assert(you.change_species("debug man")) -- should clean up any innate mutations
 assert(you.set_xl(1, false))
 you.moveto(you_x, you_y) -- restore original player pos

--- a/crawl-ref/source/util/gen-apt.pl
+++ b/crawl-ref/source/util/gen-apt.pl
@@ -134,6 +134,7 @@ sub aptitude_table
         next if $sp eq 'Mayflytaur';
         next if $sp eq 'Deep Dwarf';
         next if $sp eq 'Meteoran';
+        next if $sp eq 'Debug Man';
 
         my $line = '';
         $line .= fix_draco_species($sp, \$seen_draconian_length);

--- a/crawl-ref/source/util/species-gen/species-type-header.txt
+++ b/crawl-ref/source/util/species-gen/species-type-header.txt
@@ -76,5 +76,6 @@ enum species_type
 #endif
     SP_MOUNTAIN_DWARF,
     SP_COGLIN,
+    SP_DEBUG_MAN,
 
     // Auto-generated enums start here


### PR DESCRIPTION
Give DE the mp regeneration mutation from DS that doubles their base mp regen. This is intended to be a tiny boost to DE in the early game that also makes their mutation screen look less bare without adding complexity or shaking up species balance.

Add a new debug man species for use in the mutation test.