### PR TITLE
Work towards removing glu dependency

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2390,6 +2390,11 @@ tile_filter_scaling = false
         Setting it to true filters the textures resulting in a smoother but
         blurrier image.
 
+tile_use_mipmaps = auto
+        Used in conjunction with tile_cell_pixels or tile_sidebar_pixels.
+        Setting it to true filters the textures resulting in a smoother but
+        blurrier image.
+
 tile_force_overlay = false
         Setting this option to true will force the message window to appear as
         an overlay on top of the screen. If you use this option, making your

--- a/crawl-ref/source/fontwrapper-ft.cc
+++ b/crawl-ref/source/fontwrapper-ft.cc
@@ -155,19 +155,8 @@ bool FTFontWrapper::configure_font()
 
     // atlas[0] always contains a full-white block (never evicted)
     // this is currently used by colour_bar
-    // TODO: couldn't this loop be reduced to a memset??
     {
-        for (int y = 0; y < m_max_advance.y; y++)
-            for (int x = 0; x < m_max_advance.x; x++)
-            {
-                unsigned int idx = x + y * charsz.x;
-                idx *= 4;
-                pixels[idx]     = 255;
-                pixels[idx + 1] = 255;
-                pixels[idx + 2] = 255;
-                pixels[idx + 3] = 255;
-            }
-
+        memset(pixels.data(), 255, sizeof(unsigned char) * pixels.size());
         LoadTextureArgs texture_args = LoadTextureArgs::CreateSubtextureForFont(
             pixels.data(),
             charsz.x, charsz.y,

--- a/crawl-ref/source/fontwrapper-ft.cc
+++ b/crawl-ref/source/fontwrapper-ft.cc
@@ -157,10 +157,10 @@ bool FTFontWrapper::configure_font()
     // this is currently used by colour_bar
     // TODO: couldn't this loop be reduced to a memset??
     {
-        for (int x = 0; x < m_max_advance.x; x++)
-            for (int y = 0; y < m_max_advance.y; y++)
+        for (int y = 0; y < m_max_advance.y; y++)
+            for (int x = 0; x < m_max_advance.x; x++)
             {
-                unsigned int idx = x + y * m_max_advance.x;
+                unsigned int idx = x + y * charsz.x;
                 idx *= 4;
                 pixels[idx]     = 255;
                 pixels[idx + 1] = 255;
@@ -303,8 +303,8 @@ void FTFontWrapper::load_glyph(unsigned int c, char32_t uchar)
         bmp->width = min(bmp->width, ftint(charsz.x));
         bmp->rows = min(bmp->rows, ftint(charsz.y));
 
-        for (ftint x = 0; x < bmp->width; x++)
-            for (ftint y = 0; y < bmp->rows; y++)
+        for (ftint y = 0; y < bmp->rows; y++)
+            for (ftint x = 0; x < bmp->width; x++)
             {
                 unsigned int idx = offset_x + x + (offset_y + y) * charsz.x;
                 idx *= 4;

--- a/crawl-ref/source/fontwrapper-ft.cc
+++ b/crawl-ref/source/fontwrapper-ft.cc
@@ -142,11 +142,12 @@ bool FTFontWrapper::configure_font()
 
     // initialise empty texture of correct size
     unwind_bool noscaling(Options.tile_filter_scaling, false);
-    // Note: unclear why this is NO_OFFSET, NO_OFFSET, but 0, 0 for the other call.
-    // It may be that we can treat NO_OFFSET == 0, unclear...
-    LoadTextureArgs texture_args = LoadTextureArgs::CreateForFont(
+    // Note: this is loading the original font atlas, if I understand right
+    // We never mipmap it (should we??)
+    LoadTextureArgs texture_args = LoadTextureArgs::CreateForTexture(
+        pixels,
         m_ft_width, m_ft_height,
-        LoadTextureArgs::NO_OFFSET, LoadTextureArgs::NO_OFFSET
+        MIPMAP_NONE
     );
     m_tex.load_texture(texture_args);
 
@@ -169,7 +170,9 @@ bool FTFontWrapper::configure_font()
                 pixels[idx + 3] = 255;
             }
 
-        // Note: Offsets of 0 not the same as NO_OFFSET... unclear if we can change this
+        // Note: Offsets of 0 not the same as NO_OFFSET
+        // This is instead taking part of the font atlas texture.
+        // Whereas NO_OFFSET is taking just a portion of the texture
         LoadTextureArgs texture_args2 = LoadTextureArgs::CreateForFont(
             charsz.x, charsz.y,
             0, 0

--- a/crawl-ref/source/fontwrapper-ft.cc
+++ b/crawl-ref/source/fontwrapper-ft.cc
@@ -142,7 +142,13 @@ bool FTFontWrapper::configure_font()
 
     // initialise empty texture of correct size
     unwind_bool noscaling(Options.tile_filter_scaling, false);
-    m_tex.load_texture(nullptr, m_ft_width, m_ft_height, MIPMAP_NONE);
+    // Note: unclear why this is NO_OFFSET, NO_OFFSET, but 0, 0 for the other call.
+    // It may be that we can treat NO_OFFSET == 0, unclear...
+    LoadTextureArgs texture_args = LoadTextureArgs::CreateForFont(
+        m_ft_width, m_ft_height,
+        LoadTextureArgs::NO_OFFSET, LoadTextureArgs::NO_OFFSET
+    );
+    m_tex.load_texture(texture_args);
 
     m_glyphs.clear();
 
@@ -163,8 +169,12 @@ bool FTFontWrapper::configure_font()
                 pixels[idx + 3] = 255;
             }
 
-        bool success = m_tex.load_texture(pixels, charsz.x, charsz.y,
-                                          MIPMAP_NONE, 0, 0);
+        // Note: Offsets of 0 not the same as NO_OFFSET... unclear if we can change this
+        LoadTextureArgs texture_args2 = LoadTextureArgs::CreateForFont(
+            charsz.x, charsz.y,
+            0, 0
+        );
+        bool success = m_tex.load_texture(texture_args2);
         ASSERT(success);
     }
 
@@ -310,10 +320,12 @@ void FTFontWrapper::load_glyph(unsigned int c, char32_t uchar)
             }
 
         unwind_bool noscaling(Options.tile_filter_scaling, false);
-        bool success = m_tex.load_texture(pixels, charsz.x, charsz.y,
-                            MIPMAP_NONE,
-                            (c % GLYPHS_PER_ROWCOL) * charsz.x,
-                            (c / GLYPHS_PER_ROWCOL) * charsz.y);
+        LoadTextureArgs texture_args = LoadTextureArgs::CreateForFont(
+            charsz.x, charsz.y,
+            (c % GLYPHS_PER_ROWCOL) * charsz.x,
+            (c / GLYPHS_PER_ROWCOL) * charsz.y
+        );
+        bool success = m_tex.load_texture(texture_args);
         ASSERT(success);
     }
 }

--- a/crawl-ref/source/fontwrapper-ft.cc
+++ b/crawl-ref/source/fontwrapper-ft.cc
@@ -144,10 +144,10 @@ bool FTFontWrapper::configure_font()
     unwind_bool noscaling(Options.tile_filter_scaling, false);
     // Note: this is loading the original font atlas, if I understand right
     // We never mipmap it (should we??)
-    LoadTextureArgs texture_args = LoadTextureArgs::CreateForTexture(
-        pixels,
+    LoadTextureArgs texture_args = LoadTextureArgs::CreateForFont(
+        nullptr,
         m_ft_width, m_ft_height,
-        MIPMAP_NONE
+        LoadTextureArgs::NO_OFFSET, LoadTextureArgs::NO_OFFSET
     );
     m_tex.load_texture(texture_args);
 
@@ -172,8 +172,9 @@ bool FTFontWrapper::configure_font()
 
         // Note: Offsets of 0 not the same as NO_OFFSET
         // This is instead taking part of the font atlas texture.
-        // Whereas NO_OFFSET is taking just a portion of the texture
+        // Whereas NO_OFFSET would create? a new texture
         LoadTextureArgs texture_args2 = LoadTextureArgs::CreateForFont(
+            pixels,
             charsz.x, charsz.y,
             0, 0
         );
@@ -324,6 +325,7 @@ void FTFontWrapper::load_glyph(unsigned int c, char32_t uchar)
 
         unwind_bool noscaling(Options.tile_filter_scaling, false);
         LoadTextureArgs texture_args = LoadTextureArgs::CreateForFont(
+            pixels,
             charsz.x, charsz.y,
             (c % GLYPHS_PER_ROWCOL) * charsz.x,
             (c / GLYPHS_PER_ROWCOL) * charsz.y

--- a/crawl-ref/source/fontwrapper-ft.h
+++ b/crawl-ref/source/fontwrapper-ft.h
@@ -151,7 +151,7 @@ protected:
 
     FT_Byte *ttf;
     FT_Face face;
-    unsigned char *pixels;
+    std::vector<unsigned char> pixels;
     unsigned int fsize;
 };
 

--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -395,7 +395,7 @@ void OGLStateManager::load_texture(LoadTextureArgs texture)
         gluBuild2DMipmaps(GL_TEXTURE_2D, bpp, texture.width, texture.height,
                           texture_format, format, texture.pixels);
         // TODO: glGenerateMipmap()
-        ASSERT(texture.xoffset == -1 && texture.yoffset == -1);
+        // Note: LoadTextureArgs enforces that offset == NO_OFFSET if mip_opt = MIPMAP_CREATE
     }
     else
 #endif
@@ -404,8 +404,7 @@ void OGLStateManager::load_texture(LoadTextureArgs texture)
                         Options.tile_filter_scaling ? GL_LINEAR : GL_NEAREST);
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
                         Options.tile_filter_scaling ? GL_LINEAR : GL_NEAREST);
