### PR TITLE
Make fair_adjacent_iterator fair

### DIFF
--- a/crawl-ref/source/coordit.h
+++ b/crawl-ref/source/coordit.h
@@ -4,6 +4,7 @@
 #include "coord-circle.h"
 #include "los-type.h"
 
+#include <cstdint>
 #include <vector>
 
 using std::vector;
@@ -166,13 +167,21 @@ private:
     void push_neigh(coord_def from, int dx, int dy);
 };
 
-// If this becomes performance-critical, reimplement it as adjacent_iterator
-// with a permutation array.
-class fair_adjacent_iterator : public distance_iterator
+class fair_adjacent_iterator
 {
 public:
-    fair_adjacent_iterator(coord_def _center, bool _exclude_center = true)
-        : distance_iterator(_center, true, _exclude_center, 1) {}
+    fair_adjacent_iterator(coord_def _center);
+
+    operator bool() const noexcept PURE;
+    coord_def operator *() const noexcept PURE;
+    //const coord_def *operator->() const PURE;
+
+    void operator ++ ();
+    void operator ++ (int);
+private:
+    coord_def center;
+    std::uint_fast32_t remaining; // used as an array of 8 4-bit numbers
+    std::uint_fast8_t remaining_count;
 };
 
 # ifdef DEBUG_TESTS

--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -299,8 +299,6 @@ void blink_fineff::fire()
     if (!pal || !pal->alive() || pal->no_tele())
         return;
 
-    int cells_seen = 0;
-    coord_def target;
     for (fair_adjacent_iterator ai(defend->pos()); ai; ++ai)
     {
         // No blinking into teleport closets.
@@ -309,14 +307,10 @@ void blink_fineff::fire()
         // XXX: allow fedhasites to be blinked into plants?
         if (actor_at(*ai) || !pal->is_habitable(*ai))
             continue;
-        cells_seen++;
-        if (one_chance_in(cells_seen))
-            target = *ai;
-    }
-    if (!cells_seen)
-        return;
 
-    pal->blink_to(target);
+        pal->blink_to(*ai);
+        break;
+    }
 }
 
 void teleport_fineff::fire()

--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -109,7 +109,10 @@ bool ugly_thing_mutate(monster& ugly, bool force)
             continue;
 
         if (act->is_player() && get_contamination_level())
+        {
             msg = " basks in your mutagenic energy and changes!";
+            break;
+        }
         else if (mons_genus(act->type) == MONS_UGLY_THING)
         {
             msg = " basks in the mutagenic energy from its kin and changes!";
@@ -117,6 +120,7 @@ bool ugly_thing_mutate(monster& ugly, bool force)
                 make_low_colour(act->as_monster()->colour);
             if (make_low_colour(ugly.colour) != other_colour)
                 new_colour = other_colour;
+            break;
         }
     }
 

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -8193,7 +8193,7 @@ static monster* _find_ally_to_throw(const monster &mons)
     int furthest_dist = -1;
 
     monster* best = nullptr;
-    for (fair_adjacent_iterator ai(mons.pos(), true); ai; ++ai)
+    for (fair_adjacent_iterator ai(mons.pos()); ai; ++ai)
     {
         monster* throwee = monster_at(*ai);
 

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -301,6 +301,7 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
                 && monster_habitable_grid(orig, env.grid(*ai)))
             {
                 pos = *ai;
+                break;
             }
         }
 


### PR DESCRIPTION
The old fair_adjacent_iterator would visit the tiles around it in the following order
1 4 6
2 x 7
3 5 8
starting from a random tile and wrapping around when it reached the last tile e.g. if the random start was 4 then 4,5,6,7,8,1,2,3. So imagine for example a yellow ugly thing surrounded by walls and other ugly things trying to pick a random ugly thing around it when changing colour as shown below

w=wall
r=red ugly thing
y=yellow ugly thing
b=brown ugly thing
c=cyan ugly thing
g=green ugly thing

w w r
w y b
w c g

if the random start was an adjacent ugly thing that ugly thing would be selected, however, if the random start was one of the walls the iterator would be advanced until it reached the cyan ugly thing and it would be selected givng the cyan ugly thing a 5/8 chance of being selected and the red, brown and green ugly things 1/8 chance each.

This change makes fair_adjacent_iterator visit the tiles around it in a random order (without repeats)