### PR TITLE
Add method to remove abandoned shops from StashTracker

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -68,6 +68,7 @@
 #include "skills.h"
 #include "spl-book.h"
 #include "sprint.h"
+#include "stash.h"
 #include "state.h"
 #include "stringutil.h"
 #include "tag-version.h"
@@ -3124,6 +3125,7 @@ void excommunication(bool voluntary, god_type new_god)
             branch_bribe[it->id] = 0;
         add_daction(DACT_BRIBE_TIMEOUT);
         add_daction(DACT_REMOVE_GOZAG_SHOPS);
+        StashTrack.remove_dead_shops();
         shopping_list.remove_dead_shops();
         you.exp_docked[old_god] = excom_xp_docked();
         you.exp_docked_total[old_god] = you.exp_docked[old_god];

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1136,9 +1136,7 @@ void StashTracker::remove_dead_shops()
             shops_to_remove.insert(rs.pos);
     }
     for (auto &lpos : shops_to_remove)
-    {
         remove_shop(lpos);
-    }
 }
 
 void StashTracker::remove_shop(const level_pos &pos)

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -273,6 +273,7 @@ public:
 
     void dump(const char *filename, bool identify = false) const;
 
+    void remove_dead_shops();
     void remove_shop(const level_pos &pos);
 private:
     void get_matching_stashes(const base_pattern &search,


### PR DESCRIPTION
This fixes #3822. There Gozag shops still appear in the StashTracker, even after the shops are closed, due to leaving Gozag.

To fix this I use a similar approach to what is done to remove these kind of shops from the shopping list in
`shopping_list.remove_dead_shops()`.

### Potential Missing Improvement
I am unsure whether the similar code of removing dead shops from the StashTracker and the shopping list can/should be combined in a single method (i.e. the methods `StashTrack.remove_dead_shops()` and `shopping_list.remove_dead_shops()`).

I would be happy for feedback.