### PR TITLE
fix: "Ran out of altars for temple" error (thirdmesn, Vajrapani)

### DIFF
--- a/crawl-ref/source/dat/des/branches/temple.des
+++ b/crawl-ref/source/dat/des/branches/temple.des
@@ -1035,7 +1035,7 @@ ENDMAP
 # <<2>> Nine to twelve altars
 # <<3>> Thirteen to fifteen altars
 # <<4>> Sixteen to twenty altars
-# <<5>> Twenty-one altars
+# <<5>> Twenty-one to twenty-six altars
 # <<6>> Variable altars, generic layouts
 # <<7>> Variable altars, unusual layouts
 # <<8>> Rare temples, tagged with temple_rare
@@ -2387,9 +2387,9 @@ twwwwwwwwwwwwwwwwwwwwwwwwwwwwwwt
 tttttttttttttttttttttttttttttttt
 ENDMAP
 
-# 18 gods
+# 20 gods
 NAME:    regret_index_temple_chain_breaker
-TAGS:    temple_altars_18
+TAGS:    temple_altars_20
 TAGS:    no_rotate
 PLACE:   Temple
 ORIENT:  encompass
@@ -2555,9 +2555,9 @@ cccccc.........B...c..........cc
               ccc
 ENDMAP
 
-# 18 gods
+# 19 gods
 NAME:    mainiacjoe_temple_bowtie_tessellation
-TAGS:    temple_altars_18
+TAGS:    temple_altars_19
 PLACE:   Temple
 ORIENT:  encompass
 SUBST:   c : cvb
@@ -2751,7 +2751,7 @@ xxxxxxxxxxxx
 ENDMAP
 
 ##############################################################################
-# <<5>> Twenty-one gods.
+# <<5>> Twenty-one to twenty-six gods.
 
 NAME:    kilobyte_greek_temple
 TAGS:    no_rotate temple_altars_21
@@ -3033,7 +3033,7 @@ llllllClllllllllllllllllllEllllllllDlllllllllllllll
 ENDMAP
 
 NAME:    mainiacjoe_temple_archimedes_tessellation
-TAGS:    temple_altars_21
+TAGS:    temple_altars_22
 PLACE:   Temple
 ORIENT:  encompass
 TAGS:    no_pool_fixup
@@ -3166,7 +3166,7 @@ cc......x.....x.......xxx............x.....x......x...x......cc
 ENDMAP
 
 NAME:    mainiacjoe_temple_hex_bubbles
-TAGS:    temple_altars_21
+TAGS:    temple_altars_22
 PLACE:   Temple
 ORIENT:  encompass
 NSUBST:  B = 1:{ / *:B
@@ -5373,7 +5373,7 @@ ENDMAP
 
 # every god in the game
 NAME:   hellmonk_choose_your_character
-TAGS:   temple_rare temple_altars_22 no_rotate no_vmirror no_hmirror
+TAGS:   temple_rare temple_altars_26 no_rotate no_vmirror no_hmirror
 PLACE:  Temple
 ORIENT: encompass
 WEIGHT: 1


### PR DESCRIPTION
A few temple vaults had a temple_altars_X tag where X was lower than the number of altars in the vault. This caused the "Ran out of altars for temple" error during the creation of a new character/dungeon.

This commit fixes the issue by increasing the tag values to match the number of altars in the vault. This change results in temple vaults with 22 and 26 altars, instead of the previous max of 21.

Note: Does not update temple vaults with a variable temple count due to substitution removing the superfluous altars in the vault.

Resolves #2810
Resolves #3846