### PR TITLE
document git conventions

### DIFF
--- a/crawl-ref/docs/develop/contribution-process.md
+++ b/crawl-ref/docs/develop/contribution-process.md
@@ -125,7 +125,10 @@ would prefer this to be limited to small changes like vaults or artwork.
   get merged faster, all things being equal. A *very common* mistake is to
   put a lot of text in the PR first comment, and leave the commit message blank.
   Usually, this will require a devteam member to manually copy information
-  from the PR and reformat for a commit message, slowing the process.
+  from the PR and reformat for a commit message, slowing the process. Additionally,
+  commit messages should be formatted according to standard Git conventions; see
+  https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/
+  for a list of common conventions.
 * PRs that fix bugs are very likely to get merged in some form (though you may
   receive suggestions for alternative strategies for fixing the bug).
 * PRs that change gameplay in particular need to be carefully thought out, and

--- a/crawl-ref/docs/develop/git/quickstart.txt
+++ b/crawl-ref/docs/develop/git/quickstart.txt
@@ -180,6 +180,16 @@ Using git for Stone Soup development
 
    $ git commit -a -m "Fitted player.cc with mountain dwarves"
 
+   A number of tools for working with git, and a few parts of git itself,
+   expect commit messages to follow certain conventions. The most important
+   ones are:
+
+   1. Keep the first line 50 characters or less
+   2. Leave the second line blank
+
+   https://www.freecodecamp.org/news/writing-good-commit-messages-a-practical-guide/
+   has some more common conventions.
+
    When you're done, your change has been committed to your local
    repository. Let's try git status again:
 


### PR DESCRIPTION
The git quickstart guide now mentions the most important git commit message conventions, and links to a page with more detailed information and additional common conventions.