### PR TITLE
Remove GLU dependency

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -83,7 +83,7 @@ libsqlite3-dev libz-dev pkg-config python3-yaml binutils-gold python-is-python3
 
 # Dependencies for tiles builds
 sudo apt install libsdl2-image-dev libsdl2-mixer-dev libsdl2-dev \
-libfreetype6-dev libglu1-mesa libglu1-mesa-dev libpng-dev fonts-dejavu-core \
+libfreetype6-dev libpng-dev fonts-dejavu-core \
 advancecomp pngcrush
 ```
 

--- a/crawl-ref/source/MSVC/Console.props
+++ b/crawl-ref/source/MSVC/Console.props
@@ -12,7 +12,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>zlib.lib;opengl32.lib;glu32.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>zlib.lib;opengl32.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\contrib\bin\8.0\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/crawl-ref/source/MSVC/Console.vsprops
+++ b/crawl-ref/source/MSVC/Console.vsprops
@@ -11,7 +11,7 @@
 	/>
 	<Tool
 		Name="VCLinkerTool"
-		AdditionalDependencies="zlib.lib opengl32.lib glu32.lib dxguid.lib"
+		AdditionalDependencies="zlib.lib opengl32.lib dxguid.lib"
 		AdditionalLibraryDirectories="&quot;$(SolutionDir)\..\contrib\bin\8.0\$(PlatformName)&quot;"
 	/>
 </VisualStudioPropertySheet>

--- a/crawl-ref/source/MSVC/Tiles.props
+++ b/crawl-ref/source/MSVC/Tiles.props
@@ -12,7 +12,7 @@
       <PreprocessorDefinitions>USE_TILE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2main.lib;libpng.lib;zlib.lib;freetype.lib;opengl32.lib;glu32.lib;winmm.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>SDL2.lib;SDL2_image.lib;SDL2main.lib;libpng.lib;zlib.lib;freetype.lib;opengl32.lib;winmm.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(SolutionDir)\..\contrib\bin\8.0\$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>

--- a/crawl-ref/source/MSVC/Tiles.vsprops
+++ b/crawl-ref/source/MSVC/Tiles.vsprops
@@ -11,7 +11,7 @@
 	/>
 	<Tool
 		Name="VCLinkerTool"
-		AdditionalDependencies="SDL2.lib SDL2_image.lib SDLmain.lib libpng.lib zlib.lib freetype.lib opengl32.lib glu32.lib winmm.lib dxguid.lib"
+		AdditionalDependencies="SDL2.lib SDL2_image.lib SDLmain.lib libpng.lib zlib.lib freetype.lib opengl32.lib winmm.lib dxguid.lib"
 		AdditionalLibraryDirectories="&quot;$(SolutionDir)\..\contrib\bin\8.0\$(PlatformName)&quot;"
 	/>
 </VisualStudioPropertySheet>

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -779,9 +779,9 @@ endif # pkg-config
 ifndef GLES
 ifneq ($(uname_S),Darwin)
 ifeq ($(msys),Yes)
-LIBS += -lopengl32 -lglu32
+LIBS += -lopengl32
 else
-LIBS += -lGL -lGLU
+LIBS += -lGL
 endif
 endif
 endif

--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -4,6 +4,7 @@
 #ifdef USE_GL
 
 #include "glwrapper-ogl.h"
+#include <iostream>
 
 // How do we get access to the GL calls?
 // If other UI types use the -ogl wrapper they should
@@ -19,11 +20,7 @@
 #  include <GLES/gl.h>
 # else
 #  include <SDL_opengl.h>
-#  if defined(__MACOSX__)
-#   include <OpenGL/glu.h>
-#  else
-#   include <GL/glu.h>
-#  endif
+#  include <SDL_video.h>
 # endif
 #endif
 
@@ -147,6 +144,79 @@ OGLStateManager::OGLStateManager()
     glDepthFunc(GL_LEQUAL);
 
     m_window_height = 0;
+#ifndef USE_GLES
+    // TODO: we probably can do this for GLES TOO, but maybe requires tweaks?
+
+    // OpenGL doesn't specify what the GetProcAddress function returns
+    // if the implementation does not support a function
+    // (e.g. because it doesn't support the OpenGL version in question)
+    // So we need to check the version before we try to get the
+    // glGenerateMipmap function.
+    const GLubyte* versionString = glGetString(GL_VERSION);
+    if (versionString == nullptr)
+    {
+        cout << "Mipmap Setup: Failed to load OpenGL version." << endl;
+        return;
+    }
+    // We will never see 2 digit OpenGL major versions - 4.6 came out in 2016,
+    // and Vulkan is carrying the torch now
+    //
+    // It's doubtful we'll even see an OpenGL 5.
+    // But we'll be paranoid. We'll consider OpenGL 3.X - 9.X as all fine
+    bool supported_first_digit = ('3' <= versionString[0]) &&
+                                 (versionString[0] <= '9');
+    // Anything other than X.Y would be very weird.
+    // It's incredibly unlikely OpenGL 10 will ever exist.
+    bool second_character_is_dot = versionString[1] == '.';
+    if (!supported_first_digit || !second_character_is_dot)
+    {
+        cout
+            << "Mipmap Setup: Disabled because OpenGL version: "
+            << versionString
+            << "does not provide glGenerateMipmap."
+            << endl;
+        return;
+    }
+
+    // We have to load the library dynamically before we can load the function
+    // from the library via GetProcAddress.
+    // That's how dynamic loading works.
+    // It's possible the library is already loaded anyway,
+    // but we're being careful here.
+    if (SDL_GL_LoadLibrary(NULL) != 0)
+    {
+        // success == 0 for this API.
+        // If we can't load it, we probably wouldn't get this far at all.
+        // But just in case, we'll handle it.
+        cout
+            << "Mipmap Setup: Disabled because SDL_GL_LoadLibrary failed."
+            << endl;
+        return;
+    }
+
+    // Because we already checked the version is higher enough,
+    // SDL_GL_GetProcAddress should always get a non-null pointer back.
+    // But we'll log in case this does somehow happen.
+    m_mipmapFn = SDL_GL_GetProcAddress("glGenerateMipmap");
+    if (m_mipmapFn == nullptr)
+    {
+        cout
+            << "Mipmap Setup: Failed to load glGenerateMipmap function."
+            << endl;
+        return;
+    }
+    else
+    {
+        cout
+            << "Mipmap Setup: success, loaded with OpenGL version: "
+            << versionString
+            << endl;
+    }
+#else
+    cout
+        << "Mipmap Setup: skipped, not supported in this build configuration."
+        << endl;
+#endif
 }
 
 void OGLStateManager::set(const GLState& state)
@@ -394,8 +464,16 @@ void OGLStateManager::load_texture(unsigned char *pixels, unsigned int width,
                         GL_LINEAR_MIPMAP_NEAREST);
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
                         Options.tile_filter_scaling ? GL_LINEAR : GL_NEAREST);
-        gluBuild2DMipmaps(GL_TEXTURE_2D, bpp, width, height,
-                          texture_format, format, pixels);
+        glTexImage2D(GL_TEXTURE_2D, 0, bpp, width, height, 0,
+                     texture_format, format, pixels);
+        // TODO: possibly restructure this into the main block below
+        // so that we support mipmapping when glTexSubImage2D should be called.
+        if (m_mipmapFn != nullptr)
+        {
+            PFNGLGENERATEMIPMAPPROC mipmapFn =
+                    reinterpret_cast<PFNGLGENERATEMIPMAPPROC>(m_mipmapFn);
+            mipmapFn(GL_TEXTURE_2D);
+        }
     }
     else
 #endif

--- a/crawl-ref/source/glwrapper-ogl.h
+++ b/crawl-ref/source/glwrapper-ogl.h
@@ -38,6 +38,11 @@ public:
 protected:
     GLState m_current_state;
     int m_window_height;
+    // optional, possibly nullptr function pointer to OpenGL 3+ function
+    // The function pointer type is often ifdef'd in annoying headers
+    // So we save the cast for the point where we use it, rather than
+    // cluttering this header.
+    void* m_mipmapFn = nullptr;
 
 private:
     bool glDebug(const char* msg) const;


### PR DESCRIPTION
Avoid depending on deprecated GLU library by dynamically loading
OpenGL 3+ function glGenerateMipmap where available.
If it's not available, Where it's not, we just render without mipmapping.

Note that for a lot of resolution / rc setting / zoom level combos,
we don't mipmap anyway, and this PR doesn't change those cases at all.

Also note that OpenGL 3.0 was released in 2008.
glGenerateMipmap is available even on decade old GPUs and iGPUs as a result.
For players running truly ancient GPUs and systems that supported GLU,
but not OpenGL 3, and who happened to have just the right setup for us to
enable mipmapping, we will now render without it.

If anyone actually does turn out to be affected, they may be able to use
a version of llvmpipe that supports OpenGL 3+ as a software renderer.
llvmpipe is available on Linux and Unix-like systems.

Also note we could turn on mipmapping on GLES targets according to
https://registry.khronos.org/OpenGL-Refpages/es3.0/html/glGenerateMipmap.xhtml.

This may be quite useful for low resolution screens, like older android phones.
But I'll leave that for a future commit.
