### PR TITLE
block entry of > 27 skill target

### DIFF
--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -922,8 +922,17 @@ int SkillMenu::read_skill_target(skill_type sk)
         return -1;
     }
     else
+    {
         input = round(atof(result_buf) * 10.0);    // TODO: parse fixed point?
-
+        if (input > 270)
+        {
+            // 27.0 is the maximum target
+            set_help("<lightred>Your training target must be 27 or below!</lightred>");
+            return -1;
+        }
+        else
+            set_help("");
+    }
     you.set_training_target(sk, input);
     cancel_set_target();
     refresh_display();

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1775,6 +1775,11 @@ void player::clear_training_targets()
  */
 bool player::set_training_target(const skill_type sk, const int target, bool announce)
 {
+    if (target > 270) // if target is above 270, reject with an error
+    {
+        mpr("Your training target must be 27 or below!");
+        return false;
+    }
     const int ranged_target = min(max((int) target, 0), 270);
     if (announce && ranged_target != (int) training_targets[sk])
     {


### PR DESCRIPTION
Skill target gets set to 27 silently when user entered a number greater than 27. This change blocks setting the skill level to 27 and prompts the user to enter a number of 27 or lower in webtiles.