### PR TITLE
Add damage to ability descriptions

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -659,6 +659,14 @@ static beam_type _chaos_beam_flavour(bolt* beam)
     return flavour;
 }
 
+dice_def combustion_breath_damage(int pow, bool allow_random)
+{
+    if (allow_random)
+        return dice_def(3, 3 + div_rand_round(pow * 2, 3));
+    else
+        return dice_def(3, 3 + pow * 2 / 3);
+}
+
 static void _combustion_breath_explode(bolt *parent, coord_def pos)
 {
     bolt beam;
@@ -666,7 +674,7 @@ static void _combustion_breath_explode(bolt *parent, coord_def pos)
     bolt_parent_init(*parent, beam);
     beam.name         = "fiery explosion";
     beam.aux_source   = "combustion breath";
-    beam.damage       = dice_def(3, 3 + div_rand_round(parent->ench_power * 2, 3));
+    beam.damage       = combustion_breath_damage(parent->ench_power);
     beam.colour       = RED;
     beam.flavour      = BEAM_FIRE;
     beam.is_explosion = true;

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -374,6 +374,8 @@ int zap_to_hit(zap_type z_type, int power, bool is_monster);
 dice_def zap_damage(zap_type z_type, int power, bool is_monster, bool random = true);
 colour_t zap_colour(zap_type z_type);
 
+dice_def combustion_breath_damage(int pow, bool allow_random = true);
+
 void zappy(zap_type z_type, int power, bool is_monster, bolt &pbolt);
 void bolt_parent_init(const bolt &parent, bolt &child);
 

--- a/crawl-ref/source/god-abil.h
+++ b/crawl-ref/source/god-abil.h
@@ -11,6 +11,7 @@
 #include "god-type.h"
 #include "item-prop-enum.h" // brand_type
 #include "los-type.h"
+#include "random.h"
 #include "recite-eligibility.h"
 #include "recite-type.h"
 #include "spl-cast.h"
@@ -134,6 +135,8 @@ void lugonu_bend_space();
 
 void cheibriados_time_bend(int pow);
 void cheibriados_temporal_distortion();
+int slouch_damage_formula(int mon_speed = 10, int mon_energy_usage = 10,
+                          int jerk_num = 1, int jerk_denom = 1);
 spret cheibriados_slouch(bool fail);
 void cheibriados_time_step(int pow);
 
@@ -170,6 +173,7 @@ void gozag_deduct_bribe(branch_type br, int amount);
 bool gozag_check_bribe_branch(bool quiet = false);
 bool gozag_bribe_branch();
 
+dice_def qazlal_upheaval_damage(bool allow_random = true);
 spret qazlal_upheaval(coord_def target, bool quiet = false,
                            bool fail = false, dist *player_target=nullptr);
 vector<coord_def> find_elemental_targets();
@@ -188,11 +192,14 @@ void ru_reset_sacrifice_timer(bool clear_timer = false,
 bool will_ru_retaliate();
 void ru_do_retribution(monster* mons, int damage);
 void ru_draw_out_power();
+dice_def ru_power_leap_damage(bool allow_random = true);
 bool ru_power_leap();
 int cell_has_valid_target(coord_def where);
+int apocalypse_die_size(bool allow_random = true);
 bool ru_apocalypse();
 string ru_sacrifice_vector(ability_type sac);
 
+dice_def uskayaw_stomp_extra_damage(bool allow_random = true);
 bool uskayaw_stomp();
 bool uskayaw_line_pass();
 spret uskayaw_grand_finale(bool fail);

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -2270,9 +2270,11 @@ bool trainable_skills(bool check_all)
     return false;
 }
 
-int skill_bump(skill_type skill, int scale)
+// Currently only for ABIL_BEOGH_SMITING, see ability.cc::_beogh_smiting_power
+int skill_bump(skill_type skill, int scale, bool allow_random)
 {
-    const int sk = you.skill_rdiv(skill, scale);
+    const int sk = allow_random ? you.skill_rdiv(skill, scale)
+                                : you.skill(skill, scale);
     return sk + min(sk, 3 * scale);
 }
 

--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -129,7 +129,7 @@ int elemental_preference(spell_type spell, int scale = 1);
 
 void skill_menu(int flag = 0, int exp = 0);
 void dump_skills(string &text);
-int skill_bump(skill_type skill, int scale = 1);
+int skill_bump(skill_type skill, int scale = 1, bool allow_random = true);
 void fixup_skills();
 
 bool target_met(skill_type sk);

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -37,6 +37,7 @@
 #include "mon-tentacle.h"
 #include "notes.h" // NOTE_DREAMSHARD
 #include "player.h"
+#include "random.h"
 #include "religion.h"
 #include "spl-clouds.h"
 #include "spl-util.h"
@@ -937,6 +938,16 @@ spret cast_tomb(int pow, actor* victim, int source, bool fail)
     return spret::success;
 }
 
