### PR TITLE
Fix Hep ancestors sometimes spawning incorrectly

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4690,6 +4690,17 @@ void delayed_monster_done(string success, delayed_callback callback)
     _delayed_done_callbacks.push_back(callback);
 }
 
+static bool _needs_to_spawn_hepliaklqana_ancestor()
+{
+    return you_worship(GOD_HEPLIAKLQANA)
+            // You don't get an ancestor under penence
+           && !player_under_penance()
+           // You must have enough piety for an ancestor
+           && have_passive(passive_t::frail)
+           // An ancestor must not already exist
+           && hepliaklqana_ancestor() == MID_NOBODY;
+}
+
 static void _place_delayed_monsters()
 {
     // Last monster that was successfully placed (so far).
@@ -4709,7 +4720,23 @@ static void _place_delayed_monsters()
             prev_god = mg.god;
         }
 
-        monster *mon = create_monster(mg);
+        monster *mon = nullptr;
+        if (mons_is_hepliaklqana_ancestor(mg.cls))
+        {
+            // If the player gained enough piety to gain an ancestor on an
+            // enemy's turn or at the start of their turn (e.g. from an enemy
+            // digging or the player's passwal ending), they will get a turn
+            // to act before their ancestor is summoned. During this turn they
+            // can rename their ancestor or lose the piety needed to have one
+            // or lose their god etc.
+            if (_needs_to_spawn_hepliaklqana_ancestor())
+            {
+                mg = hepliaklqana_ancestor_gen_data();
+                mon = create_monster(mg);
+            }
+        }
+        else
+            mon = create_monster(mg);
 
         if (cback)
             (*cback)(mg, mon, placed);


### PR DESCRIPTION
If the player gained enough piety to gain an ancestor on an enemy's turn or at the start of their turn (e.g. from an enemy digging or the player's passwal finishing), they will get a turn to act before their ancestor is summoned as the ancestor will be summoned at the end of the player's turn. Delaying the summoning of the ancestor to the end of the player's turn is done by storing a copy of the ancestor in a queue. This lead to a bug reported by krajj7 (aka chujev) where changing your ancestor's name on this turn would result in them spawning with the old name. Fix this by using the actual data for the ancestor instead of the data in the queue.

Queueing up spawning an ancestor also lead to a bug reported by NephilaWeaver where a teleport trap could teleport you into unexplored terrain giving you enough piety for an ancestor and then piety delay could bring you below the piety required for an ancestor but fail to remove your ancestor as it hadn't spawned yet. Then at the end of your next turn, your ancestor would spawn even though you didn't have enough piety. Then when your got enough piety for an ancestor, a second one would spawn. Fix this by checking if spawning an ancestor is needed before spawning one from the queue.

Fixes #3300
Fixes #3450