### PR TITLE
Make auto-training train spell skills more readily for djinn.

### DIFF
--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -599,13 +599,15 @@ static void _setup_generic(const newgame_def& ng,
         set_form(transformation::beast, 1); // hacky...
     }
 
-    reassess_starting_skills();
+    reassess_starting_skills(false);
     init_skill_order();
     init_can_currently_train();
     init_train();
     if (you.religion == GOD_TROG)
         join_trog_skills();
     init_training();
+    if (you.has_mutation(MUT_INNATE_CASTER))
+        cleanup_innate_magic_skills();
 
     // Apply autoinscribe rules to inventory.
     request_autoinscribe();

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -252,7 +252,7 @@ void cleanup_innate_magic_skills()
 // Characters are actually granted skill points, not skill levels.
 // Here we take racial aptitudes into account in determining final
 // skill levels.
-void reassess_starting_skills()
+void reassess_starting_skills(bool balance_djinn)
 {
     // go backwards, need to do Dodging before Armour
     // "sk >= SK_FIRST_SKILL" might be optimised away, so do this differently.
@@ -311,7 +311,8 @@ void reassess_starting_skills()
         }
     }
 
-    if (you.has_mutation(MUT_INNATE_CASTER))
+    // For a new game, this is called after training is calculated.
+    if (balance_djinn && you.has_mutation(MUT_INNATE_CASTER))
         cleanup_innate_magic_skills();
 }
 
@@ -843,7 +844,7 @@ static void _balance_magic_training()
     ASSERT(n_skills > 0);
     // Total training for all magic skills should be the base average,
     // divided between each skill.
-    const int to_train = max(train_total / (n_skills * n_skills), 1);
+    const int to_train = max(train_total / n_skills, 1);
     for (skill_type sk = SK_SPELLCASTING; sk <= SK_LAST_MAGIC; ++sk)
         if (!is_removed_skill(sk) && you.skills[sk] < MAX_SKILL_LEVEL)
             you.training[sk] = to_train;

--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -62,7 +62,7 @@ int calc_skill_cost(int skill_cost_level);
 void check_skill_cost_change();
 
 bool skill_default_shown(skill_type sk);
-void reassess_starting_skills();
+void reassess_starting_skills(bool balance_djinn = true);
 bool check_selected_skills();
 void init_train();
 void init_can_currently_train();


### PR DESCRIPTION
Calculate how much exercise spell skills gives for a new character before splitting spell skills. This means that level 1 djinn auto-train magic to a similar degree to other species.

Train spell skills (roughly) in proportion to the exercise put into them, where it had been much less.

The aim of this is to make the auto-train behaviour feel similar for Djinn to the way it feels for other species. The 0.31 version feels very different to me, with no spell training at level 1 and little emphasis on it later on (to the extent that setting focus on a different skill could eliminate spell skill training altogether).