### PR TITLE
fix: Make spells that never miss unaffected by blindness

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5737,7 +5737,8 @@ void bolt::affect_monster(monster* mon)
 
     int hit_margin = _test_beam_hit(beam_hit, rand_ev, r);
 
-    if (you.duration[DUR_BLIND] && agent() && agent()->is_player())
+    if (you.duration[DUR_BLIND] && beam_hit != AUTOMATIC_HIT && agent()
+        && agent()->is_player())
     {
         const int distance = you.pos().distance_from(mon->pos());
         if (x_chance_in_y(player_blind_miss_chance(distance), 100))


### PR DESCRIPTION

When a player is blinded, they can miss with spells that are supposed to never miss, such as Magic Dart, LRD, and Chain Lightning. This only applies to spells that solely rely on having AUTOMATIC_HIT as their to hit for this purpose (e.g. Fireball doesn't currently miss even when blinded, since it is an explosion). This commit makes sure that the aforementioned spells will be unaffected by blindness.
