### PR TITLE
Break system packages (Fix MacOS build?)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,8 +337,17 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install pkg-config libpng
+      # To fix an error running new version of pip3 in virtualised environments.
+      # > You may restore the old behavior of pip by passing
+      # > the '--break-system-packages' flag to pip, or by adding
+      # > 'break-system-packages = true' to your pip.conf file. The latter
+      # > will permanently disable this error.
+      # > If you disable this error, we STRONGLY recommend that you additionally
+      # > pass the '--user' flag to pip, or set 'user = true' in your pip.conf
+      # > file. Failure to do this can result in a broken Homebrew installation.
+      # https://peps.python.org/pep-0668/
       - name: Install pyyaml
-        run: pip3 install pyyaml
+        run: pip3 install pyyaml --break-system-packages --user
       - name: diagnostic
         run: |
           echo $PATH


### PR DESCRIPTION
Just seeing if this works but I had the same error in WSL and --break-system-packages just forces the "old" behaviour of pip install, so it's worth a try