### PR TITLE
Change the spelling of some words to Australian English.

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1440,7 +1440,7 @@ The scales of a swamp dragon. It confers resistance to poison on its wearer.
 talisman of death
 
 A grey-black vessel, infused with dark power through a sickening ritual.
-Transforms the user into an undying offense against life itself.
+Transforms the user into an undying offence against life itself.
 
 Foes struck by user's melee weapons or hands are weakened, slowed, and drained.
 The user can also heal themself by tormenting living foes nearby; Shapeshifting

--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -899,11 +899,11 @@ skilled in archery.
 centaur warrior
 
 A muscular centaur, veteran of numerous battles, armed with well-made weapons
-and able to use them skillfully.
+and able to use them skilfully.
 %%%%
 cerulean imp
 
-A small, willful minor demon. Its wings, far larger than its scrawny body, were
+A small, wilful minor demon. Its wings, far larger than its scrawny body, were
 made to soar, and it lands only rarely and with the greatest reluctance.
 %%%%
 chaos spawn
@@ -1158,7 +1158,7 @@ stand in its way.
 %%%%
 draconian knight
 
-A draconian protected by thick scales, skillful weapon use, and complementary
+A draconian protected by thick scales, skilful weapon use, and complementary
 magic.
 %%%%
 draconian monk

--- a/crawl-ref/source/dat/descript/status.txt
+++ b/crawl-ref/source/dat/descript/status.txt
@@ -596,7 +596,7 @@ Any equipped weapons and armour are melded.
 %%%%
 Death status
 
-You have been transformed into an undying offense against life itself.
+You have been transformed into an undying offence against life itself.
 
 Foes struck by your hands or melee weapons are weakened, slowed, and drained,
 and you can heal yourself by tormenting living foes nearby. You also resist

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2473,7 +2473,7 @@ static string _describe_talisman_form(const item_def &item, bool monster)
     if (below_target || hp != 100 || ac || ev || loses_body_ac)
     {
         if (!monster)
-            description += "\n\nDefense:";
+            description += "\n\nDefence:";
         if (below_target || hp != 100)
         {
             description += make_stringf("\nHP:            %d%%", hp);
@@ -2499,7 +2499,7 @@ static string _describe_talisman_form(const item_def &item, bool monster)
 
     // offense
     if (!monster)
-        description += "\n\nOffense:";
+        description += "\n\nOffence:";
     const int uc = form->get_base_unarmed_damage(false); // TODO: compare to your base form?
                                                          // folks don't know nudists have 3
     const int max_uc = form->get_base_unarmed_damage(false, true);

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1195,7 +1195,7 @@ private:
         }
         if (!tfd.defenses.empty())
         {
-            add_entry(new MenuEntry("<w>Defense:</w>", MEL_ITEM, 1, 0));
+            add_entry(new MenuEntry("<w>Defence:</w>", MEL_ITEM, 1, 0));
             add_entry(new MenuEntry("", MEL_ITEM, 1, 0)); // XXX  spacing kludge?
         }
         for (auto skinfo : tfd.defenses)
@@ -1205,7 +1205,7 @@ private:
         }
         if (!tfd.offenses.empty())
         {
-            add_entry(new MenuEntry("<w>Offense:</w>", MEL_ITEM, 1, 0));
+            add_entry(new MenuEntry("<w>Offence:</w>", MEL_ITEM, 1, 0));
             add_entry(new MenuEntry("", MEL_ITEM, 1, 0)); // XXX  spacing kludge?
         }
         for (auto skinfo : tfd.offenses)

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3787,7 +3787,7 @@ void handle_flame_wave()
     bolt beam;
     if (!_prep_flame_wave(beam, pow, lvl))
     {
-        mpr("You stop channeling waves of flame.");
+        mpr("You stop channelling waves of flame.");
         end_flame_wave();
         return;
     }

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1357,7 +1357,7 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
 
     case SPELL_DEATH_CHANNEL:
         if (temp && you.duration[DUR_DEATH_CHANNEL])
-            return "you are already channeling the dead.";
+            return "you are already channelling the dead.";
         if (have_passive(passive_t::reaping))
             return "you are already reaping souls!";
         break;


### PR DESCRIPTION
Change a few places where a word used a spelling which is not spelt correctly according to
https://www.australian-dictionary.com.au/wordcheck/.

This only changes things in places where the spellings may be displayed to the user. I include the documentation in this. I haven't changed the changelog or doc/develop, or any of the contrib stuff.

This changes:

channeling -> channelling
dueling -> duelling
offense -> offence
defense -> defence
skillfull/skillfully -> skilful/skilfully
willful -> wilful