### PR TITLE
Describe fewer things which have been excluded as stairs.

### DIFF
--- a/crawl-ref/source/exclude.cc
+++ b/crawl-ref/source/exclude.cc
@@ -521,7 +521,7 @@ void set_exclude(const coord_def &p, int radius, bool autoexcl, bool vaultexcl,
                 const dungeon_feature_type feat = cell.feat();
                 if (feat_is_door(feat))
                     desc = "door";
-                else
+                else if (feat_is_travelable_stair(feat))
                 {
                     const command_type dir = feat_stair_direction(feat);
                     if (dir == CMD_GO_UPSTAIRS)


### PR DESCRIPTION
Only describe an excluded square as being up- or downstairs in the dungeon overview if it goes to another level, and if its exact destination can be predicted after using it once.

This means that it no longer describes things such as one-way gates, portals, shops or transporters as being stairs.