### PR TITLE
Fix barding being incorrectly marked permanently useless

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1952,15 +1952,10 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
 
     if (sub_type == ARM_BARDING)
     {
-        if (!you.can_wear_barding(ignore_temporary))
+        if (!you.can_wear_barding())
         {
             if (verbose)
-            {
-                if (ignore_temporary)
-                    mprf(MSGCH_PROMPT, "You can't wear that!");
-                else
-                    mprf(MSGCH_PROMPT, "You can wear that only in your normal form.");
-            }
+                mprf(MSGCH_PROMPT, "You can't wear that!");
             return false;
         }
     }


### PR DESCRIPTION
Barding for races that can wear it should be marked temporarily useless in a form that melds it, not permanently useless. This was causing it to be impossible to get from acquirement and show as the wrong colour in the inventory while in a form that melds it.