### PR TITLE
Improve autoaim behavior and make ranged targeting avoid actors in between

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -2450,9 +2450,9 @@ bool activate_talent(const talent& tal, dist *target)
         args.hitfunc = hitfunc.get();
         args.restricts = testbits(abil.flags, abflag::target) ? DIR_TARGET
                                                               : DIR_NONE;
-        args.mode = TARG_HOSTILE;
+        args.mode = is_targeted ? TARG_HOSTILE : TARG_NONE;
         args.range = range;
-        args.needs_path = !testbits(abil.flags, abflag::target);
+        args.needs_path = testbits(abil.flags, abflag::dir_or_target);
         args.top_prompt = make_stringf("%s: <w>%s</w>",
                                        is_targeted ? "Aiming" : "Activating",
                                        ability_name(abil.ability).c_str());

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -818,7 +818,9 @@ void bolt::apply_beam_conducts()
 void bolt::choose_ray()
 {
     if ((!chose_ray || reflections > 0)
-        && (no_actor_perm_lof || !find_ray(source, target, ray, opc_no_actor))
+        && (no_actor_perm_lof || !(agent() && agent()->is_player()
+            ? find_ray(source, target, ray, opc_shoot_through)
+            : find_ray(source, target, ray, opc_no_actor)))
         && !find_ray(source, target, ray, opc_solid_see)
         // If fire is blocked, at least try a visible path so the
         // error message is better.

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -818,6 +818,7 @@ void bolt::apply_beam_conducts()
 void bolt::choose_ray()
 {
     if ((!chose_ray || reflections > 0)
+        && (no_actor_perm_lof || !find_ray(source, target, ray, opc_no_actor))
         && !find_ray(source, target, ray, opc_solid_see)
         // If fire is blocked, at least try a visible path so the
         // error message is better.

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -7375,10 +7375,15 @@ bool always_shoot_through_monster(const actor *originator, const monster &victim
 // and players can shoot through their demonic guardians.
 bool shoot_through_monster(const bolt& beam, const monster* victim)
 {
-    actor *originator = beam.agent();
+    return shoot_through_monster(beam.agent(), victim);
+}
+
+bool shoot_through_monster(const actor* originator, const monster* victim)
+{
     if (!victim || !originator)
         return false;
-    return god_protects(originator, *victim)
+    // Can't shoot through slimes
+    return (god_protects(originator, *victim) && !have_passive(passive_t::neutral_slimes))
            || (originator->is_player()
                && testbits(victim->flags, MF_DEMONIC_GUARDIAN));
 }

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -128,6 +128,9 @@ struct bolt
     bool   quiet_debug = false;    // Disable any debug spam.
 #endif
 
+    bool   no_actor_perm_lof = false;   // Don't attempt to find a ray
+                                        // without a blocking actor
+    
     // OUTPUT parameters (tracing, ID)
     bool obvious_effect = false; // is this a non-enchantment, or did it already
                                  // show some effect or message? (Otherwise, we'll

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -130,7 +130,7 @@ struct bolt
 
     bool   no_actor_perm_lof = false;   // Don't attempt to find a ray
                                         // without a blocking actor
-    
+
     // OUTPUT parameters (tracing, ID)
     bool obvious_effect = false; // is this a non-enchantment, or did it already
                                  // show some effect or message? (Otherwise, we'll

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -381,6 +381,7 @@ int explosion_noise(int rad);
 
 bool always_shoot_through_monster(const actor *agent, const monster &mon);
 bool shoot_through_monster(const bolt& beam, const monster* victim);
+bool shoot_through_monster(const actor* originator, const monster* victim);
 
 int omnireflect_chance_denom(int SH);
 

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1102,7 +1102,7 @@ bool direction_chooser::find_default_monster_target(coord_def& result) const
     if (mons_target != nullptr
         && _want_target_monster(mons_target, mode, hitfunc)
         && in_range(mons_target->pos())
-        && (!needs_path || _blocked_ray_shoot(mons_target->pos())))
+        && (!needs_path || !_blocked_ray_shoot(mons_target->pos())))
     {
         result = mons_target->pos();
         return true;

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1794,7 +1794,7 @@ void direction_chooser::toggle_beam()
     if (show_beam)
     {
         have_beam = find_ray_priority(you.pos(), target(), beam,
-                             opc_no_actor, opc_solid_see, you.current_vision);
+                             opc_shoot_through, opc_solid_see, you.current_vision);
     }
 }
 
@@ -2321,7 +2321,7 @@ public:
                 // XX code duplication
                 m_dc.have_beam = m_dc.show_beam
                                  && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
-                                    opc_no_actor, opc_solid_see, you.current_vision);
+                                    opc_shoot_through, opc_solid_see, you.current_vision);
                 m_dc.need_text_redraw = true;
                 m_dc.need_viewport_redraw = true;
                 m_dc.need_cursor_redraw = true;
@@ -2377,7 +2377,7 @@ public:
         {
             m_dc.have_beam = m_dc.show_beam
                              && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
-                                opc_no_actor, opc_solid_see, you.current_vision);
+                                opc_shoot_through, opc_solid_see, you.current_vision);
             m_dc.need_text_redraw = true;
             m_dc.need_viewport_redraw = true;
             m_dc.need_cursor_redraw = true;
