### PR TITLE
fix: some warnings produced by header_build_tests

### DIFF
--- a/crawl-ref/source/conduct-type.h
+++ b/crawl-ref/source/conduct-type.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "tag-version.h"
 enum conduct_type
 {
     DID_NOTHING,

--- a/crawl-ref/source/newgame-def.h
+++ b/crawl-ref/source/newgame-def.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 #include "game-type.h"
 #include "item-prop-enum.h"

--- a/crawl-ref/source/package.h
+++ b/crawl-ref/source/package.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cstdint>
 #ifdef USE_ZLIB
 #include <zlib.h>
 #endif
@@ -87,7 +88,7 @@ public:
 
     // statistics
     plen_t get_slack();
-    plen_t get_size() const { return file_len; };
+    plen_t get_size() const { return file_len; }
     plen_t get_chunk_fragmentation(const string &name);
     plen_t get_chunk_compressed_length(const string &name);
 private:


### PR DESCRIPTION
* Add missing include to conduct-type.h to ensure it is self-contained (e.g. not depending on other headers happening to include tag-version.h before including it)
* Remove unnecessary semicolon.
* Add missing cstdint includes