### PR TITLE
Extend single-day holidays to three days.

### DIFF
--- a/crawl-ref/source/misc.cc
+++ b/crawl-ref/source/misc.cc
@@ -178,7 +178,9 @@ bool today_is_halloween()
     const time_t curr_time = time(nullptr);
     const struct tm *date = TIME_FN(&curr_time);
     // tm_mon is zero-based in case you are wondering
-    return date->tm_mon == 9 && date->tm_mday == 31;
+    // Oct 30th-31th, Nov 1st
+    return date->tm_mon == 9 && date->tm_mday >= 30
+        || date->tm_mon == 10 && date->tm_mday == 1;
 }
 
 /// It's beginning to feel an awful lot like Christmas.
@@ -209,5 +211,7 @@ bool today_is_serious()
     const time_t curr_time = time(nullptr);
     const struct tm *date = TIME_FN(&curr_time);
     // As ever, note that tm_mon is 0-based.
-    return date->tm_mon == 3 && date->tm_mday == 1;
+    // March 31st, April 1st-2nd
+    return date->tm_mon == 2 && date->tm_mday == 31
+        || date->tm_mon == 3 && date->tm_mday <= 2;
 }


### PR DESCRIPTION
Since servers use UTC to determine the time, Halloween evening in the Americas doesn't count as Halloween in web games. Extend Halloween and April Fool's to 3 days so it's covered by all time zones. The winter holidays already last over 2 weeks so remain unchanged.

(tested changes with system clock change)