-        ASSERT((texture.xoffset >= 0) == (texture.yoffset >= 0));
-        if (texture.xoffset >= 0 && texture.yoffset >= 0)
+        if (texture.has_offset())
         {
             glTexSubImage2D(GL_TEXTURE_2D, 0, texture.xoffset, texture.yoffset, texture.width, texture.height,
                          texture_format, format, texture.pixels);

--- a/crawl-ref/source/glwrapper-ogl.h
+++ b/crawl-ref/source/glwrapper-ogl.h
@@ -30,9 +30,7 @@ public:
     virtual void delete_textures(size_t count, unsigned int *textures) override;
     virtual void generate_textures(size_t count, unsigned int *textures) override;
     virtual void bind_texture(unsigned int texture) override;
-    virtual void load_texture(unsigned char *pixels, unsigned int width,
-                              unsigned int height, MipMapOptions mip_opt,
-                              int xoffset=-1, int yoffset=-1) override;
+    virtual void load_texture(LoadTextureArgs texture) override;
     int logical_to_device(int n) const override;
     int device_to_logical(int n, bool round=true) const override;
 protected:

--- a/crawl-ref/source/glwrapper.h
+++ b/crawl-ref/source/glwrapper.h
@@ -156,9 +156,7 @@ public:
     virtual void delete_textures(size_t count, unsigned int *textures) = 0;
     virtual void generate_textures(size_t count, unsigned int *textures) = 0;
     virtual void bind_texture(unsigned int texture) = 0;
-    virtual void load_texture(unsigned char *pixels, unsigned int width,
-                              unsigned int height, MipMapOptions mip_opt,
-                              int xoffset=-1, int yoffset=-1) = 0;
+    virtual void load_texture(LoadTextureArgs texture) = 0;
 
     virtual int logical_to_device(int n) const = 0;
     virtual int device_to_logical(int n, bool round=true) const = 0;

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -830,6 +830,8 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(tile_skip_title), false),
         new BoolGameOption(SIMPLE_NAME(tile_menu_icons), true),
         new BoolGameOption(SIMPLE_NAME(tile_filter_scaling), false),
