### PR TITLE
Stop mortars from colliding with "a floor" and then being "destroyed!".

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1148,7 +1148,7 @@ static void _handle_hellfire_mortar(monster& mortar)
             if (i + 1 == path.size())
             {
                 simple_monster_message(mortar, " sinks back into the magma.");
-                monster_die(mortar, KILL_NON_ACTOR, true);
+                monster_die(mortar, KILL_NON_ACTOR, NON_MONSTER, true);
                 return;
             }
 
@@ -1162,18 +1162,21 @@ static void _handle_hellfire_mortar(monster& mortar)
             // die.
             if (env.grid(new_pos) != DNGN_LAVA || actor_at(new_pos))
             {
-                const string reason = actor_at(new_pos)
-                                        ? actor_at(new_pos)->name(DESC_THE).c_str()
-                                        : article_a(feat_type_name(env.grid(new_pos)));
-
                 if (you.can_see(mortar))
                 {
-                    mprf("%s collides with %s and sinks back into the magma.",
-                         mortar.name(DESC_THE).c_str(),
-                         reason.c_str());
+                    string barrier, collides = " collides with ", _and = " and";
+                    if (actor_at(new_pos))
+                        barrier = actor_at(new_pos)->name(DESC_THE);
+                    else if (cell_is_solid(new_pos))
+                        barrier = article_a(feat_type_name(env.grid(new_pos)));
+                    else
+                        collides = _and = "";
+
+                    mpr(mortar.name(DESC_THE) + collides + barrier + _and +
+                        " sinks back into the magma.");
                 }
 
-                monster_die(mortar, KILL_NON_ACTOR, true);
+                monster_die(mortar, KILL_NON_ACTOR, NON_MONSTER, true);
                 return;
             }
 


### PR DESCRIPTION
If the lava stream for Hellfire Mortar is shortened by an obstacle which is no longer there when the mortar reaches the spot, and the player sees it, this could give the message "The hellfire mortar collides with a floor and sinks back into the magma."

Omit the "collides with a floor " part unless the mortar hits a monster or "solid" terrain.

Remove the death message which followed this (which seemed redundant) and stop blaming a monster for the death. That is, change the killer_index in monster_die() to NON_MONSTER and the silent flag to true.

...

I don't have an opinion on the mechanics of Hellfire Mortar, but the messages seemed a bit off.

A mortar could collide with "a floor" (not even "the floor") if it ran out of magma. It called monster_die() with a killer_index of "true". As killer_index isn't a boolean, this was just some monster on the level. I've changed this to "no-one" and silenced the death message.