### PR TITLE
Fix a few things about wanderer

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -265,12 +265,18 @@ void reassess_starting_skills()
         you.skill_points[sk] = you.skills[sk] ?
             skill_exp_needed(you.skills[sk], sk, SP_HUMAN) + 1 : 0;
 
+        item_def* current_armour = you.slot_item(EQ_BODY_ARMOUR);
+
+        // No one who can't wear mundane heavy armour should start with
+        // the Armour skill -- D:1 dragon armour is too unlikely.
+        // However, specifically except the special case of Sp/Tr/On
+        // wanderers starting with acid dragon scales.
         if (sk == SK_DODGING && you.skills[SK_ARMOUR]
             && (is_useless_skill(SK_ARMOUR)
-                || you_can_wear(EQ_BODY_ARMOUR) != true))
+                || you_can_wear(EQ_BODY_ARMOUR) != true)
+            && !(current_armour
+                 && current_armour->sub_type == ARM_ACID_DRAGON_ARMOUR))
         {
-            // No one who can't wear mundane heavy armour should start with
-            // the Armour skill -- D:1 dragon armour is too unlikely.
             you.skill_points[sk] += skill_exp_needed(you.skills[SK_ARMOUR],
                 SK_ARMOUR, SP_HUMAN) + 1;
             you.skills[SK_ARMOUR] = 0;


### PR DESCRIPTION
  - Troll, oni and spriggan wanderers now actually get armour when they roll armour skill (acid dragon scales for good quality, otherwise an aux slot) as originally intended. They'll also get armour skill if they start with acid dragon scales.
  - Ghoul wanderers can now get potions of attraction like every other species
  - Formicid wanderers can now start with a quarterstaff or a ranged weapon and a shield
  - Starting wands of warping now get 2-4 charges like iceblast/roots instead of getting 15

Also, to incentivise using starting unarmed combat skill when wanderers get it, make wanderers that start with unarmed skill not get the default club/dagger if they weren't assigned another weapon.

This is courtesy of me generating hundreds of wanderers for testing their stats, and a couple of other changes I intend to put in separate PRs (namely: reducing the strength of staves skill, as +0 quarterstaves are too good for "decent" quality, some adjustments to throwing skill, and adjustments to starting stats).