### PR TITLE
Let grey draconians keep iron scales in dragon form

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -359,6 +359,8 @@ mutation_activity_type mutation_activity_level(mutation_type mut)
                 return mutation_activity_type::FULL;
             if (mut == MUT_STEAM_RESISTANCE && drag == MONS_STEAM_DRAGON)
                 return mutation_activity_type::FULL;
+            if (mut == MUT_IRON_FUSED_SCALES && drag == MONS_IRON_DRAGON)
+                return mutation_activity_type::FULL;
         }
         // Vampire bats keep their fangs.
         if (you.form == transformation::bat


### PR DESCRIPTION
Other draconian get to keep the mutations they get from their colour
when possible in dragon form, so it would be consistent for grey
draconians to keep their iron-fused scales.

Fixes #4111