### PR TITLE
Let wizards give items to shops.

### DIFF
--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -52,7 +52,7 @@ void adjust_item(int from_slot)
     if (from_slot == -1)
     {
         from_slot = prompt_invent_item("Adjust which item?",
-                                       menu_type::invlist, OSEL_ANY);
+                                       menu_type::invlist, OSEL_PORTABLE);
         if (prompt_failed(from_slot))
             return;
 
@@ -61,7 +61,7 @@ void adjust_item(int from_slot)
 
     const int to_slot = prompt_invent_item("Adjust to which letter? ",
                                            menu_type::invlist,
-                                           OSEL_ANY, OPER_ANY,
+                                           OSEL_PORTABLE, OPER_ANY,
                                            invprompt_flag::unthings_ok
                                             | invprompt_flag::manual_list);
     if (to_slot == PROMPT_ABORT

--- a/crawl-ref/source/catch2-tests/test_items.cc
+++ b/crawl-ref/source/catch2-tests/test_items.cc
@@ -31,7 +31,7 @@ TEST_CASE_METHOD( MockPlayerYouTestsFixture,
     for (int i=0; i < ENDOFPACK; i++)
         REQUIRE(you.inv[i].base_type == OBJ_UNASSIGNED);
 
-    REQUIRE(!any_items_of_type(OSEL_ANY));
+    REQUIRE(!any_items_of_type(OSEL_PORTABLE));
 
 }
 
@@ -78,7 +78,7 @@ TEST_CASE_METHOD( MockPlayerYouTestsFixture,
 
     move_item_to_inv(scroll_of_fear);
 
-    REQUIRE(any_items_of_type(OSEL_ANY));
+    REQUIRE(any_items_of_type(OSEL_PORTABLE));
 
     int num_fear_stacks_in_invent = 0;
 
@@ -110,7 +110,7 @@ TEST_CASE_METHOD( MockPlayerYouTestsFixture,
 
     REQUIRE(you.base_ac_from(armour, 100) == 600);
 
-    REQUIRE(any_items_of_type(OSEL_ANY));
+    REQUIRE(any_items_of_type(OSEL_PORTABLE));
 
     int num_armours = 0;
 

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -407,7 +407,7 @@ static const char *targeting_help_wiz =
     "<h>Wizard targeting commands:</h>\n"
     "<w>Ctrl-C</w> : cycle through beam paths\n"
     "<w>D</w>: get debugging information about the monster\n"
-    "<w>o</w>: give item to monster\n"
+    "<w>o</w>: give item to monster or shop\n"
     "<w>F</w>: cycle monster friendly/good neutral/neutral/hostile\n"
     "<w>Ctrl-H</w>: heal the monster fully\n"
     "<w>P</w>: apply divine blessing to monster\n"

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -67,6 +67,7 @@
 #include "view.h"
 #include "viewmap.h"
 #include "wiz-dgn.h"
+#include "wiz-item.h"
 #include "wiz-mon.h"
 
 #ifdef WIZARD
@@ -2019,6 +2020,11 @@ void direction_chooser::handle_wizard_command(command_type key_command,
             need_viewport_redraw = true;
         }
         return;
+
+    case CMD_TARGET_WIZARD_GIVE_ITEM:
+        if (!m)
+            wizard_give_shop_item(target());
+        break;
 
     default:
         break;

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -492,7 +492,8 @@ string no_selectables_message(int item_selector)
 {
     switch (item_selector)
     {
-    case OSEL_ANY:
+    case OSEL_ANYTHING:
+    case OSEL_PORTABLE:
         return "You aren't carrying anything.";
     case OSEL_WIELD:
     case OBJ_WEAPONS:
@@ -1135,14 +1136,14 @@ vector<SelItem> select_items(const vector<const item_def*> &items,
 bool item_is_selected(const item_def &i, int selector)
 {
     const object_class_type itype = i.base_type;
-    if (selector == OSEL_ANY || selector == itype
-                                && itype != OBJ_ARMOUR)
-    {
+    if (selector == itype && itype != OBJ_ARMOUR)
         return true;
-    }
 
     switch (selector)
     {
+    case OSEL_ANYTHING:
+    case OSEL_PORTABLE:
+        return true;
     case OBJ_ARMOUR:
         return itype == OBJ_ARMOUR && can_wear_armour(i, false, false);
 
@@ -1282,7 +1283,7 @@ bool any_items_of_type(int selector, int excluded_slot, bool inspect_floor)
 // type = menu_type::drop allows the multidrop toggle
 static int _invent_select(const char *title = nullptr,
                                     menu_type type = menu_type::invlist,
-                                    int item_selector = OSEL_ANY,
+                                    int item_selector = OSEL_PORTABLE,
                                     int excluded_slot = -1,
                                     int flags = MF_NOSELECT,
                                     invtitle_annotator titlefn = nullptr,
@@ -1316,7 +1317,7 @@ static int _invent_select(const char *title = nullptr,
 void display_inventory()
 {
     InvMenu menu(MF_SINGLESELECT | MF_ALLOW_FORMATTING | MF_SECONDARY_SCROLL);
-    menu.load_inv_items(OSEL_ANY, -1);
+    menu.load_inv_items(OSEL_PORTABLE, -1);
     menu.set_type(menu_type::describe);
 
     menu.show(true);
@@ -1384,7 +1385,7 @@ vector<SelItem> prompt_drop_items(const vector<SelItem> &preselected_items)
     // multi-select some items to drop
     _invent_select("",
                       menu_type::drop,
-                      OSEL_ANY,
+                      OSEL_PORTABLE,
                       -1,
                       MF_MULTISELECT | MF_ALLOW_FILTER | MF_SELECT_QTY,
                       _drop_menu_titlefn,
@@ -1807,8 +1808,8 @@ bool check_warning_inscriptions(const item_def& item,
  * @param flags            See comments on invent_prompt_flags.
  * @param other_valid_char A character that, if not '\0', will cause
  *                         PROMPT_GOT_SPECIAL to be returned when pressed.
- * @param type_out         Output: OSEL_ANY if the user was in `*`, type_expect
- *                         otherwise. Ignored if nullptr.
+ * @param type_out         Output: OSEL_PORTABLE if the user was in `*`,
+ *                         type_expect otherwise. Ignored if nullptr.
  *
  * @return  the inventory slot of an item or one of the following special values
  *          - PROMPT_ABORT:       if the player hits escape.
@@ -1857,7 +1858,7 @@ int prompt_invent_item(const char *prompt,
     }
 
     if (keyin == '*')
-        current_type_expected = OSEL_ANY;
+        current_type_expected = OSEL_PORTABLE;
 
     // ugh, why is this done manually
     while (true)
@@ -1871,7 +1872,7 @@ int prompt_invent_item(const char *prompt,
         if (need_prompt)
         {
             mprf(MSGCH_PROMPT, "%s (<w>?</w> for menu, <w>Esc</w> to quit)",
-                 current_type_expected == OSEL_ANY && view_all_prompt
+                 current_type_expected == OSEL_PORTABLE && view_all_prompt
                  ? view_all_prompt : prompt);
         }
         else
@@ -1899,7 +1900,7 @@ int prompt_invent_item(const char *prompt,
             // The "view inventory listing" mode.
             vector< SelItem > items;
             const auto last_keyin = keyin;
-            current_type_expected = keyin == '*' ? OSEL_ANY : type_expect;
+            current_type_expected = keyin == '*' ? OSEL_PORTABLE : type_expect;
             int mflags = MF_SINGLESELECT | MF_ANYPRINTABLE | MF_SECONDARY_SCROLL;
             if (other_valid_char == '-')
                 mflags |= MF_SPECIAL_MINUS;
@@ -1907,7 +1908,7 @@ int prompt_invent_item(const char *prompt,
             while (true)
             {
                 keyin = _invent_select(
-                    current_type_expected == OSEL_ANY && view_all_prompt
+                    current_type_expected == OSEL_PORTABLE && view_all_prompt
                         ? view_all_prompt : prompt,
                     mtype, current_type_expected, -1, mflags, nullptr, &items);
 

--- a/crawl-ref/source/invent.h
+++ b/crawl-ref/source/invent.h
@@ -156,7 +156,8 @@ public:
     // Loads items from the player's inventory into the menu, and sets the
     // title to the stock title. If "procfn" is provided, it'll be called for
     // each MenuEntry added, *excluding the title*.
-    void load_inv_items(int item_selector = OSEL_ANY, int excluded_slot = -1,
+    void load_inv_items(int item_selector = OSEL_PORTABLE,
+                        int excluded_slot = -1,
                         function<MenuEntry* (MenuEntry*)> procfn = nullptr);
 
     vector<SelItem> get_selitems() const;

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -230,7 +230,7 @@ static int _default_osel(operation_types oper)
     case OPER_UNEQUIP:
         return OSEL_WORN_EQUIPABLE;
     default:
-        return OSEL_ANY; // buggy?
+        return OSEL_PORTABLE; // buggy?
     }
 }
 
@@ -360,7 +360,7 @@ void UseItemMenu::reset(operation_types _oper, const char* prompt_override)
     else
         set_title(_default_use_title(oper));
     // see `item_is_selected` for more on what can be used for item_type.
-    if (item_type_filter == OSEL_ANY)
+    if (item_type_filter == OSEL_PORTABLE)
         item_type_filter = _default_osel(oper);
 
     populate_list();
@@ -373,7 +373,7 @@ void UseItemMenu::reset(operation_types _oper, const char* prompt_override)
     update_more();
 }
 
-UseItemMenu::UseItemMenu(operation_types _oper, int item_type=OSEL_ANY,
+UseItemMenu::UseItemMenu(operation_types _oper, int item_type=OSEL_PORTABLE,
                                     const char* prompt=nullptr)
     : InvMenu(MF_SINGLESELECT | MF_ARROWS_SELECT
                 | MF_INIT_HOVER | MF_ALLOW_FORMATTING),
@@ -412,9 +412,13 @@ bool UseItemMenu::populate_list(bool check_only)
 
     for (const auto *it : floor)
     {
+        if (!it->defined())
+            continue;
+
         // ...only stuff that can go into your inventory though
-        if (!it->defined() || item_is_stationary(*it) || item_is_spellbook(*it)
-            || item_is_collectible(*it) || it->base_type == OBJ_GOLD)
+        if ((item_is_stationary(*it) || item_is_spellbook(*it)
+             || item_is_collectible(*it) || it->base_type == OBJ_GOLD)
+            && item_type_filter != OSEL_ANYTHING)
         {
             continue;
         }
@@ -867,7 +871,7 @@ bool UseItemMenu::process_key(int key)
     }
     else if (key == CK_TAB && _equip_oper(oper))
     {
-        item_type_filter = OSEL_ANY;
+        item_type_filter = OSEL_PORTABLE;
         save_hover();
         switch (oper)
         {
@@ -3187,7 +3191,7 @@ void prompt_inscribe_item()
     }
 
     int item_slot = prompt_invent_item("Inscribe which item?",
-                                       menu_type::invlist, OSEL_ANY);
+                                       menu_type::invlist, OSEL_PORTABLE);
 
     if (prompt_failed(item_slot))
         return;

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -16,7 +16,7 @@
 const int ARMOUR_EQUIP_DELAY = 5;
 
 operation_types use_an_item_menu(item_def *&target, operation_types oper,
-                int item_type=OSEL_ANY,
+                int item_type=OSEL_PORTABLE,
                 const char* prompt=nullptr,
                 function<bool ()> allowcancel = [](){ return true; });
 // Change the lambda to always_true<> when g++ 4.7 support is dropped.

--- a/crawl-ref/source/object-selector-type.h
+++ b/crawl-ref/source/object-selector-type.h
@@ -2,7 +2,7 @@
 
 enum object_selector
 {
-    OSEL_ANY                     =  -1,
+    OSEL_PORTABLE                =  -1,
     OSEL_WIELD                   =  -2,
     OSEL_UNIDENT                 =  -3,
     OSEL_ENCHANTABLE_ARMOUR      =  -4,
@@ -23,4 +23,5 @@ enum object_selector
     OSEL_WEARABLE                = -19,
     OSEL_AMULET                  = -20,
     OSEL_ARTEFACT_WEAPON         = -21,
+    OSEL_ANYTHING                = -22,
 };

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -299,7 +299,7 @@ static shared_ptr<quiver::action> _fire_prompt_for_item()
         (can_throw ? " ([<w>*</w>] to toss any item)" : ""));
     const string alt_title =
         "<lightgray>Toss away which item?</lightgray>";
-    int selector = fireables ? OSEL_QUIVER_ACTION : OSEL_ANY;
+    int selector = fireables ? OSEL_QUIVER_ACTION : OSEL_PORTABLE;
     // TODO: the output api here is awkward
     // TODO: it would be nice if items with disabled actions got grayed out
     slot = prompt_invent_item(
@@ -314,7 +314,7 @@ static shared_ptr<quiver::action> _fire_prompt_for_item()
     if (slot == -1)
         return nullptr;
 
-    return selector == OSEL_ANY && can_throw
+    return selector == OSEL_PORTABLE && can_throw
         ? quiver::ammo_to_action(slot, true) // throw/toss only
         : quiver::slot_to_action(slot, false); // use
 }

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -24,6 +24,7 @@
 #include "invent.h"
 #include "item-prop.h"
 #include "item-status-flag-type.h"
+#include "item-use.h"
 #include "items.h"
 #include "jobs.h"
 #include "libutil.h"
@@ -1457,5 +1458,26 @@ void wizard_unobtain_runes_and_orb()
     invalidate_agrid(true);
 
     mpr("Unobtained all runes and the Orb of Zot.");
+}
+
+void wizard_give_shop_item(const coord_def& where)
+{
+    auto shop = shop_at(where);
+    if (!shop)
+        return;
+
+    item_def *item = nullptr;
+    auto ask = "Give which item to " + shop_name(*shop) + "?";
+    auto oper = use_an_item_menu(item, OPER_ANY, OSEL_ANY, ask.c_str());
+    if (oper == OPER_NONE)
+        return;
+
+    mprf("Gave %s", item->name(DESC_A).c_str());
+    item->pos = shop->pos;
+    item->link = ITEM_IN_SHOP;
+    shop->stock.push_back(*item);
+    if (item >= env.item.begin() && item < env.item.end())
+        unlink_item(item->index());
+    item->clear();
 }
 #endif

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -342,7 +342,8 @@ void wizard_tweak_object()
     char specs[50];
     int keyin;
 
-    int item = prompt_invent_item("Tweak which item? ", menu_type::invlist, OSEL_ANY);
+    int item = prompt_invent_item("Tweak which item? ", menu_type::invlist,
+                                  OSEL_PORTABLE);
 
     if (prompt_failed(item))
         return;
@@ -454,7 +455,7 @@ static bool _make_book_randart(item_def &book)
 void wizard_value_item()
 {
     const int i = prompt_invent_item("Value of which item?",
-                                     menu_type::invlist, OSEL_ANY);
+                                     menu_type::invlist, OSEL_PORTABLE);
 
     if (prompt_failed(i))
         return;
@@ -563,7 +564,7 @@ void wizard_create_all_artefacts(bool override_unique)
 void wizard_make_object_randart()
 {
     int i = prompt_invent_item("Make an artefact out of which item?",
-                                menu_type::invlist, OSEL_ANY);
+                                menu_type::invlist, OSEL_PORTABLE);
 
     if (prompt_failed(i))
         return;
@@ -1468,7 +1469,7 @@ void wizard_give_shop_item(const coord_def& where)
 
     item_def *item = nullptr;
     auto ask = "Give which item to " + shop_name(*shop) + "?";
-    auto oper = use_an_item_menu(item, OPER_ANY, OSEL_ANY, ask.c_str());
+    auto oper = use_an_item_menu(item, OPER_ANY, OSEL_ANYTHING, ask.c_str());
     if (oper == OPER_NONE)
         return;
 

--- a/crawl-ref/source/wiz-item.h
+++ b/crawl-ref/source/wiz-item.h
@@ -20,3 +20,4 @@ void wizard_unidentify_all_items();
 void debug_item_statistics();
 void wizard_recharge_evokers();
 void wizard_unobtain_runes_and_orb();
+void wizard_give_shop_item(const coord_def& where);

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -629,7 +629,7 @@ void wizard_give_monster_item(monster* mon)
     }
 
     int player_slot = prompt_invent_item("Give which item to monster?",
-                                          menu_type::drop, OSEL_ANY);
+                                          menu_type::drop, OSEL_PORTABLE);
 
     if (prompt_failed(player_slot))
         return;


### PR DESCRIPTION
Add a wizard mode command to give an item to a shop, to give a straightforward way to test things which involve a shop with a specific inventory.

Allow an item prompt to select any item from inventory or the floor. Rename the existing OSEL_ANY item selector as OSEL_PORTABLE to make the distinction clear. Use the new selector for "give item to shop" so books can be donated. It may be useful elsewhere, but I haven't looked.