### PR TITLE
Fix formicids able to shaft while in non-mutaion-preserving forms

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7962,6 +7962,13 @@ bool player::do_shaft()
 
 bool player::can_do_shaft_ability(bool quiet) const
 {
+    if (!form_keeps_mutations())
+    {
+        if (!quiet)
+            mpr("You can't shaft yourself in current form.");
+        return false;
+    }
+
     if (attribute[ATTR_HELD])
     {
         if (!quiet)


### PR DESCRIPTION
Previously, if formicid character was in a form that disables mutations, ability menu would remove both Dig and Shaft self, but the latter was still possible by using ability quiver. Now this workaround is removed.

fixes #3776