### PR TITLE
Improve the A screen for forms

### DIFF
--- a/crawl-ref/source/form-data.h
+++ b/crawl-ref/source/form-data.h
@@ -58,7 +58,10 @@ struct form_entry
 
     // pairs of the form {terse_description, full_description} for display in
     // `A` and `%`. Either can be empty.
+    // Resistances (except rTorm), flight, amphibious, no grasping,
+    // melded equipment are added separately in mutation.cc:_get_form_badmuts
     vector<pair<string,string>> fakemuts;
+    vector<pair<string,string>> badmuts;
 };
 
 static const form_entry formdata[] =
@@ -73,6 +76,7 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "", 0, "", "", "", "",
+    {},
     {}
 },
 #if TAG_MAJOR_VERSION == 34
@@ -88,7 +92,8 @@ static const form_entry formdata[] =
     "hiss", -4, "front pincers", "", "crawl onto", "flesh",
     { {"venomous fangs", "You have venomous fangs."},
       {"", "You are tiny and dextrous."} // short-form "tiny" is automatically added
-    }
+    },
+    { {"poison vulnerability", "You are susceptible to poisons. (rPois-)"}}
 },
 #endif
 {
@@ -101,6 +106,7 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, RED, "", { "hit", "slash", "slice", "shred" },
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "", 0, "", "", "", "",
+    {},
     {}
 },
 {
@@ -113,9 +119,10 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_FORBID, true, true,
     "", 0, "", "", "place yourself before", "stone",
-    { { "slow and powerful", "Your actions are slow, but your melee attacks are powerful." },
+    { { "powerful", "Your melee attacks are powerful." },
       { "torment resistance 1", "You are resistant to unholy torment." } // same as MUT_TORMENT_RESISTANCE
-    }
+    }, // rElec, rN+, poison immunity are added separately
+    { { "slow", "All of your actions are slow." } }
 },
 {
     transformation::serpent, MONS_ANACONDA, "Serpent", "snake-form", "snake",
@@ -127,7 +134,9 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", { "hit", "lash", "body-slam", "crush" },
     FC_DEFAULT, FC_ENABLE, FC_ENABLE, false, true,
     "hiss", -2, "", "", "coil in front of", "flesh",
-    { { "constrict", "You have a powerful constriction melee attack."} }
+    { { "constrict", "You have a powerful constriction melee attack."} },
+    // cold-blooded and amphibious are added separately
+    {}
 },
 
 {
@@ -142,7 +151,8 @@ static const form_entry formdata[] =
     "roar", 6, "foreclaw", "", "bow your head before", "flesh",
     { { "dragon claw", "You have a powerful clawing attack." },
       { "dragon scales", "Your giant scaled body is strong and resilient, but less evasive." },
-    }
+    }, // resistances, breath, flying added separately
+    {}
 },
 
 {
@@ -155,10 +165,11 @@ static const form_entry formdata[] =
     SPWPN_DRAINING, MAGENTA, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_FORBID, true, true,
     "", 0, "", "", "", "bone",
-    { { "vile attack", "Your melee and unarmed attacks drain, slow and weaken victims."},
-      { "torment immunity", "You are immune to unholy pain and torment."},
-      { "no potions", "<lightred>You cannot drink.</lightred>" },
-    }
+    { { "vile attack", "Your melee attacks drain, slow and weaken victims." },
+      { "siphon essence", "You can torment nearby foes to heal from their wounds." },
+      { "torment immunity", "You are immune to unholy pain and torment." },
+    }, // rC+, rN+++, poison immunity added separately
+    { { "no potions", "You cannot drink." } }
 },
 
 {
@@ -171,8 +182,11 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "Teeth", ANIMAL_VERBS,
     FC_ENABLE, FC_FORBID, FC_ENABLE, false, true,
     "squeak", -8, "foreclaw", "", "perch on", "flesh",
-    {
-      {"", "You are tiny and dextrous."} // short-form "tiny" is automatically added
+    { { "extremely fast", "You cover ground extremely quickly." },
+      { "", "You are tiny, dextrous, and very evasive." } // short-form "tiny" is automatically added
+    },
+    { { "weak attacks", "Your unarmed attacks are very weak." },
+      { "no casting", "You cannot cast spells." },
     }
 },
 
@@ -186,7 +200,10 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "Teeth", ANIMAL_VERBS,
     FC_DEFAULT, FC_FORBID, FC_ENABLE, false, true,
     "squeal", 0, "front trotter", "trotter", "bow your head before", "flesh",
-    {} // XX UC penalty?
+    { { "very fast", "You cover ground very quickly." } },
+    { { "weak attacks", "Your unarmed attacks are very weak." },
+      { "no casting", "You cannot cast spells." },
+    }
 },
 
 #if TAG_MAJOR_VERSION == 34
