### PR TITLE
Don't show MPRegen line on % screen for djinn

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2529,17 +2529,20 @@ static vector<formatted_string> _get_overview_resistances(
     out += chop_string("HPRegen", cwidth);
     out += make_stringf("%d.%02d/turn\n", regen/100, regen%100);
 
-    out += chop_string("MPRegen", cwidth);
+    if (!you.has_mutation(MUT_HP_CASTING))
+    {
+        out += chop_string("MPRegen", cwidth);
 #if TAG_MAJOR_VERSION == 34
-    const bool etheric = player_equip_unrand(UNRAND_ETHERIC_CAGE);
-    const int mp_regen = player_mp_regen() //round up
-                         + (etheric ? 50 : 0); // on average
-    out += make_stringf("%d.%02d/turn%s\n", mp_regen / 100, mp_regen % 100,
-                        etheric ? "*" : "");
+        const bool etheric = player_equip_unrand(UNRAND_ETHERIC_CAGE);
+        const int mp_regen = player_mp_regen() //round up
+                            + (etheric ? 50 : 0); // on average
+        out += make_stringf("%d.%02d/turn%s\n", mp_regen / 100, mp_regen % 100,
+                            etheric ? "*" : "");
 #else
-    const int mp_regen = player_mp_regen(); // round up
-    out += make_stringf("%d.%02d/turn\n", mp_regen / 100, mp_regen % 100);
+        const int mp_regen = player_mp_regen(); // round up
+        out += make_stringf("%d.%02d/turn\n", mp_regen / 100, mp_regen % 100);
 #endif
+    }
 
     cols.add_formatted(0, out, false);
 


### PR DESCRIPTION
Self-explanatory. I can't think of anywhere else this might be displayed, but if there is anywhere else, it should of course be removed from there as well.