### PR TITLE
Improve player tracers

### DIFF
--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -1610,22 +1610,15 @@ void attack::maybe_trigger_autodazzler()
         proj.source_id = MID_PLAYER;
         proj.draw_delay = 5;
         proj.attitude = ATT_FRIENDLY;
-        proj.is_tracer = true;
-        proj.is_targeting = true;
-
-        // To suppress prompts for aiming at allies. We'll never fire in that
-        // situation anyway.
-        proj.thrower = KILL_MON_MISSILE;
+        proj.thrower = KILL_YOU_MISSILE;
+        targeting_tracer tracer;
 
         // Make sure the beam path is clear
-        proj.fire();
-        if (proj.friend_info.count == 0)
+        proj.fire(tracer);
+        if (tracer.friend_info.count == 0)
         {
             mpr("Your autodazzler retaliates!");
 
-            proj.thrower = KILL_YOU_MISSILE;
-            proj.is_tracer = false;
-            proj.is_targeting = false;
             proj.fire();
         }
     }

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1493,7 +1493,6 @@ static void _storm_card(int power)
     {
         bolt beam;
         beam.flavour           = BEAM_ELECTRICITY;
-        beam.is_tracer         = false;
         beam.is_explosion      = true;
         beam.glyph             = dchar_glyph(DCHAR_FIRED_BURST);
         beam.name              = "electrical discharge";

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -496,7 +496,7 @@ void wind_blast(actor* agent, int pow, coord_def target)
     wind_beam.affects_nothing = true;
     wind_beam.source          = agent->pos();
     wind_beam.range           = LOS_RADIUS;
-    wind_beam.is_tracer       = true;
+    wind_beam.set_is_tracer(true);
 
     if (agent->is_player())
     {

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -4001,9 +4001,9 @@ spret qazlal_upheaval(coord_def target, bool quiet, bool fail, dist *player_targ
         tempbeam.hit       = AUTOMATIC_HIT;
         tempbeam.damage    = dice_def(AUTOMATIC_HIT, 1);
         tempbeam.thrower   = KILL_YOU;
-        tempbeam.is_tracer = true;
-        tempbeam.explode(false);
-        if (tempbeam.beam_cancelled)
+        player_beam_tracer tracer;
+        tempbeam.explode(tracer, false);
+        if (cancel_beam_prompt(tempbeam, tracer))
             return spret::abort;
     }
     else

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -1272,10 +1272,10 @@ static bool _simple_shot_tracer(coord_def source, coord_def target,
     tracer.target = target;
     tracer.source_id = source_mid;
     tracer.damage = dice_def(100, 1);
-    tracer.is_tracer = true;
-    tracer.fire();
+    targeting_tracer target_tracer;
+    tracer.fire(target_tracer);
 
-    return mons_should_fire(tracer);
+    return mons_should_fire(tracer, target_tracer);
 }
 
 // Gets all spots within a certain radius of the player where your shadow could
@@ -1516,13 +1516,13 @@ static int _shadow_zap_tracer(zap_type ztype, coord_def source, coord_def target
     tracer.source = source;
     tracer.target = target;
     tracer.source_id = MID_PLAYER_SHADOW_DUMMY;
-    tracer.is_tracer = true;
-    tracer.fire();
+    targeting_tracer target_tracer;
+    tracer.fire(target_tracer);
 
-    if (tracer.friend_info.power > 0)
+    if (target_tracer.friend_info.power > 0)
         return 0;
     else
-        return tracer.foe_info.power;
+        return target_tracer.foe_info.power;
 }
 
 // Tries to find a vaguely 'best' spot to cast a given zap at some random

--- a/crawl-ref/source/l-spells.cc
+++ b/crawl-ref/source/l-spells.cc
@@ -138,13 +138,9 @@ LUAFN(l_spells_path)
     beam.source = src;
     beam.attitude = ATT_FRIENDLY;
     zappy(zap, power, false, beam);
-    beam.is_tracer = true;
-    beam.is_targeting = true;
+    beam.set_is_tracer(true);
     beam.range = range;
     beam.target = aim;
-    beam.dont_stop_player = true;
-    beam.friend_info.dont_stop = true;
-    beam.foe_info.dont_stop = true;
     beam.ex_size = 0;
     beam.aimed_at_spot = true;
     if (lua_isboolean(ls, 6))

--- a/crawl-ref/source/misc.h
+++ b/crawl-ref/source/misc.h
@@ -34,7 +34,23 @@ struct counted_monster_list
     typedef vector<counted_monster> counted_list;
     counted_list list;
     void add(const monster* mons);
-    int count();
-    bool empty() { return list.empty(); }
-    string describe(description_level_type desc = DESC_THE);
+    int count() const;
+    bool empty() const { return list.empty(); }
+    string describe(description_level_type desc = DESC_THE) const;
+};
+
+struct attacked_monster_list
+{
+    void add(const monster& mons, string adj, string suffix, bool penance);
+    int count() const { return m_victims.count(); };
+    bool empty() const { return m_victims.empty(); }
+    string describe() const;
+    bool penance() const { return m_penance; };
+    const char* suffix() const { return m_suffix.c_str(); }
+
+private:
+    counted_monster_list m_victims;
+    string m_adj;
+    string m_suffix;
+    bool m_penance = false;
 };

--- a/crawl-ref/source/mon-abil.cc
+++ b/crawl-ref/source/mon-abil.cc
@@ -1079,8 +1079,9 @@ bool mon_special_ability(monster* mons)
                 beem.target = foe->pos();
                 setup_mons_cast(mons, beem, SPELL_THORN_VOLLEY);
 
-                fire_tracer(mons, beem);
-                if (mons_should_fire(beem))
+                targeting_tracer tracer;
+                fire_tracer(mons, tracer, beem);
+                if (mons_should_fire(beem, tracer))
                 {
                     make_mons_stop_fleeing(mons);
                     _mons_cast_abil(mons, beem, SPELL_THORN_VOLLEY);

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -858,7 +858,7 @@ static bool _handle_swoop_or_flank(monster& mons)
     bolt tracer;
     tracer.source = mons.pos();
     tracer.target = target;
-    tracer.is_tracer = true;
+    tracer.set_is_tracer(true);
     tracer.pierce = true;
     tracer.range = LOS_RADIUS;
     tracer.fire();
@@ -1104,12 +1104,13 @@ static void _handle_hellfire_mortar(monster& mortar)
     {
         if (!mons_aligned(&mortar, *ai) && monster_los_is_valid(&mortar, *ai))
         {
-            bolt tracer = mons_spell_beam(&mortar, SPELL_MAGMA_BARRAGE, 100);
-            tracer.source = mortar.pos();
-            tracer.target = ai->pos();
+            bolt beam = mons_spell_beam(&mortar, SPELL_MAGMA_BARRAGE, 100);
+            beam.source = mortar.pos();
+            beam.target = ai->pos();
 
-            fire_tracer(&mortar, tracer);
-            if (mons_should_fire(tracer))
+            targeting_tracer tracer;
+            fire_tracer(&mortar, tracer, beam);
+            if (mons_should_fire(beam, tracer))
                 targs.push_back(ai->pos());
         }
     }
@@ -1433,8 +1434,9 @@ static bool _handle_wand(monster& mons)
     beem.source     = mons.pos();
     beem.aux_source =
         wand->name(DESC_QUALNAME, false, true, false, false);
-    fire_tracer(&mons, beem);
-    if (!mons_should_fire(beem))
+    targeting_tracer tracer;
+    fire_tracer(&mons, tracer, beem);
+    if (!mons_should_fire(beem, tracer))
         return false;
 
     _mons_fire_wand(mons, mzap, beem);
@@ -1594,15 +1596,16 @@ bool handle_throw(monster* mons, bolt & beem, bool teleport, bool check_only)
         }
     }
 
