### PR TITLE
Allow demigod monks

### DIFF
--- a/crawl-ref/source/ng-restr.cc
+++ b/crawl-ref/source/ng-restr.cc
@@ -32,8 +32,7 @@ static bool _banned_combination(job_type job, species_type species)
     if (species::mutation_level(species, MUT_FORLORN)
         && (job == JOB_BERSERKER
             || job == JOB_CHAOS_KNIGHT
-            || job == JOB_CINDER_ACOLYTE
-            || job == JOB_MONK))
+            || job == JOB_CINDER_ACOLYTE))
     {
         return true;
     }

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1402,7 +1402,7 @@ static void _redraw_title()
     if (you_worship(GOD_NO_GOD))
     {
         if (you.char_class == JOB_MONK
-            && !you.has_mutation(MUT_FORLORN) // XX is this necessary?
+            && !you.has_mutation(MUT_FORLORN)
             && !had_gods())
         {
             if (small_layout)


### PR DESCRIPTION
This reverts commit df79c29.

Demigod monks were banned way back in 0.14 after the piety bonus was added and monks were allowed to use weapons, as they were strictly inferior to fighter, gladiator, skald, warper, and later reaver, without being suitably distinct.

Now, monks start with an orb of light and a potion of ambrosia to help them on their way. They also start with high dex, compared to every other background with a melee weapon choice. They feel unique enough even without the 2* piety bonus. Thus, let's allow demigods to be monks again.

[Also, the image of a demigod beginning as a monk worshipping itself and reflecting on its own divine ancestry seems perfectly acceptable.]