### PR TITLE
Fix: white splash screen when OpenGL 3+ unavailable (Ge0ff)

### DIFF
--- a/crawl-ref/source/glwrapper-ogl.cc
+++ b/crawl-ref/source/glwrapper-ogl.cc
@@ -460,8 +460,11 @@ void OGLStateManager::load_texture(unsigned char *pixels, unsigned int width,
     if (mip_opt == MIPMAP_CREATE)
     {
         // TODO: should min react to Options.tile_filter_scaling?
+        // TODO: fixme better when less tired
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
-                        GL_LINEAR_MIPMAP_NEAREST);
+                        m_mipmapFn != nullptr ? GL_LINEAR_MIPMAP_NEAREST :
+                        Options.tile_filter_scaling ? GL_LINEAR :
+                        GL_NEAREST);
         glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER,
                         Options.tile_filter_scaling ? GL_LINEAR : GL_NEAREST);
         glTexImage2D(GL_TEXTURE_2D, 0, bpp, width, height, 0,


### PR DESCRIPTION
I thought GL_TEXTURE_MIN_FILTER had the same value for both branches.

I thought incorrectly.

Fix it in the simplest possible way for now.
I'll clean this up more in a future PR.

Bug was introduced in #4217.

Credit to Ge0ff for reporting.