### PR TITLE
Fix red draconians in dragon form having two breath abilities

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3907,6 +3907,7 @@ bool player_has_ability(ability_type abil, bool include_unusable)
     case ABIL_BREATHE_FIRE:
         // red draconian handled before the switch
         return you.form == transformation::dragon
+               && you.species != SP_RED_DRACONIAN
                && species::dragon_form(you.species) == MONS_FIRE_DRAGON;
     case ABIL_BLINKBOLT:
         return you.form == transformation::storm;


### PR DESCRIPTION
Prevent them from having the usual Breathe Fire. Now they just get their innate breath.