### PR TITLE
Fix the way the scroller works when a menu grows.

### DIFF
--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -222,6 +222,7 @@ void UIMenu::update_items()
     _invalidate_sizereq();
 
     item_info.resize(m_menu->items.size());
+    do_layout(m_region.width, m_num_columns, true);
     for (unsigned int i = 0; i < m_menu->items.size(); ++i)
         update_item(i);
 


### PR DESCRIPTION
Previously, if a player had a spell library containing every spell, searching it for "hat" led to Shatter being selected. Searching for "a" after this led to Shatter still being selected, but only the top of the spell list being displayed.

This happened because UIMenu::update_items() resized item_info but didn't set the x, y, row or column fields, and UIMenu::get_item_region() relied on those being up to date.

Call UIMenu::do_layout() to fix it.