### PR TITLE
Don't let non-damaging walls or clouds stop running.

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -4594,12 +4594,8 @@ bool runrest::run_should_stop() const
     const coord_def targ = you.pos() + pos;
     const map_cell& tcell = env.map_knowledge(targ);
 
-    // XXX: probably this should ignore cosmetic clouds (non-opaque)
-    if (tcell.cloud() != CLOUD_NONE
-        && !you.cloud_immune())
-    {
+    if (!_is_safe_cloud(targ))
         return true;
-    }
 
     if (is_excluded(targ) && !is_stair_exclusion(targ))
     {
@@ -4614,7 +4610,7 @@ bool runrest::run_should_stop() const
     if (mon && !fedhas_passthrough(tcell.monsterinfo()))
         return true;
 
-    if (count_adjacent_slime_walls(targ))
+    if (slime_wall_neighbour(targ) && !actor_slime_wall_immune(&you))
         return true;
 
     for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Let the player run (shift+dir) through safe clouds.

Let the player run up to slimy walls if immune to their effects.

In both cases, the player could already travel through an affected square.