@@ -200,6 +217,7 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "", 0, "", "", "", "",
+    {},
     {}
 },
 #endif
@@ -214,10 +232,14 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, BROWN, "Branches", { "hit", "smack", "pummel", "thrash" },
     FC_FORBID, FC_FORBID, FC_FORBID, false, true,
     "creak", 0, "branch", "root", "sway towards", "wood",
-    {
-        { "stationary", "Your roots penetrate the ground, keeping you stationary." },
-        { "stasis", "You cannot be teleported."},
-        { "torment immunity", "You are immune to unholy pain and torment."},
+    { { "resilient", "Your bark is very hard, but your evasion is minimal." },
+      { "branches", "Your unarmed attacks smack enemies forcefully with your branches." },
+      { "torment immunity", "You are immune to unholy torment." },
+    }, // rPois added separately
+    // Technically these can have marginal benefits in some situations
+    // but they're mostly bad so let's mark them as bad.
+    { { "stationary", "Your roots penetrate the ground, keeping you stationary." },
+      { "-Tele", "You cannot be teleported." },
     }
 },
 
@@ -232,7 +254,8 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "Teeth", ANIMAL_VERBS,
     FC_DEFAULT, FC_FORBID, FC_ENABLE, false, true,
     "squeak", -8, "front leg", "", "curl into a sanctuary of spikes before", "flesh",
-    {}
+    {},
+    { { "no casting", "You cannot cast spells." }, }
 },
 #endif
 
@@ -249,9 +272,12 @@ static const form_entry formdata[] =
                                                  "engulf", "engulf" },
     FC_ENABLE, FC_FORBID, FC_FORBID, false, true,
     "whoosh", -8, "misty tendril", "strand", "swirl around", "vapour",
-    {
-        {"insubstantial", "Your tiny insubstantial body is highly resistant to most damage types." },
-    }
+    { { "", "You are tiny and evasive." },
+      { "insubstantial", "You are insubstantial and cannot be petrified, ensnared, or set on fire." },
+      { "torment immunity", "You are immune to unholy pain and torment." },
+      { "highly resistant", "You are highly resistant to most damage types. (rF++, rC++, rN+++, rElec, rCorr)" },
+    },
+    { { "no casting", "You cannot cast spells." }, }
 },
 
 #if TAG_MAJOR_VERSION == 34
@@ -265,7 +291,9 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_FORBID, FC_FORBID, false, true,
     "", 0, "", "", "", "",
-    {}
+    {},
+    { { "no casting", "You cannot cast spells." },
+    }
 },
 #endif
 
@@ -273,16 +301,17 @@ static const form_entry formdata[] =
     transformation::fungus, MONS_WANDERING_MUSHROOM, "Fungus", "fungus-form", "fungus",
     "a sentient fungus.",
     0, 0, NUM_TALISMANS,
-    EQF_PHYSICAL, MR_RES_POISON | mrd(MR_RES_NEG, 3),
+    EQF_PHYSICAL, MR_RES_POISON,
     BAD_DURATION, 0, 0, SIZE_TINY, 10,
     FormScaling().Base(12), false, FormScaling().Base(9).XLBased(),
     SPWPN_CONFUSE, BROWN, "Spores", FormAttackVerbs("release spores at"),
     FC_DEFAULT, FC_FORBID, FC_FORBID, false, true,
     "sporulate", -8, "hypha", "", "release spores on", "flesh",
-    {
-        {"", "You are tiny and evasive." },
-        {"melee confuse", "Your melee attack releases spores that confuse breathing creatures."},
-        {"terrified", "<lightred>You become terrified and freeze when enemies are visible.</lightred>"} // XX coloring is really hacky here
+    { { "", "You are tiny and evasive." },
+      { "spores", "Your melee attacks release spores that confuse breathing creatures." },
+    }, // rPois, no grasping added separately
+    { { "terrified", "You become terrified and freeze when enemies are visible." },
+      { "no casting", "You cannot cast spells." },
     }
 },
 
@@ -297,12 +326,14 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, MAGENTA, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_FORBID, FC_FORBID, true, true,
     "", 0, "", "", "", "shadow",
