### PR TITLE
Forbid Cheibriados coglins from making rampaging gizmos

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -2035,7 +2035,9 @@ static void _apply_gizmo_prop(item_def& gizmo, gizmo_prop_type prop)
             break;
 
         case GIZMO_RAMPAGE:
-            artefact_set_property(gizmo, ARTP_RAMPAGING, 1);
+            // Don't give rampage to Chei worshippers
+            if (!you.religion == GOD_CHEIBRIADOS)
+                artefact_set_property(gizmo, ARTP_RAMPAGING, 1);
             artefact_set_property(gizmo, ARTP_ACROBAT, 1);
             break;
 


### PR DESCRIPTION
It feels a bit lame to get a gizmo that is forbidden by your god, and we should assume thematically that coglins have some control over the gizmos they create.

Chei worshippers will now just get Acrobat on gizmos that would otherwise have Rampage/Acrobat. These gizmos will be a bit weak, but I figure we probably shouldn't tweak anything else about gizmo properties for Chei worshippers.

[I'd love a better way than just explicitly referencing Cheibriados here, but I am not aware of a suitable function.]

Resolves #4025.