### PR TITLE
Let freezing/flaming brands trigger rF-/rC- warning messages for players

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1420,8 +1420,10 @@ bool attack::apply_damage_brand(const char *what)
 
         // Player took fire/cold damage with rF-/rC-
         if (print_resist_vulnerability_message)
+        {
             mpr(brand == SPWPN_FLAMING ? "The fire burns you terribly!"
                                        : "You feel a terrible chill!");
+        }
         print_resist_vulnerability_message = false;
     }
 

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -63,7 +63,8 @@ attack::attack(actor *attk, actor *defn, actor *blame)
       damage_brand(SPWPN_NORMAL), wpn_skill(SK_UNARMED_COMBAT),
       art_props(0), unrand_entry(nullptr),
       attacker_to_hit_penalty(0), attack_verb("bug"), verb_degree(),
-      no_damage_message(), special_damage_message(), aux_attack(), aux_verb(),
+      no_damage_message(), special_damage_message(),
+      print_resist_vulnerability_message(), aux_attack(), aux_verb(),
       defender_shield(nullptr), simu(false),
       aux_source(""), kill_type(KILLED_BY_MONSTER)
 {
@@ -1415,8 +1416,13 @@ bool attack::apply_damage_brand(const char *what)
     if (needs_message && !special_damage_message.empty())
     {
         mpr(special_damage_message);
-
         special_damage_message.clear();
+
+        // Player took fire/cold damage with rF-/rC-
+        if (print_resist_vulnerability_message)
+            mpr(brand == SPWPN_FLAMING ? "The fire burns you terribly!"
+                                       : "You feel a terrible chill!");
+        print_resist_vulnerability_message = false;
     }
 
     // Preserve Nessos's brand stacking in a hacky way -- but to be fair, it
@@ -1440,8 +1446,10 @@ void attack::calc_elemental_brand_damage(beam_type flavour,
                                          const char *verb,
                                          const char *what)
 {
+    int pre_resist_damage = random2(damage_done) / 2 + 1;
+
     special_damage = resist_adjust_damage(defender, flavour,
-                                          random2(damage_done) / 2 + 1);
+                                          pre_resist_damage);
 
     if (needs_message && special_damage > 0 && verb)
     {
@@ -1455,6 +1463,9 @@ void attack::calc_elemental_brand_damage(beam_type flavour,
             defender_name(!what).c_str(),
             attack_strength_punctuation(special_damage).c_str());
     }
+
+    if (special_damage > pre_resist_damage)
+        print_resist_vulnerability_message = true;
 }
 
 int attack::player_stab_weapon_bonus(int damage)

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -78,6 +78,7 @@ public:
     string     attack_verb, verb_degree;
     string     no_damage_message;
     string     special_damage_message;
+    bool       print_resist_vulnerability_message;
     string     aux_attack, aux_verb;
 
     item_def        *defender_shield;


### PR DESCRIPTION
If flaming/freezing deal extra damage to the player because the player has rF-/rC-, print the usual "The fire burns you terribly!"/ "You feel a terrible chill!" messages. I admit that the former doesn't go too well with the messages "@the_monster@ burns you" that are printed by the flaming brand itself, but I figure it's important to keep this message universally consistent.

It's a little bit hacky, but I want to avoid spamming the message log with resist messages for freezing/flaming, and we can't let this amuse Xom because that would be way too easy to abuse. (Both of these happen if check_your_resists is used, the normal way to get these messages.)