### PR TITLE
Add a note to distinguish explore mode deaths from Felid deaths

### DIFF
--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -1234,6 +1234,8 @@ void ouch(int dam, kill_method_type death_type, mid_t source, const char *aux,
                 take_note(Note(NOTE_DEATH, you.hp, you.hp_max,
                                 death_desc.c_str()), true);
                 _wizard_restore_life();
+                take_note(Note(NOTE_DEATH, you.hp, you.hp_max,
+                                "You cheat death using unusual wizardly powers."), true);
                 return;
             }
         }


### PR DESCRIPTION
I've sometimes practices in explore mode and have wanted to know how many times I've literally *cheated* death. There's no consistent string to search for to identify this. Especially with Felids it is hard to tell which deaths are cheats and which are legit revivals.