### PR TITLE
Let the user look at more "nogen" items in the help menu.

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -72,6 +72,7 @@
 # * chaotic:  Is treated as a chaotic item.
 # * clarity:  Provides clarity.
 # * corrode:  Randomly causes corrosion when taking damage.
+# * deleted:  Never randomly generated. Should only appear in old games.
 # * drain:    Causes draining when unequipped.
 # * elec:     Grants electrical resistance.
 # * evil:     Is treated as an evil item (hated by good gods).
@@ -387,7 +388,7 @@ TILE:    urand_bloodbane
 TILE_EQ: bloodbane
 BRAND:   SPWPN_DRAINING
 ANGRY:   5
-BOOL:    nogen
+BOOL:    deleted
 STEALTH: -1
 # end TAG_MAJOR_VERSION
 
@@ -402,7 +403,7 @@ TILE_EQ: flaming_death
 BRAND:   SPWPN_FLAMING
 FIRE:    2
 COLD:    -1
-BOOL:    poison, skip_ego, nogen
+BOOL:    poison, skip_ego, deleted
 WILL:    1
 # end TAG_MAJOR_VERSION
 
@@ -443,10 +444,10 @@ BRAND:   SPWPN_FREEZING
 FIRE:    -1
 COLD:    2
 WILL:    1
-BOOL:    poison, skip_ego, nogen
+BOOL:    poison, skip_ego, deleted
 # end TAG_MAJOR_VERSION
 
-# TAG_MAJOR_VERSION == 34
+# start TAG_MAJOR_VERSION == 34
 NAME:     dagger "Morg"
 OBJ:      OBJ_WEAPONS/WPN_DAGGER
 PLUS:     +4
@@ -456,7 +457,7 @@ TILE_EQ:  morg
 BRAND:    SPWPN_PAIN
 INT:      5
 WILL:     1
-BOOL:     nogen
+BOOL:     deleted
 # end TAG_MAJOR_VERSION
 
 NAME:    scythe "Finisher"
@@ -589,7 +590,7 @@ BRAND:    SPWPN_REAPING
 FB_BRAND: SPWPN_PAIN
 HP:       -6
 LIFE:     1
-BOOL:     poison, nogen
+BOOL:     poison, deleted
 # end TAG_MAJOR_VERSION
 
 NAME:     trident of the Octopus King
@@ -650,7 +651,7 @@ TILE:    urand_piercer
 TILE_EQ: great_bow
 BRAND:   SPWPN_PENETRATION
 EV:      -2
-BOOL:    nogen
+BOOL:    deleted
 # end TAG_MAJOR_VERSION
 
 # start TAG_MAJOR_VERSION == 34
@@ -665,7 +666,7 @@ COLOUR:  ETC_DEATH
 TILE:    urand_blowgun
 TILE_EQ: great_bow
 STEALTH: 2
-BOOL:    inv, tilerim, nogen
+BOOL:    inv, tilerim, deleted
 # end TAG_MAJOR_VERSION
 
 NAME:    lance "Wyrmbane"
@@ -744,7 +745,7 @@ PLUS:     +27
 COLOUR:   LIGHTCYAN
 TILE:     urand_knife_of_accuracy
 TILE_EQ:  knife_of_accuracy
-BOOL:     tilerim, nogen
+BOOL:     tilerim, deleted
 # end TAG_MAJOR_VERSION
 
 # start TAG_MAJOR_VERSION == 34
@@ -757,7 +758,7 @@ COLOUR:   GREEN
 TILE:     urand_crystal_spear
 TILE_EQ:  crystal_spear
 INT:      3
-BOOL:     nogen
+BOOL:     deleted
 # end TAG_MAJOR_VERSION
 
 ENUM:     CAPTAIN
@@ -823,7 +824,7 @@ COLOUR:  RED
 TILE:    urand_bullseye
 TILE_EQ: kite_shield_bullseye
 EV:      -5
-BOOL:    nogen
+BOOL:    deleted
 # end TAG_MAJOR_VERSION
 
 NAME:    crown of Dyrovepreva
@@ -869,7 +870,7 @@ COLOUR:   ETC_FLASH
 TILE:     urand_flash
 TILE_EQ:  red
 EV:       4
-BOOL:     fly, nogen
+BOOL:     fly, deleted
 # end TAG_MAJOR_VERSION
 
 ENUM:     HOOD_ASSASSIN
@@ -1093,7 +1094,7 @@ TILE:    urand_cekugob
 AC:      1
 EV:      1
 LIFE:    2
-BOOL:    elec, poison, notelep, nogen
+BOOL:    elec, poison, notelep, deleted
 # end TAG_MAJOR_VERSION
 
 NAME:    amulet of the Four Winds
@@ -1308,7 +1309,7 @@ PLUS:     +3
 BRAND:    SPARM_JUMPING
 COLOUR:   LIGHTMAGENTA
 STEALTH:  1
