### PR TITLE
reinstate yak island

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -1423,6 +1423,51 @@ MAP
      x3
 ENDMAP
 
+# Original by Lemuel - Stranded yaks
+NAME:   lemuel_tekkud_yak_island
+TAGS:   no_pool_fixup no_monster_gen
+DEPTH:  Lair:2-, Swamp, !Swamp:$, Shoals
+WEIGHT: 5
+: if crawl.coinflip() then
+SUBST:  - = W , > = .
+: else
+SUBST:  - = w
+: end
+NSUBST: . = 6:1 / 1:2 / 1:% / *:.
+: if you.branch() == "Lair" then
+MONS:   yak w:8 / dream sheep w:20 / death yak w:20 / elephant / catoblepas w:2
+MONS:   catoblepas w:25 / dream sheep band / yak band w:15 / elephant band
+SUBST:  W = W:30 .
+: elseif you.branch() == "Swamp" then
+MONS:   spectral death yak w:25 / spectral catoblepas / spectral dream sheep w:5 /\
+        spectral centaur warrior / spectral yaktaur / spectral dire elephant w:5
+NSUBST: . = 2:1 / 1:$ / *:WW.
+SUBST:  2 = 1
+: elseif you.branch() == "Shoals" and you.depth() < 4 then
+MONS:   death yak w:30 / dream sheep w:15 / catoblepas / centaur / centaur warrior w:20
+MONS:   yaktaur ; arbalest good_item / death yak band / cyclops band w:20
+NSUBST: . = 1:1 / 1:$ / *:.
+: else -- Shoals:4
+MONS:   death yak / catoblepas / centaur warrior w:15 / yaktaur w:15
+MONS:   apis / stone giant / yaktaur captain / titan
+NSUBST: . = 2:1 / 2:$ / 1:% / *:.
+: end
+MAP
+   WWWWWWWWW
+  WWWWWwWWWWW
+ WWWWwwwwwWWWW
+WWWwwwwwwwwwWWW
+WWwwww...wwwwWW
+WWwww.....wwwWW
+Wwwww..>..wwwwW
+WWwww.....wwwWW
+WWww--...wwwwWW
+WWW---wwwwwwWWW
+ WWWWwwwwwWWWW
+  WWWWWwWWWWW
+   WWWWWWWWW
+ENDMAP
+
 ###############################################################################
 #
 # <<3>> Humanoids

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -1449,7 +1449,7 @@ MONS:   yaktaur ; arbalest good_item / death yak band / cyclops band w:20
 NSUBST: . = 1:1 / 1:$ / *:.
 : else -- Shoals:4
 MONS:   death yak / catoblepas / centaur warrior w:15 / yaktaur w:15
-MONS:   apis / stone giant / yaktaur captain / titan
+MONS:   apis / stone giant / yaktaur captain
 NSUBST: . = 2:1 / 2:$ / 1:% / *:.
 : end
 MAP


### PR DESCRIPTION
re-adds the old yak island vault removed in 530620f - but greatly increases the threat level

- 50% of the time it will be enclosed with the island inaccessible, and have a one way hatch in the middle if so
- lair (2-5) gets yaks, death yaks, dream sheep, elephants and catoblepae
- swamp (1-3) gets spectral yak and yak-adjacent creatures, weighted towards spawning death yaks but can also create some weaker (dream sheep) and scarier (dire elephants) monsters, these will fly off of the island when they hear you. will also be mostly filled with shallow water
- shoals 1-3 gets the standard yak creatures and centaurs, and can spawn a yaktaur with a decent quality arbalest or a cyclops
- shoals 4 gets the scariest set, spawning potentially multiple centaur warriors, yaktaurs and catoblepae, as well as placing either an apis, stone giant or yaktaur captain (ouch), but also has the most loot

i have a slight feeling that the lair set might be a bit undertuned and the shoals:4 set might be overtuned (is using an apis too much? i was inspired to make shoals:4 its own set because apis can already spawn there and they are a yak type monster) but i would need feedback from other people to make any solid decisions