### PR TITLE
Say something after "You have ." when wielding a non-weapon item (fix #4172)

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -5772,7 +5772,7 @@ bool describe_to_hit(const monster_info &mi, ostringstream &result,
     if (weapon != nullptr
         && !(is_weapon(*weapon) || is_throwable(&you, *weapon)))
     {
-        result << "a non-weapon item in your " << (you.species == SP_FELID ? "mouth" : you.hand_name(true));
+        result << "a non-weapon item in your " << (you.species == SP_FELID ? "mouth" : you.hand_name(false));
         return true; // breadwielding
     }
 

--- a/crawl-ref/source/describe.h
+++ b/crawl-ref/source/describe.h
@@ -100,7 +100,7 @@ string get_skill_description(skill_type skill, bool need_title = false);
 void describe_skill(skill_type skill);
 
 int hex_chance(const spell_type spell, const monster_info* mon_owner);
-void describe_to_hit(const monster_info& mi, ostringstream &result,
+bool describe_to_hit(const monster_info& mi, ostringstream &result,
                      const item_def* weapon = nullptr, bool verbose = false,
                      attack *source = nullptr, int distance = 0);
 


### PR DESCRIPTION
Method `describe_to_hit()` returns immediately if the item in hand is not a weapon, resulting in printing "You have ." in the monster desc page. These commits attempts to solve that by telling the player they're not wielding a valid weapon. Also wielding a non-weapon item should be undesirable so an exclamation mark is used instead of a period.

Should resolve #4172.

Didn't talk about this in the irc chatroom although the guide told me to do so because my IP is blocked (idk why). Hope it fixes the issue well and does not violate any conventions. (12/25: sry for the merge commit)