### PR TITLE
Fix slime not showing around slime walls after reload

### DIFF
--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -55,6 +55,7 @@
  #include "tilepick.h"
 #endif
 #include "tiles-build-specific.h"
+#include "tileview.h"
 #include "traps.h"
 #include "travel.h"
 #include "view.h"
@@ -1339,8 +1340,11 @@ static void _update_level_state()
 #endif
     for (rectangle_iterator ri(0); ri; ++ri)
     {
-        if (env.grid(*ri) == DNGN_SLIMY_WALL)
+        if (env.grid(*ri) == DNGN_SLIMY_WALL
+            || env.map_knowledge(*ri).feat() == DNGN_SLIMY_WALL)
+        {
             env.level_state |= LSTATE_SLIMY_WALL;
+        }
 
         if (is_icecovered(*ri))
 #if TAG_MAJOR_VERSION == 34
@@ -1373,12 +1377,27 @@ static void _update_level_state()
     }
 }
 
+static void _draw_tiles()
+{
+#ifdef USE_TILE
+    for (rectangle_iterator ri(coord_def(0, 0), coord_def(GXM - 1, GYM - 1));
+        ri; ++ri)
+    {
+        tile_draw_map_cell(*ri);
+    }
+#endif
+}
+
 void new_level(bool restore)
 {
     print_stats_level();
     update_whereis();
 
     _update_level_state();
+
+    // Draw remembered map
+    // Must happen after _update_level_state
+    _draw_tiles();
 
     if (restore)
         return;

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -329,7 +329,6 @@ static void _tag_read_level_items(reader &th);
 static void _tag_read_level_monsters(reader &th);
 static void _tag_read_level_tiles(reader &th);
 static void _regenerate_tile_flavour();
-static void _draw_tiles();
 
 static void _tag_construct_ghost(writer &th, vector<ghost_demon> &);
 static vector<ghost_demon> _tag_read_ghost(reader &th);
@@ -7695,9 +7694,6 @@ void _tag_read_level_tiles(reader &th)
     _debug_count_tiles();
 
     _regenerate_tile_flavour();
-
-    // Draw remembered map
-    _draw_tiles();
 }
 
 static tileidx_t _get_tile_from_vector(const unsigned int idx)
@@ -7793,16 +7789,6 @@ static void _regenerate_tile_flavour()
     tile_new_level(true, false);
 }
 
-static void _draw_tiles()
-{
-#ifdef USE_TILE
-    for (rectangle_iterator ri(coord_def(0, 0), coord_def(GXM-1, GYM-1));
-         ri; ++ri)
-    {
-        tile_draw_map_cell(*ri);
-    }
-#endif
-}
 // ------------------------------- ghost tags ---------------------------- //
 
 static void _marshallSpells(writer &th, const monster_spells &spells)


### PR DESCRIPTION
After reloading and sometimes after changing levels, the slimey acidic
floors around the walls in the Slime Pits (and oozemancy walls)
wouldn't appear.

After reloading before this change:
![Screenshot (1951)](https://github.com/user-attachments/assets/e97c809b-c9dc-4c92-ad7f-38cfc8b0c0b0)

After reloading after this change:
![Screenshot (1952)](https://github.com/user-attachments/assets/51483e1c-0d4a-49bc-af5f-dbd90e2386c5)
