### PR TITLE
Fix Hellfire Mortar power cap (#3820)

### DIFF
--- a/crawl-ref/source/zap-data.h
+++ b/crawl-ref/source/zap-data.h
@@ -652,7 +652,7 @@ _mon_hex_zap(ZAP_TUKIMAS_DANCE, BEAM_TUKIMAS_DANCE, 100),
 {
     ZAP_HELLFIRE_MORTAR_DIG,
     "",
-    100,
+    200,
     nullptr,
     nullptr,
     nullptr,


### PR DESCRIPTION
Spells implicitly take the lesser of their defined power cap and their corresponding zap's defined power cap when deciding what their real power cap should be. Since Hellfire Mortar is linked to ZAP_HELLFIRE_MORTAR_DIG, which had a cap of 100, Hellfire Mortar erroneously also had a cap of 100. Since it doesn't appear that power actually does anything for this zap, just raise the zap's cap to 200.