### PR TITLE
Fix HP/MP not updating when (un)equipping the Charlatan's Orb

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1844,9 +1844,13 @@ static void _DOOM_KNIGHT_melee_effects(item_def* /*item*/, actor* attacker,
 static void _CHARLATANS_ORB_equip(item_def */*item*/, bool */*show_msgs*/, bool /*unmeld*/)
 {
     invalidate_agrid(true);
+    calc_hp(true);
+    calc_mp(true);
 }
 
 static void _CHARLATANS_ORB_unequip(item_def */*item*/, bool */*show_msgs*/)
 {
     invalidate_agrid(true);
+    calc_hp(true);
+    calc_mp(true);
 }

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -505,6 +505,16 @@ static bool _any_crosstrained()
     return false;
 }
 
+static bool _charlatan_bonus()
+{
+    if (player_equip_unrand(UNRAND_CHARLATANS_ORB)
+        && you.skill(SK_EVOCATIONS, 10, true) > 0)
+    {
+        return true;
+    }
+    return false;
+}
+
 static bool _hermit_bonus()
 {
     if (player_equip_unrand(UNRAND_HERMITS_PENDANT)
@@ -566,6 +576,8 @@ string SkillMenuSwitch::get_help()
                 causes.push_back("cross-training");
             if (_hermit_bonus())
                 causes.push_back("the Hermit's pendant");
+            if (_charlatan_bonus())
+                causes.push_back("the Charlatan's Orb");
             result = "Skills enhanced by "
                      + comma_separated_line(causes.begin(), causes.end())
                      + " are in <green>green</green>.";


### PR DESCRIPTION
Make the Charlatan's Orb explicitly update the player's HP and MP in its equip/unequip functions.

Also add the Charlatan's Orb as a cause of increased skills on the skills screen to fix the previous text
`Skills enhanced by  are in green.`

Resolves #4015. (Forgot to mention in commit message, sorry)