### PR TITLE
Clarify options_guide.txt regarding player-defined dump sections

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2664,8 +2664,22 @@ dump_order += notes,screenshots,vaults,skill_gains,action_counts
             dump_order += -
         to place a separator between sections.
 
-        You can also add arbitrary section names; ones not mentioned here will
-        be interpreted as custom user-defined Lua functions with no arguments.
+        You can also add your own sections by writing a Lua function and
+        adding its name to the list. The function's return value will then
+        be dumped. You can reference global variables just like regular Lua
+        functions, but its name must be in lowercase, and no call arguments
+        will be provided.
+
+        Example:
+          {
+            myRace = you.race()
+            function mydumpfn()
+              return
+                "This will be printed to dump. Your species is " .. myRace
+            end
+          }
+          dump_order += mydumpfn
+
 
 4-c     Notes.
 --------------


### PR DESCRIPTION
As it stands there's no documentation of any kind regarding custom dump sections, other than options_guide mentioning it exists. A more detailed description should save potential users much of the headache figuring out how it works.