### PR TITLE
fix: Bring Asterion's ability names in line with overhauled Makhleb

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -840,7 +840,7 @@ You can stockpile enough malice to cast this spell at most three times, and this
 can only be replenished by causing the death of a sufficient number of living
 beings.
 %%%%
-Greater Servant of Makhleb spell
+Infernal Servant spell
 
 Summons a major demon.
 %%%%

--- a/crawl-ref/source/dat/descript/zh/spells.txt
+++ b/crawl-ref/source/dat/descript/zh/spells.txt
@@ -577,7 +577,7 @@ Grasping Roots spell
 召唤来自地下深处的巨大抓握的根，抓住并束缚受害者。
 如果受害人挣脱或它离开召唤者的视野，则根会撤去。
 %%%%
-Greater Servant of Makhleb spell
+Infernal Servant spell
 
 召唤一个大恶魔。
 %%%%

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3086,7 +3086,7 @@ static const struct spell_desc spelldata[] =
 },
 
 {
-    SPELL_GREATER_SERVANT_MAKHLEB, "Greater Servant of Makhleb",
+    SPELL_GREATER_SERVANT_MAKHLEB, "Infernal Servant",
     spschool::summoning,
     spflag::unholy | spflag::mons_abjure | spflag::monster,
     7,


### PR DESCRIPTION
Asterion's current ability name, "Greater Servant of Makhleb", comes from Makhleb's old ability names before the 0.32 overhaul.
    
Since the overhaul was mostly merging the lesser/greater pairs while leaving the actual mechanics untouched, I think we can keep the     existing monster spells (along with icons and descriptions), but use the new ability titles.
    
The other ability, "Major Destruction", is contrasted with another monster spell "Legendary Destruction". It is thus not changed in this PR.