### PR TITLE
Allow manifold assault to be cast when it would warn

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -946,20 +946,10 @@ bool player_unrand_bad_attempt(const item_def &weapon,
                                const actor *defender,
                                bool check_only)
 {
-    if (is_unrandom_artefact(weapon, UNRAND_DEVASTATOR))
-    {
+    const monster* defending_monster = defender ? defender->as_monster() :
+        nullptr;
 
-        targeter_smite hitfunc(&you, 1, 1, 1);
-        hitfunc.set_aim(defender->pos());
-
-        return stop_attack_prompt(hitfunc, "attack",
-                                  [](const actor *act)
-                                  {
-                                      return !never_harm_monster(&you, act->as_monster());
-                                  }, nullptr, defender->as_monster(),
-                                  check_only);
-    }
-    else if (is_unrandom_artefact(weapon, UNRAND_VARIABILITY)
+    if (is_unrandom_artefact(weapon, UNRAND_VARIABILITY)
              || is_unrandom_artefact(weapon, UNRAND_SINGING_SWORD)
                 && !silenced(you.pos()))
     {
@@ -969,7 +959,7 @@ bool player_unrand_bad_attempt(const item_def &weapon,
                                [](const actor *act)
                                {
                                    return !never_harm_monster(&you, act->as_monster());
-                               }, nullptr, defender->as_monster(),
+                               }, nullptr, defending_monster,
                                check_only);
     }
     if (is_unrandom_artefact(weapon, UNRAND_TORMENT))
@@ -982,28 +972,71 @@ bool player_unrand_bad_attempt(const item_def &weapon,
                                    return !m->res_torment()
                                        && !never_harm_monster(&you, m->as_monster());
                                },
-                                  nullptr, defender->as_monster(),
+                                  nullptr, defending_monster,
                                 check_only);
     }
-    if (is_unrandom_artefact(weapon, UNRAND_ARC_BLADE))
+
+    if (!defender)
+        return false;
+
+    return player_unrand_bad_target(weapon, *defender, check_only);
+}
+
+bool player_unrand_bad_attempt(const item_def *weapon,
+    const item_def *offhand,
+    const actor *defender,
+    bool check_only)
+{
+    return weapon && ::player_unrand_bad_attempt(*weapon, defender, check_only)
+        || offhand && ::player_unrand_bad_attempt(*offhand, defender, check_only);
+}
+
+bool player_unrand_bad_target(const item_def &weapon,
+    const actor &defender,
+    bool check_only)
+{
+    const monster* defending_monster = defender.as_monster();
+
+    if (is_unrandom_artefact(weapon, UNRAND_DEVASTATOR))
     {
-        vector<const actor *> exclude;
-        return !safe_discharge(defender->pos(), exclude, check_only);
-    }
-    if (is_unrandom_artefact(weapon, UNRAND_POWER))
-    {
-        targeter_beam hitfunc(&you, 4, ZAP_SWORD_BEAM, 100, 0, 0);
-        hitfunc.beam.aimed_at_spot = false;
-        hitfunc.set_aim(defender->pos());
+        targeter_smite hitfunc(&you, 1, 1, 1);
+        hitfunc.set_aim(defender.pos());
 
         return stop_attack_prompt(hitfunc, "attack",
                                [](const actor *act)
                                {
                                    return !never_harm_monster(&you, act->as_monster());
-                               }, nullptr, defender->as_monster(),
+                               }, nullptr, defending_monster,
+                               check_only);
+    }
+    if (is_unrandom_artefact(weapon, UNRAND_ARC_BLADE))
+    {
+        vector<const actor *> exclude;
+        return !safe_discharge(defender.pos(), exclude, check_only);
+    }
+    if (is_unrandom_artefact(weapon, UNRAND_POWER))
+    {
+        targeter_beam hitfunc(&you, 4, ZAP_SWORD_BEAM, 100, 0, 0);
+        hitfunc.beam.aimed_at_spot = false;
+        hitfunc.set_aim(defender.pos());
+
+        return stop_attack_prompt(hitfunc, "attack",
+                               [](const actor *act)
+                               {
+                                   return !never_harm_monster(&you, act->as_monster());
+                               }, nullptr, defending_monster,
                                check_only);
     }
     return false;
+}
+
+bool player_unrand_bad_target(const item_def *weapon,
+    const item_def *offhand,
+    const actor &defender,
+    bool check_only)
+{
+    return weapon && ::player_unrand_bad_target(*weapon, defender, check_only)
+        || offhand && ::player_unrand_bad_target(*offhand, defender, check_only);
 }
 
 /**

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -84,6 +84,18 @@ int mons_weapon_damage_rating(const item_def &launcher);
 bool player_unrand_bad_attempt(const item_def &weapon,
                                const actor *defender,
                                bool check_only);
+bool player_unrand_bad_attempt(const item_def *weapon,
+                               const item_def *offhand,
+                               const actor *defender,
+                               bool check_only);
+
+bool player_unrand_bad_target(const item_def &weapon,
+                              const actor &defender,
+                              bool check_only);
+bool player_unrand_bad_target(const item_def *weapon,
+                              const item_def *offhand,
+                              const actor &defender,
+                              bool check_only);
 
 bool bad_attack(const monster *mon, string& adj, string& suffix,
                 bool& would_cause_penance,

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -102,7 +102,7 @@ bool melee_attack::bad_attempt()
     if (never_harm_monster(attacker, defender->as_monster(), true))
         return true;
 
-    if (player_unrand_bad_attempt(offhand_weapon()))
+    if (!is_projected && player_unrand_bad_attempt(offhand_weapon()))
         return true;
 
     if (!cleave_targets.empty())
@@ -139,8 +139,7 @@ bool melee_attack::player_unrand_bad_attempt(const item_def *offhand,
     if (!you.can_see(*defender))
         return false;
 
-    return weapon && ::player_unrand_bad_attempt(*weapon, defender, check_only)
-        || offhand && ::player_unrand_bad_attempt(*offhand, defender, check_only);
+    return ::player_unrand_bad_attempt(weapon, offhand, defender, check_only);
 }
 
 bool melee_attack::handle_phase_attempted()


### PR DESCRIPTION
Allow manifold assaulting with a weapon that warns

Because manifold assault chooses its targets at random, it has to avoid
targets that would warn the player so as not to put them in penance etc.
However, when using a weapon that would warn when attacking any monster
(e.g. the singing sword with an ally in view) this lead to it not
finding any targets it could hit. To fix this, promt when attacking with
a weapon that would always warn when attacking and only exclude targets
where the actual target is the problem (e.g. to close to an ally when
using devastator).

Fixes #3838