+        new MaybeBoolGameOption(SIMPLE_NAME(tile_use_mipmaps),
+                                                maybe_bool::maybe, {"auto"}),
         new BoolGameOption(SIMPLE_NAME(tile_force_overlay), false),
         new TileColGameOption(SIMPLE_NAME(tile_overlay_col), "#646464"),
         new IntGameOption(SIMPLE_NAME(tile_overlay_alpha_percent), 40, 0, 100),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -908,6 +908,7 @@ public:
     fixedp<>    tile_viewport_scale;
     fixedp<>    tile_map_scale;
     bool        tile_filter_scaling;
+    maybe_bool  tile_use_mipmaps;
     int         tile_map_pixels;
 
     bool        tile_force_overlay;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -354,10 +354,24 @@ bool TilesFramework::initialise()
 
     m_image = new ImageManager();
 
-    // If the window size is less than the view height, the textures will
-    // have to be shrunk. If this isn't the case, then don't create mipmaps,
-    // as this appears to make things blurry on some users machines.
-    bool need_mips = (m_windowsz.y < 32 * VIEW_MIN_HEIGHT);
+    // If the window size is less than the view height,
+    // the textures will have to be shrunk.
+    //
+    // If this isn't the case, then don't create mipmaps unless
+    // explicitly requested as this appears to make things blurry
+    // on some users machines.
+    bool need_mips;
+    if (Options.tile_use_mipmaps == maybe_bool::maybe)
+    {
+        need_mips = (m_windowsz.y < 32 * VIEW_MIN_HEIGHT);
+    }
+    else
+    {
+        need_mips = bool(Options.tile_use_mipmaps);
+    }
+    // TODO: remove
+    cout << "need_mips: '" << need_mips << ":\n";
+
     MipMapOptions mip_opts = need_mips ? MIPMAP_CREATE : MIPMAP_NONE;
     if (!m_image->load_textures(mip_opts))
         return false;

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -358,7 +358,8 @@ bool TilesFramework::initialise()
     // have to be shrunk. If this isn't the case, then don't create mipmaps,
     // as this appears to make things blurry on some users machines.
     bool need_mips = (m_windowsz.y < 32 * VIEW_MIN_HEIGHT);
