### PR TITLE
Fix autofight not moving over web with slick slippers

### DIFF
--- a/crawl-ref/source/dat/clua/autofight.lua
+++ b/crawl-ref/source/dat/clua/autofight.lua
@@ -116,7 +116,7 @@ local function have_quiver_action(no_move)
 end
 
 local function is_safe_square(dx, dy)
-    if view.feature_at(dx, dy) == "trap_web" then
+    if view.feature_at(dx, dy) == "trap_web" and not you.is_web_immune() then
         return false
     end
     return view.is_safe_square(dx, dy)

--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -1377,6 +1377,8 @@ LUAFN(you_quiver_allows_autofight)
     PLUARET(boolean, quiver::get_secondary_action()->allow_autofight());
 }
 
+LUARET1(you_is_web_immune, boolean, you.is_web_immune())
+
 static const struct luaL_reg you_clib[] =
 {
     { "turn_is_over", you_turn_is_over },
@@ -1520,6 +1522,7 @@ static const struct luaL_reg you_clib[] =
     { "quiver_uses_mp",     you_quiver_uses_mp},
     { "quiver_allows_autofight", you_quiver_allows_autofight },
     { "activate_ability",        you_activate_ability},
+    { "is_web_immune",     you_is_web_immune },
 
     { nullptr, nullptr },
 };


### PR DESCRIPTION
When autofight was trying to move towards an enemy to attack it and the
only way you could see to reach the enemies was through a web, autofight
would give a message saying there was no safe path to the enemy and do
nothing. It should have moved through the web as the slick spippers give
immunity to them.

Fixes #3125