### PR TITLE
refactor: enum related cleanups

### DIFF
--- a/crawl-ref/source/explore-stop-options.h
+++ b/crawl-ref/source/explore-stop-options.h
@@ -1,0 +1,51 @@
+#pragma once
+
+enum explore_stop_options
+{
+    ES_NONE                      = 0x00000,
+
+    // Explored into view of an item that is NOT eligible for autopickup.
+    ES_ITEM                      = 0x00001,
+
+    // Picked up an item during greedy explore; will stop for anything
+    // that's not explicitly ignored and that is not gold.
+    ES_GREEDY_PICKUP             = 0x00002,
+
+    // Stop when picking up gold with greedy explore.
+    ES_GREEDY_PICKUP_GOLD        = 0x00004,
+
+    // Picked up an item during greedy explore, ignoring items that were
+    // thrown by the PC, and items that the player already has one of in
+    // inventory, or a bunch of other conditions (see
+    // _interesting_explore_pickup in items.cc)
+    ES_GREEDY_PICKUP_SMART       = 0x00008,
+
+    // Greedy-picked up an item previously thrown by the PC.
+    ES_GREEDY_PICKUP_THROWN      = 0x00010,
+    ES_GREEDY_PICKUP_MASK        = (ES_GREEDY_PICKUP
+                                    | ES_GREEDY_PICKUP_GOLD
+                                    | ES_GREEDY_PICKUP_SMART
+                                    | ES_GREEDY_PICKUP_THROWN),
+
+    // Explored into view of an item eligible for autopickup.
+    ES_GREEDY_ITEM               = 0x00020,
+
+    // Stepped onto a stack of items that was previously unknown to
+    // the player (for instance, when stepping onto the heap of items
+    // of a freshly killed monster).
+    ES_GREEDY_VISITED_ITEM_STACK = 0x00040,
+
+    // Explored into view of a stair, shop, altar, portal, glowing
+    // item, artefact, or branch entrance.... etc.
+    ES_STAIR                     = 0x00080,
+    ES_SHOP                      = 0x00100,
+    ES_ALTAR                     = 0x00200,
+    ES_PORTAL                    = 0x00400,
+    ES_GLOWING_ITEM              = 0x00800,
+    ES_ARTEFACT                  = 0x01000,
+    ES_RUNE                      = 0x02000,
+    ES_BRANCH                    = 0x04000,
+    ES_RUNED_DOOR                = 0x08000,
+    ES_TRANSPORTER               = 0x10000,
+    ES_RUNELIGHT                 = 0x20000,
+};

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -38,6 +38,7 @@
 #include "end.h"
 #include "errors.h"
 #include "explore-greedy-options.h"
+#include "explore-stop-options.h"
 #include "files.h"
 #include "game-options.h"
 #include "ghost.h"
@@ -3094,28 +3095,27 @@ void game_options::update_travel_terrain()
     }
 }
 
