### PR TITLE
Display PE center targets with more opacity

### DIFF
--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -667,7 +667,7 @@ bool targeter_transference::valid_aim(coord_def a)
 targeter_permafrost::targeter_permafrost(const actor &act, int power) :
     targeter_smite(&act)
 {
-    set<coord_def> possible_centres = permafrost_targets(act, power, false);
+    possible_centres = permafrost_targets(act, power, false);
     for (coord_def t : possible_centres)
     {
         targets.insert(t);
@@ -680,9 +680,12 @@ targeter_permafrost::targeter_permafrost(const actor &act, int power) :
 
 aff_type targeter_permafrost::is_affected(coord_def loc)
 {
-    // TODO: consider displaying each centre differently from the AOEs.
     if (targets.count(loc))
+    {
+        if (possible_centres.count(loc))
+            return single_target ? AFF_MULTIPLE : AFF_YES;
         return single_target ? AFF_YES : AFF_MAYBE;
+    }
     return AFF_NO;
 }
 

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -123,6 +123,7 @@ public:
     aff_type is_affected(coord_def loc) override;
 private:
     set<coord_def> targets;
+    set<coord_def> possible_centres;
     bool single_target;
 };
 


### PR DESCRIPTION
Display permafrost center targets with more opacity. This includes a nonstandard use of AFF_YES but I don't think any players would complain.