### PR TITLE
Don't leak magic if antimagic rolls 0 duration

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -6301,6 +6301,10 @@ mon_resist_type bolt::apply_enchantment_to_monster(monster* mon)
         const int dur =
             random2(div_rand_round(ench_power, mon->get_hit_dice()) + 1)
                     * BASELINE_DELAY;
+
+        if (!dur)
+            break;
+
         mon->add_ench(mon_enchant(ENCH_ANTIMAGIC, 0,
                                   agent(), // doesn't matter
                                   dur));


### PR DESCRIPTION
Antimagic frequently rolls a duration of 0 on hits but will still print the "magic leaks into the air" message which doesn't seem right to me.