### PR TITLE
Show weapons, monster weapon brand/magical staff/ranged/throwing damage properly in x-v

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -5442,23 +5442,6 @@ static string _monster_attacks_description(const monster_info& mi)
     return result.str();
 }
 
-static string _monster_missiles_description(const monster_info& mi)
-{
-    item_def *missile = mi.inv[MSLOT_MISSILE].get();
-    if (!missile)
-        return "";
-
-    string desc;
-    desc += uppercase_first(mi.pronoun(PRONOUN_SUBJECTIVE));
-    desc += mi.pronoun_plurality() ? " are quivering " : " is quivering ";
-    if (missile->is_type(OBJ_MISSILES, MI_THROWING_NET))
-        desc += missile->name(DESC_A, false, false, true, false);
-    else
-        desc += pluralise(missile->name(DESC_PLAIN, false, false, true, false));
-    desc += ".\n";
-    return desc;
-}
-
 #define SPELL_LIST_BEGIN "[SPELL_LIST_BEGIN]"
 #define SPELL_LIST_END "[SPELL_LIST_END]"
 
@@ -6250,7 +6233,6 @@ static string _monster_stat_description(const monster_info& mi, bool mark_spells
     if (mon_explodes_on_death(mi.type))
         _desc_mon_death_explosion(result, mi);
 
-    result << _monster_missiles_description(mi);
     result << _monster_habitat_description(mi);
     result << _monster_spells_description(mi, mark_spells);
 

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -709,6 +709,9 @@ monster_info::monster_info(const monster* m, int milev)
     else if (m->is_actual_spellcaster())
         props[ACTUAL_SPELLCASTER_KEY] = true;
 
+    if (m->has_spell_of_type(spschool::necromancy))
+        props[NECROMANCER_KEY] = true;
+
     // assumes spell hd modifying effects are always public
     const int spellhd = m->spell_hd();
     if (spellhd != hd)

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -14,6 +14,7 @@ using std::vector;
 #define CLOUD_IMMUNE_MB_KEY "cloud_immune"
 #define PRIEST_KEY "priest"
 #define ACTUAL_SPELLCASTER_KEY "actual_spellcaster"
+#define NECROMANCER_KEY "necromancer"
 
 enum monster_info_flags
 {
@@ -436,6 +437,11 @@ struct monster_info : public monster_info_base
     bool is_priest() const
     {
         return props.exists(PRIEST_KEY);
+    }
+
+    bool has_necromancy_spell() const
+    {
+        return props.exists(NECROMANCER_KEY);
     }
 
     bool fellow_slime() const;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4063,6 +4063,7 @@ int monster::skill(skill_type sk, int scale, bool /*real*/, bool /*temp*/) const
     case SK_NECROMANCY:
         return (has_spell_of_type(spschool::necromancy)) ? hd : hd/2;
 
+    case SK_CONJURATIONS:
     case SK_ALCHEMY:
     case SK_FIRE_MAGIC:
     case SK_ICE_MAGIC:


### PR DESCRIPTION
**Summary (see individual commits for details):**
In the x-v screen for monsters
* Add terse weapon descriptions for monsters using weapons in the Attacks column of the attacks table
* Show weapon brand max damage for most relevant brands in the Max Damage column of the attacks table, indicating clearly the bonus damage from the brand
* Show magical staff bonus damage in the Max Damage column in the same way
* Make the attack table's columns have flexible width, so that weapons, brand damage etc don't get cut off unless line length would otherwise exceed the 80 character maximum
* Show the max damage of AF_DRAIN
* Clarify AF_PURE_FIRE
* Fix an off-by-one error in x-v for all calculations involving monster weapons
* Let monsters use staves of conjuration
* Include monster slaying equipment in the damage in the Max Damage column
* Display ranged weapon damage as "Shoot" instead of "Hit" in the attack table
* Include archer bonus damage in the main damage number in the Max Damage column of the attack table, and include Nessos's special effect in the Bonus column; remove the corresponding special text notes
* Include throwing in the attack table, showing monster throwing damage properly for the first time
* Remove the now-redundant "It is quivering ..." text from x-v.

**Further todo list**
* Work out which damage bonuses do or don't apply to ranged/throwing and describe this correctly

**Some examples:**
| Monster | Before | After |
| ---- | ---- | ---- |
| tengu reaver | ![image](https://github.com/crawl/crawl/assets/37064413/a723262f-f799-4302-9b37-cf605e9e7856) | ![image](https://github.com/crawl/crawl/assets/37064413/6c26715c-b0d0-4b68-91c9-bacf56f3af5d) |
| two-headed ogre |  ![image](https://github.com/crawl/crawl/assets/37064413/31c6172e-2653-44b6-b3e4-69e3e971d527)| ![image](https://github.com/crawl/crawl/assets/37064413/5295a0bd-09b5-435c-9e22-2556b7520d20) |
| Sonja | ![image](https://github.com/crawl/crawl/assets/37064413/c3e63283-cbf8-41ab-abcf-8a08beb60ac6) | ![image](https://github.com/crawl/crawl/assets/37064413/fe71987c-7968-422c-ad01-6c3516ff60cc) |
| Nessos |  ![image](https://github.com/crawl/crawl/assets/37064413/24cf8b96-ad4a-44a9-a01e-57cc94445bc1) | ![image](https://github.com/crawl/crawl/assets/37064413/7b28d9b8-eba2-47f7-b3b8-dd2caeed7ce1) |

