### PR TITLE
Clear dimensional bullseye when apostle yields

### DIFF
--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -630,6 +630,7 @@ void monster::timeout_enchantments(int levels)
         case ENCH_MERFOLK_AVATAR_SONG:
         case ENCH_INFESTATION:
         case ENCH_HELD:
+        case ENCH_BULLSEYE_TARGET:
             del_ench(entry.first);
             break;
 


### PR DESCRIPTION
Include ENCH_BULLSEYE_TARGET in timeout_enchantments. This is to avoid accidentally causing penance when shooting another target after an apostle becomes neutral/friendly without warning.