### PR TITLE
Make permissive lof treat actors as obstacles

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -818,6 +818,7 @@ void bolt::apply_beam_conducts()
 void bolt::choose_ray()
 {
     if ((!chose_ray || reflections > 0)
+        && (no_actor_perm_lof || !find_ray(source, target, ray, opc_no_actor))
         && !find_ray(source, target, ray, opc_solid_see)
         // If fire is blocked, at least try a visible path so the
         // error message is better.

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -128,6 +128,9 @@ struct bolt
     bool   quiet_debug = false;    // Disable any debug spam.
 #endif
 
+    bool   no_actor_perm_lof = false;   // Don't attempt to find a ray
+                                        // without a blocking actor
+    
     // OUTPUT parameters (tracing, ID)
     bool obvious_effect = false; // is this a non-enchantment, or did it already
                                  // show some effect or message? (Otherwise, we'll

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -130,7 +130,7 @@ struct bolt
 
     bool   no_actor_perm_lof = false;   // Don't attempt to find a ray
                                         // without a blocking actor
-    
+
     // OUTPUT parameters (tracing, ID)
     bool obvious_effect = false; // is this a non-enchantment, or did it already
                                  // show some effect or message? (Otherwise, we'll

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1782,8 +1782,8 @@ void direction_chooser::toggle_beam()
 
     if (show_beam)
     {
-        have_beam = find_ray(you.pos(), target(), beam,
-                             opc_solid_see, you.current_vision);
+        have_beam = find_ray_priority(you.pos(), target(), beam,
+                             opc_no_actor, opc_solid_see, you.current_vision);
     }
 }
 
@@ -2309,8 +2309,8 @@ public:
                 m_dc.show_beam = !m_dc.just_looking && m_dc.needs_path;
                 // XX code duplication
                 m_dc.have_beam = m_dc.show_beam
-                                 && find_ray(you.pos(), m_dc.target(), m_dc.beam,
-                                             opc_solid_see, you.current_vision);
+                                 && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
+                                    opc_no_actor, opc_solid_see, you.current_vision);
                 m_dc.need_text_redraw = true;
                 m_dc.need_viewport_redraw = true;
                 m_dc.need_cursor_redraw = true;
@@ -2365,8 +2365,8 @@ public:
         if (old_target != m_dc.target())
         {
             m_dc.have_beam = m_dc.show_beam
-                             && find_ray(you.pos(), m_dc.target(), m_dc.beam,
-                                         opc_solid_see, you.current_vision);
+                             && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
+                                opc_no_actor, opc_solid_see, you.current_vision);
             m_dc.need_text_redraw = true;
             m_dc.need_viewport_redraw = true;
             m_dc.need_cursor_redraw = true;
@@ -2507,8 +2507,8 @@ bool direction_chooser::choose_direction()
     // If requested, show the beam on startup.
     if (show_beam)
     {
-        have_beam = find_ray(you.pos(), target(), beam,
-                             opc_solid_see, you.current_vision);
+        have_beam = find_ray_priority(you.pos(), target(), beam,
+                        opc_no_actor, opc_solid_see, you.current_vision);
         need_viewport_redraw = have_beam;
     }
     if (hitfunc)

--- a/crawl-ref/source/los.cc
+++ b/crawl-ref/source/los.cc
@@ -652,6 +652,15 @@ bool find_ray(const coord_def& source, const coord_def& target,
     return true;
 }
 
+// Find a ray prioritizing opc_priority over opc
+bool find_ray_priority(const coord_def& source, const coord_def& target,
+              ray_def& ray, const opacity_func& opc_priority, const opacity_func& opc,
+              int range, bool cycle)
+{
+    return find_ray(source, target, ray, opc_priority, range, cycle)
+        || find_ray(source, target, ray, opc, range, cycle);
+}
+
 bool exists_ray(const coord_def& source, const coord_def& target,
                 const opacity_func& opc, int range)
 {

--- a/crawl-ref/source/los.h
+++ b/crawl-ref/source/los.h
@@ -25,6 +25,9 @@ int get_los_radius();
 bool find_ray(const coord_def& source, const coord_def& target,
               ray_def& ray, const opacity_func &opc,
               int range = LOS_MAX_RANGE, bool cycle = false);
+bool find_ray_priority(const coord_def& source, const coord_def& target,
+              ray_def& ray, const opacity_func &opc_priority, const opacity_func &opc,
+              int range = LOS_MAX_RANGE, bool cycle = false);
 bool exists_ray(const coord_def& source, const coord_def& target,
                 const opacity_func &opc, int range = LOS_MAX_RANGE);
 dungeon_feature_type ray_blocker(const coord_def& source, const coord_def& target);

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -7440,7 +7440,7 @@ static coord_def _choose_throwing_target(const monster &thrower,
         ray_def ray;
         // Unusable landing sites.
         if (!_valid_throw_dest(thrower, victim, *di)
-            || !find_ray(thrower.pos(), *di, ray, opc_solid_see))
+            || !find_ray_priority(thrower.pos(), *di, ray, opc_no_actor, opc_solid_see))
         {
             continue;
         }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3007,6 +3007,7 @@ static ai_action::goodness _fire_plasma_beam_at(const actor &agent, int pow,
     beam.draw_delay   = 5;
     beam.foe_ratio    = 80; // default
     beam.is_tracer    = tracer;
+    beam.no_actor_perm_lof = true;
     zappy(ZAP_PLASMA_LIGHTNING, pow, mon, beam);
     beam.fire();
     const ai_action::goodness fire_good = beam.good_to_fire();


### PR DESCRIPTION
This change is intended to make ranged attacks and spells much less annoying to use when you have firewood / allies / slimes blocking the path by making it choose a slightly different path with the same rules as permissive los.

Previously when this happened, you would either need to reposition or drag your targeting behind your target to get a good path that doesn't hit unwanted targets. This is very annoying as it interrupts tabbing with a prompt/message and forces you to aim manually.

Currently this may cause some odd behavior with piercing beams.

A side effect is that ranged monsters become more dangerous because they are blocked a lot less frequently by their friends now.

TODO: Don't leak invisible monster locations.

Before:
![image](https://github.com/crawl/crawl/assets/146337911/37e645ce-c145-4f01-8d7c-f08fdd4d120a)
After:
![image](https://github.com/crawl/crawl/assets/146337911/d6f4712c-b645-49b8-9e8e-9916491cda81)

Before:
![image](https://github.com/crawl/crawl/assets/146337911/62b04027-43f4-4c76-8a56-6bf42a4cf6ea)
After:
![image](https://github.com/crawl/crawl/assets/146337911/3e837807-3363-48d9-8eb6-78e1a5821c33)
