### PR TITLE
Make various small improvements to ability summary on ^ screen

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -773,9 +773,9 @@ static formatted_string _describe_god_powers(god_type which_god)
             desc.textcolour(god_colour(which_god));
 
         if (piety >= piety_breakpoint(5))
-            desc.cprintf("Orcs frequently recognize you as Beogh's chosen one.\n");
+            desc.cprintf("Orcs frequently recognise you as Beogh's chosen one.\n");
         else
-            desc.cprintf("Orcs sometimes recognize you as one of their own.\n");
+            desc.cprintf("Orcs sometimes recognise you as one of their own.\n");
     }
     break;
 

--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -766,13 +766,16 @@ static formatted_string _describe_god_powers(god_type which_god)
     {
     case GOD_BEOGH:
     {
-        if (piety >= piety_breakpoint(5))
-            desc.cprintf("Orcs frequently recognise you as Beogh's chosen one.\n");
-        else if (piety >= piety_breakpoint(1))
-            desc.cprintf("Orcs sometimes recognise you as one of their own.\n");
+        have_any = true;
+        if (have_passive(passive_t::convert_orcs))
+            desc.textcolour(DARKGREY);
+        else
+            desc.textcolour(god_colour(which_god));
 
-        if (piety >= piety_breakpoint(2))
-            desc.cprintf("Your orcish followers are sometimes invigorated when you deal damage.\n");
+        if (piety >= piety_breakpoint(5))
+            desc.cprintf("Orcs frequently recognize you as Beogh's chosen one.\n");
+        else
+            desc.cprintf("Orcs sometimes recognize you as one of their own.\n");
     }
     break;
 
@@ -803,17 +806,6 @@ static formatted_string _describe_god_powers(god_type which_god)
         have_any = true;
         desc.cprintf("%s prevents you from stabbing unaware foes.\n",
                 uppercase_first(god_name(which_god)).c_str());
-        if (piety < piety_breakpoint(1))
-            desc.textcolour(DARKGREY);
-        else
-            desc.textcolour(god_colour(which_god));
-        const char *how =
-            (piety >= piety_breakpoint(5)) ? "completely" :
-            (piety >= piety_breakpoint(3)) ? "mostly" :
-                                             "partially";
-
-        desc.cprintf("%s %s shields you from negative energy.\n",
-                uppercase_first(god_name(which_god)).c_str(), how);
 
         const int halo_size = you_worship(which_god) ? you.halo_radius() : -1;
         if (halo_size < 0)
@@ -825,16 +817,25 @@ static formatted_string _describe_god_powers(god_type which_god)
                 halo_size > 5 ? " large" :
                 halo_size > 3 ? "" :
                                 " small");
+
+        if (piety < piety_breakpoint(1))
+            desc.textcolour(DARKGREY);
+        else
+            desc.textcolour(god_colour(which_god));
+        const char *how =
+            (piety >= piety_breakpoint(5)) ? "completely" :
+            (piety >= piety_breakpoint(3)) ? "mostly" :
+                                             "partially";
+        desc.cprintf("%s %s shields you from negative energy.\n",
+                uppercase_first(god_name(which_god)).c_str(), how);
         break;
     }
 
-    case GOD_FEDHAS:
-        have_any = true;
-        desc.cprintf("You can walk through plants and fire through allied plants.\n");
-        break;
-
     case GOD_JIYVA:
         have_any = true;
+        desc.cprintf("Jellies are peaceful and will consume items off the floor.\n");
+        desc.cprintf("Jiyva prevents you from injuring jellies.\n");
+
         if (!have_passive(passive_t::jelly_regen))
             desc.textcolour(DARKGREY);
         else
@@ -878,6 +879,7 @@ static formatted_string _describe_god_powers(god_type which_god)
         break;
 
     case GOD_YREDELEMNUL:
+        // TODO: Vary the text depending on the size of the umbra.
         desc.cprintf("You are surrounded by an umbra.\n"
                      "Foes that die within your umbra may be raised as undead servants.\n");
         break;
@@ -898,15 +900,9 @@ static formatted_string _describe_god_powers(god_type which_god)
         break;
     }
 
-    case GOD_GOZAG:
-        have_any = true;
-        desc.cprintf("%s turns your defeated foes' bodies to gold.\n",
-                uppercase_first(god_name(which_god)).c_str());
-        desc.cprintf("Your enemies may become distracted by gold.\n");
-        break;
-
     case GOD_HEPLIAKLQANA:
-        // XXX: move this logic back into the usual religion.cc god_powers block?
+        // Frailty occurs even under penance post-abandonment, so we can't put
+        // this in the usual god_powers block.
         have_any = true;
     {
         const auto textcol = have_passive(passive_t::frail) ? god_colour(which_god) : DARKGREY;
@@ -915,26 +911,7 @@ static formatted_string _describe_god_powers(god_type which_god)
         // Feature request: not this.
         desc.textcolour(textcol);
         desc.cprintf("Your life essence is reduced. (-10%% HP)\n");
-        desc.textcolour(textcol);
-        desc.cprintf("Your ancestor manifests to aid you.\n");
     }
-        break;
-
-    case GOD_LUGONU:
-        have_any = true;
-        desc.cprintf("You are protected from the effects of unwielding distortion weapons.\n");
-        break;
-
-    case GOD_OKAWARU:
-        have_any = true;
-        desc.cprintf("%s requires that you fight alone, and prevents you from "
-                     "gaining allies.\n",
-                uppercase_first(god_name(which_god)).c_str());
-        break;
-
-    case GOD_IGNIS:
-        have_any = true;
-        desc.cprintf("You are resistant to fire.\n");
         break;
 
     default:
@@ -987,6 +964,17 @@ static formatted_string _describe_god_powers(god_type which_god)
 
     if (!have_any)
         desc.cprintf("None.\n");
+
+    // Show Jiyva's opening of the Slime Pits at the bottom of the list
+    // We want this to stay green permanently once the player hits 6*
+    if (which_god == GOD_JIYVA)
+    {
+        if (you.one_time_ability_used[which_god])
+            desc.textcolour(god_colour(which_god));
+        else
+            desc.textcolour(DARKGREY);
+        desc.cprintf("Jiyva will unlock the Slime Pits vaults.\n");
+    }
 
     return desc;
 }

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -143,6 +143,9 @@ const vector<vector<god_power>> & get_all_god_powers()
         // Yredelemnul
         {   { 0, ABIL_YRED_LIGHT_THE_TORCH, "light the black torch and reap souls in Yredelemnul's name" },
             { 0, ABIL_YRED_RECALL_UNDEAD_HARVEST, "recall your undead harvest" },
+            { 1, "Yredelemnul will now gift you temporary undead servants when you light the torch.",
+                 "Yredelemnul will no longer gift you temporary undead servants when you light the torch.",
+                 "Yredelemnul will gift you temporary undead servants when you light the torch." },
             { 2, ABIL_YRED_HURL_TORCHLIGHT, "hurl gouts of umbral torchlight" },
             { 4, ABIL_YRED_BIND_SOUL, "bind living souls" },
             { 5, ABIL_YRED_FATHOMLESS_SHACKLES, "engulf your surroundings in Yredelemnul's grip" },
@@ -162,7 +165,9 @@ const vector<vector<god_power>> & get_all_god_powers()
         },
 
         // Okawaru
