### PR TITLE
Apply location effects to flank and swoop

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -886,6 +886,8 @@ static bool _handle_swoop_or_flank(monster& mons)
             }
         }
         mons.move_to_pos(tracer.path_taken[j+1]);
+        // Apply traps and other location effects to the monster.
+        mons.apply_location_effects(mons.pos());
         fight_melee(&mons, defender);
         mons.props[SWOOP_COOLDOWN_KEY].get_int() = you.elapsed_time
                                                   + 40 + random2(51);


### PR DESCRIPTION
Before this commit, flank and swoop attack flavours would not trigger traps and trap-like effects like sigil of bindings when moving the monster.

I haven't found an issue for this but I stumbled upon that bug while feeling clever about a ufetubus getting sigile'd. The ufetubus didn't get sigiled as I expected.