### PR TITLE
Allow self targeting with nullifying breath

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3097,11 +3097,8 @@ bool bolt::harmless_to_player() const
     if (you.cloud_immune() && is_big_cloud())
         return true;
 
-    if (origin_spell == SPELL_COMBUSTION_BREATH
-        || origin_spell == SPELL_NULLIFYING_BREATH)
-    {
+    if (origin_spell == SPELL_COMBUSTION_BREATH)
         return true;
-    }
 
     switch (flavour)
     {
@@ -4297,11 +4294,8 @@ bool bolt::ignores_player() const
     if (flavour == BEAM_DIGGING)
         return true;
 
-    if (origin_spell == SPELL_COMBUSTION_BREATH
-        || origin_spell == SPELL_NULLIFYING_BREATH)
-    {
+    if (origin_spell == SPELL_COMBUSTION_BREATH)
         return true;
-    }
 
     if (agent() && agent()->is_monster()
         && mons_is_hepliaklqana_ancestor(agent()->as_monster()->type))

--- a/crawl-ref/source/dat/descript/ability.txt
+++ b/crawl-ref/source/dat/descript/ability.txt
@@ -21,7 +21,7 @@ Nullifying Breath ability
 
 Breathes a large blast of pure antimagic that dispels magical effects from
 every creature it hits and also significantly interferes with their ability to
-cast spells for a while. It is harmless to its user.
+cast spells for a while.
 %%%%
 Steam Breath ability
 


### PR DESCRIPTION
Nullifying breath feels weaker than other breaths because of its low damage and situational use compared to just being able to kill whatever's troubling you.

The reasons why self targeting with purple draconian breath were that it provided you with too many sources of self cancellation, to make it consistent with wands of quicksilver and that it was unintuitive.

Now that the breath has been reworked into an aoe, hitting yourself with it is no longer as unintuitive as before since you no longer have to explicitly target yourself with the bolt. Its limited charges also balances it better than before. It's also completely different from quicksilver wands, removing confusion between the two.

So allow dispelling yourself again to give it more usages.