### PR TITLE
Android: Add a full screen option to the launcher

### DIFF
--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSLauncher.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSLauncher.java
@@ -10,6 +10,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.Spinner;
 
@@ -18,14 +19,17 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SwitchCompat;
 
-public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnItemSelectedListener, TextWatcher {
+public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnItemSelectedListener, TextWatcher, CompoundButton.OnCheckedChangeListener {
 
     public final static String TAG = "LAUNCHER";
 
     private static final String INIT_FILE = "/init.txt";
 
     private static final int DEFAULT_KEYBOARD = 0;
+
+    private static final boolean DEFAULT_FULL_SCREEN = true;
 
     // Crawl's init file
     private File initFile;
@@ -51,6 +55,12 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
     // Screen density
     private float density;
 
+    // Full screen input
+    SwitchCompat fullScreenSwitch;
+
+    // Full screen
+    private boolean fullScreen;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
@@ -64,6 +74,7 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
         preferences = getPreferences(Context.MODE_PRIVATE);
         keyboardOption = preferences.getInt("keyboard", DEFAULT_KEYBOARD);
         extraKeyboardOption = preferences.getInt("extra_keyboard", DEFAULT_KEYBOARD);
+        fullScreen = preferences.getBoolean("full_screen", DEFAULT_FULL_SCREEN);
 
         // Density is the relationship between px and dp
         density = getResources().getDisplayMetrics().density;
@@ -94,6 +105,11 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
         ksizeEditText.setText(Integer.toString(keyboardSizeDp));
         ksizeEditText.addTextChangedListener(this);
 
+        // Full screen switch
+        fullScreenSwitch = findViewById(R.id.fullScreen);
+        fullScreenSwitch.setChecked(fullScreen);
+        fullScreenSwitch.setOnCheckedChangeListener(this);
+
         initFile = new File(getExternalFilesDir(null)+INIT_FILE);
         resetInitFile(false);
     }
@@ -104,6 +120,7 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
         intent.putExtra("keyboard", keyboardOption);
         intent.putExtra("extra_keyboard", extraKeyboardOption);
         intent.putExtra("keyboard_size", Math.round(keyboardSizePx));
+        intent.putExtra("full_screen", fullScreen);
         startActivity(intent);
     }
 
@@ -167,5 +184,11 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
 
     @Override
     public void afterTextChanged(Editable editable) {}
+
+    @Override
+    public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+        fullScreen = b;
+        preferences.edit().putBoolean("full_screen", fullScreen).apply();
+    }
 
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -69,6 +69,7 @@ public class SDLActivity extends AppCompatActivity {
     protected static int keyboardOption;
     protected static int extraKeyboardOption;
     protected static int keyboardSize;
+    protected static boolean fullScreen;
     protected static View mTextEdit;
     protected static boolean mScreenKeyboardShown;
     protected static boolean mScreenExtraKeyboardShown;
@@ -147,6 +148,7 @@ public class SDLActivity extends AppCompatActivity {
         keyboardOption = 0;
         extraKeyboardOption = 0;
         keyboardSize = 0;
+        fullScreen = true;
         mTextEdit = null;
         mLayout = null;
         mClipboardHandler = null;
@@ -232,6 +234,8 @@ public class SDLActivity extends AppCompatActivity {
         Log.i(TAG, "Extra keyboard option: " + extraKeyboardOption);
         keyboardSize = intent.getIntExtra("keyboard_size", 0);
         Log.i(TAG, "Extra keyboard option: " + keyboardSize);
+        fullScreen = intent.getBooleanExtra("full_screen", false);
+        Log.i(TAG, "Full screen: " + fullScreen);
 
         mLayout = new RelativeLayout(this);
         mLayout.setBackgroundColor(getResources().getColor(R.color.black));
@@ -376,10 +380,18 @@ public class SDLActivity extends AppCompatActivity {
            return;
         }
 
+        // Full screen
+        // Once UI flags have been cleared (for example, by navigating away from the activity),
+        // your app needs to reset them if you want to hide the bars again
+        if (fullScreen) {
+            View decorView = getWindow().getDecorView();
+            int uiOptions = View.SYSTEM_UI_FLAG_FULLSCREEN;
+            decorView.setSystemUiVisibility(uiOptions);
+        }
+
         SDLActivity.mHasFocus = hasFocus;
         if (hasFocus) {
            mNextNativeState = NativeState.RESUMED;
-
         } else {
            mNextNativeState = NativeState.PAUSED;
         }

--- a/crawl-ref/source/android-project/app/src/main/res/layout/launcher.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/layout/launcher.xml
@@ -126,6 +126,42 @@
                     android:layout_weight="1"
                     android:inputType="number" />
             </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:layout_marginHorizontal="6dp"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="50dp"
+                    android:layout_weight="1"
+                    android:gravity="right"
+                    android:layout_marginTop="4dp"
+                    android:layout_marginRight="6dp"
+                    android:text="@string/full_screen"
+                    android:textStyle="bold" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:focusable="true"
+                    android:focusableInTouchMode="true"
+                    android:orientation="horizontal">
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/fullScreen"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:checked="true" />
+
+                </LinearLayout>
+            </LinearLayout>
         </LinearLayout>
     </ScrollView>
 </RelativeLayout>

--- a/crawl-ref/source/android-project/app/src/main/res/values/constants.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/values/constants.xml
@@ -6,6 +6,8 @@
         <item name="android:textColor">@color/white</item>
         <item name="colorButtonNormal">@color/gray</item>
         <item name="android:windowAnimationStyle">@style/CrawlActivityAnimation</item>
+        <item name="colorControlActivated">@color/light_green</item>
+        <item name="colorSwitchThumbNormal">@color/gray</item>
     </style>
     <style name="CrawlActivityAnimation" parent="@android:style/Animation.Activity">
         <item name="android:activityOpenEnterAnimation">@anim/slide_in_right</item>

--- a/crawl-ref/source/android-project/app/src/main/res/values/strings.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="keyboard">Keyboard</string>
     <string name="extra_keyboard">Extra directional pad</string>
     <string name="keyboard_size">Keyboard size</string>
+    <string name="full_screen">Full screen</string>
     <string-array name="sort_options">
         <item>Name asc.</item>
         <item>Name desc.</item>


### PR DESCRIPTION
I got this message from an Android user:
    
> can't enable full screen mode by setting "tile_full_screen = true",
> still shows a black bar on top with device status.
    
I agree a full screen option for Android can improve the user
experience. Mostly when playing on landscape mode with modern devices.
    
You can read this in the docs:
    
> Where you set the UI flags makes a difference. If you hide the system
> bars in your activity's onCreate() method and the user presses Home,
> the system bars will reappear. When the user reopens the activity,
> onCreate() won't get called, so the system bars will remain visible.
> If you want system UI changes to persist as the user navigates in and
> out of your activity, set UI flags in onResume() or
> onWindowFocusChanged().
    
Tried both options and the behaviour when using onWindowsFocusChanged
is more consistent. When using onResume, full screen is lost whenever
you open the top menu.

![Screenshot_20240820_102151](https://github.com/user-attachments/assets/0baab2e9-1986-4c4b-9b30-56efd37ef45d)