### PR TITLE
Fix a couple more things about the new Webtiles colours

### DIFF
--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -22,7 +22,7 @@ function ($, comm, client, ui, enums, cr, util, options, scroller) {
     function item_colour(item)
     {
         if (item.colour === undefined)
-            return 7; /* lightgray */
+            return 7;
         return item.colour;
     }
 

--- a/crawl-ref/source/webserver/game_data/static/menu.js
+++ b/crawl-ref/source/webserver/game_data/static/menu.js
@@ -21,7 +21,9 @@ function ($, comm, client, ui, enums, cr, util, options, scroller) {
 
     function item_colour(item)
     {
-        return item.colour || 7;
+        if (item.colour === undefined)
+            return 7; /* lightgray */
+        return item.colour;
     }
 
     function menu_title_indent()

--- a/crawl-ref/source/webserver/game_data/static/style.css
+++ b/crawl-ref/source/webserver/game_data/static/style.css
@@ -111,7 +111,7 @@ canvas {
     background-color: var(--color-4); /* red */
 }
 #stats_hp_bar_poison {
-    background-color: yellow;
+    background-color: var(--color-14); /* yellow */
 }
 #stats_hp_bar_increase {
     background-color: var(--color-2); /* green */


### PR DESCRIPTION
Previously, using black as a menu_colour option was never useful, because black text is always invisible on the black game background. However, we can now redefine the colour black, as of d719f66, opening up a 16th possible text colour to use with menu_colour.

Upon trying to do exactly this myself, I discovered the Webtiles inventory UI implicitly, and apparently unintentionally, replaces black text with lightgray, regardless of what black may have been rebound to. Let's fix this, so we really can have a 16th colour.

Also fix the poison HP-bar colour being `yellow` instead of redefinable yellow.