### PR TITLE
Fix crash in Xom's wave of despair effect

### DIFF
--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2878,9 +2878,11 @@ static void _xom_wave_of_despair(int sever)
             dummy.position = *di;
 
             item_def* corpse = place_monster_corpse(dummy, true);
-            turn_corpse_into_skeleton(*corpse);
             if (corpse)
+            {
+                turn_corpse_into_skeleton(*corpse);
                 skeleton_count++;
+            }
         }
     }
 


### PR DESCRIPTION
If `place_monster_corpse` returns nullptr, the game crashes when trying to call `turn_corpse_into_skeleton`.

Possible when placing a skeleton on a terrain feature that destroys items, like lava. (`move_item_to_grid` destroys the would-be corpse item)

Example crash log: https://underhound.eu/crawl/morgue/seandewar5/crash-seandewar5-20240902-225318.txt