+    targeting_tracer tracer;
     // Fire tracer.
     if (!teleport)
-        fire_tracer(mons, beem);
+        fire_tracer(mons, tracer, beem);
 
     // Clear fake damage (will be set correctly in mons_throw).
     beem.damage = dice_def();
 
     // Good idea?
-    if (teleport || mons_should_fire(beem) || interference != DO_NOTHING)
+    if (teleport || mons_should_fire(beem, tracer) || interference != DO_NOTHING)
     {
         if (check_only)
             return true;

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1170,7 +1170,7 @@ static bool _merfolk_avatar_movement_effect(const monster* mons)
     tracer.target          = mons->pos();
     tracer.source          = you.pos();
     tracer.range           = LOS_RADIUS;
-    tracer.is_tracer       = true;
+    tracer.set_is_tracer(true);
     tracer.aimed_at_spot   = true;
     tracer.fire();
 

--- a/crawl-ref/source/mon-explode.cc
+++ b/crawl-ref/source/mon-explode.cc
@@ -34,7 +34,7 @@
 
 static void _setup_base_explosion(bolt & beam, const monster& origin)
 {
-    beam.is_tracer    = false;
+    beam.set_is_tracer(false);
     beam.is_explosion = true;
     beam.is_death_effect = true;
     beam.source_id    = origin.mid;

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -356,7 +356,8 @@ void define_monster(monster& mons, bool friendly = false);
 void mons_pacify(monster& mon, mon_attitude_type att = ATT_GOOD_NEUTRAL,
                  bool no_xp = false);
 
-bool mons_should_fire(bolt &beam, bool ignore_good_idea = false);
+bool mons_should_fire(const bolt &beam, const targeting_tracer& tracer,
+                      bool ignore_good_idea = false);
 
 bool mons_has_los_ability(monster_type mon_type);
 bool ms_ranged_spell(spell_type monspell, bool attack_only = false,

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -590,10 +590,7 @@ monster* get_rampage_target(coord_def move)
     beam.thrower         = KILL_YOU;
     beam.pierce          = true;
     beam.affects_nothing = true;
-    beam.is_tracer       = true;
-    // is_targeting prevents bolt::do_fire() from interrupting with a message
-    // if our tracer crosses something that blocks line of fire.
-    beam.is_targeting    = true;
+    beam.set_is_tracer(true);
     beam.fire();
 
     // Iterate the tracer to see if the first visible target is a hostile mons.

--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -164,11 +164,11 @@ spret cast_big_c(int pow, spell_type spl, const actor *caster, bolt &beam,
     beam.thrower           = KILL_YOU;
     beam.hit               = AUTOMATIC_HIT;
     beam.damage            = CONVENIENT_NONZERO_DAMAGE;
-    beam.is_tracer         = true;
     beam.use_target_as_pos = true;
     beam.origin_spell      = spl;
-    beam.affect_endpoint();
-    if (beam.beam_cancelled)
+    player_beam_tracer tracer;
+    beam.affect_endpoint(tracer);
+    if (cancel_beam_prompt(beam, tracer))
         return spret::abort;
 
     fail_check();

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1823,14 +1823,13 @@ static bool _battlesphere_should_fire(actor* target,
 {
     beam.source = firing_pos;
     beam.target = target->pos();
-    beam.foe_info.reset();
-    beam.friend_info.reset();
+    targeting_tracer tracer;
 
     // Fire tracer.
-    beam.fire();
+    beam.fire(tracer);
 
     // If we hit at least *something*, mark this as a possible fallback
-    if (beam.friend_info.count == 0 && beam.foe_info.count > 0)
+    if (tracer.friend_info.count == 0 && tracer.foe_info.count > 0)
     {
         // And if we hit our primary target, actually fire
         if (beam.hit_count.count(target->mid))
@@ -1845,7 +1844,7 @@ static bool _battlesphere_should_fire(actor* target,
 static void _fire_battlesphere(monster* battlesphere, bolt& beam)
 {
     beam.thrower = battlesphere->summoner == MID_PLAYER ? KILL_YOU : KILL_MON;
-    beam.is_tracer = false;
+    beam.set_is_tracer(false);
 
     battlesphere->foe = actor_at(beam.target)->mindex();
     battlesphere->target = beam.target;
@@ -1912,7 +1911,6 @@ bool trigger_battlesphere(actor* agent)
     beam.target      = target->pos();
     beam.source_id   = battlesphere->mid;
     beam.attitude    = mons_attitude(*battlesphere);
-    beam.is_tracer   = true;
 
     coord_def fallback_pos;
     // First, just try to fire from our present position
@@ -3150,7 +3148,7 @@ spret cast_hellfire_mortar(const actor& agent, bolt& beam, int pow, bool fail)
     beam.source = agent.pos();
     beam.source_id = agent.mid;
     beam.origin_spell = SPELL_HELLFIRE_MORTAR;
-    beam.is_tracer = true;
+    beam.set_is_tracer(true);
     beam.fire();
 
     // Check whether the path ends because it reached max range, or because it
@@ -4416,7 +4414,6 @@ bool splinterfrost_block_fragment(monster& block, const coord_def& aim)
     beam.source = block.pos();
     beam.attitude = block.attitude;
     beam.set_agent(agent);
-    beam.dont_stop_player = true;
     beam.target = aim_spot;
     beam.range = steps_taken;
     beam.aimed_at_spot = true;

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1602,7 +1602,7 @@ spret cast_apportation(int pow, bolt& beam, bool fail)
             mons->del_ench(ENCH_HELD, true);
     }
 
-    beam.is_tracer = true;
+    beam.set_is_tracer(true);
     beam.aimed_at_spot = true;
     beam.affects_nothing = true;
     beam.fire();

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1809,16 +1809,12 @@ bool spell_no_hostile_in_range(spell_type spell)
         bool found = false;
         beam.source_id = MID_PLAYER;
         beam.range = range;
-        beam.is_tracer = true;
-        beam.is_targeting = true;
         beam.source  = you.pos();
-        beam.dont_stop_player = true;
-        beam.friend_info.dont_stop = true;
-        beam.foe_info.dont_stop = true;
         beam.attitude = ATT_FRIENDLY;
 #ifdef DEBUG_DIAGNOSTICS
         beam.quiet_debug = true;
 #endif
+        targeting_tracer tracer;
 
         const bool smite = testbits(flags, spflag::target);
 
@@ -1847,23 +1843,19 @@ bool spell_no_hostile_in_range(spell_type spell)
                 // be good to move basic explosion radius info into spell_desc
                 // or possibly zap_data. -gammafunk
                 tempbeam.ex_size = tempbeam.is_explosion ? 1 : 0;
-                tempbeam.explode();
+                tempbeam.explode(tracer);
             }
             else
-                tempbeam.fire();
-
-            int foes = tempbeam.foe_info.count;
-            int friends = tempbeam.friend_info.count;
+                tempbeam.fire(tracer);
 
             // Need to check both beam flavours for Plasma Beam.
             if (zap == ZAP_PLASMA)
             {
                 tempbeam.flavour = BEAM_ELECTRICITY;
-                tempbeam.fire();
-                foes += tempbeam.foe_info.count;
+                tempbeam.fire(tracer);
             }
 
-            if (foes > 0 || allow_friends && friends > 0)
+            if (tracer.foe_info.count > 0 || allow_friends && tracer.friend_info.count > 0)
             {
                 found = true;
                 break;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -202,14 +202,10 @@ targeter_beam::targeter_beam(const actor *act, int r, zap_type zap,
     origin = aim = act->pos();
     beam.attitude = ATT_FRIENDLY;
     zappy(zap, pow, false, beam);
-    beam.is_tracer = true;
-    beam.is_targeting = true;
+    beam.set_is_tracer(true);
     beam.range = range;
     beam.source = origin;
     beam.target = aim;
-    beam.dont_stop_player = true;
-    beam.friend_info.dont_stop = true;
-    beam.foe_info.dont_stop = true;
     beam.ex_size = min_ex_rad;
     beam.aimed_at_spot = true;
 

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -676,31 +676,24 @@ void throw_it(quiver::action &a)
         pbolt.damage = dice_def(1, 100);
 
         // Init tracer variables.
-        pbolt.foe_info.reset();
-        pbolt.friend_info.reset();
-        pbolt.foe_ratio = 100;
-        pbolt.is_tracer = true;
+        player_beam_tracer tracer;
         pbolt.overshoot_prompt = false;
 
-        pbolt.fire();
+        pbolt.fire(tracer);
 
         pbolt.hit    = 0;
         pbolt.damage = dice_def();
         if (pbolt.friendly_past_target)
             pbolt.aimed_at_spot = true;
-        if (pbolt.foe_info.count)
+        if (tracer.has_hit_foe())
             aimed_at_foe = true; // dubious
 
-        // Should only happen if the player answered 'n' to one of those
-        // "Fire through friendly?" prompts.
-        if (pbolt.beam_cancelled)
+        if (cancel_beam_prompt(pbolt, tracer))
         {
             you.turn_is_over = false;
             return;
         }
     }
-
-    pbolt.is_tracer = false;
 
     // Now start real firing!
     origin_set_unknown(item);
@@ -782,7 +775,7 @@ static void _player_shoot(bolt &pbolt, item_def &item, item_def const *launcher)
 
     // Ensure we're firing a 'missile'-type beam.
     pbolt.pierce    = false;
-    pbolt.is_tracer = false;
+    pbolt.set_is_tracer(false);
 
     pbolt.loudness = item.base_type == OBJ_MISSILES
                    ? ammo_type_damage(item.sub_type) / 3


### PR DESCRIPTION
Players can fire two kinds of tracers. The first is used to check for a target and e.g. gray out your quivered spell if it has no target. The second is fired by functions like `player_tracer` and warns when there are bad targets (e.g. yourself or an ally). Instead of choosing between these two by setting a combination of flags on a bolt before firing it, choose between them by passing a different tracer class to the bolts fire method.

when firing a tracer with the `player_tracer` function don't just warn about one of your allies that would be hit, instead warn about all of them in the same way that melee attacks do (e.g. when using the singing sword). Also, don't spam warnings when firing a starbust that will target you multiple time, instead just say up to how many times the starbust can hit you.

Fixes #4151