### PR TITLE
1h enhancer staves for small species

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -691,7 +691,7 @@ static const weapon_def Weapon_prop[] =
     // Staves
     // WPN_STAFF is for weapon stats for magical staves only.
     { WPN_STAFF,             "staff",               5,  5, 12,
-        SK_STAVES,       SIZE_LITTLE, SIZE_MEDIUM, MI_NONE,
+        SK_STAVES,       SIZE_LITTLE, SIZE_LITTLE, MI_NONE,
         DAMV_CRUSHING, 0, 0, 15, {} },
     { WPN_QUARTERSTAFF,      "quarterstaff",        10, 3, 13,
         SK_STAVES,       SIZE_LITTLE, NUM_SIZE_LEVELS,  MI_NONE,


### PR DESCRIPTION
Enhancer staves are currently two handed for Ko and Sp.  I feel like it mostly catches people off guard and doesn't matter much as far as their power level goes. 

It might be worth taking a look at other stuff since it feels like there is little reason behind what is two and what is one handed for small species.