### PR TITLE
Optionally add target location description

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -376,7 +376,12 @@ void direction_chooser::describe_cell() const
 {
     print_top_prompt();
     print_key_hints();
-
+    if (Options.monster_item_view_coordinates)
+    {
+        const coord_def relpos = target() - you.pos();
+        string location_str = make_stringf("Location (%d, %d)", relpos.x, -relpos.y);
+        mprf(MSGCH_PLAIN, "%s", location_str.c_str());
+    }
     if (!you.see_cell(target()))
     {
         // FIXME: make this better integrated.
@@ -2596,6 +2601,12 @@ string get_terse_square_desc(const coord_def &gc)
 
 void terse_describe_square(const coord_def &c, bool in_range)
 {
+    if (Options.monster_item_view_coordinates)
+    {
+        const coord_def relpos = c - you.pos();
+        string location_str = make_stringf("Location (%d, %d)", relpos.x, -relpos.y);
+        mprf(MSGCH_PLAIN, "%s", location_str.c_str());
+    }
     if (!you.see_cell(c))
         _describe_oos_square(c);
     else if (in_bounds(c))

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -127,6 +127,9 @@ public:
     direction_chooser(dist& moves, const direction_chooser_args& args);
     bool noninteractive();
     bool choose_direction();
+    // Returns a description of the target location. This includes
+    // the monster respecting visibility, dungeon features and clouds.
+    // If there is no monster at the target location, return the empty string
     string target_description() const;
 
 private:
@@ -202,8 +205,13 @@ private:
     // Apport: A short sword.
     void print_target_description(bool &did_cloud) const;
 
-    // Helper functions for the above.
+    // Prints a targeting prompt, with a string describing the monster
+    // at the choosen target location respecting visibility, if any.
+    // If there is a monster, dungeon features and clouds are also described.
     void print_target_monster_description(bool &did_cloud) const;
+    // Prints a aiming prompt, for the top level item
+    // at the current target location.
+    // Used for spells targeting items, like aportation.
     void print_target_object_description() const;
 
     // You see 2 +3 dwarven bolts here.
@@ -223,6 +231,7 @@ private:
     vector<string> target_cell_description_suffixes() const;
     vector<string> monster_description_suffixes(const monster_info& mi) const;
 
+    // Top level description method used to describe what is located in a cell
     void describe_cell() const;
 
     // Move the target to where the mouse pointer is (on tiles.)

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -209,7 +209,7 @@ private:
     // at the choosen target location respecting visibility, if any.
     // If there is a monster, dungeon features and clouds are also described.
     void print_target_monster_description(bool &did_cloud) const;
-    // Prints a aiming prompt, for the top level item
+    // Prints an aiming prompt, for the top level item
     // at the current target location.
     // Used for spells targeting items, like aportation.
     void print_target_object_description() const;


### PR DESCRIPTION
### Main Changes

In #1422 several ways to improve accessibility for visually impaired players are discussed. I believe the issue can be closed when this PR is merged.

This PR adds showing location description along with tile descriptions during aiming and viewing.

To enable this feature `Options.monster_item_view_coordinates` needs to be set to true.  See also "Options for blind players" from the options_guide.

### Other Changes
Also added some comments to some description methods.

### Pictures
Some pictures (or terminal outputs) to visualize the changes. New is `Location (x, y)`.

#### When pressing `f` with a ranged weapon:

```
Fire: e) +0 orcbow
Press: ? - help, Q - select action
Shift-Dir - straight line
Location (0, 3)


                                     sefie the Shield-Bearer           *WIZARD*
                                     Minotaur
                                     Health: 19/19     ========================
               ####                  Magic:  0/0
               #..                   AC:  6 (26%)      Str: 20
               #.ß                   EV:  8            Int: 5
               #..                   SH:  0            Dex: 9
               #.#                   XL:  1 Next:  0%  Place: Dungeon:1
               #*#                   Noise:  0 ------  Time: 6.5 (0.0)
               #*#                   e) +0 orcbow
               #☺#                   Fire: e) +0 orcbow
               #.#
               #.#
               #.#
               #..
               #.ß
               #..
               ####
```

#### When pressing `x`:
```
Press: ? - help, v - describe, . - travel
Location (0, 0)
A staircase leading out of the dungeon.


                                     sefie the Shield-Bearer           *WIZARD*
                                     Minotaur
                                     Health: 19/19     ========================
               ####                  Magic:  0/0
               #..                   AC:  6 (26%)      Str: 20
               #.ß                   EV:  8            Int: 5
               #..                   SH:  4            Dex: 9
               #.#                   XL:  1 Next:  0%  Place: Dungeon:1
               #.#                   Noise:  0 ------  Time: 1.0 (0.0)
               #.#                   a) +0 rapier
               #☺#                   Nothing quivered
               #.#
               #.#
               #.#
               #..
               #.ß
               #..
               ####

```



### Background

After discussion a few items where suggested in #1422 as improvements:

>    During standard interactions, place the terminal cursor at the new-turn underscore instead of at the player, so that "start reading from cursor" reads the message window.
>    During targeting mode, place the terminal cursor at the description portion of the message window, so that "start reading from cursor" reads what's currently being targeted (and add an option to display the player relative coordinates).
>    For other things that use the message window for a prompt move the cursor appropriately to the start of the prompt.
>    When displaying full screen menus, move the cursor to the top left
>    When full screen menus give a prompt (like in acquirement) move the cursor to the start of the prompt.

Most of the suggested changes already have been merged into crawl (except the additional positions when aiming). The cursor positioning is made unnecessary by placing the message window at the top of the terminal, and by clearing old messages (see also "Options for blind players" from the options_guide).
 