### PR TITLE
A few more tweaks to wanderer

### DIFF
--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -76,7 +76,11 @@ static void _give_wanderer_weapon(skill_type wpn_skill, bool good_item)
         break;
 
     case SK_STAVES:
+        // We only reach here for good quality staves skill.
+        // A +0 quarterstaff is plenty good enough for good staves skill.
         sub_type = WPN_QUARTERSTAFF;
+        upgrade_base = false;
+        good_item = false;
         break;
 
     case SK_RANGED_WEAPONS:
@@ -211,6 +215,10 @@ static bool _wanderer_is_useful_skill(skill_type skill,
 {
     // Reroll duplicate skills
     if (skill == sk1 || skill == sk2)
+        return false;
+
+    // Reroll decent staves skill, as no corresponding appropriate equipment
+    if (skill == SK_STAVES && sk1 != SK_NONE)
         return false;
 
     // Don't give a shield with good staves / ranged weapons

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -200,7 +200,36 @@ static skill_type _apt_weighted_choice(const skill_type * skill_array,
     return NUM_SKILLS;
 }
 
-static skill_type _wanderer_role_skill_select(bool defense)
+static bool _wanderer_is_useful_skill(skill_type skill,
+                                      skill_type sk1, skill_type sk2)
+{
+    // Reroll duplicate skills
+    if (skill == sk1 || skill == sk2)
+        return false;
+
+    // Don't give a shield with good staves / ranged weapons
+    // (except for formicids, obviously)
+    if (!you.has_mutation(MUT_QUADRUMANOUS)
+        && skill == SK_SHIELDS
+        && (sk1 == SK_STAVES
+            || sk1 == SK_RANGED_WEAPONS || sk2 == SK_RANGED_WEAPONS
+            || sk1 == SK_POLEARMS && you.body_size() <= SIZE_SMALL))
+    {
+        return false;
+    }
+    // or two handers if we have a shield (getting a 2h and a bow is ok)
+    if (!you.has_mutation(MUT_QUADRUMANOUS)
+        && sk1 == SK_SHIELDS && skill == SK_RANGED_WEAPONS)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+static skill_type _wanderer_role_skill_select(bool defense,
+                                              skill_type sk1 = SK_NONE,
+                                              skill_type sk2 = SK_NONE)
 {
     skill_type skill = NUM_SKILLS;
     const skill_type offense_skills[] =
@@ -226,13 +255,28 @@ static skill_type _wanderer_role_skill_select(bool defense)
 
     int defense_size = ARRAYSZ(defense_skills);
 
-    if (defense)
-        skill = _apt_weighted_choice(defense_skills, defense_size);
-    // reduce the chance of a spell felid a bit
-    else if (you.has_mutation(MUT_NO_GRASPING) && one_chance_in(3))
-        skill = _apt_weighted_choice(physical_skills, physical_size);
-    else
-        skill = _apt_weighted_choice(offense_skills, offense_size);
+    const skill_type weapon_skills[] =
+        { SK_AXES, SK_MACES_FLAILS, SK_RANGED_WEAPONS, SK_POLEARMS,
+          SK_SHORT_BLADES, SK_LONG_BLADES, SK_STAVES, SK_UNARMED_COMBAT };
+
+    int weapons_size = ARRAYSZ(weapon_skills);
+
+    do
+    {
+        if (defense)
+            skill = _apt_weighted_choice(defense_skills, defense_size);
+        // reduce the chance of a spell felid a bit
+        else if (you.has_mutation(MUT_NO_GRASPING) && one_chance_in(3))
+            skill = _apt_weighted_choice(physical_skills, physical_size);
+        else
+            skill = _apt_weighted_choice(offense_skills, offense_size);
+
+        // Convert good fighting skill to a random good weapon skill
+        if (skill == SK_FIGHTING && sk1 == SK_NONE)
+            skill = _apt_weighted_choice(weapon_skills, weapons_size);
+    }
+    // Reroll incompatible or duplicate skills
+    while (!_wanderer_is_useful_skill(skill, sk1, sk2));
 
     return skill;
 }
@@ -257,11 +301,8 @@ static void _setup_starting_skills(skill_type sk1, skill_type sk2,
             martial++;
         else if (sk > SK_LAST_MUNDANE && sk <= SK_LAST_MAGIC)
             magical++;
-        if (sk != SK_NONE)
-        {
-            you.skills[sk]++;
-            levels--;
-        }
+        you.skills[sk]++;
+        levels--;
     }
 
     skill_type selected = SK_NONE;
@@ -281,8 +322,7 @@ static void _setup_starting_skills(skill_type sk1, skill_type sk2,
                                           1, SK_INVOCATIONS,
                                           2, SK_SHAPESHIFTING);
 
-        if (!is_useless_skill(selected) && selected != SK_NONE
-            && you.skills[selected] < 5)
+        if (!is_useless_skill(selected) && you.skills[selected] < 5)
         {
             you.skills[selected]++;
             levels--;
@@ -580,18 +620,8 @@ static void _give_wanderer_aux_armour(int plus = 0)
         newgame_make_item(OBJ_ARMOUR, choice, 1, plus);
 }
 
-static vector<spell_type> _wanderer_good_equipment(skill_type & skill)
+static vector<spell_type> _wanderer_good_equipment(skill_type skill)
 {
-    const skill_type combined_weapon_skills[] =
-        { SK_AXES, SK_MACES_FLAILS, SK_RANGED_WEAPONS, SK_POLEARMS,
-          SK_SHORT_BLADES, SK_LONG_BLADES, SK_STAVES, SK_UNARMED_COMBAT };
-
-    int total_weapons = ARRAYSZ(combined_weapon_skills);
-
-    // Normalise the input type.
-    if (skill == SK_FIGHTING)
-        skill =  _apt_weighted_choice(combined_weapon_skills, total_weapons);
-
     switch (skill)
     {
     case SK_MACES_FLAILS:
@@ -694,33 +724,13 @@ static vector<spell_type> _wanderer_good_equipment(skill_type & skill)
     return vector<spell_type>{};
 }
 
-static vector<spell_type> _wanderer_decent_equipment(skill_type & skill,
+static vector<spell_type> _wanderer_decent_equipment(skill_type skill,
                                                      set<skill_type> & gift_skills)
 {
-    // don't give a shield if we filled our hands already
-    // or if we got a sling (likely to upgrade to a bow later)
-    // (except for formicids, obviously)
-    if (!you.has_mutation(MUT_QUADRUMANOUS)
-        && skill == SK_SHIELDS
-        && (!you.has_usable_offhand() || gift_skills.count(SK_RANGED_WEAPONS)))
-    {
-        skill = random_choose(SK_DODGING, SK_ARMOUR);
-    }
-
-    // or two handers if we have a shield (getting a 2h and a bow is ok)
-    if (!you.has_mutation(MUT_QUADRUMANOUS)
-        && gift_skills.count(SK_SHIELDS)
-        && (skill == SK_STAVES || skill == SK_RANGED_WEAPONS))
-    {
-        skill = SK_FIGHTING;
-    }
-
-    // Don't give a gift from the same skill twice; just default to
-    // a decent consumable
-    if (gift_skills.count(skill))
-        skill = SK_NONE;
 
     // don't give the player a second piece of armour
+    // - give a decent consumable instead
+    // we still want the player to get the skill levels, though
     if (gift_skills.count(SK_ARMOUR) && (skill == SK_DODGING
                                          || skill == SK_STEALTH)
         || (gift_skills.count(SK_DODGING) && (skill == SK_ARMOUR
@@ -867,8 +877,9 @@ void create_wanderer()
 
     // always give at least one "offense skill" and one "defence skill"
     skill_type gift_skill_1 = _wanderer_role_skill_select(one_chance_in(3));
-    skill_type gift_skill_2 = _wanderer_role_skill_select(false);
-    skill_type gift_skill_3 = _wanderer_role_skill_select(true);
+    skill_type gift_skill_2 = _wanderer_role_skill_select(false, gift_skill_1);
+    skill_type gift_skill_3 = _wanderer_role_skill_select(true, gift_skill_1,
+                                                          gift_skill_2);
 
     // assign remaining wanderer stat points according to gift skills
     _assign_wanderer_stats(gift_skill_1, gift_skill_2, gift_skill_3);

--- a/crawl-ref/source/ng-wanderer.cc
+++ b/crawl-ref/source/ng-wanderer.cc
@@ -120,23 +120,22 @@ static void _assign_wanderer_stats(skill_type sk1, skill_type sk2,
             case SK_AXES:
             case SK_MACES_FLAILS:
             case SK_ARMOUR:
+            case SK_POLEARMS:
+            case SK_STAVES:
                 str_count++;
                 break;
 
             case SK_SHORT_BLADES:
             case SK_LONG_BLADES:
             case SK_RANGED_WEAPONS:
-            case SK_STAVES:
             case SK_DODGING:
             case SK_SHIELDS:
             case SK_STEALTH:
                 dex_count++;
                 break;
 
-            case SK_POLEARMS:
             case SK_UNARMED_COMBAT:
             case SK_FIGHTING:
-            case SK_EVOCATIONS:
             case SK_THROWING:
             case SK_SHAPESHIFTING:
                 if (coinflip())
@@ -159,6 +158,13 @@ static void _assign_wanderer_stats(skill_type sk1, skill_type sk2,
                 int_count++;
                 break;
 
+            case SK_EVOCATIONS:
+                if (one_chance_in(3))
+                    str_count++;
+                else if (coinflip())
+                    int_count++;
+                else
+                    dex_count++;
             default:
                 break;
         }


### PR DESCRIPTION
 - Give wanderers three unique skills, rather than occasionally only getting two (when the same skill was rolled twice); incompatible skills will also be rerolled earlier in the process.
 - Tweak wanderer starting stat distribution very slightly
 - Remove decent staves skill and make good staves skill give a +0 quarterstaff.

See individual commits for details. In the process of writing this PR, I have also made a branch which generates 1,000,000 wanderers whenever a wanderer is started and records the total numbers of each skill picked, as well as the average stat gain. If you're interested, see my `NormalPerson7:wn-investigations` branch.