### PR TITLE
Preview attack delay in equipment description

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -108,7 +108,7 @@ public:
     }
     virtual item_def *offhand_weapon() const { return nullptr; }
     virtual random_var attack_delay(const item_def *projectile = nullptr,
-                                    bool rescale = true) const = 0;
+                                    bool rescale = true, bool ignore_temporary = false) const = 0;
     virtual int has_claws(bool allow_tran = true) const = 0;
     virtual item_def *shield() const = 0;
     virtual item_def *slot_item(equipment_type eq,

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1880,31 +1880,33 @@ static string _equipment_switchto_string(const item_def &item)
 
 /**
  * Describe how (un)equipping a piece of equipment might change the player's
- * AC/EV/SH stats. We don't include temporary buffs in this calculation.
+ * AC/EV/SH and attack delay stats. We don't include temporary buffs in this
+ * calculation.
  *
  * @param item    The item whose description we are writing.
  * @param remove  Whether the item is already equipped, and thus whether to
                   show the change solely from unequipping the item.
  * @return        The description.
  */
-static string _equipment_ac_ev_sh_change_description(const item_def &item,
+static string _equipment_status_change_description(const item_def &item,
                                                      bool remove = false)
 {
-    // First, test if there is any AC/EV/SH change at all.
+    // First, test if there is any status change at all.
     const int cur_ac = you.base_ac(100);
     const int cur_ev = you.evasion_scaled(100, true);
     const int cur_sh = player_displayed_shield_class(100, true);
-    int new_ac, new_ev, new_sh;
+    const int cur_ad = player_displayed_attack_delay(true);
+    int new_ac, new_ev, new_sh, new_ad;
 
     if (remove)
-        you.ac_ev_sh_without_specific_item(100, item, &new_ac, &new_ev, &new_sh);
+        you.status_without_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_ad);
     else
-        you.ac_ev_sh_with_specific_item(100, item, &new_ac, &new_ev, &new_sh);
+        you.status_with_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_ad);
 
-    // If we're previewing non-armour and there is no AC/EV/SH change, print no
+    // If we're previewing non-armour and there is no status change, print no
     // extra description at all (since almost all items of these types will
     // change nothing)
-    if (cur_ac == new_ac && cur_ev == new_ev && cur_sh == new_sh
+    if (cur_ac == new_ac && cur_ev == new_ev && cur_sh == new_sh && cur_ad == new_ad
         && (item.base_type != OBJ_ARMOUR || item.sub_type == ARM_ORB))
     {
         return "";
@@ -1953,6 +1955,13 @@ static string _equipment_ac_ev_sh_change_description(const item_def &item,
                        + _describe_point_diff(cur_sh, new_sh) + ".";
     }
 
+    // Only display attack delay line with non-weapons
+    if (item.base_type != OBJ_WEAPONS && cur_ad != new_ad)
+    {
+        description += "\nYour attack delay would "
+                       + _describe_point_diff(cur_ad, new_ad, 10) + ".";
+    }
+
     return description;
 }
 
@@ -1961,14 +1970,14 @@ static bool _you_are_wearing_item(const item_def &item)
     return get_equip_slot(&item) != EQ_NONE;
 }
 
-static string _equipment_ac_ev_sh_change(const item_def &item)
+static string _equipment_status_change(const item_def &item)
 {
     string description;
 
     if (!_you_are_wearing_item(item))
-        description = _equipment_ac_ev_sh_change_description(item);
+        description = _equipment_status_change_description(item);
     else
-        description = _equipment_ac_ev_sh_change_description(item, true);
+        description = _equipment_status_change_description(item, true);
 
     return description;
 }
@@ -2006,7 +2015,7 @@ static string _describe_weapon(const item_def &item, bool verbose, bool monster)
         description += "\n\n" + art_desc;
 
     if (verbose && crawl_state.need_save && you.could_wield(item, true, true))
-        description += _equipment_ac_ev_sh_change(item);
+        description += _equipment_status_change(item);
 
     if (verbose)
     {
@@ -2357,7 +2366,7 @@ static string _describe_armour(const item_def &item, bool verbose, bool monster)
         && can_wear_armour(item, false, true)
         && item_ident(item, ISFLAG_KNOW_PLUSES))
     {
-        description += _equipment_ac_ev_sh_change(item);
+        description += _equipment_status_change(item);
     }
 
     const int DELAY_SCALE = 100;
@@ -2639,7 +2648,7 @@ static string _describe_jewellery(const item_def &item, bool verbose)
                && item.sub_type != RING_EVASION
                && item.sub_type != AMU_REFLECTION))
     {
-        description += _equipment_ac_ev_sh_change(item);
+        description += _equipment_status_change(item);
     }
 
     return description;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -408,7 +408,7 @@ vorpal_damage_type monster::damage_type(int which_attack)
  *                    and the given projectile, in aut.
  */
 random_var monster::attack_delay(const item_def *projectile,
-                                 bool /*rescale*/) const
+                                 bool /*rescale*/, bool /*ignore_temporary*/) const
 {
     const item_def* weap = weapon();
     if (!weap || (projectile && is_throwable(this, *projectile)))

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -274,7 +274,7 @@ public:
     brand_type  damage_brand(int which_attack = -1) override;
     vorpal_damage_type damage_type(int which_attack = -1) override;
     random_var  attack_delay(const item_def *projectile = nullptr,
-                             bool rescale = true) const override;
+                             bool rescale = true, bool ignore_temporary = false) const override;
     int         has_claws(bool allow_tran = true) const override;
 
     int wearing(equipment_type slot, int type) const override;

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -271,15 +271,16 @@ brand_type player::damage_brand(int)
  *
  * @param projectile  The projectile to be thrown, if any.
  * @param rescale         Whether to re-scale the time to account for the fact that
