### PR TITLE
Fix ^ screen for Jiyva and Ignis in Webtiles (#3851)

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -834,7 +834,7 @@ static formatted_string _describe_god_powers(god_type which_god)
     case GOD_JIYVA:
         have_any = true;
         desc.cprintf("Jellies are peaceful and will consume items off the floor.\n");
-        desc.cprintf("Jiyva prevents you from injuring jellies.\n");
+        desc.cprintf("Jiyva prevents you from harming jellies.\n");
 
         if (have_passive(passive_t::jelly_regen))
             desc.textcolour(god_colour(which_god));

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -270,7 +270,7 @@ const vector<vector<god_power>> & get_all_god_powers()
         // Jiyva
         {   { 2, "Jiyva is now protecting you from corrosive effects.",
                  "Jiyva will no longer protect you from corrosive effects.",
-                 "Jiyva protects you from corrosive effects. (rCorr)" },
+                 "Jiyva protects you from corrosive effects." },
             { 3, "Jiyva will now mutate your body as you gain piety.",
                  "Jiyva will no longer mutate your body.",
                  "Jiyva will mutate your body as you gain piety." },
@@ -417,7 +417,10 @@ const vector<vector<god_power>> & get_all_god_powers()
 
         // Ignis
         {
-            { 0, "", "", "You are resistant to fire. (rF+)" },
+            // It would be nice to specify explicitly that this is rF+
+            // Unfortunately, including parentheses at the end here breaks
+            // the UI on Webtiles.
+            { 0, "", "", "You are resistant to fire." },
             { 1, ABIL_IGNIS_FIERY_ARMOUR, "armour yourself in flame" },
             { 1, ABIL_IGNIS_FOXFIRE, "call a swarm of foxfires against your foes" },
             { 7, ABIL_IGNIS_RISING_FLAME, "rocket upward and away, once" },


### PR DESCRIPTION
Apparently Webtiles uses regular expressions to parse the ^ screen, and it really doesn't like the use of parentheses in strings describing god powers. There is a way around this, but it puts the resistance in the cost column on Webtiles (in the same way as Cheibriados' stat boost), which is unacceptable.

Also change "injuring" to "harming" when referring to jellies, for better flavour.