### PR TITLE
Fix three subtle issues with stats panel weapon display in WebTiles

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1386,7 +1386,7 @@ void TilesFramework::_send_item(item_def& current, const item_def& next,
     changed |= _update_string(force_full, current.inscription,
                               next.inscription, "inscription", false);
 
-    // TODO: props?
+    // TODO: props? Hopefully covered by the name check below
 
     changed |= (current.special != next.special);
 
@@ -1394,19 +1394,20 @@ void TilesFramework::_send_item(item_def& current, const item_def& next,
     changed |= _update_int(force_full, current_uselessness,
                            is_useless_item(next, true), "useless");
 
+    // This hopefully includes all other properties we care about...
+    const string current_name = current.name(DESC_A, true, false, true);
+    const string next_name = next.name(DESC_A, true, false, true);
+    changed |= (current_name != next_name);
+
     if (changed && defined)
     {
-        string name = next.name(DESC_A, true, false, true);
-        if (force_full || current.name(DESC_A, true, false, true) != name
-            || xp_evoker_changed)
-        {
-            json_write_string("name", name);
-        }
+        if (force_full || current_name != next_name || xp_evoker_changed)
+            json_write_string("name", next_name);
 
         // -1 in this field means don't show. *note*: showing in the action
         // panel has undefined behavior for item types that don't have a
         // quiver::action implementation...
-        json_write_int("action_panel_order", _useful_consumable_order(next, name));
+        json_write_int("action_panel_order", _useful_consumable_order(next, next_name));
         json_write_string("qty_field", _qty_field_name(next));
 
         const string prefix = item_prefix(next);

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1058,6 +1058,28 @@ player_info::player_info()
     position = coord_def(-1, -1);
 }
 
+// XXX duplicates code for local tiles/console in output.cc.
+// This is necessary to allow customisation of the displayed weapon
+// on the stats display (top-right corner) correctly using the
+// menu_colour += stats:<colour>:<weapon> option.
+static uint8_t _weapon_colour(bool offhand = false)
+{
+    if (you.corrosion_amount())
+        return RED;
+
+    const item_def* weapon = offhand ? you.offhand_weapon() : you.weapon();
+
+    if (!weapon)
+        return get_form()->uc_colour;
+
+    const string prefix = item_prefix(*weapon);
+    const int prefcol = menu_colour(weapon->name(DESC_INVENTORY),
+                                    prefix, "stats", false);
+    if (prefcol != -1)
+        return prefcol;
+    return LIGHTGREY;
+}
+
 /**
  * Send the player properties to the webserver. Any player properties that
  * must be available to the WebTiles client must be sent here through an
@@ -1250,8 +1272,13 @@ void TilesFramework::_send_player(bool force_full)
     }
     json_close_object(true);
 
+    _update_int(force_full, c.weapon_colour, _weapon_colour(), "weapon_colour");
+
     _update_int(force_full, c.offhand_weapon, (bool) you.offhand_weapon(),
                 "offhand_weapon");
+
+    _update_int(force_full, c.offhand_weapon_colour, _weapon_colour(true),
+                "offhand_weapon_colour");
 
     _update_int(force_full, c.quiver_item,
                 (int8_t) you.quiver_action.get()->get_item(), "quiver_item");
@@ -1262,8 +1289,7 @@ void TilesFramework::_send_player(bool force_full)
 
     _update_string(force_full, c.unarmed_attack,
                    you.unarmed_attack_name(), "unarmed_attack");
-    _update_int(force_full, c.unarmed_attack_colour,
-                (uint8_t) get_form()->uc_colour, "unarmed_attack_colour");
+
     _update_int(force_full, c.quiver_available,
                     you.quiver_action.get()->is_valid()
                                 && you.quiver_action.get()->is_enabled(),

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -84,11 +84,12 @@ struct player_info
     FixedVector<item_def, ENDOFPACK> inv;
     FixedVector<bool, ENDOFPACK> inv_uselessness;
     FixedVector<int8_t, NUM_EQUIP> equip;
+    uint8_t weapon_colour;
     bool offhand_weapon;
+    uint8_t offhand_weapon_colour;
     int8_t quiver_item;
     string quiver_desc;
     string unarmed_attack;
-    uint8_t unarmed_attack_colour;
     bool quiver_available;
 };
 

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -161,7 +161,7 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
     }
     player.index_to_letter = index_to_letter;
 
-    function inventory_item_desc(index, parens=false)
+    function inventory_item_desc(index, parens=false, colour=-1)
     {
         var item = player.inv[index];
         var elem = $("<span>");
@@ -169,8 +169,12 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
             elem.text("(" + item.name + ")");
         else
             elem.text(item.name);
-        if (item.col != -1 && item.col != null)
+
+        if (colour != -1)
+            elem.addClass("fg" + colour);
+        else if (item.col != -1 && item.col != null)
             elem.addClass("fg" + item.col);
+
         return elem;
     }
     player.inventory_item_desc = inventory_item_desc;
@@ -180,17 +184,17 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         var elem;
         var wielded = player.equip[offhand ? enums.equip.OFFHAND
                                            : enums.equip.WEAPON];
+        var colour = offhand ? player.offhand_weapon_colour
+                             : player.weapon_colour;
+
         if (wielded == -1)
         {
             elem = $("<span>");
             elem.text(player.unarmed_attack);
-            elem.addClass("fg" + player.unarmed_attack_colour);
+            elem.addClass("fg" + colour);
         }
         else
-            elem = inventory_item_desc(wielded);
-
-        if (player.has_status("corroded"))
-            elem.addClass("corroded_weapon");
+            elem = inventory_item_desc(wielded, false, colour);
 
         return elem;
     }

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -88,12 +88,6 @@ canvas {
 .boosted_defense {
     color: #729fcf; /* lightblue */
 }
-#game #stats_weapon .corroded_weapon {
-    color: #a40000; /* red */
-}
-#game #stats_offhand_weapon .corroded_weapon {
-    color: #a40000; /* red */
-}
 
 .bar span {
     display: inline-block;


### PR DESCRIPTION
Having fiddled with my menu_colour settings extensively in my rc file I have noticed that the weapon display in the stats panel (top-right corner) does not work as expected.

Three related issues exist:
  1. Due to these colours being set on the JS side, which only has access to the inventory set of menu_colour options, the setting `menu_colour += stats:<colour>:<weapon description>` was essentially useless, as the inventory setting was always used.
  2. The item colour for the stats-weapon panel was not updated when a weapon was equipped, meaning it only displayed in the correct (equipped, typically lightgreen) colour when reloading the game, or when equipping the weapon directly from the ground.
  3. Most concerningly, this also applied to when a weapon was adjusted with the `=i` command if the slots of two weapons with the same base type and enchantment were swapped. For randart weapons this could mean the weapon display could become completely decoupled from reality.

Since the expansion of quiver functionality, these issues have not existed for the quiver slot, as the entire quiver description including the colour is computed on the C++ side. Hence (particularly with launchers) you could end up with the same item in your weapon and quiver slots written in different colours.

This PR fixes both issues by passing the weapon colour(s) directly from the C++ side as a separate piece of information. Incorporate the old unarmed_attack_colour information into this. The separate checks for corrosion on the JS side have also been removed, as they are handled by this new information.

[Note: I've done this by duplicating some code. It would be nice to unduplicate it, I just have absolutely no idea which file the resulting `weapon_colour` function should go in, so if anyone has any suggestions, I'd be happy to improve that. Alternatively, it's probably not a very big deal to leave it as it is here.

Tested on a local WebTiles server.] 

