### PR TITLE
Fix merfolk equipping barding when in beast form (EscapistDaydreamer)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1952,7 +1952,7 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
 
     if (sub_type == ARM_BARDING)
     {
-        if (you.can_wear_barding(ignore_temporary))
+        if (you.can_wear_barding(!ignore_temporary))
             return true;
         if (verbose)
         {


### PR DESCRIPTION
Beast form should meld barding and it was melding them correctly if you put on the barding and then activated the form. However, it was letting you put on and benefit from barding if you activated the form first.

fixes #4142