### PR TITLE
Let beam targeter take whether it's harmless into account.

### DIFF
--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -210,6 +210,7 @@ public:
 
     bool can_affect_actor(const actor *act) const;
     bool can_affect_wall(const coord_def& p, bool map_knowledge = false) const;
+    bool harmless_to_player() const;
     bool ignores_monster(const monster* mon) const;
     bool ignores_player() const;
     bool can_knockback(int dam = -1) const;
@@ -251,7 +252,6 @@ private:
     bool can_burn_trees() const;
     bool is_bouncy(dungeon_feature_type feat) const;
     bool stop_at_target() const;
-    bool harmless_to_player() const;
     bool is_reflectable(const actor &whom) const;
     bool found_player() const;
     bool need_regress() const;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -380,7 +380,7 @@ bool targeter_beam::affects_monster(const monster_info& mon)
 
 bool targeter_beam::harmful_to_player()
 {
-    return !beam.ignores_player();
+    return !beam.ignores_player() && !beam.harmless_to_player();
 }
 
 targeter_view::targeter_view()


### PR DESCRIPTION
The situation I was trying to fix is to stop Mephitic Cloud targeter from trying to avoid the Qazlal-worshipping player. The harmlessness check is already there, but not called by the beam targeter.

`bolt::harmless_to_player()` was private. However, it makes sense for the beam targeter to call this, and making it public would be the straightforward way to do this.