### PR TITLE
Add method to remove abandoned shops from StashTracker

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -68,6 +68,7 @@
 #include "skills.h"
 #include "spl-book.h"
 #include "sprint.h"
+#include "stash.h"
 #include "state.h"
 #include "stringutil.h"
 #include "tag-version.h"
@@ -3124,6 +3125,7 @@ void excommunication(bool voluntary, god_type new_god)
             branch_bribe[it->id] = 0;
         add_daction(DACT_BRIBE_TIMEOUT);
         add_daction(DACT_REMOVE_GOZAG_SHOPS);
+        StashTrack.remove_dead_shops();
         shopping_list.remove_dead_shops();
         you.exp_docked[old_god] = excom_xp_docked();
         you.exp_docked_total[old_god] = you.exp_docked[old_god];

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -15,6 +15,7 @@
 #include "branch.h"
 #include "cio.h"
 #include "colour.h"
+#include "dactions.h"
 #include "describe.h"
 #include "dgn-overview.h"
 #include "english.h"
@@ -2072,6 +2073,7 @@ void ShoppingList::remove_dead_shops()
     {
         const level_pos place = thing_pos(thing);
         le.go_to(place.id); // thereby running DACT_REMOVE_GOZAG_SHOPS
+        catchup_dactions();
         const shop_struct *shop = shop_at(place.pos);
 
         if (!shop)

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -273,6 +273,7 @@ public:
 
     void dump(const char *filename, bool identify = false) const;
 
+    void remove_dead_shops();
     void remove_shop(const level_pos &pos);
 private:
     void get_matching_stashes(const base_pattern &search,


### PR DESCRIPTION

#### Problem 
When leaving Gozag his shops close. However, in #3822 it is mentioned that the closed shops still appear in the StashTracker.

#### Implementation
To fix this I use a similar approach to what is done to remove these
kind of shops from the shopping list in
`shopping_list.remove_dead_shops()`.

Additionally, `shopping_list.remove_dead_shops()` assumed that when calling 
`level_excursion::go_to(level_id)` dactions are performed. 
However, calling that method will not trigger dactions. Hence, I added a call to execute dactions to the method.

#### Potential Issues
I am unsure whether the similar code of removing dead shops from
the StashTracker and the shopping list can/should be combined in a
single method. I would be happy for feedback.