### PR TITLE
Simplify monster::weapon() and don't randomise

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -5007,36 +5007,13 @@ struct mon_attack_info
     }
 };
 
-/**
- * What weapon is the given monster using for the given attack, if any?
- *
- * @param mi        The monster in question.
- * @param atk       The attack number. (E.g. 0, 1, 2...)
- * @return          The melee weapon being used by the monster for the given
- *                  attack, if any.
- */
-static const item_def* _weapon_for_attack(const monster_info& mi, int atk)
-{
-    // XXX: duplicates monster::weapon()
-    if ((atk % 2) && mi.wields_two_weapons())
-    {
-        item_def *alt_weap = mi.inv[MSLOT_ALT_WEAPON].get();
-        if (alt_weap && is_weapon(*alt_weap))
-            return alt_weap;
-    }
-    item_def* weapon = mi.inv[MSLOT_WEAPON].get();
-    if (weapon && is_weapon(*weapon))
-        return weapon;
-    return nullptr;
-}
-
 static mon_attack_info _atk_info(const monster_info& mi, int i)
 {
     const mon_attack_def &attack = mi.attack[i];
-    const item_def* weapon = nullptr;
-    // XXX: duplicates monster::weapon()
-    if (attack.type == AT_HIT || attack.type == AT_WEAP_ONLY)
-        weapon = _weapon_for_attack(mi, i);
+    const item_def* weapon = mons_weapon_for_attack(attack.type,
+                                 mi.wields_two_weapons(), i,
+                                 mi.inv[MSLOT_WEAPON].get(),
+                                 mi.inv[MSLOT_ALT_WEAPON].get());
     mon_attack_info attack_info = { attack, weapon };
     return attack_info;
 }

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3523,6 +3523,36 @@ bool mons_wields_two_weapons(const monster& mon)
     return mons_class_wields_two_weapons(mons_base_type(mon));
 }
 
+/**
+ * What weapon is the given monster using for the given attack, if any?
+ *
+ * @param at        The attack type of this round
+ * @param wields_two_weapons   Whether the monster is a dual-wielder
+ * @param which_attack   The attack number. 0, 1, 2, 3, or -1 for wielded.
+ * @param main_weapon   Current main weapon of the attacker
+ * @param alt_weapon    Current offhand weapon of the attacker
+ * @return          The weapon being used by the monster for the given
+ *                  attack, if any.
+ */
+item_def *mons_weapon_for_attack(attack_type at, bool wields_two_weapons,
+                                 int which_attack, item_def *main_weapon,
+                                 item_def *offhand_weapon)
+{
+    if (at != AT_HIT && at != AT_WEAP_ONLY)
+        return nullptr;
+
+    // Monster is single wielder, or no offhand carried
+    if (!wields_two_weapons || !offhand_weapon || !is_weapon(*offhand_weapon))
+        return main_weapon;
+    // Dual wielder but missing main weapon
+    if (!main_weapon || !is_weapon(*main_weapon))
+        return offhand_weapon;
+    // Choose based on odd/even
+    return which_attack > 0 && which_attack % 2
+           ? offhand_weapon
+           : main_weapon;
+}
+
 // When this monster reaches its target, does it do impact damage
 // and then cease to exist?
 bool mons_destroyed_on_impact(const monster& m)

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -278,6 +278,9 @@ int mons_demon_tier(monster_type mc);
 
 bool mons_class_wields_two_weapons(monster_type mc);
 bool mons_wields_two_weapons(const monster& m);
+item_def *mons_weapon_for_attack(attack_type at, bool wields_two_weapons,
+                                 int which_attack, item_def *main_weapon,
+                                 item_def *offhand_weapon);
 bool mons_self_destructs(const monster& m);
 bool mons_blows_up(const monster& m);
 bool mons_destroyed_on_impact(const monster& m);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -465,29 +465,16 @@ static int _mons_offhand_weapon_index(const monster* m)
 item_def *monster::weapon(int which_attack) const
 {
     const mon_attack_def attk = mons_attack_spec(*this, which_attack);
-    if (attk.type != AT_HIT && attk.type != AT_WEAP_ONLY)
-        return nullptr;
 
-    // Even/odd attacks use main/offhand weapon.
-    if (which_attack > 1)
-        which_attack &= 1;
+    const int weap = inv[MSLOT_WEAPON];
+    item_def *main_weapon = weap == NON_ITEM ? nullptr : &env.item[weap];
 
-    // This randomly picks one of the wielded weapons for monsters that can use
-    // two weapons. Not ideal, but better than nothing. fight.cc does it right,
-    // for various values of right.
-    int weap = inv[MSLOT_WEAPON];
+    const int offhand = _mons_offhand_weapon_index(this);
+    item_def *offhand_weapon = offhand == NON_ITEM ? nullptr
+                                                   : &env.item[offhand];
 
-    if (which_attack && mons_wields_two_weapons(*this))
-    {
-        const int offhand = _mons_offhand_weapon_index(this);
-        if (offhand != NON_ITEM
-            && (weap == NON_ITEM || which_attack == 1 || coinflip()))
-        {
-            weap = offhand;
-        }
-    }
-
-    return weap == NON_ITEM ? nullptr : &env.item[weap];
+    return mons_weapon_for_attack(attk.type, mons_wields_two_weapons(*this),
+                                  which_attack, main_weapon, offhand_weapon);
 }
 
 /**


### PR DESCRIPTION
The function contained two contradictory comments, neither of which accurately described the actual logic taking place.

It seems that calling this method with no parameters, which_attack defaults to -1 and in the last of a monster with the two_weapons flag this meant a coinflip() would be used to decide whether main or offhand weapons were returned.

This was certainly unexpected for a caller; you might expect the weapon choice to be randomised during combat rounds but when which_attack was 0 or 1 it wouldn't randomise and would return main for 0 and offhand for 1. Values of 2 or above are seemingly never used for two_weapons monsters who all have exactly 2 attacks anyway.

Looking at places that call this method, it could certainly have been resulting in buggy behaviour, particularly for coglin player shadows, as generally callers are expecting weapon() to return the same result twice in a row, which was not in fact guaranteed.

I removed the randomness entirely but if wanted it should probably just apply for any attack number >= 0.

Extracting the decision logic to another method I was also able to dedupe the same logic when used for monster_info instead of monster; which itself wasn't an accurate replication of the logic anyway.