### PR TITLE
Add a god protection check to monsters in Fulsome Fusillade clouds (Resolves #3985)

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -5152,7 +5152,8 @@ static void _do_fusillade_hit(monster* mon, int power, beam_type flavour)
     exp.colour        = concoction_colour[flavour];
     exp.fire();
 
-    if (flavour == BEAM_MMISSILE && mon && mon->alive())
+    if (flavour == BEAM_MMISSILE && mon && mon->alive()
+        && !god_protects(mon, true))
     {
         // Do reaction here
         beam_type effect = *random_choose_weighted(reaction_effects);


### PR DESCRIPTION
## Summary

Hep ancestors and Dith player shadows are immune to Fulsome Fusillade's damage, but are currently affected by cloud effects. This change adds a god protection check to monsters and doesn't apply the effects to those which are protected.

Reported by [acrobat3](https://github.com/acrobat3) and resolves [#3985](https://github.com/crawl/crawl/issues/3985)

## Changes

* Added a `!god_protects(mon, true)` check to flavour application logic in the following code:
  * `crawl-ref/source/spl-damage.cc`
    * `static void _do_fusillade_hit(monster* mon, int power, beam_type flavour)`

## Investigation

Issue investigated and fix validated in the following git issue comment: https://github.com/crawl/crawl/issues/3985#issuecomment-2307877387