### PR TITLE
Fix a message for items giving magic regeneration.

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1091,19 +1091,10 @@ static void _handle_regen_item_equip(const item_def& item)
         return;
     }
 
-    bool activate = false;
-    if (regen_hp && you.hp == you.hp_max
-        && (!regen_mp || you.magic_points == you.max_magic_points))
-    {
-        activate = true;
-    }
-    else if (regen_mp && you.magic_points == you.max_magic_points
-             && (!regen_hp || you.hp == you.hp_max))
-    {
-        activate = true;
-    }
+    bool low_mp = regen_mp && you.magic_points < you.max_magic_points;
+    bool low_hp = regen_hp && you.hp < you.hp_max;
 
-    if (activate)
+    if (!low_mp && !low_hp)
     {
         mprf("The %s throb%s to your%s body.", item_name.c_str(),
              plural ? " as they attune themselves" : "s as it attunes itself",
@@ -1113,8 +1104,7 @@ static void _handle_regen_item_equip(const item_def& item)
     }
 
     mprf("The %s cannot attune %s to your%s body.", item_name.c_str(),
-         plural ? "themselves" : "itself",
-         you.hp < you.hp_max ? " injured" : " exhausted");
+         plural ? "themselves" : "itself", low_hp ? " injured" : " exhausted");
 
     you.activated.set(eq_slot, false);
     return;


### PR DESCRIPTION
Before, the game referred to "your injured body" if you tried to wear an amulet of magic regeneration when your health and magic were both below their maxima.

The message for that item no longer mentions your physical injuries.