### PR TITLE
Tweak wanderer good-throwing and good-weapon starting equipment

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -191,14 +191,14 @@ item_def* newgame_make_item(object_class_type base,
     return &item;
 }
 
-static void _give_throwing_ammo()
+void give_throwing_ammo(int n)
 {
     if (species::can_throw_large_rocks(you.species))
-        newgame_make_item(OBJ_MISSILES, MI_LARGE_ROCK, 1);
+        newgame_make_item(OBJ_MISSILES, MI_LARGE_ROCK, n);
     else if (you.body_size(PSIZE_TORSO) <= SIZE_SMALL)
-        newgame_make_item(OBJ_MISSILES, MI_BOOMERANG, 2);
+        newgame_make_item(OBJ_MISSILES, MI_BOOMERANG, 2*n);
     else
-        newgame_make_item(OBJ_MISSILES, MI_JAVELIN, 1);
+        newgame_make_item(OBJ_MISSILES, MI_JAVELIN, n);
 }
 
 static void _give_job_spells(job_type job)
@@ -302,7 +302,7 @@ void give_items_skills(const newgame_def& ng)
     give_job_skills(you.char_class);
     _give_job_spells(you.char_class);
     if (you.char_class == JOB_GLADIATOR)
-        _give_throwing_ammo();
+        give_throwing_ammo(1);
 
     if (you.has_mutation(MUT_NO_GRASPING)) // i.e. felids
         you.skills[SK_THROWING] = 0;

--- a/crawl-ref/source/ng-setup.h
+++ b/crawl-ref/source/ng-setup.h
@@ -21,4 +21,5 @@ struct newgame_def;
 void setup_game(const newgame_def& ng, bool normal_dungeon_setup=true);
 void initial_dungeon_setup();
 
+void give_throwing_ammo(int n);
 void give_items_skills(const newgame_def& ng);

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -19,13 +19,18 @@ static void _give_wanderer_weapon(skill_type wpn_skill, bool good_item)
 {
     if (wpn_skill == SK_THROWING)
     {
-        // good_item always gives curare
+        // good_item always assigns 7 ammo: 1-4 curare, the rest javelins
         if (good_item)
         {
-            newgame_make_item(OBJ_MISSILES, MI_DART, 1 + random2(4),
+            const int num_curare = 1 + random2(4);
+            newgame_make_item(OBJ_MISSILES, MI_DART, num_curare,
                               0, SPMSL_CURARE);
+
+            // Gives large rocks for large species, 2x boomerangs for small
+            const int num_javelins = 7 - num_curare;
+            give_throwing_ammo(num_javelins);
         }
-        // Otherwise, we get some poisoned darts or some boomerangs.
+        // Otherwise, we get 7-15 poisoned darts or 6-10 boomerangs.
         else
         {
             if (one_chance_in(3))
@@ -39,11 +44,12 @@ static void _give_wanderer_weapon(skill_type wpn_skill, bool good_item)
                               0, SPMSL_POISONED);
             }
         }
+        return; // don't give a dagger as well
     }
 
     weapon_type sub_type;
     int plus = 0;
-    bool upgrade_base = good_item && one_chance_in(5);
+    bool upgrade_base = good_item && one_chance_in(3);
     int ego = SPWPN_NORMAL;
 
     // Now fill in the type according to the random wpn_skill.


### PR DESCRIPTION
Previously, the good set of throwing items for wanderer was 1-4 curare-tipped darts and a +2 dagger. Neither of these scale well with throwing skill, which is likely to be your highest skill. This could also be extremely disappointing if you got 1 curare dart and it mulched immediately. To encourage actually training throwing skill, replace the enchanted dagger with large rocks/javelins/boomerangs (depending on size), up to a total of 7 pieces of ammunition. (Note: this uses the same code as the gladiator background, so small species will get double the number of boomerangs.)

Also, the good set of weapon items for all weapon skills had a 4/5 chance of giving a +2 enchantment to a decent-quality weapon (falchion, mace, etc), and a 1/5 chance of upgrading to a good-quality weapon (long sword, flail, etc). In practice this upgrade was rather rare, and starting with a +2 decent weapon is a little too frequent. So let's bump the upgrade chance to 1/3, for the sake of variety.

[Notes: quarterstaves are still way too good compared to all of the other decent-quality weapons. I'd like to replace it with a magical staff, but a magical staff felt just slightly too weak in melee without a matching magic school in my testing to be viable as a starting weapon. Any thoughts on this?]