### PR TITLE
Fix stash search prefixes for golden dragon scales

### DIFF
--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -136,7 +136,7 @@ function ch_stash_search_annotate_item(it)
       ["pearl"] = "rN+",
       ["storm"] = "rElec",
       ["shadow"] = "Stlth++++",
-      ["gold"] = "rF+ rC+ rPois"
+      ["golden"] = "rF+ rC+ rPois"
     }
     local t = it.name("base"):match("%w+")
     if props[t] then


### PR DESCRIPTION
Presumably broke after the rename from gold -> golden.

I also noticed test/stress/qw.rc has the old name still, but it already seems to have been fixed in the qw repo, so I left that alone. (The file seems rather out-of-date anyway; it generates other errors as a result)