### PR TITLE
Update player doll to visually lose wings when big wings mutation is lost (Resolves #3973)

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2570,6 +2570,9 @@ static bool _delete_single_mutation_level(mutation_type mutat,
 
     case MUT_BIG_WINGS:
         land_player();
+#ifdef USE_TILE
+        init_player_doll();
+#endif
         break;
 
     case MUT_HORNS:


### PR DESCRIPTION
## Summary

Draconian wings would remain on player dolls until saving and reloading if they had lost their big wings mutation. This change has the loss of the big wing mutation initialize the player doll so we properly lose the wings when this occurs.

Reported by [kuniqsX](https://github.com/kuniqsX) and resolves [#3973](https://github.com/crawl/crawl/issues/3973)

## Changes

* Added `init_player_doll();` with a `USE_TILE` def compiler flag under the `MUT_BIG_WINGS` switch case for the following code:
  * `crawl-ref/source/mutation.cc`
    * `static bool _delete_single_mutation_level(mutation_type mutat, ...`

## Investigation

Tested with the committed code change alongside the *NOT* committed code changes to `potion.cc` for easy reproduction:
```c++
    bool effect(bool = true, int = 40, bool = true) const override
    {
        if (have_passive(passive_t::cleanse_mut_potions))
            simple_god_message(" cleanses your potion of mutation!");
        else
            mpr("You feel extremely strange.");
        bool mutated = false;

        static bool true_to_add = true;

        // Remove mutations.
        if (!true_to_add)
        {
            mprf(MSGCH_DIAGNOSTICS, "Removing MUT_BIG_WINGS");
            mutated |= delete_mutation(MUT_BIG_WINGS, "potion of mutation", false);
        }
        // Add mutations.
        else
        {
            mprf(MSGCH_DIAGNOSTICS, "Adding MUT_BIG_WINGS");
            mutated |= mutate(MUT_BIG_WINGS, "potion of mutation", false);
            learned_something_new(HINT_YOU_MUTATED);
        }
        true_to_add = !true_to_add;
        return mutated;
    }
```
1. Starting out with no wings on a draconian
<img width="93" alt="Screenshot 2024-08-23 at 6 40 09 PM" src="https://github.com/user-attachments/assets/d8f6af0b-63d6-472f-bdde-b8a33a51da5c">

2. Wings appear on the player doll after mutating and gaining the big wings mutation
<img width="526" alt="Screenshot 2024-08-23 at 6 40 38 PM" src="https://github.com/user-attachments/assets/aab3ccdd-7be1-4266-a7b0-302388631124">

3. Wings properly disappear after removing the big wings mutation
<img width="512" alt="Screenshot 2024-08-23 at 6 40 50 PM" src="https://github.com/user-attachments/assets/6477c560-9cd5-4b23-8ded-02e90c216245">
