### PR TITLE
Changed resting with inhibited regeneration mutation

### DIFF
--- a/crawl-ref/source/mutation-data.h
+++ b/crawl-ref/source/mutation-data.h
@@ -248,7 +248,7 @@ static const mutation_def mut_data[] =
 { MUT_INHIBITED_REGENERATION, 3, 1, mutflag::bad, false,
   "inhibited regeneration",
 
-  {"You do not regenerate when monsters are visible.", "", ""},
+  {"You do not regenerate when monsters are nearby.", "", ""},
 
   {"Your regeneration stops near monsters.", "", ""},
 

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1091,7 +1091,7 @@ static vector<string> _get_fakemuts(bool terse)
         else
         {
             result.push_back(
-                _formmut("You do not regenerate when monsters are visible."));
+                _formmut("You do not regenerate when monsters are nearby."));
             result.push_back(
                 _formmut("You are frail without blood (-20% HP)."));
             result.push_back(

--- a/crawl-ref/source/nearby-danger.cc
+++ b/crawl-ref/source/nearby-danger.cc
@@ -173,7 +173,8 @@ bool mons_is_safe(const monster* mon, const bool want_move,
 }
 
 static string _seen_monsters_announcement(const vector<monster*> &visible,
-                                          bool sensed_monster)
+                                          bool sensed_monster,
+                                          bool inhibited_reg = false)
 {
     // Announce the presence of monsters (Eidolos).
     if (visible.size() == 1)
@@ -185,6 +186,8 @@ static string _seen_monsters_announcement(const vector<monster*> &visible,
         return "There are monsters nearby!";
     if (sensed_monster)
         return "There is a strange disturbance nearby!";
+    if (inhibited_reg)
+        return "You feel the presence of a monster inhibiting your regeneration.";
     return "";
 }
 
@@ -341,17 +344,20 @@ bool can_rest_here(bool announce)
     // before iterating over each monster.
     vector<monster*> visible;
     bool sensed = false;
+    bool inhibited_reg = false;
     for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
     {
         if (!regeneration_is_inhibited(*mi))
             continue;
+        inhibited_reg = true;
         if (mi->visible_to(&you))
             visible.push_back(*mi);
         else if (env.map_knowledge(mi->pos()).flags & MAP_INVISIBLE_MONSTER)
             sensed = true;
     }
 
-    const string announcement = _seen_monsters_announcement(visible, sensed);
+    const string announcement = _seen_monsters_announcement(visible, sensed,
+                                                            inhibited_reg);
     if (announcement.empty())
         return true;
 


### PR DESCRIPTION
### Problem 
This fixes #4018 

So far, resting with the mutation inhibited regeneration while an invisible monster is nearby that the player is not aware off resulted in the normal `You start resting` message, without letting any time pass.

Why we get a zero delay is not clear to me. As the control flow is 
* `main._do_rest()` -->
*  `_start_running(...)` --> 
* `you.running.initialise(...)` and here I would expect to get a non-zero delay. But that is not what happens.

Perhaps someone can explain why that does not happen?

### Suggested Change
Now, a message is generated that indicates that there is a monster nearby, which inhibits regeneration, and still we do not let time pass.

Additionally, changed the description of the mutation to indicate that monsters need not be visible to prevent regeneration.

A different possible way to handle things might be to let time pass, e.g. 1 aut. However, in my view that is usually not what the player intends when pressing 5 with some monster nearby. If the player intends to let time pass, they can still let it pass in small increments using `.` or `s`.

