### PR TITLE
Fix cursed item background not being red

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -4618,7 +4618,7 @@ item_def get_item_known_info(const item_def& item)
     ii.flags = item.flags & (0
             | ISFLAG_IDENT_MASK
             | ISFLAG_ARTEFACT_MASK | ISFLAG_DROPPED | ISFLAG_THROWN
-            | ISFLAG_COSMETIC_MASK);
+            | ISFLAG_COSMETIC_MASK | ISFLAG_CURSED);
 
     if (in_inventory(item))
     {


### PR DESCRIPTION
In local tiles. Should be fine for ISFLAG_CURSED to be included in get_item_known_info now that the only source of curses is ash.

Closes #3683