### PR TITLE
Warn when summoning with fulsome fusillade active

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1475,6 +1475,8 @@ string stop_summoning_reason(resists_t resists, monclass_flags_t flags)
         return "noxious bog";
     if (you.duration[DUR_VORTEX])
         return "polar vortex";
+    if (you.duration[DUR_FUSILLADE])
+        return "fulsome fusillade";
     return "";
 }
 


### PR DESCRIPTION
Fulsome fusillade can damage your summons so it should warn when you
try to summon with it active, similar to spells like polar vortex.

Should resolve #4055