### PR TITLE
adjustments to the stats of some jellies

### DIFF
--- a/crawl-ref/source/dat/mons/acid-blob.yaml
+++ b/crawl-ref/source/dat/mons/acid-blob.yaml
@@ -4,7 +4,7 @@ flags: [eat_doors, see_invis, unblindable, web_immune, acid_splash, no_skeleton]
 resists: {poison: 1, acid: 3}
 xp_mult: 12
 genus: jelly
-will: 160
+will: 80
 attacks:
  - {type: hit, flavour: acid, damage: 42}
 hd: 18

--- a/crawl-ref/source/dat/mons/azure-jelly.yaml
+++ b/crawl-ref/source/dat/mons/azure-jelly.yaml
@@ -1,16 +1,14 @@
 name: "azure jelly"
 glyph: {char: "J", colour: lightblue}
 flags: [eat_doors, see_invis, unblindable, web_immune, no_skeleton]
-resists: {poison: 1, fire: -1, cold: 1, acid: 3}
+resists: {poison: 1, fire: -1, cold: 3, acid: 3}
 xp_mult: 14
 genus: jelly
 will: 80
 attacks:
- - {type: hit, flavour: cold, damage: 12}
- - {type: hit, flavour: cold, damage: 12}
- - {type: hit, damage: 12}
- - {type: hit, damage: 12}
-hd: 15
+ - {type: hit, flavour: cold, damage: 24}
+ - {type: hit, flavour: cold, damage: 18}
+hd: 16
 hp_10x: 825
 ac: 5
 ev: 10

--- a/crawl-ref/source/dat/mons/rockslime.yaml
+++ b/crawl-ref/source/dat/mons/rockslime.yaml
@@ -1,9 +1,9 @@
 name: "rockslime"
 glyph: {char: "J", colour: brown}
 flags: [eat_doors, see_invis, unblindable, web_immune, no_skeleton]
-resists: {elec: 1, poison: 1, fire: 2}
+resists: {elec: 1, poison: 1, fire: 2, acid: 3}
 genus: jelly
-will: 60
+will: 120
 attacks:
  - {type: hit, flavour: trample, damage: 50}
 hd: 20

--- a/crawl-ref/source/dat/mons/slime-creature.yaml
+++ b/crawl-ref/source/dat/mons/slime-creature.yaml
@@ -1,7 +1,7 @@
 name: "slime creature"
 glyph: {char: "J", colour: green}
 flags: [unblindable, web_immune, no_skeleton, herd]
-resists: {poison: 1}
+resists: {poison: 1, acid: 3}
 xp_mult: 3
 genus: jelly
 will: 40


### PR DESCRIPTION
for acid blobs, i have reduced their willpower from 160 to 80 (based off of their sibling, azure jelly) because i believe it's unreasonably high and somewhat out of place for a medium-threat (in slime) artillery unit to have Will in the same leagues as royal mummies and killer klowns, surpassing dissolution and nearing the levels of TRJ itself, instead i have given some of that willpower to rockslimes (60 -> 120) because they are already quite effective "blocker" enemies

for azure jellies, i removed their two elementally neutral attacks and increased the damage of their cold attacks, while also very slightly buffing their HD to add some more cold damage. i have also increased their cold resistance to rC+++ (their description says they are "extremely cold" so i imagine they would have more than just one level of cold resist). their two plain attacks do pretty low damage for slime (only 12) so merging them with the cold attacks which already do most of the damage seemed like a good idea

for rockslimes and slime creatures, rockslimes seem to already be made out of acidic goop (they can eat doors), slime creatures having it feels a bit questionable, but seeing as all the other jellies (save for formless jellyfish, it felt a bit too iffy to add it to them) are acid immune it shouldn't be too unreasonable