+
 void game_options::update_use_animations()
 {
+    static const std::map<const string, use_animation_type> ANIMATION_TYPES =
+    {
+        {  "beam", UA_BEAM },
+        {  "range", UA_RANGE },
+        {  "hp", UA_HP },
+        {  "monster_in_sight", UA_MONSTER_IN_SIGHT },
+        {  "pickup", UA_PICKUP },
+        {  "monster", UA_MONSTER },
+        {  "player", UA_PLAYER },
+        {  "branch_entry", UA_BRANCH_ENTRY }
+    };
+
     use_animations_type animations = UA_ALWAYS_ON; // not 0!
     for (const string &type : use_animations_option)
     {
-        // TODO: dataify into a map
-        if (type == "beam")
-            animations |= UA_BEAM;
-        else if (type == "range")
-            animations |= UA_RANGE;
-        else if (type == "hp")
-            animations |= UA_HP;
-        else if (type == "monster_in_sight")
-            animations |= UA_MONSTER_IN_SIGHT;
-        else if (type == "pickup")
-            animations |= UA_PICKUP;
-        else if (type == "monster")
-            animations |= UA_MONSTER;
-        else if (type == "player")
-            animations |= UA_PLAYER;
-        else if (type == "branch_entry")
-            animations |= UA_BRANCH_ENTRY;
+        const auto search = ANIMATION_TYPES.find(type);
+        if (search != ANIMATION_TYPES.end())
+            animations |= search->second;
         else
             report_error("Unknown animation type '%s'", type.c_str());
     }
@@ -3125,50 +3125,40 @@ void game_options::update_use_animations()
 
 void game_options::update_explore_stop_conditions()
 {
+    // Note: if altering these, make sure the same alternative spellings appear
+    // in update_explore_greedy_visit_conditions if relevant.
+    static const std::map<const string, explore_stop_options> STOP_CONDITIONS =
+    {
+        { "item", ES_ITEM }, { "items", ES_ITEM },
+        { "greedy_pickup", ES_GREEDY_PICKUP },
+        { "greedy_pickup_gold", ES_GREEDY_PICKUP_GOLD },
+        { "greedy_pickup_smart", ES_GREEDY_PICKUP_SMART },
+        { "greedy_pickup_thrown", ES_GREEDY_PICKUP_THROWN },
+        { "shop" , ES_SHOP }, { "shops", ES_SHOP },
+        { "stair", ES_STAIR }, { "stairs", ES_STAIR },
+        { "branch" , ES_BRANCH }, { "branches", ES_BRANCH },
+        { "portal", ES_PORTAL }, { "portals", ES_PORTAL },
+        { "altar", ES_ALTAR }, { "altars", ES_ALTAR },
+        { "runed_door", ES_RUNED_DOOR }, { "runed_doors", ES_RUNED_DOOR },
+        { "transporter", ES_TRANSPORTER }, { "transporters", ES_TRANSPORTER },
+        { "greedy_item", ES_GREEDY_ITEM }, { "greedy_items", ES_GREEDY_ITEM },
+        { "greedy_visited_item_stack", ES_GREEDY_VISITED_ITEM_STACK },
+        { "glowing" , ES_GLOWING_ITEM }, { "glowing_item", ES_GLOWING_ITEM },
+        { "glowing_items", ES_GLOWING_ITEM },
+        { "artefact", ES_ARTEFACT }, { "artefacts", ES_ARTEFACT },
+        { "artifact", ES_ARTEFACT }, { "artifacts", ES_ARTEFACT },
+        { "rune", ES_RUNE }, { "runes", ES_RUNE },
+    };
     // convert the options list into a bitfield, and save it by side-effect
     // into game_options::explore_stop. List processing is handled by the
     // option update code, and we can ignore it here.
     int conditions = ES_NONE;
     for (const string &stop : explore_stop_option)
     {
-        // TODO: dataify into a map
         const string c = replace_all_of(stop, " ", "_");
-        if (c == "item" || c == "items")
-            conditions |= ES_ITEM;
-        else if (c == "greedy_pickup")
-            conditions |= ES_GREEDY_PICKUP;
-        else if (c == "greedy_pickup_gold")
-            conditions |= ES_GREEDY_PICKUP_GOLD;
-        else if (c == "greedy_pickup_smart")
-            conditions |= ES_GREEDY_PICKUP_SMART;
-        else if (c == "greedy_pickup_thrown")
-            conditions |= ES_GREEDY_PICKUP_THROWN;
-        else if (c == "shop" || c == "shops")
-            conditions |= ES_SHOP;
-        else if (c == "stair" || c == "stairs")
-            conditions |= ES_STAIR;
-        else if (c == "branch" || c == "branches")
-            conditions |= ES_BRANCH;
-        else if (c == "portal" || c == "portals")
-            conditions |= ES_PORTAL;
-        else if (c == "altar" || c == "altars")
-            conditions |= ES_ALTAR;
-        else if (c == "runed_door" || c == "runed_doors")
-            conditions |= ES_RUNED_DOOR;
-        else if (c == "transporter" || c == "transporters")
-            conditions |= ES_TRANSPORTER;
-        else if (c == "greedy_item" || c == "greedy_items")
-            conditions |= ES_GREEDY_ITEM;
-        else if (c == "greedy_visited_item_stack")
-            conditions |= ES_GREEDY_VISITED_ITEM_STACK;
-        else if (c == "glowing" || c == "glowing_item"
-                 || c == "glowing_items")
-            conditions |= ES_GLOWING_ITEM;
-        else if (c == "artefact" || c == "artefacts"
-                 || c == "artifact" || c == "artifacts")
-            conditions |= ES_ARTEFACT;
-        else if (c == "rune" || c == "runes")
-            conditions |= ES_RUNE;
+        const auto search = STOP_CONDITIONS.find(c);
+        if (search != STOP_CONDITIONS.end())
+            conditions |= search->second;
         else
             report_error("Unknown explore stop condition '%s'", c.c_str());
     }
@@ -3177,22 +3167,24 @@ void game_options::update_explore_stop_conditions()
 
 void game_options::update_explore_greedy_visit_conditions()
 {
+    // Note: if altering these, make sure the same alternative spellings appear
+    // in update_explore_stop_conditions if relevant.
+    static const std::map<const string, explore_greedy_options> GREEDY_CONDITIONS =
+    {
+        { "glowing", EG_GLOWING },{ "glowing_item", EG_GLOWING },
+        { "glowing_items", EG_GLOWING },
+        { "artefact", EG_ARTEFACT }, { "artefacts", EG_ARTEFACT },
+        { "artifact", EG_ARTEFACT }, { "artifacts", EG_ARTEFACT },
+        { "stack", EG_STACK }, { "stacks", EG_STACK },
+        { "pile", EG_STACK }, { "piles", EG_STACK },
+    };
     int conditions = EG_NONE;
     for (const string &stop : explore_greedy_visit_option)
     {
-        // TODO: dataify into a map
         const string c = replace_all_of(stop, " ", "_");
-        if (c == "glowing" || c == "glowing_item"
-                 || c == "glowing_items")
-        {
-            conditions |= EG_GLOWING;
-        }
-        else if (c == "artefact" || c == "artefacts"
-                 || c == "artifact" || c == "artifacts")
-            conditions |= EG_ARTEFACT;
-        else if (c == "stack" || c == "stacks"
-                 || c == "pile" || c == "piles")
-            conditions |= EG_STACK;
+        const auto search = GREEDY_CONDITIONS.find(c);
+        if (search != GREEDY_CONDITIONS.end())
+            conditions |= search->second;
         else
             report_error("Unknown greedy visit condition '%s'", c.c_str());
     }

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -11,6 +11,7 @@
 #include "confirm-prompt-type.h"
 #include "easy-confirm-type.h"
 #include "explore-greedy-options.h"
+#include "explore-stop-options.h"
 #include "feature.h"
 #include "fixedp.h"
 #include "flang-t.h"

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -1701,9 +1701,7 @@ int player_prot_life(bool allow_random, bool temp, bool items)
 // want to go past 6 (see below). -- bwr
 int player_movement_speed(bool check_terrain, bool temp)
 {
-    int mv = you.form == transformation::none
-        ? 10
-        : form_base_movespeed(you.form);
+    int mv = form_base_movespeed(you.form);
 
     if (check_terrain && feat_is_water(env.grid(you.pos())))
     {

--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -520,7 +520,7 @@ void force_show_update_at(const coord_def &gp, layers_type layers)
     if (!in_bounds(gp))
         return;
 
-    if (layers & LAYER_MONSTERS)
+    if (layers & Layer::MONSTERS)
     {
         monster* mons = monster_at(gp);
         if (mons && mons->alive())
@@ -529,11 +529,11 @@ void force_show_update_at(const coord_def &gp, layers_type layers)
             _mark_invisible_at(gp);
     }
 
-    if (layers & LAYER_CLOUDS)
+    if (layers & Layer::CLOUDS)
         if (cloud_struct* cloud = cloud_at(gp))
             _update_cloud(*cloud);
 
-    if (layers & LAYER_ITEMS)
+    if (layers & Layer::ITEMS)
         update_item_at(gp);
 }
 

--- a/crawl-ref/source/show.h
+++ b/crawl-ref/source/show.h
@@ -76,19 +76,19 @@ struct show_info
 
 class monster;
 
-enum layer_type
+enum class Layer
 {
-    LAYERS_NONE           = 0,
-    LAYER_MONSTERS        = (1 << 0),
-    LAYER_PLAYER          = (1 << 1),
-    LAYER_ITEMS           = (1 << 2),
-    LAYER_CLOUDS          = (1 << 3),
-    LAYER_MONSTER_WEAPONS = (1 << 4),
-    LAYER_MONSTER_HEALTH  = (1 << 5),
+    None            = 0,
+    MONSTERS        = (1 << 0),
+    PLAYER          = (1 << 1),
+    ITEMS           = (1 << 2),
+    CLOUDS          = (1 << 3),
+    MONSTER_WEAPONS = (1 << 4),
+    MONSTER_HEALTH  = (1 << 5),
 };
-DEF_BITFIELD(layers_type, layer_type, 5);
-constexpr layers_type LAYERS_ALL = LAYER_MONSTERS | LAYER_PLAYER
-                                 | LAYER_ITEMS | LAYER_CLOUDS;
+DEF_BITFIELD(layers_type, Layer, 5);
+constexpr layers_type LAYERS_ALL = Layer::MONSTERS | Layer::PLAYER
+                                 | Layer::ITEMS | Layer::CLOUDS;
 
 void show_init(layers_type layers = LAYERS_ALL);
 void update_item_at(const coord_def &gp, bool wizard = false);

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -2009,16 +2009,19 @@ void vampire_update_transformations()
     }
 }
 
-// TODO: dataify? move to member functions?
 int form_base_movespeed(transformation tran)
 {
     // statue form is handled as a multiplier in player_speed, not a movespeed.
-    if (tran == transformation::bat)
-        return 5; // but allowed minimum is six
-    else if (tran == transformation::pig)
-        return 7;
-    else
-        return 10;
+    switch (tran)
+    {
+        case transformation::bat:
+            return 5; // but allowed minimum is six
+        case transformation::pig:
+            return 7;
+        case transformation::none:
+        default:
+            return 10;
+    }
 }
 
 bool draconian_dragon_exception()

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -12,6 +12,7 @@
 #include "command-type.h"
 #include "daction-type.h"
 #include "exclude.h"
+#include "explore-stop-options.h"
 #include "travel-defs.h"
 
 class reader;
@@ -153,56 +154,6 @@ const int PD_CLOUD = -20101;
  * referenced in: travel - view
  * *********************************************************************** */
 extern travel_distance_grid_t travel_point_distance;
-
-enum explore_stop_type
-{
-    ES_NONE                      = 0x00000,
-
-    // Explored into view of an item that is NOT eligible for autopickup.
-    ES_ITEM                      = 0x00001,
-
-    // Picked up an item during greedy explore; will stop for anything
-    // that's not explicitly ignored and that is not gold.
-    ES_GREEDY_PICKUP             = 0x00002,
-
-    // Stop when picking up gold with greedy explore.
-    ES_GREEDY_PICKUP_GOLD        = 0x00004,
-
-    // Picked up an item during greedy explore, ignoring items that were
-    // thrown by the PC, and items that the player already has one of in
-    // inventory, or a bunch of other conditions (see
-    // _interesting_explore_pickup in items.cc)
-    ES_GREEDY_PICKUP_SMART       = 0x00008,
-
-    // Greedy-picked up an item previously thrown by the PC.
-    ES_GREEDY_PICKUP_THROWN      = 0x00010,
-    ES_GREEDY_PICKUP_MASK        = (ES_GREEDY_PICKUP
-                                    | ES_GREEDY_PICKUP_GOLD
-                                    | ES_GREEDY_PICKUP_SMART
-                                    | ES_GREEDY_PICKUP_THROWN),
-
-    // Explored into view of an item eligible for autopickup.
-    ES_GREEDY_ITEM               = 0x00020,
-
-    // Stepped onto a stack of items that was previously unknown to
-    // the player (for instance, when stepping onto the heap of items
-    // of a freshly killed monster).
-    ES_GREEDY_VISITED_ITEM_STACK = 0x00040,
-
-    // Explored into view of a stair, shop, altar, portal, glowing
-    // item, artefact, or branch entrance.... etc.
-    ES_STAIR                     = 0x00080,
-    ES_SHOP                      = 0x00100,
-    ES_ALTAR                     = 0x00200,
-    ES_PORTAL                    = 0x00400,
-    ES_GLOWING_ITEM              = 0x00800,
-    ES_ARTEFACT                  = 0x01000,
-    ES_RUNE                      = 0x02000,
-    ES_BRANCH                    = 0x04000,
-    ES_RUNED_DOOR                = 0x08000,
-    ES_TRANSPORTER               = 0x10000,
-    ES_RUNELIGHT                 = 0x20000,
-};
 
 ////////////////////////////////////////////////////////////////////////////
 // Structs for interlevel travel.

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -83,7 +83,7 @@
 #include "xom.h"
 
 static layers_type _layers = LAYERS_ALL;
-static layers_type _layers_saved = LAYERS_NONE;
+static layers_type _layers_saved = Layer::None;
 
 crawl_view_geometry crawl_view;
 
@@ -923,7 +923,7 @@ string screenshot()
     return ss.str();
 }
 
-int viewmap_flash_colour()
+colour_t viewmap_flash_colour()
 {
     // This only shows the fullscreen colour when we're showing all layers,
     // and hides it for parseability's sake when toggling individual layers.
@@ -1710,7 +1710,7 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
     else if (!crawl_view.in_los_bounds_g(gc))
         _draw_outside_los(cell, gc, coord_def());
     else if (gc == you.pos() && you.on_current_level
-             && _layers & LAYER_PLAYER
+             && _layers & Layer::PLAYER
              && !crawl_state.game_is_arena()
              && !crawl_state.arena_suspended)
     {
@@ -1817,7 +1817,7 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
     if ((_layers != LAYERS_ALL || Options.always_show_exclusions)
         && you.on_current_level
         && map_bounds(gc)
-        && (_layers == LAYERS_NONE
+        && (_layers == Layer::None
             || gc != you.pos()
                && (env.map_knowledge(gc).monster() == MONS_NO_MONSTER
                    || !you.see_cell(gc)))
@@ -1840,8 +1840,8 @@ static void _config_layers_menu()
     bool exit = false;
 
     _layers = _layers_saved;
-    crawl_state.viewport_weapons    = !!(_layers & LAYER_MONSTER_WEAPONS);
-    crawl_state.viewport_monster_hp = !!(_layers & LAYER_MONSTER_HEALTH);
+    crawl_state.viewport_weapons    = !!(_layers & Layer::MONSTER_WEAPONS);
+    crawl_state.viewport_monster_hp = !!(_layers & Layer::MONSTER_HEALTH);
 
     msgwin_set_temporary(true);
     while (!exit)
@@ -1859,20 +1859,20 @@ static void _config_layers_menu()
                            "<%s>monster (h)ealth</%s>"
 #endif
                            ,
-           _layers & LAYER_MONSTERS        ? "lightgrey" : "darkgrey",
-           _layers & LAYER_MONSTERS        ? "lightgrey" : "darkgrey",
-           _layers & LAYER_PLAYER          ? "lightgrey" : "darkgrey",
-           _layers & LAYER_PLAYER          ? "lightgrey" : "darkgrey",
-           _layers & LAYER_ITEMS           ? "lightgrey" : "darkgrey",
-           _layers & LAYER_ITEMS           ? "lightgrey" : "darkgrey",
-           _layers & LAYER_CLOUDS          ? "lightgrey" : "darkgrey",
-           _layers & LAYER_CLOUDS          ? "lightgrey" : "darkgrey"
+           _layers & Layer::MONSTERS        ? "lightgrey" : "darkgrey",
+           _layers & Layer::MONSTERS        ? "lightgrey" : "darkgrey",
+           _layers & Layer::PLAYER          ? "lightgrey" : "darkgrey",
+           _layers & Layer::PLAYER          ? "lightgrey" : "darkgrey",
+           _layers & Layer::ITEMS           ? "lightgrey" : "darkgrey",
+           _layers & Layer::ITEMS           ? "lightgrey" : "darkgrey",
+           _layers & Layer::CLOUDS          ? "lightgrey" : "darkgrey",
+           _layers & Layer::CLOUDS          ? "lightgrey" : "darkgrey"
 #ifndef USE_TILE_LOCAL
            ,
-           _layers & LAYER_MONSTER_WEAPONS ? "lightgrey" : "darkgrey",
-           _layers & LAYER_MONSTER_WEAPONS ? "lightgrey" : "darkgrey",
-           _layers & LAYER_MONSTER_HEALTH  ? "lightgrey" : "darkgrey",
-           _layers & LAYER_MONSTER_HEALTH  ? "lightgrey" : "darkgrey"
+           _layers & Layer::MONSTER_WEAPONS ? "lightgrey" : "darkgrey",
+           _layers & Layer::MONSTER_WEAPONS ? "lightgrey" : "darkgrey",
+           _layers & Layer::MONSTER_HEALTH  ? "lightgrey" : "darkgrey",
+           _layers & Layer::MONSTER_HEALTH  ? "lightgrey" : "darkgrey"
 #endif
         );
         mprf(MSGCH_PROMPT, "Press 'a' to toggle all layers. "
@@ -1880,28 +1880,28 @@ static void _config_layers_menu()
 
         switch (get_ch())
         {
-        case 'm': _layers_saved = _layers ^= LAYER_MONSTERS;        break;
-        case 'p': _layers_saved = _layers ^= LAYER_PLAYER;          break;
-        case 'i': _layers_saved = _layers ^= LAYER_ITEMS;           break;
-        case 'c': _layers_saved = _layers ^= LAYER_CLOUDS;          break;
+        case 'm': _layers_saved = _layers ^= Layer::MONSTERS;        break;
+        case 'p': _layers_saved = _layers ^= Layer::PLAYER;          break;
+        case 'i': _layers_saved = _layers ^= Layer::ITEMS;           break;
+        case 'c': _layers_saved = _layers ^= Layer::CLOUDS;          break;
 #ifndef USE_TILE_LOCAL
-        case 'w': _layers_saved = _layers ^= LAYER_MONSTER_WEAPONS;
-                  if (_layers & LAYER_MONSTER_WEAPONS)
-                      _layers_saved = _layers |= LAYER_MONSTERS;
+        case 'w': _layers_saved = _layers ^= Layer::MONSTER_WEAPONS;
+                  if (_layers & Layer::MONSTER_WEAPONS)
+                      _layers_saved = _layers |= Layer::MONSTERS;
                   break;
-        case 'h': _layers_saved = _layers ^= LAYER_MONSTER_HEALTH;
-                  if (_layers & LAYER_MONSTER_HEALTH)
-                      _layers_saved = _layers |= LAYER_MONSTERS;
+        case 'h': _layers_saved = _layers ^= Layer::MONSTER_HEALTH;
+                  if (_layers & Layer::MONSTER_HEALTH)
+                      _layers_saved = _layers |= Layer::MONSTERS;
                   break;
 #endif
         case 'a': if (_layers)
-                      _layers_saved = _layers = LAYERS_NONE;
+                      _layers_saved = _layers = Layer::None;
                   else
                   {
 #ifndef USE_TILE_LOCAL
                       _layers_saved = _layers = LAYERS_ALL
-                                      | LAYER_MONSTER_WEAPONS
-                                      | LAYER_MONSTER_HEALTH;
+                                      | Layer::MONSTER_WEAPONS
+                                      | Layer::MONSTER_HEALTH;
 #else
                       _layers_saved = _layers = LAYERS_ALL;
 #endif
@@ -1909,14 +1909,14 @@ static void _config_layers_menu()
                   break;
         default:
             _layers = LAYERS_ALL;
-            crawl_state.viewport_weapons    = !!(_layers & LAYER_MONSTER_WEAPONS);
-            crawl_state.viewport_monster_hp = !!(_layers & LAYER_MONSTER_HEALTH);
+            crawl_state.viewport_weapons    = !!(_layers & Layer::MONSTER_WEAPONS);
+            crawl_state.viewport_monster_hp = !!(_layers & Layer::MONSTER_HEALTH);
             exit = true;
             break;
         }
 
-        crawl_state.viewport_weapons    = !!(_layers & LAYER_MONSTER_WEAPONS);
-        crawl_state.viewport_monster_hp = !!(_layers & LAYER_MONSTER_HEALTH);
+        crawl_state.viewport_weapons    = !!(_layers & Layer::MONSTER_WEAPONS);
+        crawl_state.viewport_monster_hp = !!(_layers & Layer::MONSTER_HEALTH);
 
         msgwin_clear_temporary();
     }
@@ -1939,8 +1939,8 @@ void reset_show_terrain()
         mprf(MSGCH_PROMPT, "Restoring view layers.");
 
     _layers = LAYERS_ALL;
-    crawl_state.viewport_weapons    = !!(_layers & LAYER_MONSTER_WEAPONS);
-    crawl_state.viewport_monster_hp = !!(_layers & LAYER_MONSTER_HEALTH);
+    crawl_state.viewport_weapons    = !!(_layers & Layer::MONSTER_WEAPONS);
+    crawl_state.viewport_monster_hp = !!(_layers & Layer::MONSTER_HEALTH);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/crawl-ref/source/view.h
+++ b/crawl-ref/source/view.h
@@ -26,7 +26,7 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
 
 string screenshot();
 
-int viewmap_flash_colour();
+colour_t viewmap_flash_colour();
 bool view_update();
 void view_update_at(const coord_def &pos);
 class targeter;

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -429,7 +429,7 @@ void wizard_map_level()
     for (rectangle_iterator ri(BOUNDARY_BORDER - 1); ri; ++ri)
     {
         update_item_at(*ri, true);
-        show_update_at(*ri, LAYER_ITEMS);
+        show_update_at(*ri, Layer::ITEMS);
 
 #ifdef USE_TILE
         tiles.update_minimap(*ri);


### PR DESCRIPTION
 * Split explore_stop_options into its own header.
 * Make initfile parsing use maps instead of brute force else-ifs
 * Make the layers enum a enum class
 * simplify base movespeed logic in form_base_movespeed
 * Fix return type of viewmap_flash_clour and fix compiler warning.
 * Fix incorrect enum bitfiddling in viewmap_flash_colour.
Only the last bullet point has any behavioral change.

The intent of a135081b66271c96c04bea8a314a81b1ae5e9791
was to display the flash colour if all 4 layers were
on, or at least that's what the comment said.
The actual behavior was to display it if any of the 4 were on.

