### PR TITLE
Use more nouns when a boulder pushes something into the unknown.

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1028,6 +1028,8 @@ static void _handle_boulder_movement(monster& boulder)
                 blocker_name = blocker->name(DESC_THE);
             else
                 blocker_name = feature_description_at(targ + dir);
+            if (blocker_name.empty())
+                blocker_name = "something";
 
             if (blocker || cell_is_solid(targ + dir))
             {


### PR DESCRIPTION
Brom's Barrelling Boulder can push monsters into terrain you haven't seen. This created a message such as " Your boulder crushes the orc against  and falls apart!" as feature_description_at() returns an empty string for unknown terrain.

Replace the empty string with "something" for that message.