### PR TITLE
Make the `base_type` of classed draconians their corresponding colors instead of randomly chosen.

### DIFF
--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -1059,7 +1059,32 @@ static int _describe_monster(const string &key, const string &suffix,
     // Might be better to show all possible combinations rather than picking
     // one at random as this does?
     if (mons_is_draconian_job(mon_num))
-        base_type = random_draconian_monster_species();
+    {
+        // Classed draconians have fixed colours since 0.28
+        switch (mon_num)
+        {
+        case MONS_DRACONIAN_STORMCALLER:
+            base_type = MONS_WHITE_DRACONIAN;
+            break;
+        case MONS_DRACONIAN_MONK:
+            base_type = MONS_GREEN_DRACONIAN;
+            break;
+        case MONS_DRACONIAN_SHIFTER:
+            base_type = MONS_PURPLE_DRACONIAN;
+            break;
+        case MONS_DRACONIAN_ANNIHILATOR:
+            base_type = MONS_YELLOW_DRACONIAN;
+            break;
+        case MONS_DRACONIAN_KNIGHT:
+            base_type = MONS_BLACK_DRACONIAN;
+            break;
+        case MONS_DRACONIAN_SCORCHER:
+            base_type = MONS_RED_DRACONIAN;
+            break;
+        default:
+            base_type = random_draconian_monster_species();
+        }
+    }
     monster_info mi(mon_num, base_type);
     // Avoid slime creature being described as "buggy"
     if (mi.type == MONS_SLIME_CREATURE)


### PR DESCRIPTION
In #4001, when you lookup information about draconian stormcaller, the color is randomly generated instead of white. This is because of lines lookup-help.cc:1061-1062. This commit attempts to fix that by assigning colors to them using a switch-case statement. Info about which color should be which is grabbed from lines mon-util.cc:2723-2728.

Should resolve #4001.