### PR TITLE
fix corrosion chances for high degree corrodes

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7211,7 +7211,7 @@ bool player::corrode_equipment(const char* corrosion_source, int degree)
         if (!x_chance_in_y(prev_corr, prev_corr + 28))
         {
             props[CORROSION_KEY].get_int() += res_corr() ? 2 : 4;
-            prev_corr++;
+            prev_corr = props[CORROSION_KEY].get_int();
             did_corrode = true;
         }
 


### PR DESCRIPTION
High degree corrodes currently compute the odds of avoiding the second corrode as if corrosion is 1 higher instead of 4 higher.

Likely broken in 7d2b172

not likely relevant since only ever applies to wu jian wrath