### PR TITLE
 Changed attack evaluation order

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -113,7 +113,6 @@ bool attack::handle_phase_damaged()
     // Inflict stored damage
     damage_done = inflict_damage(damage_done);
 
-    apply_damage_brand();
     // TODO: Unify these, added here so we can get rid of player_attack
     if (attacker->is_player())
     {

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -405,6 +405,7 @@ void attack::init_attack(skill_type unarmed_skill, int attack_number)
     attacker_visible   = attacker->observable();
     defender_visible   = defender && defender->observable();
     needs_message      = (attacker_visible || defender_visible);
+    attacker_descr     = atk_name(DESC_THE);
 
     if (attacker->is_monster())
     {
@@ -677,7 +678,7 @@ void attack::drain_defender()
             special_damage_message =
                 make_stringf(
                     "%s %s %s%s",
-                    atk_name(DESC_THE).c_str(),
+                    attacker_descr.c_str(),
                     attacker->conj_verb("drain").c_str(),
                     defender_name(true).c_str(),
                     attack_strength_punctuation(special_damage).c_str());
@@ -690,7 +691,7 @@ void attack::drain_defender_speed()
     if (needs_message)
     {
         mprf("%s %s %s vigour!",
-             atk_name(DESC_THE).c_str(),
+             attacker_descr.c_str(),
              attacker->conj_verb("drain").c_str(),
              def_name(DESC_ITS).c_str());
     }
@@ -1465,7 +1466,7 @@ void attack::calc_elemental_brand_damage(beam_type flavour,
         // XXX: assumes "what" is singular
         special_damage_message = make_stringf(
             "%s %s %s%s",
-            what ? what : atk_name(DESC_THE).c_str(),
+            what ? what : attacker_descr.c_str(),
             what ? conjugate_verb(verb, false).c_str()
                  : attacker->conj_verb(verb).c_str(),
             // Don't allow reflexive if the subject wasn't the attacker.

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -113,6 +113,7 @@ bool attack::handle_phase_damaged()
     // Inflict stored damage
     damage_done = inflict_damage(damage_done);
 
+    apply_damage_brand();
     // TODO: Unify these, added here so we can get rid of player_attack
     if (attacker->is_player())
     {

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -79,6 +79,8 @@ public:
     string     no_damage_message;
     string     special_damage_message;
     string     aux_attack, aux_verb;
+    // stored to have the descr even when the attacker disappears
+    string     attacker_descr; 
 
     item_def        *defender_shield;
 

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -80,7 +80,7 @@ public:
     string     special_damage_message;
     string     aux_attack, aux_verb;
     // stored to have the descr even when the attacker disappears
-    string     attacker_descr; 
+    string     attacker_descr;
 
     item_def        *defender_shield;
 
@@ -116,8 +116,7 @@ protected:
     virtual void init_attack(skill_type unarmed_skill, int attack_number);
 
     /* Attack Phases */
-    // The return values indicate whether the attack evaluation should
-    // should be aborted, e.g. because the enemy was banished or died
+    // These methods return true if the attack should continue
     virtual bool handle_phase_attempted();
     virtual bool handle_phase_dodged() = 0;
     virtual bool handle_phase_blocked();

--- a/crawl-ref/source/attack.h
+++ b/crawl-ref/source/attack.h
@@ -114,6 +114,8 @@ protected:
     virtual void init_attack(skill_type unarmed_skill, int attack_number);
 
     /* Attack Phases */
+    // The return values indicate whether the attack evaluation should
+    // should be aborted, e.g. because the enemy was banished or died
     virtual bool handle_phase_attempted();
     virtual bool handle_phase_dodged() = 0;
     virtual bool handle_phase_blocked();
@@ -143,6 +145,10 @@ protected:
         UNUSED(verbose);
         return false;
     }
+
+    // Computes brand effects (flaming weapons, etc.), and brandlike effects.
+    // Returns true when further damage calculation
+    // should be aborted (e.g. because the defender has been banished).
     virtual bool apply_damage_brand(const char *what = nullptr);
     void calc_elemental_brand_damage(beam_type flavour,
                                      const char *verb,
@@ -154,6 +160,10 @@ protected:
     /* Attack Effects */
     virtual bool mons_attack_effects() = 0;
     void alert_defender();
+
+    // Computes the distortion effect, such as banishment, additional damage,
+    // teleport or blinking.
+    // Returns true when the defender has been banished, false otherwise.
     bool distortion_affects_defender();
     void antimagic_affects_defender(int pow);
     void pain_affects_defender();

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -4363,9 +4363,7 @@ bool melee_attack::apply_damage_brand(const char *what)
             result = result || attack::apply_damage_brand(what);
         }
     }
-
-
-    return did_work || result;
+    return result;
 }
 
 bool melee_attack::_vamp_wants_blood_from_monster(const monster* mon)

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -666,6 +666,16 @@ bool melee_attack::handle_phase_hit()
 
     maybe_trigger_jinxbite();
 
+    // Check for weapon brand & inflict that damage too
+    apply_damage_brand();
+
+    // Apply flux form's sfx.
+    if (attacker->is_player() && you.form == transformation::flux
+        && defender->alive() && defender->is_monster())
+    {
+        _apply_flux_contam(*(defender->as_monster()));
+    }
+
     // Fireworks when using Serpent's Lash to kill.
     if (!defender->alive()
         && defender->as_monster()->has_blood()
@@ -4341,10 +4351,11 @@ bool melee_attack::apply_damage_brand(const char *what)
     // Staff damage overrides any brands
     bool did_work = apply_staff_damage();
     bool result = false;
-    if(!did_work)
+    if (!did_work)
     {
         result = result || attack::apply_damage_brand(what);
-        if (weapon && testbits(weapon->flags, ISFLAG_CHAOTIC)
+        // if the defender did no disappear and the weapon is chaotic
+        if (!result && weapon && testbits(weapon->flags, ISFLAG_CHAOTIC)
             && defender->alive())
         {
             unwind_var<brand_type> save_brand(damage_brand);
@@ -4352,12 +4363,7 @@ bool melee_attack::apply_damage_brand(const char *what)
             result = result || attack::apply_damage_brand(what);
         }
     }
-    // Apply flux form's sfx.
-    if (attacker->is_player() && you.form == transformation::flux
-        && defender->alive() && defender->is_monster())
-    {
-        _apply_flux_contam(*(defender->as_monster()));
-    }
+
 
     return did_work || result;
 }

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -165,6 +165,9 @@ private:
     void attacker_sustain_passive_damage();
     int  staff_damage(stave_type staff) const;
     string staff_message(stave_type staff, int damage) const;
+
+    // Returns whether this method is applicable for the ongoing attack.
+    // If it is applicable it will apply the resulting staff damage.
     bool apply_staff_damage();
     void player_stab_check() override;
     bool player_good_stab() override;

--- a/crawl-ref/source/melee-attack.h
+++ b/crawl-ref/source/melee-attack.h
@@ -166,8 +166,7 @@ private:
     int  staff_damage(stave_type staff) const;
     string staff_message(stave_type staff, int damage) const;
 
-    // Returns whether this method is applicable for the ongoing attack.
-    // If it is applicable it will apply the resulting staff damage.
+    // Returns true if staff damage was applied
     bool apply_staff_damage();
     void player_stab_check() override;
     bool player_good_stab() override;

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -321,31 +321,6 @@ bool ranged_attack::handle_phase_hit()
         maybe_trigger_jinxbite();
     }
 
-    if ((using_weapon() || throwing())
-        && (!defender->is_player() || !you.pending_revival))
-    {
-        if (using_weapon()
-            && apply_damage_brand(projectile->name(DESC_THE).c_str()))
-        {
-            return false;
-        }
-
-        if (using_weapon() && testbits(weapon->flags, ISFLAG_CHAOTIC)
-            && defender->alive())
-        {
-            unwind_var<brand_type> save_brand(damage_brand);
-            damage_brand = SPWPN_CHAOS;
-            if (apply_damage_brand(projectile->name(DESC_THE).c_str()))
-                return false;
-        }
-
-        if ((!defender->is_player() || !you.pending_revival)
-            && apply_missile_brand())
-        {
-            return false;
-        }
-    }
-
     // XXX: unify this with melee_attack's code
     if (attacker->is_player() && defender->is_monster())
     {
@@ -400,6 +375,37 @@ int ranged_attack::calc_mon_to_hit_base()
     ASSERT(attacker->is_monster());
     return mon_to_hit_base(attacker->get_hit_dice(), attacker->as_monster()->is_archer());
 }
+
+bool ranged_attack::apply_damage_brand(const char *what)
+{
+    (void) what;
+
+    if (!using_weapon() && !throwing())
+        return false;
+    else if (defender->is_player() && you.pending_revival)
+        return false;
+
+    if (using_weapon()
+        && attack::apply_damage_brand(projectile->name(DESC_THE).c_str()))
+    {
+        return true;
+    }
+    if (using_weapon() && testbits(weapon->flags, ISFLAG_CHAOTIC)
+        && defender->alive())
+    {
+        unwind_var<brand_type> save_brand(damage_brand);
+        damage_brand = SPWPN_CHAOS;
+        if (attack::apply_damage_brand(projectile->name(DESC_THE).c_str()))
+            return true;
+    }
+
+    if (apply_missile_brand())
+        return true;
+
+    return false;
+}
+
+
 
 int ranged_attack::apply_damage_modifiers(int damage)
 {

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -380,9 +380,8 @@ bool ranged_attack::apply_damage_brand(const char *what)
 {
     (void) what;
 
-    if (!using_weapon() && !throwing())
-        return false;
-    else if (defender->is_player() && you.pending_revival)
+    if ((!using_weapon() && !throwing())
+        || (defender->is_player() && you.pending_revival))
         return false;
 
     if (using_weapon()
@@ -399,13 +398,8 @@ bool ranged_attack::apply_damage_brand(const char *what)
             return true;
     }
 
-    if (apply_missile_brand())
-        return true;
-
-    return false;
+    return apply_missile_brand();
 }
-
-
 
 int ranged_attack::apply_damage_modifiers(int damage)
 {

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -382,7 +382,9 @@ bool ranged_attack::apply_damage_brand(const char *what)
 
     if ((!using_weapon() && !throwing())
         || (defender->is_player() && you.pending_revival))
+    {
         return false;
+    }
 
     if (using_weapon()
         && attack::apply_damage_brand(projectile->name(DESC_THE).c_str()))

--- a/crawl-ref/source/ranged-attack.h
+++ b/crawl-ref/source/ranged-attack.h
@@ -43,6 +43,7 @@ private:
     bool apply_missile_brand();
     bool throwing() const;
     bool clumsy_throwing() const;
+    bool apply_damage_brand(const char *what = nullptr) override;
 
     /* Weapon Effects */
     bool check_unrand_effects() override;

--- a/crawl-ref/source/ranged-attack.h
+++ b/crawl-ref/source/ranged-attack.h
@@ -38,6 +38,8 @@ private:
     special_missile_type random_chaos_missile_brand();
     bool dart_check(special_missile_type type);
     int dart_duration_roll(special_missile_type type);
+    // Applies the effects of the missile brand.
+    // Returns true if the defender has been killed, and false otherwise.
     bool apply_missile_brand();
     bool throwing() const;
     bool clumsy_throwing() const;


### PR DESCRIPTION
This fixes #4041 

### Problem

There, it was reported that in one turn a Reaper attacked, dragging the player back, while dragging the player back, stepped on a shaft trap, which caused the Reaper to be shafted. 

This resulted in a message `DEAD MONSTER burns you.` because the brand damage was evaluated after the monster was shafted.

### Changes

Moved brand damage calculation from phase_hit to phase_damaged. The reason for this is to have `apply_damage_brand()` called right after `announce_hit()`, before `mons_attack_effects()` is called. The reason is that both methods are closely linked to the weapon, while `mons_attack_effects()` is not.

This reordering fixes #4041 because the disappearance of the attacker was caused by the dragging ability, which is handled in `mons_attack_effects()`.

The bug could also have been fixed by simply checking inside `apply_damage_brand()`, whether the attacker is still alive. However, that route seemed less sensible to me.

I also moved the call to `_apply_flux_contam()` because in its nature it seemed quite similar to a weapon brand.