### PR TITLE
Fix: no prompt when invoking Summon Divine Warrior while having Fulsome Fusillade active (#4182)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3420,6 +3420,8 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
 
     case ABIL_TSO_SUMMON_DIVINE_WARRIOR:
         fail_check();
+        if (stop_summoning_prompt(MR_RES_POISON, M_FLIES))
+            return spret::abort;
         summon_holy_warrior(you.skill(SK_INVOCATIONS, 4), false);
         break;
 


### PR DESCRIPTION
Currently, when the player tries to Summon Divine Warrior (TSO ability), while having Fulsome Fusillade (or Polar Vortex) active, the game does not prompt the player to confirm the action, rather it simply summons, which easily causes penance. This commit aims to fix this issue by calling ```stop_summoning_prompt``` before calling ```summon_holy_warrior``` at ability.cc:3423-3424.