### PR TITLE
Don't auto-hide currently unmemorisable spells when picking up books

### DIFF
--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -427,10 +427,9 @@ bool library_add_spells(vector<spell_type> spells, bool quiet)
         if (!you.spell_library[st])
         {
             you.spell_library.set(st, true);
-            bool memorise = you_can_memorise(st);
-            if (memorise)
+            if (you_can_memorise(st))
                 new_spells.push_back(st);
-            if (!memorise || Options.auto_hide_spells)
+            if (Options.auto_hide_spells)
                 you.hidden_spells.set(st, true);
         }
     }


### PR DESCRIPTION
Previously, if you worshipped Okawaru (for example), spells which could not be memorised would be silently added to your library and also hidden in your library.

Spells that can't be memorised do not appear on the spell library interface, so this had no actual effect as long as the spell could not be memorised. But, say, if you then abandoned Okawaru, you would find all your previously unmemorisable spells hidden in the library (so that, to unhide and memorise them, you would have to visit the "Show" screen).

In practice, this meant many players would just assume the spell was lost forever.

Resolves #3994.