### PR TITLE
Trove: Fix trove_misc_dual_throne_room veto

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -165,7 +165,7 @@ function trove.get_trove_item(e, value, base_item)
   local chosen = util.random_from(prices)
   item.base_type = chosen.base
   item.sub_type = chosen.type
-  if chosen.base == "armour" or chosen.base == "wand" then
+  if chosen.base == "armour" then
     item.plus1 = chosen.quant
   elseif chosen.base == "weapon" then
     item.plus1 = chosen.quant

--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -929,9 +929,9 @@ COLOUR:  ' = yellow
 FTILE:   ' = floor_limestone
 : trove.setup_features(_G)
 veto {{ return crawl.game_started()
-        and (you.base_skill("Evocations") < 4
-             and not crawl.one_chance_in(3)
-             or you.mutation("inability to use devices") == 1) }}
+        and (you.mutation("inability to use devices") == 1
+             and you.mutation("no forms") == 1
+             or not crawl.one_chance_in(3)) }}
 MAP
   xxxxx
   xdxex


### PR DESCRIPTION
The trove contains two misc and four talismans, so should not be vetoed only by no-device mutation