### PR TITLE
Add more flair to using Rising Flame on D:1

### DIFF
--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -717,7 +717,8 @@ void rise_through_ceiling()
         && you.depth == 1
         && player_has_orb())
     {
-        mpr("With a burst of heat and light, you rocket upward!");
+        mpr("With a blazing flash, you soar upward victoriously "
+            "engulfed in flames, breaking free from the dungeon's grasp!");
         floor_transition(DNGN_EXIT_DUNGEON, DNGN_EXIT_DUNGEON,
                          level_id(BRANCH_DUNGEON, 0), true, true, false, false);
     }


### PR DESCRIPTION
There was used default message from the ability, which does not fits the celebrating moment of escaping
from dungeon.

So the messages chain with the tweak is:
```
You begin to rise into the air.
..
__message from the commit__
You have escaped!
```

PS. The message is a bit long, so feel free to adjust it