### PR TITLE
feat: Improve developer experience by reminding them ccache exists

### DIFF
--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -490,6 +490,7 @@ set up.
 
 On Linux, try installing the `ccache` with your package manager. You will need
 to add the ccache directory to your `PATH`.
+See [this StackExchange answer](https://askubuntu.com/a/470636).
 
 On macOS, run `brew install ccache` and follow the instructions to update your
 `PATH`.

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1296,6 +1296,23 @@ greet:
 		                  "at INSTALL.md: the solution to your problem just might be in there!";\
 	fi
 
+# In case it breaks things on an exotic target
+ifndef SUPPRESS_BUILD_CHECKS
+     ifneq (,$(findstring ccache,$(shell which $(GCC))))
+         $(warning ccache not found in path for C compiler $(GCC). You can make your build much faster.)
+         $(warning See "https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.md#ccache")
+         $(warning Suppress using SUPPRESS_BUILD_CHECKS=)
+     endif
+# Check separately, you could screw up and only symlink one.
+     ifneq (,$(findstring ccache,$(shell which $(GXX))))
+         $(warning ccache not found in path for C++ compiler $(GXX). You can make your build much faster.)
+         $(warning See "https://github.com/crawl/crawl/blob/master/crawl-ref/INSTALL.md#ccache")
+         $(warning Suppress using SUPPRESS_BUILD_CHECKS=)
+    endif
+    # TODO: check sysctl -n hw.ncpu or nproc if available, and warn if -j1.
+    # Not all Make implementations necessarily provide us with the value of j explicitly.
+endif
+
 docs: $(GENERATED_DOCS)
 
 


### PR DESCRIPTION
Validate that ccache is installed and that the compiler is symlinked to use ccache.

Update docs to point to a helpful answer on setting up ccache.