- *                   finesse doesn't stack with haste.
+*                   finesse doesn't stack with haste.
+ * @param ignore_temporary  Whether to ignore temp modifiers like haste.
  * @return           A random_var representing the range of possible values of
  *                   attack delay. It can be casted to an int, in which case
  *                   its value is determined by the appropriate rolls.
  */
-random_var player::attack_delay(const item_def *projectile, bool rescale) const
+random_var player::attack_delay(const item_def *projectile, bool rescale, bool ignore_temporary) const
 {
     const item_def *primary = weapon();
-    const random_var primary_delay = attack_delay_with(projectile, rescale, primary);
+    const random_var primary_delay = attack_delay_with(projectile, rescale, primary, ignore_temporary);
     if (projectile && !is_launcher_ammo(*projectile))
         return primary_delay; // throwing doesn't use the offhand
 
@@ -292,12 +293,12 @@ random_var player::attack_delay(const item_def *projectile, bool rescale) const
     }
 
     // re-use of projectile is very dubious here
-    const random_var offhand_delay = attack_delay_with(projectile, rescale, offhand);
+    const random_var offhand_delay = attack_delay_with(projectile, rescale, offhand, ignore_temporary);
     return div_rand_round(primary_delay + offhand_delay, 2);
 }
 
 random_var player::attack_delay_with(const item_def *projectile, bool rescale,
-                                     const item_def *weap) const
+                                     const item_def *weap, bool ignore_temporary) const
 {
     // The delay for swinging non-weapons and tossing non-missiles.
     random_var attk_delay(15);
@@ -369,7 +370,7 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         attk_delay += div_rand_round(random_var(aevp), DELAY_SCALE);
     }
 
-    if (you.duration[DUR_FINESSE])
+    if (you.duration[DUR_FINESSE] && !ignore_temporary)
     {
         ASSERT(!you.duration[DUR_BERSERK]);
         // Finesse shouldn't stack with Haste, so we make this attack take
@@ -379,8 +380,8 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         attk_delay = div_rand_round(attk_delay, 2);
     }
 
-    return rv::max(div_rand_round(attk_delay * player_speed(), BASELINE_DELAY),
-                   random_var(1));
+    return rv::max(ignore_temporary ? attk_delay : div_rand_round(attk_delay * player_speed(),
+                     BASELINE_DELAY),random_var(1));
 }
 
 // Returns the item in the given equipment slot, nullptr if the slot is empty.

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -9030,7 +9030,7 @@ bool player::allies_forbidden()
 /**
  * Calculate the attack delay value that should be displayed to players.
  * Currently only used for equipment swap preview.
-* 
+ *
  * @param ignore_temporary  Whether to include temporary effects like haste.
                           Currently counts stat drain / heroism skill boosts
                           even if enabled.
@@ -9040,4 +9040,3 @@ int player_displayed_attack_delay(bool ignore_temporary)
 {
     return _delay(you.weapon(), ignore_temporary);
 }
-

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -627,9 +627,9 @@ public:
     brand_type  damage_brand(int which_attack = -1) override;
     vorpal_damage_type damage_type(int which_attack = -1) override;
     random_var  attack_delay(const item_def *projectile = nullptr,
-                             bool rescale = true) const override;
+                             bool rescale = true, bool ignore_temporary = false) const override;
     random_var  attack_delay_with(const item_def *projectile, bool rescale,
-                                  const item_def *weapon) const;
+                                  const item_def *weapon, bool ignore_temporary = false) const;
     int         constriction_damage(constrict_type typ) const override;
 
     int       has_claws(bool allow_tran = true) const override;
@@ -866,11 +866,11 @@ public:
     int adjusted_body_armour_penalty(int scale = 1) const;
     int adjusted_shield_penalty(int scale = 1) const;
 
-    // Calculates total permanent EV/SH if the player was/wasn't wearing a given item
-    void ac_ev_sh_with_specific_item(int scale, const item_def& new_item,
-                                     int *ac, int *ev, int *sh);
-    void ac_ev_sh_without_specific_item(int scale, const item_def& item_to_remove,
-                                        int *ac, int *ev, int *sh);
+    // Calculates total permanent status if the player was/wasn't wearing a given item
+    void status_with_specific_item(int scale, const item_def& new_item,
+                                     int *ac, int *ev, int *sh, int *ad);
+    void status_without_specific_item(int scale, const item_def& item_to_remove,
+                                        int *ac, int *ev, int *sh, int *ad);
 
     bool wearing_light_armour(bool with_skill = false) const;
     int  skill(skill_type skill, int scale = 1, bool real = false,
@@ -1220,3 +1220,5 @@ bool need_expiration_warning(coord_def p = you.pos());
 
 bool player_has_orb();
 bool player_on_orb_run();
+
+int player_displayed_attack_delay(bool ignore_temporary);


### PR DESCRIPTION
Include attack delay when previewing equipment. This is important for rangers especially those who are wearing cursed or ^drain/contam/fragile armor.

Currently wondering if I should add this for damage rating too but I'd like feedback before proceeding with it.

![image](https://github.com/crawl/crawl/assets/146337911/60bd6efe-f756-4df5-8614-2b6987b3ac88)
