### PR TITLE
Don't leak invisible monsters when casting Gell's Gavotte

### DIFF
--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -2304,13 +2304,14 @@ static bool _gavotte_will_wall_slam(const monster* mon, coord_def dir)
     return false;
 }
 
-vector<monster*> gavotte_affected_monsters(const coord_def dir)
+vector<monster*> gavotte_affected_monsters(const coord_def dir, bool actual)
 {
     vector<monster*> affected;
 
     for (monster_near_iterator mi(you.pos()); mi; ++mi)
     {
-        if (!mi->is_stationary() && you.see_cell_no_trans(mi->pos()))
+        if (!mi->is_stationary() && you.see_cell_no_trans(mi->pos())
+            && (actual || you.can_see(**mi)))
         {
             if (_gavotte_will_wall_slam(*mi, dir))
                 affected.push_back(*mi);

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -71,4 +71,5 @@ spret cast_piledriver(int pow, bool fail);
 
 dice_def gavotte_impact_damage(int pow, int dist, bool random);
 spret cast_gavotte(int pow, const coord_def dir, bool fail);
-vector<monster*> gavotte_affected_monsters(const coord_def dir);
+vector<monster*> gavotte_affected_monsters(const coord_def dir,
+                                           bool actual = true);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2202,7 +2202,7 @@ bool targeter_gavotte::set_aim(coord_def a)
     tempbeam.fire();
     path_taken = tempbeam.path_taken;
 
-    vector<monster*> affected = gavotte_affected_monsters(a - you.pos());
+    vector<monster*> affected = gavotte_affected_monsters(a - you.pos(), false);
     for (monster* mon : affected)
         affected_monsters.push_back(mon->pos());
 


### PR DESCRIPTION
Fix the targeter revealing the locations of invisible monsters in line of sight when they would be hurt by the spell.