### PR TITLE
Cast OTR with uppercase Z when all enemies resist poison (CrawlOdds)

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3437,23 +3437,25 @@ static bool _toxic_can_affect(const actor *act)
     return act->res_poison() < (act->is_player() ? 3 : 1);
 }
 
-spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool mon_tracer)
+spret cast_toxic_radiance(actor *agent, int pow, bool fail, bool tracer)
 {
-    // XXX: This must come before the player check, due to Marionette.
-    if (mon_tracer)
+    if (tracer)
     {
-        for (actor_near_iterator ai(agent->pos(), LOS_NO_TRANS); ai; ++ai)
+        for (actor_near_iterator ai(agent, LOS_NO_TRANS); ai; ++ai)
         {
             if (!_toxic_can_affect(*ai) || mons_aligned(agent, *ai))
                 continue;
-            else
-                return spret::success;
+            const monster* mons = ai->as_monster();
+            if (mons && !mons_is_threatening(*mons))
+                continue;
+            return spret::success;
         }
 
         // Didn't find any susceptible targets
         return spret::abort;
     }
-    else if (agent->is_player())
+
+    if (agent->is_player())
     {
         targeter_radius hitfunc(&you, LOS_NO_TRANS);
         if (stop_attack_prompt(hitfunc, "poison", _toxic_can_affect))

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -107,7 +107,7 @@ bool dazzle_target(actor *victim, const actor *agent, int pow);
 spret cast_dazzling_flash(const actor *caster, int pow, bool fail, bool tracer = false);
 
 spret cast_toxic_radiance(actor *caster, int pow, bool fail = false,
-                               bool mon_tracer = false);
+                               bool tracer = false);
 void toxic_radiance_effect(actor* agent, int mult, bool on_cast = false);
 
 dice_def glaciate_damage(int pow, int eff_range);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1648,7 +1648,6 @@ bool spell_no_hostile_in_range(spell_type spell)
     case SPELL_FIRE_STORM:
         return false;
 
-    case SPELL_OLGREBS_TOXIC_RADIANCE:
     case SPELL_IGNITION:
     case SPELL_FROZEN_RAMPARTS:
     case SPELL_FULSOME_FUSILLADE:
@@ -1681,6 +1680,9 @@ bool spell_no_hostile_in_range(spell_type spell)
 
         return true;
     }
+
+    case SPELL_OLGREBS_TOXIC_RADIANCE:
+        return cast_toxic_radiance(&you, pow, false, true) == spret::abort;
 
     case SPELL_IGNITE_POISON:
         return cast_ignite_poison(&you, -1, false, true) == spret::abort;


### PR DESCRIPTION
When casting Olgreb's toxic radiance with no enemies in view, it would give the message "You can't see any susceptible monsters within range! (Use Z to cast anyway)". However, when casting with only poison resistant and immune enemies in view, it would cast normally even though it couldn't effect anything. Fix this inconsistency by also requiring uppercase Z to cast with only poison reistant and immune enemies in view.

This change also fixes a bug where monsters would always act as if they could see invisibly even when they couldn't when deciding whether to cast OTR.

Fixes #3957