### PR TITLE
Don't say that an undead kraken has died.

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2841,7 +2841,14 @@ item_def* monster_die(monster& mons, killer_type killer,
             && !was_banished)
         {
             if (mons_base_type(mons) == MONS_KRAKEN)
-                mpr("The dead kraken's tentacles slide back into the water.");
+            {
+                const char *dead = "", *die = "slide back into the water";
+                if (!mons_is_zombified(mons))
+                    dead = "dead ";
+                else if (mons.type == MONS_SIMULACRUM)
+                    die = "melt away";
+                mprf("The %skraken's tentacles %s.", dead, die);
+            }
             else if (mons.type == MONS_TENTACLED_STARSPAWN)
                 mpr("The starspawn's tentacles wither and die.");
         }


### PR DESCRIPTION
A kraken's "death" message referred to "The dead kraken's tentacles" even if it had been undead.

It now omits "dead" in this case, and says that simulacrum tentacles melt away (not "evaporate", like the head, as there's no icy vapour).