### PR TITLE
Fixed Yred bind soul ability

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3463,7 +3463,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         int pain = you.hp / 3;
         dec_hp(pain, false);
         mons->add_ench(mon_enchant(ENCH_SOUL_RIPE, pain, &you,
-                                   INFINITE_DURATION));
+                                   30));
         mprf("You wrap your dark will around %s soul!",
               mons->name(DESC_ITS).c_str());
         break;

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1792,36 +1792,14 @@ void monster::apply_enchantment(const mon_enchant &me)
         break;
 
     case ENCH_SOUL_RIPE:
+        // decrease duration if monster is not visible
         if (!cell_see_cell(you.pos(), pos(), LOS_NO_TRANS))
         {
-            // This implies the player *just* lost sight of us, so start the countdown
-            if (me.duration == INFINITE_DURATION)
+            if (!decay_enchantment(ENCH_SOUL_RIPE)
+                && me.duration <= 10)
             {
-                // XXX: The most awkward way to work around not being able to lower
-                //      duration directly, or decay things with INFINITE_DURATION....
-                mon_enchant timeout(ENCH_SOUL_RIPE, me.degree, &you, 20);
-                del_ench(en, true, false);
-                add_ench(timeout);
-            }
-            else
-            {
-                if (!decay_enchantment(ENCH_SOUL_RIPE)
-                    && me.duration <= 10)
-                {
-                    mprf("Your grip on %s soul is slipping...",
-                         name(DESC_ITS, true).c_str());
-                }
-            }
-
-        }
-        else
-        {
-            if (me.duration < INFINITE_DURATION)
-            {
-                // XXX: See above. I hate it. Surely there's a better way than this.
-                mon_enchant renew(ENCH_SOUL_RIPE, me.degree, &you, INFINITE_DURATION);
-                del_ench(en, true, false);
-                add_ench(renew);
+                mprf("Your grip on %s soul is slipping...",
+                    name(DESC_ITS, true).c_str());
             }
         }
         break;

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -704,6 +704,10 @@ monster* update_monster(monster& mon, int turns)
 
     mon.foe_memory = max(mon.foe_memory - turns, 0);
 
+    // Yredelemnul bind soul requires the monster stay in our LOS
+    if(mon.has_ench(ENCH_SOUL_RIPE))
+        mon.del_ench(ENCH_SOUL_RIPE, true, false);
+
     // FIXME:  Convert literal string 10 to constant to convert to auts
     if (turns >= 10 && mon.alive())
         mon.timeout_enchantments(turns / 10);

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -705,7 +705,7 @@ monster* update_monster(monster& mon, int turns)
     mon.foe_memory = max(mon.foe_memory - turns, 0);
 
     // Yredelemnul bind soul requires the monster stay in our LOS
-    if(mon.has_ench(ENCH_SOUL_RIPE))
+    if (mon.has_ench(ENCH_SOUL_RIPE))
         mon.del_ench(ENCH_SOUL_RIPE, true, false);
 
     // FIXME:  Convert literal string 10 to constant to convert to auts


### PR DESCRIPTION
Before, bind_soul had infinite duration. Whenever we lost sight of the monster, the duration was changed to finite
duration, and changed back to infinite duration again, when we saw the monster again.

However, in the case that we went up some stairs the code to make the duration finite is not executed.

Now, bind_soul has finite duration (I randomly picked 30 auts), but the
duration is only decreased when the monster is not in our sight.

If we change floors without the monster, the enchantment is cancelled on
our return to the floor. 

Sidenote: I think having for every enchantment an extra case in `timed-effects.update_monster` seems strange, but I am not sure how to do it better. Happy for suggestions. 