### PR TITLE
Update add_autopickup_func to use capitalized subtype

### DIFF
--- a/crawl-ref/settings/advanced_optioneering.txt
+++ b/crawl-ref/settings/advanced_optioneering.txt
@@ -27,8 +27,8 @@ add_autopickup_func(function(it, name)
     return
   end
   if it.class(true) == "armour" then
-    local good_slots = {cloak="Cloak", helmet="Helmet", gloves="Gloves",
-                        boots="Boots"}
+    local good_slots = {Cloak="Cloak", Helmet="Helmet", Gloves="Gloves",
+                        Boots="Boots"}
     st, _ = it.subtype()
     if good_slots[st] ~= nil and items.equipped_at(good_slots[st]) == nil then
       return true


### PR DESCRIPTION
The autopickup function is matching against the return from l_item_do_subtype, which is a wrapper around equip_slot_name, which in 2dbd7c1f was changed so that the strings are capitalized.

thanks to @lmplojin on discord for the pointer.