### PR TITLE
Fix compilation against modern vendor-neutral OpenGL implementation.

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -788,7 +788,14 @@ ifneq ($(uname_S),Darwin)
 ifeq ($(msys),Yes)
 LIBS += -lopengl32 -lglu32
 else
-LIBS += -lGL -lGLU
+
+ifdef GLVND
+LIBS += -lOpenGL   # Use modern vendor-neutral OpenGL
+DEFINES_L += -DUSE_GLVND
+else
+LIBS += -lGL -lGLU # Use legacy GLX
+endif
+
 endif
 endif
 endif

--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -22,7 +22,9 @@
 #  if defined(__MACOSX__)
 #   include <OpenGL/glu.h>
 #  else
-#   include <GL/glu.h>
+#   ifndef USE_GLVND
+#    include <GL/glu.h>
+#   endif
 #  endif
 # endif
 #endif
@@ -386,7 +388,7 @@ void OGLStateManager::load_texture(unsigned char *pixels, unsigned int width,
     glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glDebug("glTexParameterf GL_TEXTURE_WRAP_T");
 #endif
-#ifndef USE_GLES
+#if !defined(USE_GLES) && !defined(USE_GLVND)
     if (mip_opt == MIPMAP_CREATE)
     {
         // TODO: should min react to Options.tile_filter_scaling?


### PR DESCRIPTION
Adds the GLVND makefile parameter and corresponding defines so the game can be built on GNU/Linux against modern vendor-neutral OpenGL implementation supported by MESA, instead of having to rely on deprecated GLX which is X11 only.

Pass `GLVND=y` to build against modern OpenGL, default is for now using legacy GLX implementation.