-        {   { 1, ABIL_OKAWARU_HEROISM, "gain great but temporary skills" },
+        {
+            { -1, "", "", "Okawaru requires that you fight alone, and prevents you from gaining allies." },
+            { 1, ABIL_OKAWARU_HEROISM, "gain great but temporary skills" },
             { 4, ABIL_OKAWARU_FINESSE, "speed up your combat" },
             { 5, ABIL_OKAWARU_DUEL, "enter into single combat with a foe"},
             { 5, "Okawaru will now gift you throwing weapons as you gain piety.",
@@ -233,7 +238,9 @@ const vector<vector<god_power>> & get_all_god_powers()
         },
 
         // Lugonu
-        {   { 1, ABIL_LUGONU_ABYSS_EXIT,
+        {   {-1, "", "", "Lugonu protects you from the effects of unwielding distortion weapons." },
+            {-1, "", "", "Lugonu may banish nearby foes when other gods try to punish you." },
+            { 1, ABIL_LUGONU_ABYSS_EXIT,
                  "depart the Abyss",
                  "depart the Abyss at will" },
             { 2, ABIL_LUGONU_BANISH, "banish your foes" },
@@ -247,8 +254,13 @@ const vector<vector<god_power>> & get_all_god_powers()
         // Beogh
         {   { 2, ABIL_BEOGH_SMITING, "smite your foes" },
             { 1, ABIL_BEOGH_RECALL_APOSTLES, "recall your orcish followers" },
+            { 3, "Beogh will now send orc apostles to challenge you in battle as you gain piety.",
+                 "Beogh will no longer send orc apostles to challenge you in battle.",
+                 "Beogh will send orc apostles to challenge you in battle as you gain piety." },
+            { 3, "", "", "You can recruit apostles that you defeat into your service." },
+            { 3, "", "", "Your orcish followers are sometimes invigorated when you deal damage." },
             { 5, ABIL_BEOGH_BLOOD_FOR_BLOOD, "rally a vengeful horde" },
-            { 0, ABIL_BEOGH_RECRUIT_APOSTLE, "recruit orcish followers" },
+            { 0, ABIL_BEOGH_RECRUIT_APOSTLE, "" },
             { 0, ABIL_BEOGH_DISMISS_APOSTLE_1, ""},
             { 0, ABIL_BEOGH_DISMISS_APOSTLE_2, ""},
             { 0, ABIL_BEOGH_DISMISS_APOSTLE_3, ""},
@@ -258,7 +270,7 @@ const vector<vector<god_power>> & get_all_god_powers()
         // Jiyva
         {   { 2, "Jiyva is now protecting you from corrosive effects.",
                  "Jiyva will no longer protect you from corrosive effects.",
-                 "Jiyva protects you from corrosive effects." },
+                 "Jiyva protects you from corrosive effects. (rCorr)" },
             { 3, "Jiyva will now mutate your body as you gain piety.",
                  "Jiyva will no longer mutate your body.",
                  "Jiyva will mutate your body as you gain piety." },
@@ -271,6 +283,7 @@ const vector<vector<god_power>> & get_all_god_powers()
 
         // Fedhas
         {
+            { 0, "", "", "You can walk through plants and fire through allied plants." },
             { 2, ABIL_FEDHAS_WALL_OF_BRIARS, "encircle yourself with summoned briar patches"},
             { 3, ABIL_FEDHAS_GROW_BALLISTOMYCETE, "grow a ballistomycete" },
             { 4, ABIL_FEDHAS_OVERGROW, "transform dungeon walls and trees into plant allies"},
@@ -320,7 +333,9 @@ const vector<vector<god_power>> & get_all_god_powers()
         },
 
         // Gozag
-        {   { 0, ABIL_GOZAG_POTION_PETITION, "petition Gozag for potion effects" },
+        {   { 0, "", "", "Gozag turns your defeated foes' bodies to gold." },
+            { 0, "", "", "Your enemies may become distracted by gold." },
+            { 0, ABIL_GOZAG_POTION_PETITION, "petition Gozag for potion effects" },
             { 0, ABIL_GOZAG_CALL_MERCHANT,
                  "fund merchants seeking to open stores in the dungeon" },
             { 0, ABIL_GOZAG_BRIBE_BRANCH,
@@ -376,7 +391,8 @@ const vector<vector<god_power>> & get_all_god_powers()
         },
 
         // Hepliaklqana
-        {   { 1, ABIL_HEPLIAKLQANA_RECALL, "recall your ancestor" },
+        {   { 1, "", "", "Your ancestor manifests to aid you." },
+            { 1, ABIL_HEPLIAKLQANA_RECALL, "recall your ancestor" },
             { 1, ABIL_HEPLIAKLQANA_IDENTITY, "remember your ancestor's identity" },
             { 3, ABIL_HEPLIAKLQANA_TRANSFERENCE, "swap creatures with your ancestor" },
             { 4, ABIL_HEPLIAKLQANA_IDEALISE, "heal and protect your ancestor" },
@@ -401,9 +417,10 @@ const vector<vector<god_power>> & get_all_god_powers()
 
         // Ignis
         {
+            { 0, "", "", "You are resistant to fire. (rF+)" },
             { 1, ABIL_IGNIS_FIERY_ARMOUR, "armour yourself in flame" },
             { 1, ABIL_IGNIS_FOXFIRE, "call a swarm of foxfires against your foes" },
-            { 7, ABIL_IGNIS_RISING_FLAME, "rocket upward and away" },
+            { 7, ABIL_IGNIS_RISING_FLAME, "rocket upward and away, once" },
         },
     };
     static bool god_powers_init = false;


### PR DESCRIPTION
 - Beogh: add lines for Beogh sending challenges as you gain piety, and explain that they can be recruited if you defeat them; improve various other inconsistencies around ^ for new Beogh
 - Ignis: explain that Rising Flame is one-use-only
 - Lugonu: show passive banishment on other gods' wrath
 - Yredelemnul: explain that light the torch gives allies at 1*

Also move a number of passive abilities with hardcoded descriptions describe-god.cc to the table of god powers in religion.cc. The only abilities left in describe-god.cc are those that have unusual criteria (e.g. Hep frailty), or those whose text changes as you gain piety (e.g. lifesaving, umbra).

There remain several minor passives (e.g. Trog's ally protection and berserk extension, Jiyva's jelly eating and jelly protection, Elyvilon's ally lifesaving) which are too minor to appear on ^.