### PR TITLE
[webTile] : add expiring description for expiring status

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1214,7 +1214,14 @@ void TilesFramework::_send_player(bool force_full)
                 // Don't claim Zot is impending when it's not near.
                 if (dbname == "Zot" && status.light_colour == WHITE)
                     dbname = "Zot count";
-                const string dbdesc = getLongDescription(dbname + " status");
+                string dbdesc = getLongDescription(dbname + " status");
+                
+                // add expiring description
+                if(status.short_text.find(" (expiring)") != std::string::npos) 
+                {
+                    dbdesc += " (expiring)";
+                }
+
                 json_write_string("desc", dbdesc.size() ? dbdesc : "No description found");
             }
             if (!status.short_text.empty())


### PR DESCRIPTION
### What changed?
It would be beneficial to indicate status expiration in the tooltip description ui, especially for status like DDoor. 
While this is a workaround, I have implemented it with simple string matching.
Every expiring status wil now display "(expiring)" in its tooltip description. 

we can already check status detail with '@' but it would be helpful check it with addtional ui

### screenshots
| Before (without Expiration Indicator)           | After (with Expiration Indicator)           |
|---------------------------------|---------------------------------------------|
|<img width="411" alt="스크린샷 2024-11-05 오후 5 01 08" src="https://github.com/user-attachments/assets/980f7c2f-fc4b-4266-8423-e2a7feaa21ae">|<img width="410" alt="스크린샷 2024-11-05 오후 5 02 12" src="https://github.com/user-attachments/assets/c3cf4442-bcc9-4e63-87d8-60266c266903">|

