### PR TITLE
Show coglins' offhand weapon in the WebTiles interface

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1250,6 +1250,9 @@ void TilesFramework::_send_player(bool force_full)
     }
     json_close_object(true);
 
+    _update_int(force_full, c.offhand_weapon, (bool) you.offhand_weapon(),
+                "offhand_weapon");
+
     _update_int(force_full, c.quiver_item,
                 (int8_t) you.quiver_action.get()->get_item(), "quiver_item");
 

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -84,6 +84,7 @@ struct player_info
     FixedVector<item_def, ENDOFPACK> inv;
     FixedVector<bool, ENDOFPACK> inv_uselessness;
     FixedVector<int8_t, NUM_EQUIP> equip;
+    bool offhand_weapon;
     int8_t quiver_item;
     string quiver_desc;
     string unarmed_attack;

--- a/crawl-ref/source/webserver/game_data/static/enums.js
+++ b/crawl-ref/source/webserver/game_data/static/enums.js
@@ -58,7 +58,7 @@ define(function () {
     exports.equip.HELMET = val++;
     exports.equip.GLOVES = val++;
     exports.equip.BOOTS = val++;
-    exports.equip.SHIELD = val++;
+    exports.equip.OFFHAND = val++;
     exports.equip.BODY_ARMOUR = val++;
     exports.equip.LEFT_RING = val++;
     exports.equip.RIGHT_RING = val++;

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -175,10 +175,11 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
     }
     player.inventory_item_desc = inventory_item_desc;
 
-    function wielded_weapon()
+    function wielded_weapon(offhand=false)
     {
         var elem;
-        var wielded = player.equip[enums.equip.WEAPON];
+        var wielded = player.equip[offhand ? enums.equip.OFFHAND
+                                           : enums.equip.WEAPON];
         if (wielded == -1)
         {
             elem = $("<span>");
@@ -236,7 +237,10 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         elem.text(player[type]);
         elem.removeClass();
         if (type == "sh" && player.incapacitated()
-            && player.equip[enums.equip.SHIELD] != -1)
+            && player.equip[enums.equip.OFFHAND] != -1)
+            // XXX This really doesn't work properly
+            // Orbs, and coglins with offhand weapons, also trigger this...
+            // Amulets of reflection on the other hand, do not...
             elem.addClass("degenerated_defense");
         else if (player.has_status(defense_boosters[type]))
             elem.addClass("boosted_defense");
@@ -446,6 +450,15 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         $("#stats_weapon_letter").text(
             index_to_letter(player.equip[enums.equip.WEAPON]) + ")");
         $("#stats_weapon").html(wielded_weapon());
+
+        if (player.offhand_weapon) // Coglin dual wielding
+            $("#stats_offhand_weapon_line").show();
+        else
+            $("#stats_offhand_weapon_line").hide();
+
+        $("#stats_offhand_weapon_letter").text(
+            index_to_letter(player.equip[enums.equip.OFFHAND]) + ")");
+        $("#stats_offhand_weapon").html(wielded_weapon(true));
 
         $("#stats_quiver").html(quiver());
     }

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -91,6 +91,9 @@ canvas {
 #game #stats_weapon .corroded_weapon {
     color: #a40000; /* red */
 }
+#game #stats_offhand_weapon .corroded_weapon {
+    color: #a40000; /* red */
+}
 
 .bar span {
     display: inline-block;
@@ -203,6 +206,21 @@ canvas {
 }
 
 #stats_weapon
+{
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: block;
+    overflow: hidden;
+}
+
+#stats_offhand_weapon_letter
+{
+    float: left;
+    display: block;
+    margin-right:0.5em;
+}
+
+#stats_offhand_weapon
 {
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -137,6 +137,12 @@
             ><span id="stats_weapon"></span
           ></span>
         </div>
+        <div id="stats_offhand_weapon_line" style="float: left; width: 100%">
+          <span class="stats_caption" id="stats_offhand_weapon_letter"></span>
+          <span id="stats_offhand_weapon_container"
+            ><span id="stats_offhand_weapon"></span
+          ></span>
+        </div>
         <div id="stats_quiver_line" style="float: left; width: 100%">
           <span class="stats_caption" id="stats_quiver_letter"></span>
           <span id="stats_quiver"></span>


### PR DESCRIPTION
Add a second weapon line for coglins to the WebTiles interface, just below the normal weapon line and above the quiver, which is hidden in all cases where you don't have an offhand weapon equipped.

This works differently from console/offline tiles, but I personally think this is how those formats should work too. (Currently, they have both weapons listed on the same line, which gives each weapon awfully little space for its properties, or in the case of artefacts, even just the name can be too long.)

[Important note: as this code relates to WebTiles I am unable to test it! I'm hoping the checks will reveal any mistakes.]