### PR TITLE
Updated version of Monkooky's Qazlal Upheaval friendly fire PR.

### DIFF
--- a/crawl-ref/source/beam-type.h
+++ b/crawl-ref/source/beam-type.h
@@ -40,6 +40,7 @@ enum beam_type                  // bolt::flavour
     BEAM_FOUL_FLAME,
     BEAM_CRYSTALLIZING,
     BEAM_WARPING,
+    BEAM_QAZLAL,
 
     // Enchantments
     BEAM_SLOW,

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3158,6 +3158,9 @@ bool bolt::harmless_to_player() const
         return agent(true)->is_player()
                || (bool)!(you.holiness() & (MH_NATURAL | MH_DEMONIC | MH_HOLY));
 
+    case BEAM_QAZLAL:
+        return true;
+
     default:
         return false;
     }
@@ -4316,6 +4319,9 @@ bool bolt::ignores_player() const
                || !agent()->can_constrict(you, flavour == BEAM_ROOTS ? CONSTRICT_ROOTS
                                                                      : CONSTRICT_BVC);
     }
+
+    if (flavour == BEAM_QAZLAL)
+        return true;
 
     return false;
 }
@@ -5531,6 +5537,11 @@ bool bolt::ignores_monster(const monster* mon) const
         return true;
 
     if (flavour == BEAM_WATER && mon->type == MONS_WATER_ELEMENTAL)
+        return true;
+
+    int summon_type = 0;
+    mon->is_summoned(nullptr, &summon_type);
+    if (flavour == BEAM_QAZLAL && summon_type == MON_SUMM_AID)
         return true;
 
     return false;
@@ -7244,6 +7255,7 @@ static string _beam_type_name(beam_type type)
     case BEAM_UMBRAL_TORCHLIGHT:     return "umbral torchlight";
     case BEAM_CRYSTALLIZING:         return "crystallizing";
     case BEAM_WARPING:               return "spatial disruption";
+    case BEAM_QAZLAL:                return "upheaval targetter";
 
     case NUM_BEAMS:                  die("invalid beam type");
     }

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3557,6 +3557,7 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
         args.mode = TARG_HOSTILE;
         args.needs_path = false;
         args.top_prompt = "Aiming: <white>Upheaval</white>";
+        args.self = confirm_prompt_type::none;
         args.hitfunc = &tgt;
         if (!spell_direction(*player_target, beam, &args))
             return spret::abort;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3528,7 +3528,7 @@ static int _upheaval_radius(int pow)
 
 spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_target)
 {
-    int pow = you.skill(SK_INVOCATIONS, 6);
+    const int pow = you.skill(SK_INVOCATIONS, 6);
     const int max_radius = _upheaval_radius(pow);
 
     bolt beam;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3786,6 +3786,7 @@ spret qazlal_disaster_area(bool fail)
     vector<coord_def> targets;
     vector<int> weights;
     const int pow = you.skill(SK_INVOCATIONS, 6);
+    const int upheaval_radius = _upheaval_radius(pow);
     for (radius_iterator ri(you.pos(), LOS_RADIUS, C_SQUARE, LOS_NO_TRANS, true);
          ri; ++ri)
     {
@@ -3806,6 +3807,10 @@ spret qazlal_disaster_area(bool fail)
         {
             friendlies = true;
         }
+
+        const int range = you.pos().distance_from(*ri);
+        if (range <= upheaval_radius)
+            continue;
 
         const int dist = grid_distance(you.pos(), *ri);
 


### PR DESCRIPTION
The original is at #3332.

The only changes made in this version are to update it for current trunk, put the Disaster Area radius limitation back in so it doesn't always blast everything in LOS, constify a variable, disable the prompt when aiming it at yourself, and refactor it to actually not damage things it shouldn't damage when directly aimed at those things.