### PR TITLE
Preserve bribe enchantments for reviving bennu

### DIFF
--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -694,6 +694,9 @@ void bennu_revive_fineff::fire()
         newmons->props[OKAWARU_DUEL_TARGET_KEY] = true;
         newmons->props[OKAWARU_DUEL_CURRENT_KEY] = true;
     }
+
+    if (gozag_bribe.ench != ENCH_NONE)
+        newmons->add_ench(gozag_bribe);
 }
 
 void avoided_death_fineff::fire()

--- a/crawl-ref/source/fineff.h
+++ b/crawl-ref/source/fineff.h
@@ -361,21 +361,24 @@ public:
     void fire() override;
 
     static void schedule(coord_def pos, int revives, beh_type attitude,
-                         unsigned short foe, bool duel)
+                         unsigned short foe, bool duel, mon_enchant gozag_bribe)
     {
-        final_effect::schedule(new bennu_revive_fineff(pos, revives, attitude, foe, duel));
+        final_effect::schedule(new bennu_revive_fineff(pos, revives, attitude,
+                                                       foe, duel, gozag_bribe));
     }
 protected:
     bennu_revive_fineff(coord_def pos, int _revives, beh_type _att,
-                        unsigned short _foe, bool _duel)
+                        unsigned short _foe, bool _duel,
+                        mon_enchant _gozag_bribe)
         : final_effect(0, 0, pos), revives(_revives), attitude(_att), foe(_foe),
-          duel(_duel)
+          duel(_duel), gozag_bribe(_gozag_bribe)
     {
     }
     int revives;
     beh_type attitude;
     unsigned short foe;
     bool duel;
+    mon_enchant gozag_bribe;
 };
 
 class avoided_death_fineff : public final_effect

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -2870,12 +2870,17 @@ item_def* monster_die(monster& mons, killer_type killer,
             const beh_type att = mons.has_ench(ENCH_CHARM)
                                  ? BEH_HOSTILE : SAME_ATTITUDE(&mons);
 
+            // Carry over bribe enchantments (as otherwise revived bribed
+            // bennu will follow the player out of their branch)
+            const mon_enchant gozag_bribe = mons.get_ench(ENCH_NEUTRAL_BRIBED,
+                                                          ENCH_FRIENDLY_BRIBED);
+
             // Don't consider this a victory yet, and duel the new bennu.
             if (duel)
                 mons.props.erase(OKAWARU_DUEL_CURRENT_KEY);
 
             bennu_revive_fineff::schedule(mons.pos(), revives, att, mons.foe,
-                                          duel);
+                                          duel, gozag_bribe);
         }
     }
 


### PR DESCRIPTION
Previously, if a bennu was friendly-bribed in their first life, it would revive as a permanent friendly ally that could follow the player everywhere. If it was temporarily neutral-bribed, it would revive as a permanent neutral monster.

Fix this issue by preserving friendly and neutral bribe enchantments upon revival.

Sidenote: currently unbribed bennu get a second chance to become bribed upon revival - is this good behaviour?

Resolves #4026.