### PR TITLE
Fix blink targeter revealing invisible enemies + Bind Soul targeter revealing the true Mara

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1687,7 +1687,7 @@ void yred_fathomless_shackles_effect(int delay)
 
 bool yred_can_bind_soul(monster* mon)
 {
-    return mons_can_be_spectralised(*mon, true)
+    return mons_can_be_spectralised(*mon, true, true)
            && !mon->has_ench(ENCH_SOUL_RIPE)
            && mon->attitude != ATT_FRIENDLY;
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1772,11 +1772,14 @@ bool mons_class_can_be_spectralised(monster_type mzc, bool divine)
 
 // Does this monster have a soul that can be used for necromancy (Death
 // Channel, Simulacrum, Yredelemnul's Bind Soul)? For Bind Soul, allow
-// monsters with no attacks if they have some spells to use.
-bool mons_can_be_spectralised(const monster& mon, bool divine)
+// monsters with no attacks if they have some spells to use. When using
+// for the purposes of interface, take into account only known effects.
+bool mons_can_be_spectralised(const monster& mon, bool divine, bool only_known)
 {
     return mons_class_can_be_spectralised(mon.type, divine)
-           && !mon.is_summoned()
+           && (!mon.is_summoned()
+               || only_known && mon.has_ench(ENCH_PHANTOM_MIRROR)
+                    && mon.mons_species() != MONS_PLAYER_ILLUSION)
            && !mons_is_tentacle_or_tentacle_segment(mon.type)
            && (!testbits(mon.flags, MF_NO_REWARD)
                || mon.props.exists(KIKU_WRETCH_KEY))

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -319,7 +319,8 @@ bool mons_is_zombified(const monster& mons);
 bool mons_class_can_be_zombified(monster_type mc);
 bool mons_can_be_zombified(const monster& mon);
 bool mons_class_can_be_spectralised(monster_type mc, bool divine = false);
-bool mons_can_be_spectralised(const monster& mon, bool divine = false);
+bool mons_can_be_spectralised(const monster& mon, bool divine = false,
+                              bool only_known = false);
 bool mons_class_can_use_stairs(monster_type mc);
 bool mons_class_can_use_transporter(monster_type mc);
 bool mons_can_use_stairs(const monster& mon,

--- a/crawl-ref/source/teleport.cc
+++ b/crawl-ref/source/teleport.cc
@@ -408,8 +408,12 @@ bool valid_blink_destination(const actor &moved, const coord_def& target,
     if (!in_bounds(target))
         return false;
     actor *targ_act = actor_at(target);
-    if (targ_act && (incl_unseen || moved.can_see(*targ_act)))
+    if (targ_act
+        && (incl_unseen || moved.can_see(*targ_act)
+            || env.map_knowledge(targ_act->pos()).invisible_monster()))
+    {
         return false;
+    }
     if (forbid_unhabitable)
     {
         if (!moved.is_habitable(target))
@@ -429,7 +433,7 @@ vector<coord_def> find_blink_targets()
 {
     vector<coord_def> result;
     for (radius_iterator ri(you.pos(), LOS_NO_TRANS); ri; ++ri)
-        if (valid_blink_destination(you, *ri))
+        if (valid_blink_destination(you, *ri, false, true, false))
             result.push_back(*ri);
 
     return result;


### PR DESCRIPTION
Blink targeter only shows invis enemies when they are known
![image](https://github.com/crawl/crawl/assets/7819240/8cefe471-7253-4044-9633-8a692fd055d9)
![image](https://github.com/crawl/crawl/assets/7819240/11649139-df38-48c3-8a06-93e14f6de368)



Bind soul targeter allows targets that are summons that you don't know for sure are summons. (Actually casting bind soul on these will reveal that the monster is a fake, but that costs a turn, MP, and piety). Maybe it shouldn't cost piety when it fails? 
![image](https://github.com/crawl/crawl/assets/7819240/466ef7b6-f6c0-4a41-a6e9-88d4166351ea)