@@ -2529,7 +2529,7 @@ bool direction_chooser::choose_direction()
     if (show_beam)
     {
         have_beam = find_ray_priority(you.pos(), target(), beam,
-                        opc_no_actor, opc_solid_see, you.current_vision);
+                        opc_shoot_through, opc_solid_see, you.current_vision);
         need_viewport_redraw = have_beam;
     }
     if (hitfunc)

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -2466,6 +2466,12 @@ void direction_chooser::update_validity()
 
 bool direction_chooser::noninteractive()
 {
+    // If whatever target is given to us by autofight is useless,
+    // automatically try to find a better one.
+    const monster* mon = monster_at(moves.target);
+    if (hitfunc && !hitfunc->affects_monster(monster_info(mon)))
+        moves.find_target = true;
+
     // if target is unset, this will find previous or closest target; if
     // target is set this will adjust targeting depending on custom
     // behavior

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -481,6 +481,7 @@ direction_chooser::direction_chooser(dist& moves_,
     show_boring_feats(args.show_boring_feats),
     hitfunc(args.hitfunc),
     default_place(args.default_place),
+    ignore_self(args.ignore_self),
     renderer(*this),
     unrestricted(args.unrestricted),
     force_cancel(false),
@@ -1145,7 +1146,7 @@ bool direction_chooser::find_default_monster_target(coord_def& result) const
         && hitfunc->can_affect_outside_range()
         && (!hitfunc->set_aim(result)
             || hitfunc->is_affected(result) < AFF_YES
-            || hitfunc->is_affected(you.pos()) > AFF_NO))
+            || (!ignore_self && hitfunc->is_affected(you.pos()) > AFF_NO)))
     {
         coord_def old_result;
         if (success)
@@ -1154,6 +1155,9 @@ bool direction_chooser::find_default_monster_target(coord_def& result) const
         {
             for (aff_type allowed_self_aff : { AFF_NO, AFF_MAYBE, AFF_YES })
             {
+                if (ignore_self && allowed_self_aff != AFF_YES)
+                    continue;
+
                 success = _find_square_wrapper(result, 1,
                                        bind(_find_monster_expl,
                                             placeholders::_1, mode,

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1786,8 +1786,8 @@ void direction_chooser::toggle_beam()
 
     if (show_beam)
     {
-        have_beam = find_ray(you.pos(), target(), beam,
-                             opc_solid_see, you.current_vision);
+        have_beam = find_ray_priority(you.pos(), target(), beam,
+                             opc_no_actor, opc_solid_see, you.current_vision);
     }
 }
 
@@ -2313,8 +2313,8 @@ public:
                 m_dc.show_beam = !m_dc.just_looking && m_dc.needs_path;
                 // XX code duplication
                 m_dc.have_beam = m_dc.show_beam
-                                 && find_ray(you.pos(), m_dc.target(), m_dc.beam,
-                                             opc_solid_see, you.current_vision);
+                                 && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
+                                    opc_no_actor, opc_solid_see, you.current_vision);
                 m_dc.need_text_redraw = true;
                 m_dc.need_viewport_redraw = true;
                 m_dc.need_cursor_redraw = true;
@@ -2369,8 +2369,8 @@ public:
         if (old_target != m_dc.target())
         {
             m_dc.have_beam = m_dc.show_beam
-                             && find_ray(you.pos(), m_dc.target(), m_dc.beam,
-                                         opc_solid_see, you.current_vision);
+                             && find_ray_priority(you.pos(), m_dc.target(), m_dc.beam,
+                                opc_no_actor, opc_solid_see, you.current_vision);
             m_dc.need_text_redraw = true;
             m_dc.need_viewport_redraw = true;
             m_dc.need_cursor_redraw = true;
@@ -2517,8 +2517,8 @@ bool direction_chooser::choose_direction()
     // If requested, show the beam on startup.
     if (show_beam)
     {
-        have_beam = find_ray(you.pos(), target(), beam,
-                             opc_solid_see, you.current_vision);
+        have_beam = find_ray_priority(you.pos(), target(), beam,
+                        opc_no_actor, opc_solid_see, you.current_vision);
         need_viewport_redraw = have_beam;
     }
     if (hitfunc)

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1238,7 +1238,7 @@ coord_def direction_chooser::find_default_target() const
                                        hitfunc,
                                        LS_FLIPVH);
     }
-    else if ((mode != TARG_ANY && mode != TARG_FRIEND)
+    else if ((mode != TARG_ANY && mode != TARG_FRIEND && mode != TARG_NONE)
              || self == confirm_prompt_type::cancel)
     {
         success = find_default_monster_target(result);
@@ -2805,6 +2805,8 @@ static bool _want_target_monster(const monster *mon, targ_mode_type mode,
     {
     case TARG_ANY:
         return true;
+    case TARG_NONE:
+        return false;
     case TARG_HOSTILE:
         return mons_attitude(*mon) == ATT_HOSTILE
             || mon->has_ench(ENCH_FRENZIED);
@@ -2840,7 +2842,7 @@ static bool _find_monster(const coord_def& where, targ_mode_type mode,
     }
 
     // Target the player for friendly and general spells.
-    if ((mode == TARG_FRIEND || mode == TARG_ANY) && where == you.pos())
+    if ((mode == TARG_FRIEND || mode == TARG_ANY || mode == TARG_NONE) && where == you.pos())
         return true;
 
     // Don't target out of range

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -84,6 +84,7 @@ struct direction_chooser_args
     bool show_boring_feats;
     desc_filter get_desc_func;
     coord_def default_place;
+    bool ignore_self;
 
     direction_chooser_args() :
         hitfunc(nullptr),
@@ -101,7 +102,8 @@ struct direction_chooser_args
         show_floor_desc(false),
         show_boring_feats(true),
         get_desc_func(nullptr),
-        default_place(0, 0)
+        default_place(0, 0),
+        ignore_self(false)
     { }
 
 };
@@ -268,6 +270,7 @@ private:
     bool show_boring_feats;
     targeter *hitfunc;         // Determine what would be hit.
     coord_def default_place;    // Start somewhere other than you.pos()?
+    bool ignore_self;
 
     // Internal data.
     ray_def beam;               // The (possibly invalid) beam.

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5150,6 +5150,7 @@ bool ru_power_leap()
         args.needs_path = false;
         args.top_prompt = "Aiming: <white>Power Leap</white>";
         args.self = confirm_prompt_type::cancel;
+        args.ignore_self = true;
         const int explosion_size = 1;
         targeter_smite tgt(&you, args.range, explosion_size, explosion_size);
         tgt.obeys_mesmerise = true;
@@ -5782,6 +5783,7 @@ static coord_def _get_transference_target()
     args.needs_path = false;
     args.self = confirm_prompt_type::none;
     args.show_floor_desc = true;
+    args.ignore_self = true;
     args.top_prompt = "Select a target.";
 
     direction(spd, args);

--- a/crawl-ref/source/los.cc
+++ b/crawl-ref/source/los.cc
@@ -652,6 +652,15 @@ bool find_ray(const coord_def& source, const coord_def& target,
     return true;
 }
 
+// Find a ray prioritizing opc_priority over opc
+bool find_ray_priority(const coord_def& source, const coord_def& target,
+              ray_def& ray, const opacity_func& opc_priority, const opacity_func& opc,
+              int range, bool cycle)
+{
+    return find_ray(source, target, ray, opc_priority, range, cycle)
+        || find_ray(source, target, ray, opc, range, cycle);
+}
+
 bool exists_ray(const coord_def& source, const coord_def& target,
                 const opacity_func& opc, int range)
 {

--- a/crawl-ref/source/los.h
+++ b/crawl-ref/source/los.h
@@ -25,6 +25,9 @@ int get_los_radius();
 bool find_ray(const coord_def& source, const coord_def& target,
               ray_def& ray, const opacity_func &opc,
               int range = LOS_MAX_RANGE, bool cycle = false);
+bool find_ray_priority(const coord_def& source, const coord_def& target,
+              ray_def& ray, const opacity_func &opc_priority, const opacity_func &opc,
+              int range = LOS_MAX_RANGE, bool cycle = false);
 bool exists_ray(const coord_def& source, const coord_def& target,
                 const opacity_func &opc, int range = LOS_MAX_RANGE);
 dungeon_feature_type ray_blocker(const coord_def& source, const coord_def& target);

--- a/crawl-ref/source/losparam.cc
+++ b/crawl-ref/source/losparam.cc
@@ -21,6 +21,7 @@ const opacity_immob opc_immob = opacity_immob();
 const opacity_solid opc_solid = opacity_solid();
 const opacity_solid_see opc_solid_see = opacity_solid_see();
 const opacity_no_actor opc_no_actor = opacity_no_actor();
+const opacity_shoot_through opc_shoot_through = opacity_shoot_through();
 const opacity_excl opc_excl = opacity_excl();
 
 opacity_type opacity_default::operator()(const coord_def& p) const
@@ -117,6 +118,15 @@ opacity_type opacity_no_actor::operator()(const coord_def& p) const
         return OPC_OPAQUE;
     else
         return OPC_CLEAR;
+}
+
+opacity_type opacity_shoot_through::operator()(const coord_def& p) const
+{
+    if (feat_is_solid(env.grid(p))
+        || monster_at(p) && !shoot_through_monster(&you, monster_at(p)))
+        return OPC_OPAQUE;
+
+    return OPC_CLEAR;
 }
 
 opacity_type opacity_excl::operator()(const coord_def& p) const

--- a/crawl-ref/source/losparam.cc
+++ b/crawl-ref/source/losparam.cc
@@ -124,7 +124,9 @@ opacity_type opacity_shoot_through::operator()(const coord_def& p) const
 {
     if (feat_is_solid(env.grid(p))
         || monster_at(p) && !shoot_through_monster(&you, monster_at(p)))
+    {
         return OPC_OPAQUE;
+    }
 
     return OPC_CLEAR;
 }

--- a/crawl-ref/source/losparam.h
+++ b/crawl-ref/source/losparam.h
@@ -149,6 +149,17 @@ public:
 };
 extern const opacity_no_actor opc_no_actor;
 
+// Make any actor (as well as solid features) block.
+// Note that the blocking actors are still "visible".
+class opacity_shoot_through : public opacity_func
+{
+public:
+    CLONE(opacity_shoot_through)
+
+    opacity_type operator()(const coord_def& p) const override;
+};
+extern const opacity_shoot_through opc_shoot_through;
+
 // A cell is considered clear unless the player knows it's
 // opaque.
 class opacity_excl : public opacity_func

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -7440,7 +7440,7 @@ static coord_def _choose_throwing_target(const monster &thrower,
         ray_def ray;
         // Unusable landing sites.
         if (!_valid_throw_dest(thrower, victim, *di)
-            || !find_ray(thrower.pos(), *di, ray, opc_solid_see))
+            || !find_ray_priority(thrower.pos(), *di, ray, opc_no_actor, opc_solid_see))
         {
             continue;
         }

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1957,6 +1957,7 @@ spret your_spells(spell_type spell, int powc, bool actual_spell,
     if (use_targeter)
     {
         const targ_mode_type targ =
+              !is_targeted                        ? TARG_NONE :
               testbits(flags, spflag::neutral)    ? TARG_ANY :
               testbits(flags, spflag::helpful)    ? TARG_FRIEND :
               testbits(flags, spflag::obj)        ? TARG_MOVABLE_OBJECT :
@@ -1972,7 +1973,7 @@ spret your_spells(spell_type spell, int powc, bool actual_spell,
         // sure why
         const char *prompt = get_spell_target_prompt(spell);
 
-        const bool needs_path = !testbits(flags, spflag::target)
+        const bool needs_path = testbits(flags, spflag::dir_or_target)
                                 // Apportation must be spflag::target, since a
                                 // shift-direction makes no sense for it, but
                                 // it nevertheless requires line-of-fire.

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2008,6 +2008,16 @@ spret your_spells(spell_type spell, int powc, bool actual_spell,
         args.top_prompt = title;
         args.behaviour = &beh;
 
+        zap_type zap = spell_to_zap(spell);
+        if (zap != NUM_ZAPS)
+        {
+            bolt tempbeam;
+            tempbeam.thrower = KILL_YOU_MISSILE;
+            tempbeam.origin_spell = spell;
+            zappy(zap, 0, false, tempbeam);
+            args.ignore_self = tempbeam.ignores_player();
+        }
+
         // if the spell is useless and we have somehow gotten this far, it's
         // a forced cast. Setting this prevents the direction chooser from
         // looking for selecting a default target (which doesn't factor in

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3007,6 +3007,7 @@ static ai_action::goodness _fire_plasma_beam_at(const actor &agent, int pow,
     beam.draw_delay   = 5;
     beam.foe_ratio    = 80; // default
     beam.is_tracer    = tracer;
+    beam.no_actor_perm_lof = true;
     zappy(ZAP_PLASMA_LIGHTNING, pow, mon, beam);
     beam.fire();
     const ai_action::goodness fire_good = beam.good_to_fire();

--- a/crawl-ref/source/targ-mode-type.h
+++ b/crawl-ref/source/targ-mode-type.h
@@ -8,5 +8,6 @@ enum targ_mode_type
     TARG_HOSTILE,
     TARG_MOVABLE_OBJECT,    // Movable objects only
     TARG_MOBILE_MONSTER,    // Non-stationary monsters
+    TARG_NONE, // Non-targeted 
     TARG_NUM_MODES
 };

--- a/crawl-ref/source/targ-mode-type.h
+++ b/crawl-ref/source/targ-mode-type.h
@@ -8,6 +8,6 @@ enum targ_mode_type
     TARG_HOSTILE,
     TARG_MOVABLE_OBJECT,    // Movable objects only
     TARG_MOBILE_MONSTER,    // Non-stationary monsters
-    TARG_NONE, // Non-targeted 
+    TARG_NONE, // Non-targeted
     TARG_NUM_MODES
 };


### PR DESCRIPTION
(In case you're wondering why this is a new pr, I didn't know renaming a branch would close the pr. Original: #3687)

Don't avoid aiming at self with harmless spells. This is relevant for wand of roots.

When autofiring, don't attempt to hit immune targets. This is relevant for any spell that has immune monsters.

Also attempt to choose a target who isn't blocked by allies / plants / slimes you can't shoot through.

Should possibly put the code for the above inside the autofight lua somehow?

Closes #3232 #1966 #2447

Make most ranged attacks from you and monsters avoid hitting actors on the way to the target. This change is intended to make ranged attacks and spells much less annoying to use when you have firewood / allies / slimes blocking the path by making it choose a slightly different path with the same rules as permissive los.

Previously when this happened, you would either need to reposition or drag your targeting behind your target to get a good path that doesn't hit unwanted targets. This is very annoying as it interrupts tabbing with a prompt/message and forces you to aim manually.

Currently this may cause some odd behavior with piercing beams.

A side effect is that ranged monsters become more dangerous because they are blocked a lot less frequently by their friends now.

TODO: Don't leak invisible monster locations. #3017 would solve this in a more elegant fashion.

Before:
![image](https://github.com/crawl/crawl/assets/146337911/37e645ce-c145-4f01-8d7c-f08fdd4d120a)
After:
![image](https://github.com/crawl/crawl/assets/146337911/d6f4712c-b645-49b8-9e8e-9916491cda81)

Before:
![image](https://github.com/crawl/crawl/assets/146337911/62b04027-43f4-4c76-8a56-6bf42a4cf6ea)
After:
![image](https://github.com/crawl/crawl/assets/146337911/3e837807-3363-48d9-8eb6-78e1a5821c33)
