### PR TITLE
Mark transporter destinations as known on entering a fully_mapped level

### DIFF
--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -2037,6 +2037,14 @@ static void _fixup_transmuters()
 }
 #endif
 
+/// Learn where each transporter on the current level goes.
+static void _learn_transporters()
+{
+    auto li = travel_cache.find_level_info(level_id::current());
+    for (auto &tp : li->get_transporters())
+        li->update_transporter(tp.position, get_transporter_dest(tp.position));
+}
+
 /**
  * Load the current level.
  *
@@ -2381,7 +2389,10 @@ bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,
         you.attribute[ATTR_ABYSS_ENTOURAGE] = 0;
         gozag_count_level_gold();
         if (branches[you.where_are_you].branch_flags & brflag::fully_map)
+        {
             magic_mapping(GDM, 100, true, false, false, true, false);
+            _learn_transporters();
+        }
     }
 
 

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4839,7 +4839,8 @@ void explore_discoveries::found_feature(const coord_def &pos,
     }
     else if (feat == DNGN_TRANSPORTER)
     {
-        seen_tracked_feature(feat);
+        if (is_unknown_transporter(pos))
+            seen_tracked_feature(feat);
         if (ES_transporter)
         {
             for (orth_adjacent_iterator ai(pos); ai; ++ai)


### PR DESCRIPTION
This lets the player use travel commands to reach an altar in hellmonk_temple_divided_pantheon (where there are transporters between the stairs and most of the altars) without first visiting the transporters manually.

brflag::fully_map now also prevents transporters from appearing in the level overview. On other levels this happens until the transporter is used.