### PR TITLE
Use article_a() instead of "a article" in a few places.

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -34,6 +34,7 @@
 #include "dgn-overview.h"
 #include "dgn-shoals.h"
 #include "end.h"
+#include "english.h"
 #include "fight.h"
 #include "files.h"
 #include "flood-find.h"
@@ -3599,7 +3600,7 @@ static void _place_traps()
         env.grid(ts.pos) = ts.feature();
         ts.prepare_ammo();
         env.trap[ts.pos] = ts;
-        dprf("placed a %s trap", trap_name(type).c_str());
+        dprf("placed %s trap", article_a(trap_name(type)).c_str());
     }
 
     if (player_in_branch(BRANCH_SPIDER))
@@ -6437,7 +6438,7 @@ static void _place_specific_trap(const coord_def& where, trap_spec* spec,
     env.grid(where) = trap_feature(spec_type);
     t.prepare_ammo(charges);
     env.trap[where] = t;
-    dprf("placed a %s trap", trap_name(spec_type).c_str());
+    dprf("placed %s trap", article_a(trap_name(spec_type)).c_str());
 }
 
 /**

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1568,8 +1568,8 @@ bool stop_summoning_prompt(resists_t resists, monclass_flags_t flags,
     if (noun.empty())
         return false;
 
-    string prompt = make_stringf("Really %s while emitting a %s?",
-                                 verb.c_str(), noun.c_str());
+    string prompt = make_stringf("Really %s while emitting %s?",
+                                 verb.c_str(), article_a(noun).c_str());
 
     if (yesno(prompt.c_str(), false, 'n'))
         return false;

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -48,6 +48,7 @@
 #include "directn.h"
 #include "dungeon.h"
 #include "end.h"
+#include "english.h"
 #include "tile-env.h"
 #include "errors.h"
 #include "player-save-info.h"
@@ -3196,8 +3197,8 @@ static bool _restore_game(const string& filename)
     if (!crawl_state.bypassed_startup_menu
         && menu_game_type != crawl_state.type)
     {
-        if (!yesno(("You already have a "
-                        + _type_name_processed(save_info.saved_game_type) +
+        auto atype = article_a(_type_name_processed(save_info.saved_game_type));
+        if (!yesno(("You already have " + atype +
                     " game saved under the name '" + save_info.name + "';\n"
                     "do you want to load that instead?").c_str(),
                    true, 'n'))

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -866,8 +866,7 @@ void hints_monster_seen(const monster& mon)
     if (is_tiles())
     {
         text +=
-            string("monster is a ") +
-            mon.name(DESC_PLAIN).c_str() +
+            "monster is " + mon.name(DESC_A) +
             ". You can learn about any monster by hovering your mouse over it,"
             " and read its description by <w>right-clicking</w> on it.";
     }

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -4440,9 +4440,9 @@ bool read(item_def* scroll, dist *target)
         && which_scroll != SCR_AMNESIA
         && which_scroll != SCR_ACQUIREMENT)
     {
-        mprf("It %s a %s.",
+        mprf("It %s %s.",
              scroll->quantity < prev_quantity ? "was" : "is",
-             scroll_name.c_str());
+             article_a(scroll_name).c_str());
     }
 
     if (!alreadyknown)

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -1416,9 +1416,9 @@ static string _prompt_for_regex(const LookupType &lookup_type, string &err)
         : lookup_type.type == "spell" ? " Preface with '@' to search by school."
         : "";
     const string prompt = make_stringf(
-         "Describe a %s; partial names and regexps are fine.%s\n"
+         "Describe %s; partial names and regexps are fine.%s\n"
          "Describe what? ",
-         type.c_str(), extra.c_str());
+         article_a(type).c_str(), extra.c_str());
 
     char buf[80];
     if (msgwin_get_line(prompt, buf, sizeof(buf)) || buf[0] == '\0')

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -982,9 +982,9 @@ static void _handle_boulder_movement(monster& boulder)
     {
         if (you.can_see(boulder))
         {
-            mprf("%s slams into a %s and falls apart!",
+            mprf("%s slams into %s and falls apart!",
                  boulder.name(DESC_THE).c_str(),
-                 feat_type_name(env.grid(targ)));
+                 article_a(feat_type_name(env.grid(targ))).c_str());
         }
         monster_die(boulder, KILL_NONE, true);
         return;

--- a/crawl-ref/source/potion.cc
+++ b/crawl-ref/source/potion.cc
@@ -13,6 +13,7 @@
 
 #include "art-enum.h"
 #include "cloud.h"
+#include "english.h"
 #include "god-conduct.h"
 #include "god-passive.h"
 #include "god-wrath.h" // reduce_xp_penance
@@ -919,7 +920,7 @@ bool quaff_potion(item_def &potion)
     if (!was_known)
     {
         identify_item(potion);
-        mprf("It was a %s.", potion.name(DESC_QUALNAME).c_str());
+        mprf("It was %s.", article_a(potion.name(DESC_QUALNAME)).c_str());
     }
 
     const potion_type ptyp = static_cast<potion_type>(potion.sub_type);

--- a/crawl-ref/source/shout.cc
+++ b/crawl-ref/source/shout.cc
@@ -770,9 +770,9 @@ void yell(const actor* mon)
             }
             else
             {
-                mprf("You feel a %s rip itself from your throat, "
+                mprf("You feel %s rip itself from your throat, "
                      "but you make no sound!",
-                     shout_verb.c_str());
+                     article_a(shout_verb).c_str());
             }
         }
         else


### PR DESCRIPTION
Replace "a %s" (and equivalent) with article_a() in some places where the noun can start with a vowel sound, or where the noun isn't clear from the context.

For instance, typing ?/i with the default setup now prints "Describe an item;" rather than "Describe a item;".