### PR TITLE
fix: Yred keeps bound hydra heads

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3504,6 +3504,10 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         dec_hp(pain, false);
         mons->add_ench(mon_enchant(ENCH_SOUL_RIPE, pain, &you,
                                    INFINITE_DURATION));
+
+        if (mons->mons_species() == MONS_HYDRA)
+            mons->props[OLD_HEADS_KEY].get_int() = mons->num_heads;
+
         mprf("You wrap your dark will around %s soul!",
               mons->name(DESC_ITS).c_str());
         break;

--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3504,10 +3504,6 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         dec_hp(pain, false);
         mons->add_ench(mon_enchant(ENCH_SOUL_RIPE, pain, &you,
                                    INFINITE_DURATION));
-
-        if (mons->mons_species() == MONS_HYDRA)
-            mons->props[OLD_HEADS_KEY].get_int() = mons->num_heads;
-
         mprf("You wrap your dark will around %s soul!",
               mons->name(DESC_ITS).c_str());
         break;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1747,7 +1747,7 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     {
         if (orig.heads() < mon->props[OLD_HEADS_KEY].get_int())
         {
-            mprf("Yredelemnul restores the hydra's soul to its natural glory!");
+            mpr("Yredelemnul restores the hydra's soul to its natural glory!");
             mon->num_heads = mon->props[OLD_HEADS_KEY].get_int();
         }
         else

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1702,8 +1702,8 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     remove_bound_soul_companion();
     add_daction(DACT_OLD_CHARMD_SOULS_POOF);
 
-    const string whose = you.can_see(*mon) ? apostrophise(mon->name(DESC_THE))
-                                           : mon->pronoun(PRONOUN_POSSESSIVE);
+    string whose = you.can_see(*mon) ? apostrophise(mon->name(DESC_THE))
+                                     : mon->pronoun(PRONOUN_POSSESSIVE);
 
     // Heal the health we paid wrestling for this soul
     you.heal(mon->get_ench(ENCH_SOUL_RIPE).degree);
@@ -1742,6 +1742,20 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     // Use the original monster type as the zombified type here, to get
     // the proper stats from it.
     define_zombie(mon, mon->type, MONS_BOUND_SOUL);
+
+    if (orig.mons_species() == MONS_HYDRA)
+    {
+        if (orig.heads() < mon->props[OLD_HEADS_KEY].get_int())
+        {
+            mprf("Yredelemnul restores the hydra's soul to it's natural glory!");
+            mon->num_heads = mon->props[OLD_HEADS_KEY].get_int();
+        }
+        else
+            mon->num_heads = orig.heads();
+
+        whose = you.can_see(*mon) ? apostrophise(orig.name(DESC_THE))
+                                           : orig.pronoun(PRONOUN_POSSESSIVE);
+    }
 
     // Modify health based on invocations skill
     mon->max_hit_points = yred_get_bound_soul_hp(orig.type);

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1747,7 +1747,7 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     {
         if (orig.heads() < mon->props[OLD_HEADS_KEY].get_int())
         {
-            mprf("Yredelemnul restores the hydra's soul to it's natural glory!");
+            mprf("Yredelemnul restores the hydra's soul to its natural glory!");
             mon->num_heads = mon->props[OLD_HEADS_KEY].get_int();
         }
         else

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1702,8 +1702,8 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     remove_bound_soul_companion();
     add_daction(DACT_OLD_CHARMD_SOULS_POOF);
 
-    string whose = you.can_see(*mon) ? apostrophise(mon->name(DESC_THE))
-                                     : mon->pronoun(PRONOUN_POSSESSIVE);
+    const string whose = you.can_see(*mon) ? apostrophise(mon->name(DESC_THE))
+                                           : mon->pronoun(PRONOUN_POSSESSIVE);
 
     // Heal the health we paid wrestling for this soul
     you.heal(mon->get_ench(ENCH_SOUL_RIPE).degree);
@@ -1744,18 +1744,7 @@ void yred_make_bound_soul(monster* mon, bool force_hostile)
     define_zombie(mon, mon->type, MONS_BOUND_SOUL);
 
     if (orig.mons_species() == MONS_HYDRA)
-    {
-        if (orig.heads() < mon->props[OLD_HEADS_KEY].get_int())
-        {
-            mpr("Yredelemnul restores the hydra's soul to its natural glory!");
-            mon->num_heads = mon->props[OLD_HEADS_KEY].get_int();
-        }
-        else
-            mon->num_heads = orig.heads();
-
-        whose = you.can_see(*mon) ? apostrophise(orig.name(DESC_THE))
-                                           : orig.pronoun(PRONOUN_POSSESSIVE);
-    }
+        mon->num_heads = mon->props[OLD_HEADS_KEY].get_int();
 
     // Modify health based on invocations skill
     mon->max_hit_points = yred_get_bound_soul_hp(orig.type);

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1426,8 +1426,10 @@ static void _make_derived_undead(monster* mons, bool quiet,
 
     if (mons->mons_species() == MONS_HYDRA)
     {
+        if (which_z == MONS_SPECTRAL_THING)
+            mg.props[MGEN_NUM_HEADS] = mons->props[OLD_HEADS_KEY].get_int();
         // No undead 0-headed hydras, sorry.
-        if (mons->heads() == 0)
+        else if (mons->heads() == 0)
         {
             if (!quiet && which_z != MONS_SKELETON)
                 mprf("A %s mist gathers momentarily, then fades.", mist);

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1082,7 +1082,10 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
         mon->mname = mg.mname;
 
     if (mg.props.exists(MGEN_NUM_HEADS))
+    {
         mon->num_heads = mg.props[MGEN_NUM_HEADS];
+        mon->props[OLD_HEADS_KEY] = mon->num_heads;
+    }
     if (mg.props.exists(MGEN_BLOB_SIZE))
         mon->blob_size = mg.props[MGEN_BLOB_SIZE];
     if (mg.props.exists(MGEN_TENTACLE_CONNECT))


### PR DESCRIPTION
Yred bound soul was not consistent for hydra.  Bound hydra would revert to the original number of heads.  Other transformed or polymorphed monsters would retain their final form when bound.  Zombie and spectral hydra also maintain their final number of heads.

This change allows Yred to maintain the final number of hydra heads; additionally, Yred will restore any heads that were permanently removed with a flaming weapon.

No change in heads
```
You wrap your dark will around the six-headed hydra's soul!
The six-headed hydra vaporises in an electric haze!
The six-headed hydra's soul is now yours.
You can see a friendly bound six-headed hydra.
```

Cutting off heads with fire
```
You wrap your dark will around the five-headed hydra's soul!
You hack one of the five-headed hydra's heads off!
You hack one of the four-headed hydra's heads off!
The three-headed hydra vaporises in an electric haze!
Yredelemnul restores the hydra's soul to it's natural glory!
The three-headed hydra's soul is now yours.
You can see a friendly bound five-headed hydra.
```

Growing additional heads
```
You wrap your dark will around the seven-headed hydra's soul!
You lop one of the seven-headed hydra's heads off!
You lop one of the eight-headed hydra's heads off!
The nine-headed hydra vaporises in an electric haze!
The nine-headed hydra's soul is now yours.
You can see  a friendly bound nine-headed hydra.
```

Resolves #4115