### PR TITLE
Revamp qaz

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -645,7 +645,7 @@ static vector<ability_def> &_get_ability_list()
 
         // Qazlal
         { ABIL_QAZLAL_UPHEAVAL, "Upheaval",
-            3, 0, generic_cost::range(3, 4), LOS_MAX_RANGE,
+            3, 0, generic_cost::range(2, 3), LOS_MAX_RANGE,
             {fail_basis::invo, 40, 5, 20},
             abflag::none },
         { ABIL_QAZLAL_ELEMENTAL_FORCE, "Elemental Force",

--- a/crawl-ref/source/cloud-type.h
+++ b/crawl-ref/source/cloud-type.h
@@ -45,6 +45,7 @@ enum cloud_type
     CLOUD_DEGENERATION,
     CLOUD_BLASTMOTES,
     CLOUD_ELECTRICITY,
+    CLOUD_ROUGH_DUST,
     NUM_CLOUD_TYPES,
 
     // Random per-square.

--- a/crawl-ref/source/cloud-type.h
+++ b/crawl-ref/source/cloud-type.h
@@ -45,7 +45,7 @@ enum cloud_type
     CLOUD_DEGENERATION,
     CLOUD_BLASTMOTES,
     CLOUD_ELECTRICITY,
-    CLOUD_ROUGH_DUST,
+    CLOUD_SAND_STORM,
     NUM_CLOUD_TYPES,
 
     // Random per-square.

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -321,11 +321,11 @@ static const cloud_data clouds[] = {
       ETC_ELECTRICITY,                                   // colour
       { TILE_CLOUD_ELECTRICITY, CTVARY_RANDOM },        // tile
     },
-    // CLOUD_ROUGH_DUST,
-    { "rough dust",  nullptr,                     // terse, verbose name
+    // CLOUD_SAND_STORM,
+    { "sand storm",  nullptr,                     // terse, verbose name
       ETC_EARTH,                                  // colour
       { TILE_CLOUD_DUST, CTVARY_DUR },            // tile
-      BEAM_NONE,                                  // beam_effect
+      BEAM_FRAG,                                  // beam_effect
       NORMAL_CLOUD_DAM,                           // base, random damage
     },
 };

--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -321,6 +321,13 @@ static const cloud_data clouds[] = {
       ETC_ELECTRICITY,                                   // colour
       { TILE_CLOUD_ELECTRICITY, CTVARY_RANDOM },        // tile
     },
+    // CLOUD_ROUGH_DUST,
+    { "rough dust",  nullptr,                     // terse, verbose name
+      ETC_EARTH,                                  // colour
+      { TILE_CLOUD_DUST, CTVARY_DUR },            // tile
+      BEAM_NONE,                                  // beam_effect
+      NORMAL_CLOUD_DAM,                           // base, random damage
+    },
 };
 COMPILE_CHECK(ARRAYSZ(clouds) == NUM_CLOUD_TYPES);
 

--- a/crawl-ref/source/dat/descript/clouds.txt
+++ b/crawl-ref/source/dat/descript/clouds.txt
@@ -190,3 +190,7 @@ The explosion is concussive, knocking adjacent creatures away.
 sparks cloud
 
 A trail of electric sparks. Atmospheric, but harmless.
+%%%%
+rough dust cloud
+
+A rough clouds of dust. Sharply polished dust are violence hard.

--- a/crawl-ref/source/dat/descript/clouds.txt
+++ b/crawl-ref/source/dat/descript/clouds.txt
@@ -191,6 +191,7 @@ sparks cloud
 
 A trail of electric sparks. Atmospheric, but harmless.
 %%%%
-rough dust cloud
+sand storm cloud
 
-A rough clouds of dust. Sharply polished dust are violence hard.
+A cloud of violently whirling sand. Creatures within will be injured, though its
+damage is sharply reduced by armor.

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -911,7 +911,7 @@ void qazlal_storm_clouds()
         do
         {
             ctype = random_choose(CLOUD_FIRE, CLOUD_COLD, CLOUD_STORM,
-                                  CLOUD_ROUGH_DUST);
+                                  CLOUD_SAND_STORM);
         } while (water && ctype == CLOUD_FIRE);
 
         place_cloud(ctype, candidates[i], random_range(3, 5), &you);

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -911,7 +911,7 @@ void qazlal_storm_clouds()
         do
         {
             ctype = random_choose(CLOUD_FIRE, CLOUD_COLD, CLOUD_STORM,
-                                  CLOUD_DUST);
+                                  CLOUD_ROUGH_DUST);
         } while (water && ctype == CLOUD_FIRE);
 
         place_cloud(ctype, candidates[i], random_range(3, 5), &you);

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -892,7 +892,7 @@ void qazlal_storm_clouds()
     const int count =
         div_rand_round(min((int)you.piety, piety_breakpoint(5))
                        * candidates.size() * you.time_taken,
-                       piety_breakpoint(5) * 7 * BASELINE_DELAY);
+                       piety_breakpoint(5) * 5 * BASELINE_DELAY);
     if (count < 0)
         return;
     shuffle_array(candidates);

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -886,7 +886,7 @@ void qazlal_storm_clouds()
             if (!cell_is_solid(*ai))
                 count++;
 
-        if (count >= 5)
+        if (count >= 3)
             candidates.push_back(*ri);
     }
     const int count =


### PR DESCRIPTION
Qaz is a god with interesting mechanics, but he's been around for a long time without any major changes, so he has some stale parts. I wanted to do this without making any major changes, but to improve things internally that weren't up to date.

 * the dust cloud changes to a sandstorm, dealing frag type damage to enemies.
 * Increases the number of clouds maintained each turn from 7 to 9 (based on piety 160) (i.e., increases the rate at which clouds are generated).
 * I relaxed the generation criteria so that clouds would still not be generated in corridors, but clouds could be generated in ambiguous terrain that would not be considered a corridor.
 * Slightly lowered the cost of Upheaval.