### PR TITLE
Don't freeze corpses that have been turned to gold

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5179,8 +5179,11 @@ void bolt::kill_monster(monster &mon)
 
     item_def *corpse = monster_die(mon, ref_killer, kindex);
 
-    if (origin_spell != SPELL_GLACIATE && origin_spell != SPELL_GLACIAL_BREATH)
+    if (origin_spell != SPELL_GLACIATE && origin_spell != SPELL_GLACIAL_BREATH
+        || goldify)
+    {
         return;
+    }
 
     if (corpse)
         destroy_item(corpse->index());


### PR DESCRIPTION
When you killed a monster with the white draconians breath ability while worshipping Gozag, you would get a message saying it shattered and turned to gold but you would get a block of ice and no gold. Fix this by not freezing a monsters corpse if it has been turned to gold.

Fixes #4185