### PR TITLE
display quiet

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -753,7 +753,7 @@ static void _print_stats_noise(int x, int y)
     if (have_passive(passive_t::dampen_noise) || player_equip_unrand(UNRAND_THIEF))
     {
         textcolour(LIGHTMAGENTA);
-        CPRINTF("Quiet: ");
+        CPRINTF("Noise/2: ");
     }
     else 
     {

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -753,7 +753,7 @@ static void _print_stats_noise(int x, int y)
     if (have_passive(passive_t::dampen_noise) || player_equip_unrand(UNRAND_THIEF))
     {
         textcolour(LIGHTMAGENTA);
-        CPRINTF("Noise/2: ");
+        CPRINTF("Noi/2: ");
     }
     else 
     {

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -750,8 +750,16 @@ static void _print_stats_noise(int x, int y)
 
     bool silence = silenced(you.pos());
     int level = silence ? 0 : you.get_noise_perception(true);
-    textcolour(HUD_CAPTION_COLOUR);
-    CPRINTF("Noise: ");
+    if (have_passive(passive_t::dampen_noise) || player_equip_unrand(UNRAND_THIEF))
+    {
+        textcolour(LIGHTMAGENTA);
+        CPRINTF("Quiet: ");
+    }
+    else 
+    {
+        textcolour(HUD_CAPTION_COLOUR);
+        CPRINTF("Noise: ");
+    }
     colour_t noisecolour;
 
     // This is calibrated roughly so that in an open-ish area:


### PR DESCRIPTION
The dampen noise effect is now output from the display.

This is expressed in a format that replaces Display Noise: with Quiet:.

This can only be seen in the cloak of Thief and Dithmenos.

![1](https://github.com/crawl/crawl/assets/117167196/579863f0-ad33-414d-8882-e86a9e1a887e)


