### PR TITLE
Don't crash if a wizard flees the Vaults without a rune.

### DIFF
--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -111,6 +111,12 @@ void wizard_level_travel(bool down)
 
     if (down)
         down_stairs(stairs, false, false);
+    else if (stairs == DNGN_EXIT_VAULTS && vaults_is_locked())
+    {
+        unlock_vaults();
+        up_stairs(stairs, false);
+        lock_vaults();
+    }
     else
         up_stairs(stairs, false);
 


### PR DESCRIPTION
Entering the Vaults via the stairs and then leaving with &u triggered an ASSERT in _rune_effect().

Fix this by briefly "unlocking" the Vaults as the wizard escapes.