-BOOL:     nogen
+BOOL:     deleted
 # end TAG_MAJOR_VERSION
 
 NAME:     dark maul
@@ -1334,7 +1335,7 @@ TILE_EQ: wizard_lightgreen
 PLUS:    +2
 BRAND:   SPARM_ARCHMAGI
 STEALTH: -1
-BOOL:    nogen
+BOOL:    deleted
 # end TAG_MAJOR_VERSION
 
 NAME:     arc blade
@@ -1444,7 +1445,7 @@ TILE_EQ: etheric_cage
 INSCRIP: RegenMP+
 PLUS:    +0
 MP:      +4
-BOOL:    mutate, elec, chaotic, nogen
+BOOL:    mutate, elec, chaotic, deleted
 VALUE:   400
 # end TAG_MAJOR_VERSION
 
@@ -1458,7 +1459,7 @@ TILE:    urand_eternal_torment
 TILE_EQ: eternal_torment
 INSCRIP: rTorment HP--
 LIFE:    3
-BOOL:    evil, seeinv, nogen, drain
+BOOL:    evil, seeinv, drain, deleted
 # end TAG_MAJOR_VERSION
 
 ENUM:    VINES
@@ -1509,7 +1510,7 @@ TILE_EQ:  talos
 COLOUR:   ETC_FIRE
 BRAND:    SPARM_PONDEROUSNESS
 FIRE:     1
-BOOL:     nogen
+BOOL:     deleted
 # end TAG_MAJOR_VERSION
 
 ENUM:     WARLOCK_MIRROR

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -1566,7 +1566,7 @@ int find_okay_unrandart(uint8_t aclass, uint8_t atype, int item_level, bool in_a
         // If an item does not generate randomly, we can only produce its index
         // here if it was lost in the abyss
         if ((!in_abyss || status != UNIQ_LOST_IN_ABYSS)
-            && entry->flags & UNRAND_FLAG_NOGEN)
+            && entry->flags & (UNRAND_FLAG_NOGEN | UNRAND_FLAG_DELETED))
         {
             continue;
         }
@@ -1624,14 +1624,8 @@ int extant_unrandart_by_exact_name(string name)
         for (unsigned int i = 0; i < ARRAYSZ(unranddata); ++i)
         {
             const int id = UNRAND_START + i;
-            if (unranddata[i].flags & UNRAND_FLAG_NOGEN
-                && id != UNRAND_DRAGONSKIN
-                && id != UNRAND_CEREBOV
-                && id != UNRAND_DISPATER
-                && id != UNRAND_ASMODEUS /* ew */)
-            {
+            if (unranddata[i].flags & UNRAND_FLAG_DELETED)
                 continue;
-            }
             cache[lowercase_string(unranddata[i].name)] = id;
         }
     }

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -36,6 +36,7 @@ enum unrand_flag_type
                               // =0x100,  // was UNRAND_FLAG_RANDAPP
     UNRAND_FLAG_UNIDED           =0x200,
     UNRAND_FLAG_SKIP_EGO         =0x400,
+    UNRAND_FLAG_DELETED          =0x800,
     // Please make sure it fits in unrandart_entry.flags (currently 16 bits).
 };
 

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -31,6 +31,7 @@ my %field_type = (
     COLOUR   => "enum",
     CORRODE  => "bool",
     DBRAND   => "str",
+    DELETED  => "bool",
     DEX      => "num",
     DESCRIP  => "str",
     DRAIN    => "bool",

--- a/crawl-ref/source/util/art-data.pl
+++ b/crawl-ref/source/util/art-data.pl
@@ -270,8 +270,8 @@ sub finish_art
 
     my $flags = "";
     my $flag;
-    foreach $flag ("SPECIAL", "HOLY", "EVIL", "CHAOTIC", "NOGEN", "RANDAPP",
-                   "UNIDED", "SKIP_EGO")
+    foreach $flag ("SPECIAL", "HOLY", "EVIL", "CHAOTIC", "DELETED", "NOGEN",
+                   "RANDAPP", "UNIDED", "SKIP_EGO")
     {
         if ($artefact->{$flag})
         {


### PR DESCRIPTION
Replace the "nogen" tag with a "deleted" one for "TAG_MAJOR_VERSION = 34" sections of art-data.txt. Both tags mean the item isn't created in the normal way. The "deleted" tag alone stops the help menu from giving details of the item.

Remove the code in extant_unrandart_by_exact_name() which let some (but not all) of the nogen items be looked up.

My hope here is that, if the data is all in art-data.txt, it's more likely to be updated correctly than it would be with two lists in completely different bits of code.

For what it's worth, the artefacts which have nogen but weren't on the list are:

faerie dragon scales (created with the Enchantress)
dreamdust necklace (created by using the dreamshard necklace)
Axe of Woe (Arena of Blood)
amulet of invisibility (Fedhas' Mad Dash)
scarf of invisibility (Fedhas' Mad Dash)