+// Add 6 to this. Damage ranges from 9-12 (avg 10) at 0 invo,
+// to 9-78 at 27 invo.
+dice_def beogh_smiting_dice(int pow, bool allow_random)
+{
+    if (allow_random)
+        return dice_def(3, div_rand_round(pow, 8));
+    else
+        return dice_def(3, pow / 8);
+}
+
 spret cast_smiting(int pow, monster* mons, bool fail)
 {
     if (mons == nullptr)
@@ -971,7 +982,7 @@ spret cast_smiting(int pow, monster* mons, bool fail)
     set_attack_conducts(conducts, *mons, you.can_see(*mons));
 
     // damage at 0 Invo ranges from 9-12 (avg 10), to 9-72 (avg 40) at 27.
-    int damage = 6 + roll_dice(3, div_rand_round(pow, 8));
+    int damage = 6 + beogh_smiting_dice(pow).roll();
 
     mprf("You smite %s%s",
          mons->name(DESC_THE).c_str(),

--- a/crawl-ref/source/spl-goditem.h
+++ b/crawl-ref/source/spl-goditem.h
@@ -3,6 +3,7 @@
 #include "cleansing-flame-source-type.h"
 #include "enchant-type.h"
 #include "holy-word-source-type.h"
+#include "random.h"
 #include "spell-type.h"
 #include "spl-cast.h"
 #include "tag-version.h"
@@ -83,6 +84,7 @@ int detect_creatures(int pow, bool telepathic = false);
 
 spret cast_tomb(int pow, actor* victim, int source, bool fail);
 
+dice_def beogh_smiting_dice(int pow, bool allow_random = true);
 spret cast_smiting(int pow, monster* mons, bool fail);
 
 string unpacifiable_reason(const monster& mon);


### PR DESCRIPTION
For the following abilities:
* all breath weapons
* storm form: blinkbolt
* demonspawn: hurl damnation
* orb of Dispater: evoke damnation
* Beogh: smiting
* Cheibriados: slouch (damage against a normal-speed monster)
* Ignis: foxfire swarm
* Jiyva: oozemancy
* Qazlal: upheaval, disaster area
* Ru: power leap, apocalypse
* Uskayaw: stomp, grand finale
* Yredelemnul: hurl torchlight
* the Shining One: cleansing flame

Makhleb's minor destruction and major destruction are too random to describe in a simple formula in any meaningful way, except potentially we could make it state the average damage in the future. The same applies to Nemelex' cards.

In many cases, abstract the power and damage formulae for these abilities to ensure the output damage is the same as listed. This often involves listing the rounded-down damage formula, where abilities use div_rand_round on skill/XL.

There are many more abilities that it would be nice to quantify in their descriptions based on the player's current skill but don't fit neatly into the damage category. It would also be nice to list ability noise, and damage at max skill, but since abilities often don't have a clearly defined power-cap and noise is often dealt with elsewhere, this is challenging.

Nonetheless, this will hopefully be useful in allowing players to see how their skill/XL affects damage output. Players should remember that there are usually no actual breakpoints and that the damage listed has usually been rounded down.

I have checked that this all seems to be working correctly.