-    {
-        {"shadow resist", "You are immune to unholy torment and to willpower attacks."},
-        {"half damage", "Damage taken is halved, but you are drained when taking damage."},
-        {"", "Your attacks are insubstantial and do half damage."}, // XX mark as badmut
-        {"bleed smoke", "You bleed smoke when taking damage."},
-        {"invisible", "You are invisible."},
+    { { "half damage", "Damage taken is halved, but you are drained when taking damage."},
+      { "bleed smoke", "You bleed smoke when taking damage." },
+      { "invisible", "You are invisible." },
+      { "unshakeable will", "Your willpower is unshakeable." },
+      { "torment immunity", "You are immune to unholy pain and torment."},
+    },
+    { { "weak attacks", "Your attacks do half damage." },
+      { "weak spells", "Your spells are much less powerful." }, // two de-enhancers
     }
 },
 
@@ -319,7 +350,8 @@ static const form_entry formdata[] =
     "roar", 4, "foreclaw", "", "bow your heads before", "flesh",
     { { "fast swimmer", "You swim very quickly." },
       { "devour", "You can devour living enemies to heal." }
-    }
+    },
+    {}
 },
 #endif
 
@@ -333,10 +365,12 @@ static const form_entry formdata[] =
     SPWPN_ELECTROCUTION, LIGHTCYAN, "", { "hit", "buffet", "batter", "blast" },
     FC_ENABLE, FC_DEFAULT, FC_FORBID, false, true,
     "bellow", 0, "", "", "place yourself before", "air",
-    { { "cleaving", "Your electrical attacks strike out in all directions at once." },
-      { "", "You are incredibly evasive." },
-      { "insubstantial", "Your insubstantial body is immune to petrification, constriction, and being set on fire"}
-    }
+    { { "electrical cleaving", "Your electrical attacks strike out in all directions at once." },
+      { "evasive", "You are incredibly evasive." },
+      { "blinkbolt", "You can turn into living lightning." },
+      { "insubstantial", "You are insubstantial and cannot be petrified, ensnared, or set on fire." },
+    }, // rElec added separately
+    {}
 },
 
 {
@@ -349,7 +383,8 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, LIGHTGREY, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "", 0, "", "", "", "",
-    { }
+    {}, // slaying bonus added separately
+    {}
 },
 
 {
@@ -362,7 +397,10 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, GREEN, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "shout twice", 0, "", "", "", "",
-    { { "devouring maw", "Your midsection houses a second, enormous mouth." },}
+    { { "devouring maw", "Your midsection houses a second, enormous mouth." },
+      { "", "You can devour living enemies to heal." }
+    },
+    {}
 },
 
 {
@@ -375,8 +413,8 @@ static const form_entry formdata[] =
     SPWPN_NORMAL, CYAN, "", DEFAULT_VERBS,
     FC_DEFAULT, FC_DEFAULT, FC_DEFAULT, true, false,
     "", 0, "", "", "", "",
-    { { "glow", "You glow with magical radiation, making you easy to see and hit." },
-      { "contaminating", "Foes you strike become dangerously contaminated with magical radiation." } }
+    { { "contaminating", "Foes you strike become dangerously contaminated with magical radiation." }, },
+    { { "glow", "You glow with magical radiation, making you easy to see and hit." } }
 },
 
 };

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1631,10 +1631,10 @@ bool player_kiku_res_torment()
 }
 
 // If temp is set to false, temporary sources or resistance won't be counted.
