### PR TITLE
Improve malign gateways targeter and simplify targeting

### DIFF
--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1392,9 +1392,12 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     }
     case SPELL_FOXFIRE:
         return make_unique<targeter_maybe_radius>(&you, LOS_NO_TRANS, 1, 0, 1);
-    // TODO: these two actually have pretty wtf positioning that uses compass
-    // directions, so this targeter is not entirely accurate.
+
     case SPELL_MALIGN_GATEWAY:
+        return make_unique<targeter_malign_gateway>(you);
+
+    // TODO: this actually has pretty wtf positioning that uses compass
+    // directions, so this targeter is not entirely accurate.
     case SPELL_SUMMON_FOREST:
         return make_unique<targeter_radius>(&you, LOS_NO_TRANS, LOS_RADIUS,
                                             0, 2);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1135,10 +1135,6 @@ bool is_gateway_target(const actor& caster, coord_def location)
     int abs_x = abs(delta.x);
     int abs_y = abs(delta.y);
 
-    // location isn't on one of the 8 compass directions
-    if (abs_x != 0 && abs_y != 0 && abs_x != abs_y)
-        return false;
-
     // Monster range of vision is equal to player range of vision, so this
     // is accurate for mosters to.
     const int current_vision = you.current_vision;
@@ -1158,14 +1154,16 @@ coord_def find_gateway_location(actor* caster)
     // is accurate for mosters to.
     const int current_vision = you.current_vision;
 
-    for (int i = 0; i < 8; ++i)
+    for (int x = -current_vision; x <= current_vision; ++x)
     {
-        const coord_def delta = Compass[i];
-
-        for (int t = 2; t <= current_vision; ++t)
+        for (int y = -current_vision; y <= current_vision; ++y)
         {
-            const coord_def test = caster->pos() + delta * t;
+            const coord_def delta{ x, y };
+            // location is to close
+            if (delta.rdist() < 2)
+                continue;
 
+            const coord_def test = caster->pos() + delta;
             if (_is_malign_gateway_summoning_spot(*caster, test, false))
                 points.push_back(test);
         }

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1086,26 +1086,88 @@ bool can_cast_malign_gateway()
     return count_malign_gateways() < 1;
 }
 
+static bool _is_malign_gateway_summoning_spot(const actor& caster,
+    const coord_def location,
+    bool targeting)
+{
+    if (!in_bounds(location)
+        || !feat_is_malign_gateway_suitable(env.grid(location)))
+    {
+        return false;
+    }
+
+    const actor* const creature = actor_at(location);
+    if (creature)
+    {
+        if (!targeting)
+            return false;
+
+        if (creature->visible_to(&caster))
+            return false;
+    }
+
+    if (targeting)
+    {
+        for (adjacent_iterator ai(location); ai; ++ai)
+        {
+            const map_cell& map_info = env.map_knowledge(*ai);
+            if (map_info.seen() && feat_is_solid(map_info.feat()))
+                return false;
+        }
+    }
+    else if (count_neighbours_with_func(location, &feat_is_solid) != 0)
+        return false;
+
+    if (!caster.see_cell_no_trans(location))
+        return false;
+
+    return true;
+}
+
+bool is_gateway_target(const actor& caster, coord_def location)
+{
+    const coord_def delta = location - caster.pos();
+
+    // location is to close
+    if (delta.rdist() < 2)
+        return false;
+
+    int abs_x = abs(delta.x);
+    int abs_y = abs(delta.y);
+
+    // location isn't on one of the 8 compass directions
+    if (abs_x != 0 && abs_y != 0 && abs_x != abs_y)
+        return false;
+
+    // Monster range of vision is equal to player range of vision, so this
+    // is accurate for mosters to.
+    const int current_vision = you.current_vision;
+
+    // location is to far
+    if (abs_x > current_vision || abs_y > current_vision)
+        return false;
+
+    return _is_malign_gateway_summoning_spot(caster, location, true);
+}
+
 coord_def find_gateway_location(actor* caster)
 {
     vector<coord_def> points;
 
-    for (coord_def delta : Compass)
+    // Monster range of vision is equal to player range of vision, so this
+    // is accurate for mosters to.
+    const int current_vision = you.current_vision;
+
+    for (int i = 0; i < 8; ++i)
     {
-        coord_def test = coord_def(-1, -1);
+        const coord_def delta = Compass[i];
 
-        for (int t = 0; t < 11; t++)
+        for (int t = 2; t <= current_vision; ++t)
         {
-            test = caster->pos() + (delta * (2+t));
-            if (!in_bounds(test) || !feat_is_malign_gateway_suitable(env.grid(test))
-                || actor_at(test)
-                || count_neighbours_with_func(test, &feat_is_solid) != 0
-                || !caster->see_cell_no_trans(test))
-            {
-                continue;
-            }
+            const coord_def test = caster->pos() + delta * t;
 
-            points.push_back(test);
+            if (_is_malign_gateway_summoning_spot(*caster, test, false))
+                points.push_back(test);
         }
     }
 

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -72,6 +72,7 @@ void create_malign_gateway(coord_def point, beh_type beh, string cause,
 spret cast_malign_gateway(actor* caster, int pow, bool fail = false,
                           bool test = false);
 coord_def find_gateway_location(actor* caster);
+bool is_gateway_target(const actor& caster, coord_def location);
 spret cast_summon_forest(actor* caster, int pow, bool fail, bool test=false);
 spret cast_forge_blazeheart_golem(int pow, bool fail);
 

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2718,3 +2718,16 @@ bool targeter_teleport_other::valid_aim(coord_def a)
 
     return true;
 }
+
+targeter_malign_gateway::targeter_malign_gateway(actor& caster)
+{
+    agent = &caster;
+}
+
+aff_type targeter_malign_gateway::is_affected(coord_def loc)
+{
+    if (is_gateway_target(*agent, loc))
+        return AFF_MAYBE;
+
+    return AFF_NO;
+}

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -726,3 +726,11 @@ public:
     targeter_teleport_other(const actor *act, int range);
     bool valid_aim(coord_def a) override;
 };
+
+class targeter_malign_gateway : public targeter
+{
+public:
+    targeter_malign_gateway(actor& caster);
+    aff_type is_affected(coord_def loc) override;
+    bool valid_aim(coord_def) override { return true; }
+};


### PR DESCRIPTION
This is similar to my PR to improve malign gateways targeter (#3968) except the spell can now target directions that aren't one of the 8 compass directions. Closes #3910