### PR TITLE
don't crash if shadow can't be placed (ChongLi)

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1814,7 +1814,12 @@ void dithmenos_shadow_spell(spell_type spell)
             // Don't cast this spell without any enemies in sight, to prevent
             // tedious pre-casting by the player.
             if (_shadow_target_exists())
-                pos = _get_shadow_spots()[0];
+            {
+                auto spots = _get_shadow_spots();
+                if (spots.empty())
+                    break;
+                pos = spots[0];
+            }
             break;
     }
 


### PR DESCRIPTION
If a player is surrounded by monsters to depth 3+, `_get_shadow_spots` produces an empty vector and the game crashes trying to dereference the first entry. Check for an empty vector first.
(https://cbro.berotato.org/morgue/ChongLi/crash-ChongLi-20240908-132253.txt)