-int player_res_poison(bool allow_random, bool temp, bool items)
+int player_res_poison(bool allow_random, bool temp, bool items, bool forms)
 {
-    const int form_rp = cur_form(temp)->res_pois();
-    if (you.is_nonliving(temp)
+    const int form_rp = forms ? cur_form(temp)->res_pois() : 0;
+    if (you.is_nonliving(temp, forms)
         || you.is_lifeless_undead(temp)
         || form_rp == 3
         || items && player_equip_unrand(UNRAND_OLGREB)

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1056,7 +1056,7 @@ int player_res_sticky_flame();
 int player_res_steam(bool allow_random = true, bool temp = true,
                      bool items = true);
 int player_res_poison(bool allow_random = true, bool temp = true,
-                      bool items = true);
+                      bool items = true, bool forms = true);
 int player_willpower(bool temp = true);
 
 int player_shield_class(int scale = 1, bool random = true,

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -132,7 +132,7 @@ Form::Form(const form_entry &fe)
       can_fly(fe.can_fly), can_swim(fe.can_swim),
       uc_brand(fe.uc_brand), uc_attack(fe.uc_attack),
       prayer_action(fe.prayer_action), equivalent_mons(fe.equivalent_mons),
-      hp_mod(fe.hp_mod), fakemuts(fe.fakemuts)
+      hp_mod(fe.hp_mod), fakemuts(fe.fakemuts), badmuts(fe.badmuts)
 { }
 
 Form::Form(transformation tran)
@@ -538,6 +538,14 @@ vector<string> Form::get_fakemuts(bool terse) const
 {
     vector<string> result;
     for (const auto &p : fakemuts)
+        result.push_back(terse ? p.first : p.second);
+    return result;
+}
+
+vector<string> Form::get_bad_fakemuts(bool terse) const
+{
+    vector<string> result;
+    for (const auto &p : badmuts)
         result.push_back(terse ? p.first : p.second);
     return result;
 }

--- a/crawl-ref/source/transform.h
+++ b/crawl-ref/source/transform.h
@@ -182,6 +182,7 @@ public:
     string melding_description() const;
 
     virtual vector<string> get_fakemuts(bool terse) const;
+    virtual vector<string> get_bad_fakemuts(bool terse) const;
 
 public:
     /// Status light ("Foo"); "" for none
@@ -292,6 +293,7 @@ private:
     const int hp_mod;
 
     vector<pair<string,string>> fakemuts;
+    vector<pair<string,string>> badmuts;
 };
 const Form* get_form(transformation form = you.form);
 const Form* cur_form(bool temp);


### PR DESCRIPTION
For the longest time (likely forever), forms' innate resistances have not been displayed on the A screen with the rest of the form properties, except for poison immunity and torment resistance (which are weirdly specific exceptions). This PR changes that. Resistances will only be displayed where the player doesn't have a (non-suppressed) mutation superseding them.

Add the blinkbolt and siphon essence abilities, clarify shadow form's spellcasting penalty, add descriptions of bad forms' offensive and defensive stats, clarify wisp form's "highly resistant" fakemut, add serpent form's cold-bloodedness, split statue form's slowness and melee bonus, display blade hands' body armour AC penalty, tone down the wording on alive Vp's regen ("accelerated" sounds faster than "unusually fast" to me, even though the effect is 1/4 of "unusually fast").

Add a new `badmuts` field to form-data.h, so that all of the red- coloured "bad" fakemuts can be displayed on A together, and to remove hacky and inconsistent <lightred> tags in form-data.h. Reclassify some existing fakemuts as bad (e.g. tree stationary, statue slow, flux glow).

Fix bugs with amphibiousness not displaying in permanent forms and poison immunity displaying as an innate fakemut instead of a form fakemut for some forms, which were caused by the addition of permanent forms in 0.31.

I haven't touched the A! "form properties" screen at all with this PR. That screen is in a troubled place, in that it's really "talisman properties" and copies the talisman description, it doesn't display if you didn't enter a form via a talisman, and it's rather obscure (I imagine many players have never noticed it...) This is on my list of things to look at in a different PR.

A few pictures below show some of the changes.

| Form | Before | After |
| ---- | ------ | ----- |
| Serpent | ![image](https://github.com/crawl/crawl/assets/37064413/eabe0768-d495-4060-b90b-68a82e07b594) | ![image](https://github.com/crawl/crawl/assets/37064413/8e04c5f7-8ab6-41f2-a7fe-8d4a6504fb91) |
| Statue | ![image](https://github.com/crawl/crawl/assets/37064413/5401009f-6804-4634-983e-622e19da6c1e) | ![image](https://github.com/crawl/crawl/assets/37064413/a0697211-acc2-4736-b06a-8dd218db81d7) |
| Storm | ![image](https://github.com/crawl/crawl/assets/37064413/f8ae63bc-4c46-47f5-8b14-90d1733fbb4f) | ![image](https://github.com/crawl/crawl/assets/37064413/52fa7950-4a9f-4945-a1ce-b9a27a720908) |
| Tree | ![image](https://github.com/crawl/crawl/assets/37064413/1190abb1-6e3a-438e-aa6a-45f910fdca4f)| ![image](https://github.com/crawl/crawl/assets/37064413/6043728f-5ff6-4744-b4c5-902231b73d93) | 
| Bat | ![image](https://github.com/crawl/crawl/assets/37064413/09600a82-4e52-4416-9512-968affc7d9b8) | ![image](https://github.com/crawl/crawl/assets/37064413/90146c74-1477-49fd-8fc8-70791ff44638) |
| Shadow | ![image](https://github.com/crawl/crawl/assets/37064413/2448a23e-d54e-4d19-a627-7dd35b565f76) | ![image](https://github.com/crawl/crawl/assets/37064413/e72afa93-d150-43cf-ad24-d5b953f4f7c6) |