### PR TITLE
remove old g++ check

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -558,14 +558,7 @@ ifdef USE_ICC
 # Some very good optimization flags.
   CFOPTIMIZE := -O2 -parallel
 else
-
-  ifneq (,$(shell $(GXX) --version|grep 'g++.*4\.2\.'))
-    # OS X uses a buggy ancient version of gcc without fixes from even
-    # subsequent point releases of 4.2.
-    CFOPTIMIZE := -O0
-  else
-    CFOPTIMIZE := -O2
-  endif
+  CFOPTIMIZE := -O2
 endif
 
 # Define this to automatically generate code optimized for your machine


### PR DESCRIPTION
The pattern matches Arch's 14.2.x, which leads to inconsistent optimization and crashes with their build flags.

It was later noted that g++ 4.2 didn't support C++11, which we require these days, so the test no longer serves a purpose anyway. And Macs have shipped clang instead of gcc for years.