### PR TITLE
Remind monsters how to open doors

### DIFF
--- a/crawl-ref/source/mon-pathfind.cc
+++ b/crawl-ref/source/mon-pathfind.cc
@@ -432,11 +432,6 @@ bool monster_pathfind::traversable(const coord_def& p)
 // its preferred habit and capability of flight or opening doors.
 bool monster_pathfind::mons_traversable(const coord_def& p)
 {
-    if (cell_is_runed(p))
-        return false;
-    if (!mons->is_habitable(p))
-        return false;
-
     return mons_can_traverse(*mons, p, traverse_in_sight);
 }
 


### PR DESCRIPTION
A fairly old bug seemingly introduced in 323ad4e. Monsters would open doors under the simplest circumstances (standing right next to them, and/or with an otherwise unobstructed view to the player) but as soon as waypoint pathfinding kicked in, the is_habitable check was happening too early and they never got to check if they were able to traverse the door. Closed doors are not considered habitable (probably since 323ad4e).

These checks were introduced to solve an issue with clinging but were not purged in 53d2a09 when clinging was removed. Both checks were duplicated in mons_can_traverse but in the correct sequence to also account for doors.