### PR TITLE
Improve drop_disables_autopickup behavior

### DIFF
--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2645,7 +2645,7 @@ bool drop_item(int item_dropped, int quant_drop)
 
     ASSERT(item.defined());
 
-    if (Options.drop_disables_autopickup)
+    if (Options.drop_disables_autopickup && item.base_type != OBJ_MISSILES)
         set_item_autopickup(item, AP_FORCE_OFF);
 
     if (copy_item_to_grid(item, you.pos(), quant_drop, true, true) == NON_ITEM)


### PR DESCRIPTION
Don't disable autopickup when dropping missiles because missiles with different brands share the same base type.