### PR TITLE
Correct how the display_char option handles gems and gold.

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2811,7 +2811,7 @@ display_char = <dungeon_character_name : symbol>
            invis_exposed, item_detected, item_orb, item_rune, item_weapon,
            item_armour, item_wand, item_scroll, item_ring, item_potion,
            item_missile, item_book, item_staff, item_rod, item_miscellany,
-           item_corpse, item_skeleton, item_gold, item_amulet, cloud,
+           item_corpse, item_skeleton, item_gold, item_gem, item_amulet, cloud,
            cloud_weak, cloud_fading, cloud_terminal, tree, transporter,
            transporter_landing, space, fired_bolt, fired_zap, fired_burst,
            fired_debug, fired_missile, fired_missile, explosion, frame_horiz,

--- a/crawl-ref/source/viewchar.cc
+++ b/crawl-ref/source/viewchar.cc
@@ -116,9 +116,9 @@ dungeon_char_type dchar_by_name(const string &name)
 #if TAG_MAJOR_VERSION == 34
         "item_rod",
 #endif
-        "item_talisman", "item_miscellany", "item_corpse", "item_skeleton", "item_gem", "item_gold",
-        "item_amulet", "cloud", "cloud_weak", "cloud_fading", "cloud_terminal",
-        "tree",
+        "item_talisman", "item_miscellany", "item_corpse", "item_skeleton",
+        "item_gold", "item_gem", "item_amulet", "cloud", "cloud_weak",
+        "cloud_fading", "cloud_terminal", "tree",
 #if TAG_MAJOR_VERSION == 34
         "teleporter",
 #endif


### PR DESCRIPTION
DCHAR_ITEM_GOLD and DCHAR_ITEM_GEM were in a different order in dchar_names[] (used by the "display_char" option) to the one in dungeon_char_type, meaning that the option had unexpected effects.

Fix this, and add item_gem to the docs for this option.