### PR TITLE
Non mindless TRJ

### DIFF
--- a/crawl-ref/source/dat/mons/royal-jelly.yaml
+++ b/crawl-ref/source/dat/mons/royal-jelly.yaml
@@ -13,7 +13,7 @@ hd: 21
 hp_10x: 2310
 ac: 8
 ev: 4
-intelligence: brainless
+intelligence: human
 speed: 14
 size: large
 shape: blob


### PR DESCRIPTION
It doesn't make sense for TRJ to be "mindless". With this change TRJ can be pacified by Ely worshipers (with a very heavy investment in invocations). Jiyva dies with the usual effects, not on pacification, but when TRJ goes up the stairs.