### PR TITLE
Fix an issue with randart staves in local tiles

### DIFF
--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -165,20 +165,26 @@ void DungeonCellBuffer::add_dngn_tile(int tileidx, int x, int y,
         m_buf_feat.add(tileidx, x, y);
 }
 
-void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y)
+void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y, bool no_base)
 {
-    tileidx_t base = tileidx_known_base_item(tileidx);
-    if (base)
-        m_buf_main.add(base, x, y);
+    if (!no_base)
+    {
+        const tileidx_t base = tileidx_known_base_item(tileidx);
+        if (base)
+            m_buf_main.add(base, x, y);
+    }
 
     m_buf_main.add(tileidx, x, y);
 }
 
-void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y, int ox, int oy)
+void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y, int ox, int oy, bool no_base)
 {
-    tileidx_t base = tileidx_known_base_item(tileidx);
-    if (base)
-        m_buf_main.add(base, x, y, ox, oy, false);
+    if (!no_base)
+    {
+        const tileidx_t base = tileidx_known_base_item(tileidx);
+        if (base)
+            m_buf_main.add(base, x, y, ox, oy, false);
+    }
 
     m_buf_main.add(tileidx, x, y, ox, oy, false);
 }

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -165,27 +165,17 @@ void DungeonCellBuffer::add_dngn_tile(int tileidx, int x, int y,
         m_buf_feat.add(tileidx, x, y);
 }
 
-void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y, bool no_base)
+void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y)
 {
-    if (!no_base)
-    {
-        const tileidx_t base = tileidx_known_base_item(tileidx);
-        if (base)
-            m_buf_main.add(base, x, y);
-    }
+    const tileidx_t base = tileidx_known_base_item(tileidx);
+    if (base)
+        m_buf_main.add(base, x, y);
 
     m_buf_main.add(tileidx, x, y);
 }
 
-void DungeonCellBuffer::add_main_tile(int tileidx, int x, int y, int ox, int oy, bool no_base)
+void DungeonCellBuffer::add_special_tile(int tileidx, int x, int y, int ox, int oy)
 {
-    if (!no_base)
-    {
-        const tileidx_t base = tileidx_known_base_item(tileidx);
-        if (base)
-            m_buf_main.add(base, x, y, ox, oy, false);
-    }
-
     m_buf_main.add(tileidx, x, y, ox, oy, false);
 }
 

--- a/crawl-ref/source/tiledgnbuf.h
+++ b/crawl-ref/source/tiledgnbuf.h
@@ -25,8 +25,8 @@ public:
     void add(const packed_cell &cell, int x, int y);
     void add_monster(const monster_info &mon, int x, int y);
     void add_dngn_tile(int tileidx, int x, int y, bool in_water = false);
-    void add_main_tile(int tileidx, int x, int y, bool no_base = false);
-    void add_main_tile(int tileidx, int x, int y, int ox, int oy, bool no_base = false);
+    void add_main_tile(int tileidx, int x, int y);
+    void add_special_tile(int tileidx, int x, int y, int ox, int oy);
     void add_spell_tile(int tileidx, int x, int y);
     void add_skill_tile(int tileidx, int x, int y);
     void add_command_tile(int tileidx, int x, int y);

--- a/crawl-ref/source/tiledgnbuf.h
+++ b/crawl-ref/source/tiledgnbuf.h
@@ -25,8 +25,8 @@ public:
     void add(const packed_cell &cell, int x, int y);
     void add_monster(const monster_info &mon, int x, int y);
     void add_dngn_tile(int tileidx, int x, int y, bool in_water = false);
-    void add_main_tile(int tileidx, int x, int y);
-    void add_main_tile(int tileidx, int x, int y, int ox, int oy);
+    void add_main_tile(int tileidx, int x, int y, bool no_base = false);
+    void add_main_tile(int tileidx, int x, int y, int ox, int oy, bool no_base = false);
     void add_spell_tile(int tileidx, int x, int y);
     void add_skill_tile(int tileidx, int x, int y);
     void add_command_tile(int tileidx, int x, int y);

--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -111,7 +111,7 @@ void InventoryRegion::pack_buffers()
                 draw_number(x, y, item.quantity);
 
             if (item.special)
-                m_buf.add_main_tile(item.special, x, y, 0, 0);
+                m_buf.add_main_tile(item.special, x, y, 0, 0, true);
 
             if (item.flag & TILEI_FLAG_INVALID && !tiles.is_using_small_layout())
                 m_buf.add_icons_tile(TILEI_MESH, x, y);

--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -111,7 +111,7 @@ void InventoryRegion::pack_buffers()
                 draw_number(x, y, item.quantity);
 
             if (item.special)
-                m_buf.add_main_tile(item.special, x, y, 0, 0, true);
+                m_buf.add_special_tile(item.special, x, y, 0, 0);
 
             if (item.flag & TILEI_FLAG_INVALID && !tiles.is_using_small_layout())
                 m_buf.add_icons_tile(TILEI_MESH, x, y);


### PR DESCRIPTION
When an item that has a randomized appearance (potions, staves) on the floor is rendered, the item's main tile is actually the "brand". The randomized tile gets added on later by calling add_main_tile which calls tileidx_known_base_item on the main tile when. This is a hack, but it lets you see the brands of identified items on the ground.

However with randart staves, the main tile gets put in the special tile slot instead. Normally this won't cause any issues, but the local tiles inventory renders items as if they were on the ground. It calls add_main_tile on the special slot which then renders the randomized staff appearance on top of the randart staff tile.

Fixed by not doing this for special tile slots.

Closes #3518