### PR TITLE
Fix display of GDR in wizmod

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -245,7 +245,7 @@ public:
     virtual bool can_be_blinded() const = 0;
 
     virtual int armour_class() const = 0;
-    virtual int gdr_perc() const = 0;
+    virtual int gdr_perc(bool random = true) const = 0;
     int apply_ac(int damage, int max_damage = 0,
                  ac_type ac_rule = ac_type::normal,
                  bool for_real = true) const;

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -474,7 +474,7 @@ public:
 
     int base_armour_class() const;
     int armour_class() const override;
-    int gdr_perc() const override { return 0; }
+    int gdr_perc(bool random = true) const override { return 0; }
     int base_evasion() const;
     int evasion(bool ignore_temporary = false,
                 const actor* /*attacker*/ = nullptr) const override;

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1035,7 +1035,7 @@ static void _print_stats_ac(int x, int y)
     string ac = make_stringf("%2d ", you.armour_class_scaled(1));
 #ifdef WIZARD
     if (you.wizard && !_is_using_small_layout())
-        ac += make_stringf("(%d%%) ", you.gdr_perc());
+        ac += make_stringf("(%d%%) ", you.gdr_perc(false));
 #endif
     textcolour(text_col);
     CGOTOXY(x+4, y, GOTO_STAT);

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6647,9 +6647,10 @@ void player::refresh_rampage_hints()
   *
   * \return GDR as a percentage.
   **/
-int player::gdr_perc() const
+int player::gdr_perc(bool random) const
 {
-    return (int)(16 * sqrt(sqrt(max(0, you.armour_class()))));
+    int ac = random ? armour_class() : armour_class_scaled(1);
+    return (int)(16 * sqrt(sqrt(max(0, ac))));
 }
 
 /**

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -855,7 +855,7 @@ public:
     int racial_ac(bool temp) const;
     int base_ac(int scale) const;
     int armour_class() const override;
-    int gdr_perc() const override;
+    int gdr_perc(bool random = true) const override;
     int evasion(bool ignore_temporary = false,
                 const actor *attacker = nullptr) const override;
     int evasion_scaled(int scale, bool ignore_temporary = false,


### PR DESCRIPTION
Use the rounded down instead of randomly rounded version of the players AC when calculating guaranteed damage reduction for display.