### PR TITLE
Fix crash on the death of summoned Blorkula the Orcula

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1013,7 +1013,7 @@ static bool _monster_avoided_death(monster* mons, killer_type killer,
     else if (_beogh_maybe_convert_orc(*mons, killer, killer_index))
         return true;
 
-    if (mons->type == MONS_BLORKULA_THE_ORCULA)
+    if (mons->type == MONS_BLORKULA_THE_ORCULA && !mons->is_summoned())
         return _blorkula_bat_split(*mons, killer);
 
     if (mons->hit_points < -25 || mons->hit_points < -mons->max_hit_points)


### PR DESCRIPTION
E.g. via the player using a phantom mirror. Make it so that only the real Blorkula splits into a colourful array of bats.