### PR TITLE
Reuse monster_iterator::advance in operator++

### DIFF
--- a/crawl-ref/source/act-iter.cc
+++ b/crawl-ref/source/act-iter.cc
@@ -188,9 +188,7 @@ monster* monster_iterator::operator->() const
 
 monster_iterator& monster_iterator::operator++()
 {
-    while (++i < MAX_MONSTERS)
-        if (env.mons[i].alive())
-            break;
+    advance();
     return *this;
 }
 


### PR DESCRIPTION
Their implementations were only different in syntax, and we have already done this for actor_near_iterator and monster_near_iterator.