### PR TITLE
Add abandoned chaos spawn temple overflow vault.

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -4784,6 +4784,43 @@ xxc..cdc..cxx
       @
 ENDMAP
 
+NAME:    dolorous_overflow_abandoned_chaos_spawn_temple
+TAGS:    temple_overflow_3 temple_overflow_xom
+TAGS:    temple_overflow_makhleb temple_overflow_nemelex_xobeh
+TAGS:    no_item_gen no_monster_gen no_trap_gen
+SHUFFLE: DEF
+KFEAT:   D = altar_xom
+KFEAT:   E = altar_makhleb
+KFEAT:   F = altar_nemelex_xobeh
+NSUBST:  G = 2:g / *:G
+NSUBST:  H = 1:+ / *:b
+NSUBST:  . = 1:i / *:.
+KPROP:   1 = no_tele_into
+MONS:    chaos spawn
+KMONS:   g = pile of debris
+KITEM:   i = any damaged weapon ego:chaos ident:all
+COLOUR:  b = lightred
+TILE:    b = dngn_crystal_lightred
+TILE:    G = dngn_scintillating_statue
+: set_feature_name("crystal_wall", "wall of orange crystal")
+: set_feature_name("granite_statue", "scintillating statue")
+MAP
+   bbHbb
+ bbbb.bbbb
+bbb.....bbb
+H....G....H
+b.........b
+b..D...E..b
+b...mmm...b
+H.G.m1m.G.H
+b...mmm...b
+b....F....b
+b.........b
+H....G....H
+bbb.....bbb
+ bbbb.bbbb
+   bbHbb
+ENDMAP
 
 ### Variable overflow altars ##################################################
 

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -928,6 +928,10 @@ The damp floor
 The floor. It remains forever damp, perhaps due to the humidity or the constant
 flow of clouds.
 %%%%
+A wall of orange crystal
+
+<A crystal wall>
+%%%%
 A wall of white crystal
 
 A wall made from low-grade crystal with an opalescent gleam.


### PR DESCRIPTION
This features altars to all three chaotic gods (now that Nemelex is considered chaotic), a walled-off chaos spawn (cf. the walled-off angel in a Zin overflow vault), a damaged chaos weapon for flavour, and chaotic decor such as (cosmetic) orange crystal walls.