### PR TITLE
Automatically identify some obsolete items.

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -1943,6 +1943,10 @@ bool item_type_known(const item_def& item)
     case OBJ_GOLD:
     case OBJ_RUNES:
     case OBJ_GEMS:
+#if TAG_MAJOR_VERSION == 34
+    case OBJ_FOOD:
+    case OBJ_RODS:
+#endif
         return true;
     default:
         break;


### PR DESCRIPTION
Add food and rods to the "always known" list in item_type_known(). This restores some behaviour from before _full_ident_mask() was deleted, in that you are no longer asked if you want to identify "removed food" items.