### PR TITLE
Add Zin vs. Nemelex temple overflow vault.

### DIFF
--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -8880,3 +8880,57 @@ VISUAL:@The_monster@'s armour gleams in the torchlight.
 w:1
 VISUAL:@The_monster@, chosen of Okawaru, glows resplendent with favour.
 %%%%
+#################################
+# Monsters who worship Nemelex Xobeh
+#################################
+goblin sharper
+
+VISUAL:@The_monster@ fiddles with @possessive@ portable altar.
+
+VISUAL:@The_monster@ shuffles one of @possessive@ decks.
+
+VISUAL:@The_monster@ fans some cards from one of @possessive@ decks.
+
+VISUAL:@The_monster@'s deck briefly glows with a rainbow of weird colours.
+
+# Kenny Rogers, "The Gambler"
+@The_monster@ chants, "Know when to hold 'em, know when to fold 'em..."
+
+@The_monster@ praises @possessive_God@.
+
+@The_monster@ grins. "So many cards! Brought to you by @my_God@!"
+
+@The_monster@ draws Degeneration. "So many ways to mutate things!"
+
+@The_monster@ draws Wild Magic. "So many ways magic can go wrong!"
+
+@The_monster@ draws Exile. "The Abyss is a horrible place!"
+
+@The_monster@ draws the Tomb. "I don't want to be sealed in with no windows!"
+
+@The_monster@ draws the Dance. "Hope the weapon's aim is true!"
+
+@The_monster@ draws the Pentagram. "Hope the demon is friendly!"
+
+@The_monster@ fumbles a card and drops it. "Whoops!"
+
+w:1
+@The_monster@ draws @_misplaced_card_@. "Wait, this doesn't belong here!"
+%%%%
+_misplaced_card_
+
+the Ace of Spades
+
+the Old Maid
+
+# Tarot
+the Hanged Man
+
+# Tarot via the Simpsons
+the Happy Squirrel
+
+# Uno
+Wild Draw Four
+
+# Nemelex's old Deck of Oddities
+Xom

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -4331,6 +4331,33 @@ xxxXXX+CCCxxx
     x.@.x
 ENDMAP
 
+NAME:   dolorous_temple_overflow_order_and_chaos_3
+TAGS:   temple_overflow_2 temple_overflow_nemelex_xobeh temple_overflow_zin
+TAGS:   no_item_gen no_monster_gen no_trap_gen transparent decor
+KPROP:  12 = no_tele_into
+MONS:   generate_awake goblin god:nemelex_xobeh name:sharper n_suf n_des n_noc
+MONS:   generate_awake angel god:zin dbname:zin_angel
+KFEAT:  A = altar_nemelex_xobeh
+KFEAT:  B = altar_zin
+KFEAT:  _ = floor
+TILE:   b = dngn_crystal_lightmagenta
+FTILE:  _ = floor_limestone
+COLOUR: b = lightmagenta
+COLOUR: _ = brown
+: set_feature_name("crystal_wall", "wall of pink crystal")
+: interest_check(_G)
+MAP
+ ....bbbb+vvvv....
+..bbbb..._...vvvv..
+.bb....U._.T....vv.
+.bmm....._.....mmv.
+.b1m..A.._..B..m2v.
+.bmm....._.....mmv.
+.bb....U._.T....vv.
+..bbbb..._...vvvv..
+ ....bbbb+vvvv....
+ENDMAP
+
 NAME:    grunt_temple_overflow_magic_moments
 TAGS:    temple_overflow_3 temple_overflow_kikubaaqudgha
 TAGS:    temple_overflow_sif_muna temple_overflow_vehumet

--- a/crawl-ref/source/dat/descript/features.txt
+++ b/crawl-ref/source/dat/descript/features.txt
@@ -932,6 +932,10 @@ A wall of orange crystal
 
 <A crystal wall>
 %%%%
+A wall of pink crystal
+
+<A crystal wall>
+%%%%
 A wall of white crystal
 
 A wall made from low-grade crystal with an opalescent gleam.

--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -1468,6 +1468,11 @@ A short, impatient and unfriendly humanoid. Goblins first appeared only a few
 years ago, but are now remarkably numerous. Sadly, no number of raucous goblin
 parties will put them in a welcoming mood toward adventurers.
 %%%%
+goblin sharper
+
+A goblin newly converted to Nemelex Xobeh. It's still learning about all the
+cards, and, thankfully, isn't inclined to use them against you.
+%%%%
 golden dragon
 
 A great winged dragon covered in shining golden scales. Legends say that its


### PR DESCRIPTION
To help integrate Nemelex vault-wise as a chaotic god, since there are Zin/Xom vaults and Zin/Makhleb vaults.

This has (cosmetic) pink crystal walls, a talking Zin angel, and a talking goblin sharper worshipping Nemelex (only dialogue, no abilities). Note that the latter's dialogue provides minor spoilers as to what some cards do.