### PR TITLE
docs: Update INSTALL.md instructions to cover Ubuntu 24.04 package requirements

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -88,6 +88,11 @@ libfreetype6-dev libpng-dev fonts-dejavu-core advancecomp pngcrush
 
 Then follow [the above compilation steps](#compiling).
 
+Note: Ubuntu 24.04+ and related distros (such as Pop!_OS 24.04) may require a few more packages: 
+```sh
+sudo apt install libglu1-mesa libglu1-mesa-dev
+```
+
 ### Fedora
 
 These instructions may work for other RPM-based distros.
@@ -598,6 +603,11 @@ To solve this, run:
 
 If this doesn't resolve the problem, you can try creating `util/release_ver`
 manually, with contents along the lines of `0.31-a0`.
+
+When compiling on Ubuntu 24.04+, you may run into build errors like:
+    glwrapper-ogl.cc:25:13: fatal error: GL/glu.h: No such file or directory
+       25 | #   include <GL/glu.h>
+See the Ubuntu section; you likely need to install libglu1-mesa and libglu1-mesa-dev
 
 ## Getting Help
 


### PR DESCRIPTION
The trunk branch of the apt repository is about a decade out of date and I prefer local to webtiles, so I went to build crawl from source because I wanted to try Forgecraft out.
I am running Pop!_OS 24.04 (which is a Ubuntu 24.04 derived distro), and I stumbled over #3998 

I was very glad that issue existed, since it saved me a lot of sleuthing.

But it would be better still to add it to INSTALL.md, like that issue suggested.
I'm not sure if these packages are auto-installed as transitive dependencies of some package, or commonly installed by default, or what on older distros (in which case I could safely add them to the existing list for crawl_tiles instead).

So instead, I'm just adding another few  lines saying "you need this for Ubuntu 24.04+", and adding an example error message to the troubleshooting message.

This is my first contribution to crawl - if you want to credit me, you can credit me as Charlie Gettys, but I'm really not fussed over credit for a few lines in a readme :smile: .

Closes #3998 
