### PR TITLE
Fix Jiyva attack absorption failing to find a name

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -559,7 +559,7 @@ void zappy(zap_type z_type, int power, bool is_monster, bolt &pbolt)
 #endif
 
     // Fill
-    pbolt.name           = zinfo->name;
+    pbolt.name           = zinfo->name ? zinfo->name : _beam_type_name(zinfo->flavour);
     pbolt.flavour        = zinfo->flavour;
     pbolt.real_flavour   = zinfo->flavour;
     pbolt.colour         = zinfo->colour;

--- a/crawl-ref/source/zap-data.h
+++ b/crawl-ref/source/zap-data.h
@@ -31,7 +31,7 @@ static zap_info _mon_hex_zap(zap_type ztype, beam_type beam,
 {
     return {
         ztype,
-        "",
+        nullptr,
         player_pow_cap,
         nullptr,
         nullptr,


### PR DESCRIPTION
For zap types constructed from hex beams.