-    if (!m_image->load_textures(need_mips))
+    MipMapOptions mip_opts = need_mips ? MIPMAP_CREATE : MIPMAP_NONE;
+    if (!m_image->load_textures(mip_opts))
         return false;
 
     calculate_default_options();

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -369,8 +369,6 @@ bool TilesFramework::initialise()
     {
         need_mips = bool(Options.tile_use_mipmaps);
     }
-    // TODO: remove
-    cout << "need_mips: '" << need_mips << ":\n";
 
     MipMapOptions mip_opts = need_mips ? MIPMAP_CREATE : MIPMAP_NONE;
     if (!m_image->load_textures(mip_opts))

--- a/crawl-ref/source/tiletex.cc
+++ b/crawl-ref/source/tiletex.cc
@@ -173,14 +173,11 @@ ImageManager::~ImageManager()
     unload_textures();
 }
 
-bool ImageManager::load_textures(bool need_mips)
+bool ImageManager::load_textures(MipMapOptions mip_opts)
 {
-    MipMapOptions mip = need_mips ?
-        MIPMAP_CREATE : MIPMAP_NONE;
-
     int i = 0;
     for (const auto &f : get_texture_filenames())
-        if (!m_textures[i++].load_texture(f.c_str(), mip))
+        if (!m_textures[i++].load_texture(f.c_str(), mip_opts))
             return false;
 
     m_textures[TEX_FLOOR].set_info(TILE_FLOOR_MAX, &tile_floor_info);

--- a/crawl-ref/source/tiletex.cc
+++ b/crawl-ref/source/tiletex.cc
@@ -59,7 +59,7 @@ bool GenericTexture::load_texture(LoadTextureArgs texture)
     // 2. we bind the texture name for writing
     // 3. load the texture with the actual tile sheet (or other texture data)
     //    in question
-    if (texture.xoffset == LoadTextureArgs::NO_OFFSET && texture.yoffset == LoadTextureArgs::NO_OFFSET)
+    if (!texture.has_offset())
     {
         m_width = texture.width;
         m_height = texture.height;

--- a/crawl-ref/source/tiletex.cc
+++ b/crawl-ref/source/tiletex.cc
@@ -47,12 +47,9 @@ bool GenericTexture::load_texture(const char *filename,
     return success;
 }
 
-bool GenericTexture::load_texture(unsigned char *pixels, unsigned int new_width,
-                                  unsigned int new_height,
-                                  MipMapOptions mip_opt,
-                                  int offsetx, int offsety)
+bool GenericTexture::load_texture(LoadTextureArgs texture)
 {
-    if (!new_width || !new_height)
+    if (!texture.width || !texture.height)
         return false;
 
     // sequence of events:
@@ -62,15 +59,15 @@ bool GenericTexture::load_texture(unsigned char *pixels, unsigned int new_width,
     // 2. we bind the texture name for writing
     // 3. load the texture with the actual tile sheet (or other texture data)
     //    in question
-    if (offsetx == -1 && offsety == -1)
+    if (texture.xoffset == LoadTextureArgs::NO_OFFSET && texture.yoffset == LoadTextureArgs::NO_OFFSET)
     {
-        m_width = new_width;
-        m_height = new_height;
+        m_width = texture.width;
+        m_height = texture.height;
         glmanager->generate_textures(1, &m_handle);
     }
 
     bind();
-    glmanager->load_texture(pixels, new_width, new_height, mip_opt, offsetx, offsety);
+    glmanager->load_texture(texture);
 
     return true;
 }

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -14,10 +14,63 @@ enum MipMapOptions
     MIPMAP_MAX,
 };
 
+// Convenience structure to encapsulate parameters that always go together
+// Not all combinations of parameters are valid, so this class's factory methods
+// enforce that only valid combinations can be created
+class LoadTextureArgs
+{
+public:
+    static constexpr int NO_OFFSET = -1;
+    // Fonts aren't being mipmapped.
+    // Currently, glwrapper-ogl.cc does not support generating mipmaps for offset textures.
+    // It's unclear if it even would be desirable to handle it
+    // Also, the pixels aren't provided - presumably because they're already in some texture that's a font atlas?
+    // If you understand the surrounding code better, please clarify why this works at all.
+    static LoadTextureArgs CreateForFont(unsigned int width, unsigned int height,
+                                             int xoffset, int yoffset)
+    {
+        return LoadTextureArgs(nullptr,
+                               width, height,
+                               MIPMAP_NONE,
+                               xoffset, yoffset);
+    }
+
+    // Textures don't have offsets, but may be mipmapped (if mipmaps are enabled globally)
+
+    static LoadTextureArgs CreateForTexture(unsigned char *pixels, unsigned int width,
+                                             unsigned int height, MipMapOptions mip_opt)
+    {
+        return LoadTextureArgs(pixels,
+                               width, height,
+                               mip_opt,
+                               NO_OFFSET, NO_OFFSET);
+    }
+
+    const unsigned char *pixels;
+    const unsigned int width;
+    const unsigned int height;
+    const MipMapOptions mip_opt;
+    const int xoffset;
+    const int yoffset;
+private:
+    LoadTextureArgs(unsigned char *my_pixels,
+                    unsigned int my_width,
+                    unsigned int my_height,
+                    MipMapOptions my_mip_opt,
+                    int my_xoffset,
+                    int my_yoffset):
+            pixels(my_pixels),
+            width(my_width),
+            height(my_height),
+            mip_opt(my_mip_opt),
+            xoffset(my_xoffset),
+            yoffset(my_yoffset)
+    {}
+};
+
 // Arbitrary post-load texture processing
 typedef bool(*tex_proc_func)(unsigned char *pixels, unsigned int w,
     unsigned int h);
-
 class GenericTexture
 {
 public:
@@ -27,8 +80,7 @@ public:
     bool load_texture(const char *filename, MipMapOptions mip_opt,
                       tex_proc_func proc = nullptr,
                       bool force_power_of_two = true);
-    bool load_texture(unsigned char *pixels, unsigned int w, unsigned int h,
-                      MipMapOptions mip_opt, int offsetx=-1, int offsety=-1);
+    bool load_texture(LoadTextureArgs texture);
     void unload_texture();
 
     unsigned int width() const { return m_width; }

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -37,7 +37,6 @@ public:
     }
 
     // Textures don't have offsets, but may be mipmapped (if mipmaps are enabled globally)
-
     static LoadTextureArgs CreateForTexture(unsigned char *pixels, unsigned int width,
                                              unsigned int height, MipMapOptions mip_opt)
     {

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -27,10 +27,10 @@ public:
     // It's unclear if it even would be desirable to handle it
     // Also, the pixels aren't provided - presumably because they're already in some texture that's a font atlas?
     // If you understand the surrounding code better, please clarify why this works at all.
-    static LoadTextureArgs CreateForFont(unsigned int width, unsigned int height,
+    static LoadTextureArgs CreateForFont(unsigned char* pixels, unsigned int width, unsigned int height,
                                              int xoffset, int yoffset)
     {
-        return LoadTextureArgs(nullptr,
+        return LoadTextureArgs(pixels,
                                width, height,
                                MIPMAP_NONE,
                                xoffset, yoffset);

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -75,7 +75,7 @@ public:
     ImageManager();
     virtual ~ImageManager();
 
-    bool load_textures(bool need_mips);
+    bool load_textures(MipMapOptions mip_opts);
     void unload_textures();
     inline const tile_info &tile_def_info(tile_def tile) const;
     const TilesTexture &get_texture(TextureID t) const;

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -22,14 +22,24 @@ class LoadTextureArgs
 {
 public:
     static constexpr int NO_OFFSET = -1;
+    // Create an empty texture
+    static LoadTextureArgs CreateEmptyTextureForFont(unsigned int width, unsigned int height)
+    {
+        return LoadTextureArgs(nullptr,
+                               width, height,
+                               MIPMAP_NONE,
+                               NO_OFFSET, NO_OFFSET);
+    }
+
     // Fonts aren't being mipmapped.
     // Currently, glwrapper-ogl.cc does not support generating mipmaps for offset textures.
     // It's unclear if it even would be desirable to handle it
     // Also, the pixels aren't provided - presumably because they're already in some texture that's a font atlas?
     // If you understand the surrounding code better, please clarify why this works at all.
-    static LoadTextureArgs CreateForFont(unsigned char* pixels, unsigned int width, unsigned int height,
+    static LoadTextureArgs CreateSubtextureForFont(unsigned char* pixels, unsigned int width, unsigned int height,
                                              int xoffset, int yoffset)
     {
+        ASSERT(pixels != nullptr);
         return LoadTextureArgs(pixels,
                                width, height,
                                MIPMAP_NONE,
@@ -40,6 +50,7 @@ public:
     static LoadTextureArgs CreateForTexture(unsigned char *pixels, unsigned int width,
                                              unsigned int height, MipMapOptions mip_opt)
     {
+        ASSERT(pixels != nullptr);
         return LoadTextureArgs(pixels,
                                width, height,
                                mip_opt,

--- a/crawl-ref/source/tiletex.h
+++ b/crawl-ref/source/tiletex.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "tilepick.h"
+#include "debug.h"
 
 enum MipMapOptions
 {
@@ -52,6 +53,11 @@ public:
     const MipMapOptions mip_opt;
     const int xoffset;
     const int yoffset;
+
+    inline bool has_offset() const
+    {
+        return xoffset != NO_OFFSET || yoffset != NO_OFFSET;
+    }
 private:
     LoadTextureArgs(unsigned char *my_pixels,
                     unsigned int my_width,
@@ -65,7 +71,16 @@ private:
             mip_opt(my_mip_opt),
             xoffset(my_xoffset),
             yoffset(my_yoffset)
-    {}
+    {
+        // It's valid for xoffset or yoffset to be zero alone.
+        // But they should only be the "magic" NO_OFFSET value together
+        ASSERT((xoffset == NO_OFFSET) == (yoffset == NO_OFFSET));
+        if (this->has_offset())
+        {
+            // offset with mipmap not supported, this should be impossible to reach
+            ASSERT(mip_opt == MIPMAP_NONE);
+        }
+    }
 };
 
 // Arbitrary post-load texture processing

--- a/crawl-ref/source/windowmanager-sdl.cc
+++ b/crawl-ref/source/windowmanager-sdl.cc
@@ -1309,7 +1309,13 @@ bool SDLWrapper::load_texture(GenericTexture *tex, const char *filename,
     {
         // TODO: could fail if texture is too large / if there are opengl errs
         opengl::check_texture_size(filename, new_width, new_height);
-        success |= tex->load_texture(pixels, new_width, new_height, mip_opt);
+        LoadTextureArgs args = LoadTextureArgs::CreateForTexture(
+                pixels,
+                new_width,
+                new_height,
+                mip_opt
+           );
+        success |= tex->load_texture(args);
         opengl::flush_opengl_errors();
     }
 


### PR DESCRIPTION
* Instead of load_textures accepting an opaque bool, have it take MipmapOptions directly
* Add a maybe_bool option to force enable or force disable mipmapping to make testing easier.
* Encapsulate 6 fields that always are passed together into a little class that enforces only valid combinations of arguments can be created, allow passing the args straight through in a few functions that do that, and deduplicate some logic to be consistent in how we check for a special case
* Give a magic number a name (NO_OFFSET).
* Try to create useful static methods to clarify what each call to load_texture does. Really we may want more than 1 load_texture method, like create_empty_texture and so forth, instead of this method that does everything depending on hard to follow conditions.
* Avoid a pointless reallocation when a resize (that no-ops if unnecessary) and memset will do.
* Fix a bug (that somehow doesn't matter?) in the glyph atlas handling of the special fully white glyph 0 - it wasn't filling in the box it clearly meant to be. Instead, simplify further and just fill in the whole temporary buffer with white.
* Also fix a loop to render glyphs to go row by row instead of column by column - should improve memory locality. Not sure if it really will matter at all for e.g. startup perf, given that the whole working buffer of pixels is often say, 2KB which should comfortably fit in L1.