### PR TITLE
Fix pressing f twice to aim quivered Dr breath

### DIFF
--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -1445,7 +1445,14 @@ namespace quiver
             {
             case ABIL_HOP:
             case ABIL_BLINKBOLT:
+            case ABIL_COMBUSTION_BREATH:
+            case ABIL_GLACIAL_BREATH:
+            case ABIL_GALVANIC_BREATH:
             case ABIL_CAUSTIC_BREATH:
+            case ABIL_NULLIFYING_BREATH:
+            case ABIL_STEAM_BREATH:
+            case ABIL_NOXIOUS_BREATH:
+            case ABIL_MUD_BREATH:
             case ABIL_DAMNATION:
             case ABIL_ELYVILON_HEAL_OTHER:
             case ABIL_LUGONU_BANISH:

--- a/crawl-ref/source/spl-zap.cc
+++ b/crawl-ref/source/spl-zap.cc
@@ -159,7 +159,6 @@ static pair<ability_type, zap_type> _abil_zaps[] =
     { ABIL_SPIT_POISON, ZAP_SPIT_POISON },
     { ABIL_BREATHE_FIRE, ZAP_BREATHE_FIRE },
     { ABIL_BREATHE_POISON, ZAP_BREATHE_POISON },
-    { ABIL_NOXIOUS_BREATH, ZAP_NOXIOUS_BREATH },
 };
 
 zap_type spell_to_zap(spell_type spell)


### PR DESCRIPTION
Previously pressing f with a quivered breath would not let you start aiming your breath until you pressed it again.