### PR TITLE
Round down the displayed damage for thrown weapons

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1450,7 +1450,7 @@ string damage_rating(const item_def *item, int *rating_value)
     // This is just SPWPN_HEAVY.
     const int post_brand_dam = brand_adjust_weapon_damage(base_dam, brand, false);
     const int heavy_dam = post_brand_dam - base_dam;
-    const int extra_base_dam = thrown ? throwing_base_damage_bonus(*item) :
+    const int extra_base_dam = thrown ? throwing_base_damage_bonus(*item, false) :
                                !item ? unarmed_base_damage_bonus(false) :
                                     heavy_dam; // 0 for non-heavy weapons
     const skill_type skill = item ? _item_training_skill(*item) : SK_UNARMED_COMBAT;

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1606,11 +1606,13 @@ int apply_fighting_skill(int damage, bool aux, bool random)
     return damage;
 }
 
-int throwing_base_damage_bonus(const item_def &proj)
+int throwing_base_damage_bonus(const item_def &proj, bool random)
 {
     // Stones get half bonus; everything else gets full bonus.
-    return div_rand_round(you.skill_rdiv(SK_THROWING)
-                          * min(4, property(proj, PWPN_DAMAGE)), 4);
+    int damage_mult = min(4, property(proj, PWPN_DAMAGE));
+    if (random)
+        return div_rand_round(you.skill_rdiv(SK_THROWING) * damage_mult, 4);
+    return (you.skill(SK_THROWING) * damage_mult) / 4;
 }
 
 int brand_adjust_weapon_damage(int base_dam, int brand, bool random)

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -116,7 +116,7 @@ bool weapon_uses_strength(skill_type wpn_skill, bool using_weapon);
 int stat_modify_damage(int base_dam, skill_type wpn_skill, bool using_weapon);
 int apply_weapon_skill(int base_dam, skill_type wpn_skill, bool random);
 int apply_fighting_skill(int base_dam, bool aux, bool random);
-int throwing_base_damage_bonus(const item_def &projectile);
+int throwing_base_damage_bonus(const item_def &projectile, bool random);
 int brand_adjust_weapon_damage(int base_dam, int brand, bool random);
 
 int unarmed_base_damage(bool random);

--- a/crawl-ref/source/ranged-attack.cc
+++ b/crawl-ref/source/ranged-attack.cc
@@ -392,7 +392,7 @@ int ranged_attack::calc_base_unarmed_damage() const
 {
     if (clumsy_throwing())
         return 0;
-    return throwing_base_damage_bonus(*projectile);
+    return throwing_base_damage_bonus(*projectile, true);
 }
 
 int ranged_attack::calc_mon_to_hit_base()


### PR DESCRIPTION
Previously, displayed damage for thrown weapon was rounded randomly possibly giving a different value each time you examined your weapon. It is now rounded down similar to unarmed.

Fixes #4047