### PR TITLE
Improve picking up part of a stack of items with the mouse in local tiles

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -4489,12 +4489,19 @@ void tile_item_pickup(int idx, bool part)
         return;
     }
 
-    if (part)
+    int quantity = env.item[idx].quantity;
+    if (part && quantity > 1)
     {
-        pickup_menu(idx);
-        return;
+        quantity = prompt_for_int("Pick up how many? ", true);
+        if (quantity < 1)
+        {
+            canned_msg(MSG_OK);
+            return;
+        }
+        if (quantity > env.item[idx].quantity)
+            quantity = env.item[idx].quantity;
     }
-    pickup_single_item(idx, -1);
+    pickup_single_item(idx, quantity);
 }
 
 void tile_item_drop(int idx, bool partdrop)


### PR DESCRIPTION
Previously cntrl-clicking an item on the ground in the local tiles onscreen inventory would bring up the item pickup menu where you could type in a number that couldn't be seen and then press a to select the item again and then press enter. Now, cntrl-clicking the item prompts for the number you want to pick up and then picks up that number when you press enter. The new way is similar to how dropping part of a stack works.

Before:
![Screenshot (1661)](https://github.com/crawl/crawl/assets/26264063/fa715b80-e441-49eb-b183-51507a0ea19f)

After:
![Screenshot (1662)](https://github.com/crawl/crawl/assets/26264063/4dc03a82-68c8-4899-9628-006ea0e4b4e3)
