### PR TITLE
I enhanced the display_overview() function to include a symbol legend…

### DIFF
--- a/crawl-ref/source/dgn-overview.cc
+++ b/crawl-ref/source/dgn-overview.cc
@@ -707,6 +707,13 @@ protected:
 void display_overview()
 {
     string disp = overview_description_string(true);
+
+    // Add the key for altar symbols at the bottom of the display
+    disp += "\n\n<white>Legend:</white>\n";
+    disp += "<green>+</green> Available Altar\n";
+    disp += "<red>x</red> Unavailable Altar\n";
+    disp += "<blue>*</blue> Locked Altar\n";
+
     linebreak_string(disp, 80);
     dgn_overview overview(disp);
     _process_command(overview.show());


### PR DESCRIPTION
… in the dungeon overview (Ctrl-O) display. The legend is a concise, color-coded key explaining altar status symbols: <green>+</green> for available, <red>x</red> for unavailable, and <blue>*</blue> for locked altars. This addition makes the symbols clear and accessible directly within the interface, ensuring players—especially novices or those with visual impairments—can understand altar statuses without needing external guidance. This improvement enhances the user-friendliness and accessibility of the Ctrl-O screen.