### PR TITLE
Teach dogs to stay

### DIFF
--- a/crawl-ref/source/mon-ench.h
+++ b/crawl-ref/source/mon-ench.h
@@ -40,7 +40,8 @@ public:
     void merge_killer(kill_category who, mid_t whos);
     void cap_degree();
 
-    void set_duration(const monster* mons, const mon_enchant *exist);
+    void add_duration(const monster* mons, const mon_enchant *exist);
+    void set_duration(int dur);
 
     bool operator < (const mon_enchant &other) const
     {
@@ -55,9 +56,11 @@ public:
 
     mon_enchant &operator += (const mon_enchant &other);
     mon_enchant operator + (const mon_enchant &other) const;
-    int calc_duration(const monster* mons, const mon_enchant *added) const;
 private:
+    int calc_duration(const monster* mons, const mon_enchant *added) const;
     int modded_speed(const monster* mons, int hdplus) const;
 };
 
 enchant_type name_to_ench(const char *name);
+    
+int calc_abj_duration(const monster* mons, int degree);

--- a/crawl-ref/source/mon-ench.h
+++ b/crawl-ref/source/mon-ench.h
@@ -55,10 +55,9 @@ public:
 
     mon_enchant &operator += (const mon_enchant &other);
     mon_enchant operator + (const mon_enchant &other) const;
-
+    int calc_duration(const monster* mons, const mon_enchant *added) const;
 private:
     int modded_speed(const monster* mons, int hdplus) const;
-    int calc_duration(const monster* mons, const mon_enchant *added) const;
 };
 
 enchant_type name_to_ench(const char *name);

--- a/crawl-ref/source/mon-ench.h
+++ b/crawl-ref/source/mon-ench.h
@@ -62,5 +62,5 @@ private:
 };
 
 enchant_type name_to_ench(const char *name);
-    
+
 int calc_abj_duration(const monster* mons, int degree);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -206,7 +206,8 @@ spret cast_call_canine_familiar(int pow, god_type god, bool fail)
         // Reset duration so the dog doesn't disappear immediately after
         mon_enchant en = old_dog->get_ench(ENCH_ABJ);
         en.degree = abj_dur;
-        en.duration = en.calc_duration(old_dog, &en);
+        en.set_duration(calc_abj_duration(old_dog, abj_dur));
+        old_dog->update_ench(en);
     }
 
     return spret::success;
@@ -1172,7 +1173,7 @@ spret summon_shadow_creatures()
             int x = max(mons->get_experience_level() - 3, 1);
             int d = min(4, 1 + div_rand_round(17, x));
             mon_enchant me = mon_enchant(ENCH_ABJ, d);
-            me.set_duration(mons, &me);
+            me.add_duration(mons, &me);
             mons->update_ench(me);
 
             // Set summon ID, to share summon cap with its band members

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -168,10 +168,11 @@ spret cast_call_canine_familiar(int pow, god_type god, bool fail)
 
     fail_check();
 
+    constexpr int abj_dur = 5;
     // Summon our dog if one isn't already active
     if (!old_dog)
     {
-        mgen_data mg = _pal_data(MONS_INUGAMI, 5, god, SPELL_CALL_CANINE_FAMILIAR);
+        mgen_data mg = _pal_data(MONS_INUGAMI, abj_dur, god, SPELL_CALL_CANINE_FAMILIAR);
 
         monster* dog = create_monster(mg);
         if (!dog)
@@ -201,6 +202,11 @@ spret cast_call_canine_familiar(int pow, god_type god, bool fail)
         old_dog->heal(random_range(5, 9) + div_rand_round(pow, 5));
         old_dog->lose_ench_levels(ENCH_POISON, 1);
         old_dog->add_ench(mon_enchant(ENCH_INSTANT_CLEAVE, 1, &you, 50));
+
+        // Reset duration so the dog doesn't disappear immediately after
+        mon_enchant en = old_dog->get_ench(ENCH_ABJ);
+        en.degree = abj_dur;
+        en.duration = en.calc_duration(old_dog, &en);
     }
 
     return spret::success;


### PR DESCRIPTION
Refresh dog duration every time you cast it to avoid situations where the dog times out immediately after you cast the spell to heal it.