### PR TITLE
Fix wanderer evoker starts from allowing duplicate evokers

### DIFF
--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -1636,16 +1636,9 @@ misc_item_type get_misc_item_type(int force_type, bool exclude)
     return NUM_MISCELLANY;
 }
 
-static void _generate_misc_item(item_def& item, int force_type, int item_level)
+// May also be called when a wanderer gets assigned a misc evoker at start
+void handle_generated_misc(misc_item_type typ)
 {
-    const auto typ = get_misc_item_type(force_type);
-    if (typ == NUM_MISCELLANY)
-    {
-        item.base_type = OBJ_WANDS;
-        generate_wand_item(item, OBJ_RANDOM, item_level);
-        return;
-    }
-    item.sub_type = typ;
     switch (typ)
     {
     case MISC_SACK_OF_SPIDERS:
@@ -1661,6 +1654,19 @@ static void _generate_misc_item(item_def& item, int force_type, int item_level)
     default:
         break;
     }
+}
+
+static void _generate_misc_item(item_def& item, int force_type, int item_level)
+{
+    const auto typ = get_misc_item_type(force_type);
+    if (typ == NUM_MISCELLANY)
+    {
+        item.base_type = OBJ_WANDS;
+        generate_wand_item(item, OBJ_RANDOM, item_level);
+        return;
+    }
+    item.sub_type = typ;
+    handle_generated_misc(typ);
 }
 
 /**

--- a/crawl-ref/source/makeitem.h
+++ b/crawl-ref/source/makeitem.h
@@ -25,6 +25,7 @@ void item_colour(item_def &item);
 jewellery_type get_random_ring_type();
 jewellery_type get_random_amulet_type();
 misc_item_type get_misc_item_type(int force_type, bool exclude = true);
+void handle_generated_misc(misc_item_type typ);
 void item_set_appearance(item_def &item);
 
 bool is_weapon_brand_ok(int type, int brand, bool strict);

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -181,6 +181,9 @@ item_def* newgame_make_item(object_class_type base,
     if (item.base_type == OBJ_MISSILES)
         _autopickup_ammo(static_cast<missile_type>(item.sub_type));
 
+    if (item.base_type == OBJ_MISCELLANY)
+        handle_generated_misc(static_cast<misc_item_type>(item.sub_type));
+
     origin_set_startequip(item);
     if (item.base_type == OBJ_WEAPONS && you.species == SP_COGLIN)
         name_weapon(item);


### PR DESCRIPTION
Previously, if your wanderer rolled a misc evoker, you could still get the same misc evoker generate in your game. Since they're meant to essentially be unrands, fix this.

[Sidenote: misc evokers are generally pretty unbalanced for starting equipment. The lightning rod in particular is insanely strong, with 4 charges of (2+)d15 unavoidable lightning damage. Some rebalancing may be desirable in future.]