### PR TITLE
Make allies avoid pressure plate traps

### DIFF
--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -131,7 +131,8 @@ bool trap_def::is_bad_for_player() const
     return type == TRAP_ALARM
            || type == TRAP_DISPERSAL
            || type == TRAP_ZOT
-           || type == TRAP_NET;
+           || type == TRAP_NET
+           || type == TRAP_PLATE;
 }
 
 bool trap_def::is_safe(actor* act) const


### PR DESCRIPTION
Consider pressure plates to be bad for the player because they spawn / uncage monsters that attack the player so that allies avoid stepping on them.