### PR TITLE
Stop lemures from thanking you for killing them.

### DIFF
--- a/crawl-ref/source/dactions.cc
+++ b/crawl-ref/source/dactions.cc
@@ -278,11 +278,44 @@ void apply_daction_to_mons(monster* mon, daction_type act, bool local,
     }
 }
 
+// Print a farewell message from any of Pikel's minions who are visible.
+static void _pikel_band_message()
+{
+    int visible_minions = 0;
+    for (monster_iterator mi; mi; ++mi)
+    {
+        if (mi->type == MONS_LEMURE
+            && mi->props.exists(PIKEL_BAND_KEY)
+            && mi->observable())
+        {
+            visible_minions++;
+        }
+    }
+    if (visible_minions > 0 && you.num_turns > 0)
+    {
+        if (you.get_mutation_level(MUT_NO_LOVE))
+        {
+            const char *substr = visible_minions > 1 ? "minions" : "minion";
+            mprf("Pikel's spell is broken, but his former %s can only feel hate"
+                 " for you!", substr);
+        }
+        else
+        {
+            const char *substr = visible_minions > 1
+                ? "minions thank you for their"
+                : "minion thanks you for its";
+            mprf("With Pikel's spell broken, his former %s freedom.", substr);
+        }
+    }
+}
+
 static void _apply_daction(daction_type act)
 {
     ASSERT_RANGE(act, 0, NUM_DACTIONS);
     dprf("applying delayed action: %s", daction_names[act]);
 
+    if (DACT_PIKEL_MINIONS == act)
+        _pikel_band_message();
     switch (act)
     {
     case DACT_JIYVA_DEAD:

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3559,35 +3559,7 @@ bool mons_is_mons_class(const monster* mons, monster_type type)
  **/
 void pikel_band_neutralise()
 {
-    int visible_minions = 0;
-    for (monster_iterator mi; mi; ++mi)
-    {
-        if (mi->type == MONS_LEMURE
-            && mi->props.exists(PIKEL_BAND_KEY)
-            && mi->observable())
-        {
-            visible_minions++;
-        }
-    }
-    string final_msg;
-    if (visible_minions > 0 && you.num_turns > 0)
-    {
-        if (you.get_mutation_level(MUT_NO_LOVE))
-        {
-            const char *substr = visible_minions > 1 ? "minions" : "minion";
-            final_msg = make_stringf("Pikel's spell is broken, but his former "
-                                     "%s can only feel hate for you!", substr);
-        }
-        else
-        {
-            const char *substr = visible_minions > 1
-                ? "minions thank you for their"
-                : "minion thanks you for its";
-            final_msg = make_stringf("With Pikel's spell broken, his former %s "
-                                     "freedom.", substr);
-        }
-    }
-    delayed_action_fineff::schedule(DACT_PIKEL_MINIONS, final_msg);
+    delayed_action_fineff::schedule(DACT_PIKEL_MINIONS, "");
 }
 
 /**


### PR DESCRIPTION
Move the "With Pikel's spell broken..." message into the DACT_PIKEL_MINIONS handler, so it only prints if you can see any lemures which survived long enough to depart.