### PR TITLE
Fixed 0_stat status for revived characters.

### DIFF
--- a/crawl-ref/source/nearby-danger.cc
+++ b/crawl-ref/source/nearby-danger.cc
@@ -505,7 +505,10 @@ void revive()
             && dur != DUR_TRANSFORMATION
             && dur != DUR_BEOGH_SEEKING_VENGEANCE
             && dur != DUR_BEOGH_DIVINE_CHALLENGE
-            && dur != DUR_GRAVE_CLAW_RECHARGE)
+            && dur != DUR_GRAVE_CLAW_RECHARGE
+            && dur != DUR_COLLAPSE
+            && dur != DUR_BRAINLESS
+            && dur != DUR_CLUMSY)
         {
             you.duration[dur] = 0;
         }


### PR DESCRIPTION
This fixes issue #4066.

Description from the issue:
> Get Felid character to collapse from 0 strength, die and collapse status is gone despite strength still lacking.

### Implementation

There are duration counters to track how long Collapse should hold. If strength > 0 the counter is decreased, and Collapse is removed when the counter is 0. On reviving the counter was mistakenly set to zero. Same for Brainless and Clumsy.

Now revive does not set those counters to 0, to retain the 0_stat status across being revived.

Sidenote: The location of the method `revive` inside `nearby-danger.cc` seems weird.