### PR TITLE
Ensure only actual spells (not evocables) trigger Coglin's SpellMotor effect (Resolves #4003)

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2196,7 +2196,7 @@ spret your_spells(spell_type spell, int powc, bool actual_spell,
             dithmenos_shadow_spell(spell);
         _spellcasting_side_effects(spell, god, !actual_spell);
 
-        if (you.wearing_ego(EQ_GIZMO, SPGIZMO_SPELLMOTOR))
+        if (you.wearing_ego(EQ_GIZMO, SPGIZMO_SPELLMOTOR) && actual_spell)
             coglin_spellmotor_attack();
 
         return spret::success;


### PR DESCRIPTION
## Summary

Coglins with a gizmo featuring the SpellMotor effect would have that ability activate when using certain evocables aside from actual spell casting.

Reported by [Vitna-1](https://github.com/Vitna-1) and resolves #4003

## Changes

* Added an `actual_spell` check before applying a `coglin_spellmotor_attack()`:
  * `crawl-ref/source/spl-util.cc`
    * `spret your_spells`

## Investigation

Tested with the change based on the table provided in the initial incident report. Note: the evocable that didn't trigger SpellMotor were not tested.

| Evocable | Triggers SpellMotor |
|--|--|
| Staff of Olgreb |No|
| Orb of Dispater |No|
| Lightning Rod |No|
| Wand of Acid |No|
| Wand of Charming |No|
| Wand of Digging |No|
| Wand of Flame |No|
| Wand of Iceblast |No|
| Wand of Light |No|
| Wand of Mindburst |No|
| Wand of Paralysis |No|
| Wand of Polymorph |No|
| Wand of Roots |No|
| Wand of Quicksilver |No|