### PR TITLE
Add missing space to Horror status light text

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -715,7 +715,7 @@ bool fill_status_info(int status, status_info& inf)
     case DUR_HORROR:
     {
         const int horror = you.props[HORROR_PENALTY_KEY].get_int();
-        inf.light_text = make_stringf("Horr(%d)", -1 * horror);
+        inf.light_text = make_stringf("Horr (%d)", -1 * horror);
         if (horror >= HORROR_LVL_OVERWHELMING)
         {
             inf.light_colour = RED;


### PR DESCRIPTION
Makes it consistent with other such status light texts, and should fix the WebTiles hover tooltip showing "No description found" despite a correct description existing in [`dat/descript/status.txt:458`](https://github.com/crawl/crawl/blob/14434f1371bfaccec06cb57e55e632dca4d32c04/crawl-ref/source/dat/descript/status.txt#L458) (though I couldn't locally test that; assumed from looking near [`tileweb.cc:1213`](https://github.com/crawl/crawl/blob/14434f1371bfaccec06cb57e55e632dca4d32c04/crawl-ref/source/tileweb.cc#L1213) and [`webserver/game_data/static/player.js:447`](https://github.com/crawl/crawl/blob/14434f1371bfaccec06cb57e55e632dca4d32c04/crawl-ref/source/webserver/game_data/static/player.js#L447)).