### PR TITLE
Don't gain experience from killing allied apostles

### DIFF
--- a/crawl-ref/source/god-companions.cc
+++ b/crawl-ref/source/god-companions.cc
@@ -631,6 +631,9 @@ void win_apostle_challenge(monster& apostle)
     apostle.stop_constricting_all();
     apostle.stop_being_constricted();
 
+    // Don't let the player get XP from killing off apostles with e.g. ?poison
+    apostle.flags |= MF_NO_REWARD;
+
     // Save the recruit's current, healthy state
     if (apostles.size() > 0)
         apostles[0] = apostle_data(apostle);


### PR DESCRIPTION
Previously it was possible to kill your apostles with e.g. scrolls of poison, not incur wrath, and gain experience from the kill.

I can't really imagine players ever wanting to take advantage of this, but nonetheless it goes against the spirit of Beogh so let's prevent apostles from giving experience.

Resolves #4024.