### PR TITLE
Stop antique shops from overcharging.

### DIFF
--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -790,12 +790,14 @@ static int _count_identical(const vector<item_def>& stock, const item_def& item)
  *  @param shop  the shop to purchase from.
  *  @param pos   where the shop is located
  *  @param index the index of the item to buy in shop.stock
+ *  @param cost  the price to deduct for this item
+ *  @param voucher use a voucher instead of paying the item cost
  *  @returns true if it went in your inventory, false otherwise.
  */
-static bool _purchase(shop_struct& shop, const level_pos& pos, int index, bool voucher)
+static bool _purchase(shop_struct& shop, const level_pos& pos, int index,
+                      int cost, bool voucher)
 {
     item_def item = shop.stock[index]; // intentional copy
-    const int cost = item_price(item, shop);
     shop.stock.erase(shop.stock.begin() + index);
 
     // Remove from shopping list if it's unique
@@ -919,7 +921,6 @@ class ShopEntry : public InvEntry
 
     string get_text() const override
     {
-        const int cost = item_price(*item, menu.shop);
         const int total_cost = menu.selected_cost();
         const bool on_list = shopping_list.is_on_list(*item, &menu.pos);
         // Colour stock as follows:
@@ -962,10 +963,11 @@ class ShopEntry : public InvEntry
 public:
     ShopEntry(const item_def& i, ShopMenu& m)
         : InvEntry(i),
-          menu(m)
+          menu(m), cost(item_price(i, m.shop))
     {
         show_background = false;
     }
+    const int cost;
 };
 
 // XX why is this MF_QUIET_SELECT?
@@ -1008,14 +1010,14 @@ int ShopMenu::selected_cost(bool use_shopping_list) const
 {
     int cost = 0;
     for (auto item : selected_entries())
-        cost += item_price(*dynamic_cast<ShopEntry*>(item)->item, shop);
+        cost += dynamic_cast<ShopEntry*>(item)->cost;
     if (use_shopping_list && cost == 0)
     {
         for (auto item : items)
         {
-            const item_def& it = *dynamic_cast<ShopEntry*>(item)->item;
-            if (shopping_list.is_on_list(it, &pos))
-                cost += item_price(it, shop);
+            auto e = dynamic_cast<ShopEntry*>(item);
+            if (shopping_list.is_on_list(*e->item, &pos))
+                cost += e->cost;
         }
     }
     return cost;
@@ -1025,7 +1027,7 @@ int ShopMenu::max_cost() const
 {
     int cost = 0;
     for (auto item : selected_entries())
-        cost = max(cost, item_price(*dynamic_cast<ShopEntry*>(item)->item, shop));
+        cost = max(cost, dynamic_cast<ShopEntry*>(item)->cost);
 
     return cost;
 }
@@ -1159,11 +1161,11 @@ void ShopMenu::purchase_selected()
         buying_from_list = true;
         for (auto item : items)
         {
-            const item_def& it = *dynamic_cast<ShopEntry*>(item)->item;
-            if (shopping_list.is_on_list(it, &pos))
+            auto e = dynamic_cast<ShopEntry*>(item);
+            if (shopping_list.is_on_list(*e->item, &pos))
             {
                 selected.push_back(item);
-                cost += item_price(it, shop);
+                cost += e->cost;
             }
         }
     }
@@ -1225,7 +1227,7 @@ void ShopMenu::purchase_selected()
     {
         const int i = static_cast<item_def*>(entry->data) - shop.stock.data();
         item_def& item(shop.stock[i]);
-        const int price = item_price(item, shop);
+        const int price = dynamic_cast<ShopEntry*>(entry)->cost;
         // Can happen if the price changes due to id status
         if (price > you.gold && price != voucher_value)
             continue;
@@ -1236,7 +1238,7 @@ void ShopMenu::purchase_selected()
 
         const int quant = item.quantity;
 
-        if (!_purchase(shop, pos, i, use_voucher))
+        if (!_purchase(shop, pos, i, price, use_voucher))
         {
             // The purchased item didn't fit into your
             // knapsack.
@@ -1290,8 +1292,8 @@ void ShopMenu::resort()
         sort(begin(items), end(items),
              [this](MenuEntry* a, MenuEntry* b)
              {
-                 return item_price(*dynamic_cast<ShopEntry*>(a)->item, shop)
-                        < item_price(*dynamic_cast<ShopEntry*>(b)->item, shop);
+                 return dynamic_cast<ShopEntry*>(a)->cost
+                        < dynamic_cast<ShopEntry*>(b)->cost;
              });
         break;
     case ORDER_ALPHABETICAL:
@@ -1385,9 +1387,10 @@ bool ShopMenu::process_key(int keyin)
             for (auto entry : selected)
             {
                 const item_def& item = *dynamic_cast<ShopEntry*>(entry)->item;
+                auto cost = dynamic_cast<ShopEntry*>(entry)->cost;
                 entry->selected_qty = 0;
                 if (!shopping_list.is_on_list(item, &pos))
-                    shopping_list.add_thing(item, item_price(item, shop), &pos);
+                    shopping_list.add_thing(item, cost, &pos);
             }
         }
         else if (can_purchase)
@@ -1421,7 +1424,7 @@ bool ShopMenu::process_key(int keyin)
         if (shopping_list.is_on_list(item, &pos))
             shopping_list.del_thing(item, &pos);
         else
-            shopping_list.add_thing(item, item_price(item, shop), &pos);
+            shopping_list.add_thing(item, entry->cost, &pos);
         update_help();
         update_menu(true);
         return true;


### PR DESCRIPTION
If an antiques shop contains two unidentified amulets, rings or wands of the same type, it gives a price for each item. If the player tries to buy both, the game charges a different price for the second item.

Change it to charge the agreed price for everything.

This avoids a situation where the player could agree to pay X for some goods but actually be charged Y for them. There are others (such as asking separately about the second item or not selling it in the same transaction), but this one doesn't involve changes to the UI.

Shops with two similar unidentified amulets, ring or wands are rare, so it shouldn't matter too much how it's handled. Charging a lot of money without warning seems like quite a bad way to do it, though.