### PR TITLE
Smooth out stat modifiers for weapon/unarmed damage

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1494,9 +1494,8 @@ int stat_modify_damage(int damage, skill_type wpn_skill, bool using_weapon)
     const bool use_str = weapon_uses_strength(wpn_skill, using_weapon);
     const int attr = use_str ? you.strength() : you.dex();
     damage *= max(1.0, 75 + 2.5 * attr);
-    damage /= 100;
 
-    return damage;
+    return div_rand_round(damage, 100);
 }
 
 int apply_weapon_skill(int damage, skill_type wpn_skill, bool random)


### PR DESCRIPTION
Currently, Crawl uses integer division when applying stat modifiers to a weapon's base damage, which results in sharp breakpoints: using a dagger, the player does exactly the same amount of damage with Dex 29 as they do with Dex 20. This is counterintuitive, misleading, and inconsistent with Crawl's design philosophy. This implements the simple fix of replacing integer division with random rounding.