### PR TITLE
When you use mon-tile as a player-tile, display their changes in water

### DIFF
--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2481,7 +2481,7 @@ tileidx_t tileidx_player_mons()
     case MONS_CENTAUR_WARRIOR: return TILEP_MONS_CENTAUR_WARRIOR_MELEE;
     case MONS_YAKTAUR:         return TILEP_MONS_YAKTAUR_MELEE;
     case MONS_YAKTAUR_CAPTAIN: return TILEP_MONS_YAKTAUR_CAPTAIN_MELEE;
-    default:                   return tileidx_monster_base(mons, 0);
+    default:                   return tileidx_monster_base(mons, 0, you.in_water());
     }
 }
 


### PR DESCRIPTION
A small modification, when you use Merfolk's Mons Tile as your player tile, it correctly displays their differential in water