### PR TITLE
fix: overflow of overlays with Qazlal's Disaster area (prawnwizard)

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -319,6 +319,7 @@ catch2-tests/test_randbook.o \
 catch2-tests/test_stringutil.o \
 catch2-tests/test_species.o \
 catch2-tests/test_tags.o \
+catch2-tests/test_tilecell.o \
 catch2-tests/test_ui.o \
 catch2-tests/test_viewmap.o \
 catch2-tests/test_spl-util.o

--- a/crawl-ref/source/catch2-tests/test_tilecell.cc
+++ b/crawl-ref/source/catch2-tests/test_tilecell.cc
@@ -1,0 +1,37 @@
+#include "catch_amalgamated.hpp"
+#include "AppHdr.h"
+#ifdef USE_TILE
+// TODO: make sure CI runs the catch2 tests with USE_TILE
+#include "tilecell.h"
+
+
+TEST_CASE( "add_overlay deduplication", "[single-file]")
+{
+    packed_cell cell;
+    cell.add_overlay(5);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.num_dngn_overlay == 1);
+
+    // Adding the same overlay twice in a row gets deduplicated
+    cell.add_overlay(5);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.num_dngn_overlay == 1);
+
+    // Adding the same overlay separately gets deduplicated
+    cell.add_overlay(6);
+    cell.add_overlay(7);
+    cell.add_overlay(6);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 6);
+    REQUIRE(cell.dngn_overlay[2] == 7);
+    REQUIRE(cell.num_dngn_overlay == 3);
+
+    cell.clear()
+    REQUIRE(cell.dngn_overlay[0] == 0);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.dngn_overlay[2] == 0);
+    REQUIRE(cell.num_dngn_overlay == 0);
+}
+#endif

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1315,8 +1315,7 @@ static void _draw_ray_cell(screen_cell_t& cell, coord_def p, bool on_target,
 {
 #ifdef USE_TILE
     UNUSED(on_target, p);
-    cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-        _tileidx_aff_type(aff);
+    cell.tile.add_overlay(_tileidx_aff_type(aff));
 #endif
     const auto bcol = _colour_aff_type(aff, on_target);
     const auto mbcol = on_target ? bcol : bcol | COLFLAG_REVERSE;
@@ -1382,8 +1381,7 @@ void direction_chooser::draw_beam(crawl_view_buffer &vbuf)
         const bool inrange = in_range(p);
         auto& cell = vbuf(grid2view(p) - 1);
 #ifdef USE_TILE
-        cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-            inrange ? TILE_RAY : TILE_RAY_OUT_OF_RANGE;
+        cell.tile.add_overlay(inrange ? TILE_RAY : TILE_RAY_OUT_OF_RANGE);
 #endif
         const auto bcol = inrange ? MAGENTA : DARKGREY;
         const auto cglyph = _get_ray_glyph(p, bcol, '*', bcol| COLFLAG_REVERSE);
@@ -1395,8 +1393,8 @@ void direction_chooser::draw_beam(crawl_view_buffer &vbuf)
     // Only draw the ray over the target on tiles.
 #ifdef USE_TILE
     auto& cell = vbuf(grid2view(target()) - 1);
-    cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-        in_range(ray.pos()) ? TILE_RAY : TILE_RAY_OUT_OF_RANGE;
+    cell.tile.add_overlay(
+            in_range(ray.pos()) ? TILE_RAY : TILE_RAY_OUT_OF_RANGE);
 #endif
 }
 

--- a/crawl-ref/source/tilecell.cc
+++ b/crawl-ref/source/tilecell.cc
@@ -17,6 +17,7 @@
 void packed_cell::clear()
 {
     num_dngn_overlay = 0;
+    dngn_overlay.fill(0);
     fg = 0;
     bg = 0;
     cloud = 0;
@@ -82,9 +83,33 @@ enum wave_type
     WV_DEEP,
 };
 
-static void _add_overlay(int tileidx, packed_cell& cell)
+
+void packed_cell::add_overlay(int tileidx)
 {
-    cell.dngn_overlay[cell.num_dngn_overlay++] = tileidx;
+    // Deduplicate existing identical overlays
+    // There's a ton of ways to implement this.
+    // This way, which does rely on the empty portion of the array being
+    // zeroed, is friendly to auto-vectorization.
+    // Clang 19.1.0 happily auto-vectorizes this on -O2
+    // auto end = dngn_overlay.begin() + num_dngn_overlay;
+    // or something like that might be more efficient for gcc though?
+    auto end = dngn_overlay.end();
+    bool not_present = find(dngn_overlay.begin(), end, tileidx) == end;
+    if (not_present)
+    {
+        const int insert_pos = num_dngn_overlay++;
+        // the lower bound is redundant, but helps e.g. clang
+        // realize that it can combine comparisons.
+        if (0 <= insert_pos && insert_pos < MAX_DNGN_OVERLAY)
+            dngn_overlay[insert_pos] = tileidx;
+        else
+        {
+            mprf(MSGCH_DIAGNOSTICS,
+                 "Too many distinct overlays to render; "
+                 "please report a bug on the Issue Tracker with a save in this "
+                 "state");
+        }
+    }
 }
 
 typedef bool (*map_predicate) (const coord_def&, crawl_view_buffer& vbuf);
@@ -137,7 +162,7 @@ static void _add_directional_overlays(const coord_def& gc, crawl_view_buffer& vb
             continue;
 
         if (dir_mask & (1 << i))
-            _add_overlay(tileidx, cell);
+            cell.add_overlay(tileidx);
 
         tileidx++;
     }
@@ -158,7 +183,7 @@ static void _pack_shoal_waves(const coord_def &gc, crawl_view_buffer& vbuf)
 
     if (feat == DNGN_DEEP_WATER && feat_has_ink)
     {
-        _add_overlay(TILE_WAVE_INK_FULL, cell);
+        cell.add_overlay(TILE_WAVE_INK_FULL);
         return;
     }
 
@@ -287,13 +312,13 @@ static void _pack_shoal_waves(const coord_def &gc, crawl_view_buffer& vbuf)
     {
         // First check for shallow water.
         if (north == WV_SHALLOW)
-            _add_overlay(TILE_WAVE_N, cell);
+            cell.add_overlay(TILE_WAVE_N);
         if (south == WV_SHALLOW)
-            _add_overlay(TILE_WAVE_S, cell);
+            cell.add_overlay(TILE_WAVE_S);
         if (east == WV_SHALLOW)
-            _add_overlay(TILE_WAVE_E, cell);
+            cell.add_overlay(TILE_WAVE_E);
         if (west == WV_SHALLOW)
-            _add_overlay(TILE_WAVE_W, cell);
+            cell.add_overlay(TILE_WAVE_W);
 
         // Then check for deep water, overwriting shallow
         // corner waves, if necessary.
@@ -303,53 +328,53 @@ static void _pack_shoal_waves(const coord_def &gc, crawl_view_buffer& vbuf)
         int mod = (feat == DNGN_SHALLOW_WATER) ? 1 : 0;
 
         if (north == WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_N + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_N + mod);
         if (south == WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_S + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_S + mod);
         if (east == WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_E + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_E + mod);
         if (west == WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_W + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_W + mod);
 
         if (ne == WV_SHALLOW && !north && !east)
-            _add_overlay(TILE_WAVE_CORNER_NE, cell);
+            cell.add_overlay(TILE_WAVE_CORNER_NE);
         else if (ne == WV_DEEP && north != WV_DEEP && east != WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_CORNER_NE + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_CORNER_NE + mod);
         if (nw == WV_SHALLOW && !north && !west)
-            _add_overlay(TILE_WAVE_CORNER_NW, cell);
+            cell.add_overlay(TILE_WAVE_CORNER_NW);
         else if (nw == WV_DEEP && north != WV_DEEP && west != WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_CORNER_NW + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_CORNER_NW + mod);
         if (se == WV_SHALLOW && !south && !east)
-            _add_overlay(TILE_WAVE_CORNER_SE, cell);
+            cell.add_overlay(TILE_WAVE_CORNER_SE);
         else if (se == WV_DEEP && south != WV_DEEP && east != WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_CORNER_SE + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_CORNER_SE + mod);
         if (sw == WV_SHALLOW && !south && !west)
-            _add_overlay(TILE_WAVE_CORNER_SW, cell);
+            cell.add_overlay(TILE_WAVE_CORNER_SW);
         else if (sw == WV_DEEP && south != WV_DEEP && west != WV_DEEP)
-            _add_overlay(TILE_WAVE_DEEP_CORNER_SW + mod, cell);
+            cell.add_overlay(TILE_WAVE_DEEP_CORNER_SW + mod);
     }
 
     // Overlay with ink sheen, if necessary.
     if (feat_has_ink)
-        _add_overlay(TILE_WAVE_INK_FULL, cell);
+        cell.add_overlay(TILE_WAVE_INK_FULL);
     else
     {
         if (inkn)
-            _add_overlay(TILE_WAVE_INK_N, cell);
+            cell.add_overlay(TILE_WAVE_INK_N);
         if (inks)
-            _add_overlay(TILE_WAVE_INK_S, cell);
+            cell.add_overlay(TILE_WAVE_INK_S);
         if (inke)
-            _add_overlay(TILE_WAVE_INK_E, cell);
+            cell.add_overlay(TILE_WAVE_INK_E);
         if (inkw)
-            _add_overlay(TILE_WAVE_INK_W, cell);
+            cell.add_overlay(TILE_WAVE_INK_W);
         if (inkne || inkn || inke)
-            _add_overlay(TILE_WAVE_INK_CORNER_NE, cell);
+            cell.add_overlay(TILE_WAVE_INK_CORNER_NE);
         if (inknw || inkn || inkw)
-            _add_overlay(TILE_WAVE_INK_CORNER_NW, cell);
+            cell.add_overlay(TILE_WAVE_INK_CORNER_NW);
         if (inkse || inks || inke)
-            _add_overlay(TILE_WAVE_INK_CORNER_SE, cell);
+            cell.add_overlay(TILE_WAVE_INK_CORNER_SE);
         if (inksw || inks || inkw)
-            _add_overlay(TILE_WAVE_INK_CORNER_SW, cell);
+            cell.add_overlay(TILE_WAVE_INK_CORNER_SW);
     }
 }
 
@@ -413,7 +438,7 @@ static void _pack_default_waves(const coord_def &gc, crawl_view_buffer& vbuf)
             if (ai->x < 0 || ai->x >= vbuf.size().x || ai->y < 0 || ai->y >= vbuf.size().y)
                 continue;
             if (_is_seen_shallow(*ai, vbuf))
-                _add_overlay(tile, cell);
+                cell.add_overlay(tile);
         }
     }
 
@@ -424,15 +449,15 @@ static void _pack_default_waves(const coord_def &gc, crawl_view_buffer& vbuf)
     if (north || west || east && (colour == BLACK || colour == LIGHTGREEN))
     {
         if (north)
-            _add_overlay(TILE_SHORE_N, cell);
+            cell.add_overlay(TILE_SHORE_N);
         if (west)
-            _add_overlay(TILE_SHORE_W, cell);
+            cell.add_overlay(TILE_SHORE_W);
         if (east)
-            _add_overlay(TILE_SHORE_E, cell);
+            cell.add_overlay(TILE_SHORE_E);
         if (north && west)
-            _add_overlay(TILE_SHORE_NW, cell);
+            cell.add_overlay(TILE_SHORE_NW);
         if (north && east)
-            _add_overlay(TILE_SHORE_NE, cell);
+            cell.add_overlay(TILE_SHORE_NE);
     }
 }
 
@@ -459,27 +484,27 @@ static void _pack_wall_shadows(const coord_def &gc, crawl_view_buffer& vbuf,
     if (_is_seen_wall(coord_def(gc.x - 1, gc.y), vbuf))
     {
         offset = _is_seen_wall(coord_def(gc.x - 1, gc.y - 1), vbuf) ? 0 : 5;
-        _add_overlay(tile + offset, cell);
+        cell.add_overlay(tile + offset);
         nw = 1;
     }
     if (_is_seen_wall(coord_def(gc.x, gc.y - 1), vbuf))
     {
-        _add_overlay(tile + 2, cell);
+        cell.add_overlay(tile + 2);
         ne = 1;
         nw = 1;
     }
     if (_is_seen_wall(coord_def(gc.x + 1, gc.y), vbuf))
     {
         offset = _is_seen_wall(coord_def(gc.x + 1, gc.y - 1), vbuf) ? 4 : 6;
-        _add_overlay(tile + offset, cell);
+        cell.add_overlay(tile + offset);
         ne = 1;
     }
 
     // corners
     if (nw == 0 && _is_seen_wall(coord_def(gc.x - 1, gc.y - 1), vbuf))
-        _add_overlay(tile + 1, cell);
+        cell.add_overlay(tile + 1);
     if (ne == 0 && _is_seen_wall(coord_def(gc.x + 1, gc.y - 1), vbuf))
-        _add_overlay(tile + 3, cell);
+        cell.add_overlay(tile + 3);
 }
 
 static bool _is_seen_slimy_wall(const coord_def& gc, crawl_view_buffer &vbuf)
@@ -517,8 +542,8 @@ void pack_cell_overlays(const coord_def &gc, crawl_view_buffer &vbuf)
         if (feat_is_wall(cell.map_knowledge.feat()))
         {
             const int count = tile_dngn_count(TILE_DNGN_WALL_ICY_WALL_OVERLAY);
-            _add_overlay(TILE_DNGN_WALL_ICY_WALL_OVERLAY
-                    + (gc.y * GXM + gc.x) % count, cell);
+            cell.add_overlay(TILE_DNGN_WALL_ICY_WALL_OVERLAY
+                    + (gc.y * GXM + gc.x) % count);
         }
         else
         {

--- a/crawl-ref/source/tilecell.h
+++ b/crawl-ref/source/tilecell.h
@@ -4,7 +4,7 @@
 #include "map-cell.h"
 #include "tag-version.h"
 
-enum halo_type
+enum halo_type: uint8_t
 {
     HALO_NONE = 0,
     HALO_RANGE = 1,
@@ -15,72 +15,82 @@ struct packed_cell
 {
     // For anything that requires multiple dungeon tiles (such as waves)
     // These tiles will be placed directly on top of the bg tile.
-    enum { MAX_DNGN_OVERLAY = 20 };
-    int num_dngn_overlay;
+    enum { MAX_DNGN_OVERLAY = 32 };
     FixedVector<int, MAX_DNGN_OVERLAY> dngn_overlay;
 
-    tileidx_t fg;
-    tileidx_t bg;
-    tile_flavour flv;
-    tileidx_t cloud;
-    set<tileidx_t> icons;
-
     // This is directly copied from env.map_knowledge by viewwindow()
+    // Here for packing / alignment purposes
     map_cell map_knowledge;
+    // Logically should go with dngn_overlay, but that would pack worse
+    short int num_dngn_overlay;
+    halo_type halo;
+    bool quad_glow: 1;
+    bool old_blood: 1;
+    bool is_highlighted_summoner: 1;
+    bool is_bloody: 1;
+    bool is_silenced: 1;
+    bool is_sanctuary: 1;
+    bool is_blasphemy: 1;
+    bool is_liquefied: 1;
+    bool mangrove_water: 1;
+    bool awakened_forest: 1;
+    bool has_bfb_corpse: 1;
 
-    bool is_highlighted_summoner;
-    bool is_bloody;
-    bool is_silenced;
-    char halo;
-    bool is_sanctuary;
-    bool is_blasphemy;
-    bool is_liquefied;
-    bool mangrove_water;
-    bool awakened_forest;
+    // Note: placed here to pack better
     uint8_t orb_glow;
     char blood_rotation;
-    bool old_blood;
     uint8_t travel_trail;
-    bool quad_glow;
     uint8_t disjunct;
-    bool has_bfb_corpse;
+
+    tile_flavour flv;
+    tileidx_t fg;
+    tileidx_t bg;
+    tileidx_t cloud;
+    set<tileidx_t> icons;
 
     bool operator ==(const packed_cell &other) const;
     bool operator !=(const packed_cell &other) const { return !(*this == other); }
 
-    packed_cell() : num_dngn_overlay(0), fg(0), bg(0), cloud(0),
-                    is_highlighted_summoner(false), is_bloody(false),
-                    is_silenced(false), halo(HALO_NONE), is_sanctuary(false),
-                    is_blasphemy(false), is_liquefied(false), mangrove_water(false),
-                    awakened_forest(false), orb_glow(0), blood_rotation(0),
-                    old_blood(false), travel_trail(0),
-                    quad_glow(false), disjunct(false), has_bfb_corpse(false)
+    packed_cell() : num_dngn_overlay(0), halo(HALO_NONE), quad_glow(false),
+                    old_blood(false), is_highlighted_summoner(false),
+                    is_bloody(false), is_silenced(false), is_sanctuary(false),
+                    is_blasphemy(false), is_liquefied(false),
+                    mangrove_water(false), awakened_forest(false),
+                    has_bfb_corpse(false), orb_glow(0), blood_rotation(0),
+                    travel_trail(0), disjunct(false), fg(0), bg(0), cloud(0)
                     {}
 
-    packed_cell(const packed_cell* c) : num_dngn_overlay(c->num_dngn_overlay),
-                                        fg(c->fg), bg(c->bg), flv(c->flv),
-                                        cloud(c->cloud),
-                                        map_knowledge(c->map_knowledge),
+    packed_cell(const packed_cell* c) : map_knowledge(c->map_knowledge),
+                                        num_dngn_overlay(c->num_dngn_overlay),
+                                        halo(c->halo),
+                                        quad_glow(c->quad_glow),
+                                        old_blood(c->old_blood),
                                         is_highlighted_summoner(c->is_highlighted_summoner),
                                         is_bloody(c->is_bloody),
                                         is_silenced(c->is_silenced),
-                                        halo(c->halo),
                                         is_sanctuary(c->is_sanctuary),
                                         is_blasphemy(c->is_blasphemy),
                                         is_liquefied(c->is_liquefied),
                                         mangrove_water(c->mangrove_water),
                                         awakened_forest(c->awakened_forest),
+                                        has_bfb_corpse(c->has_bfb_corpse),
                                         orb_glow(c->orb_glow),
                                         blood_rotation(c->blood_rotation),
-                                        old_blood(c->old_blood),
                                         travel_trail(c->travel_trail),
-                                        quad_glow(c->quad_glow),
                                         disjunct(c->disjunct),
-                                        has_bfb_corpse(c->has_bfb_corpse)
+                                        flv(c->flv),
+                                        fg(c->fg),
+                                        bg(c->bg),
+                                        cloud(c->cloud)
                                         {}
 
     void clear();
+    // Add an additional overlay to the given cell.
+    void add_overlay(int tileidx);
 };
+// SSE2 / XMM registers = 128 bits or 16 bytes
+// Current size of 32x int32 == 1024 bits is large, but at least it aligns well
+COMPILE_CHECK(sizeof(FixedVector<int, packed_cell::MAX_DNGN_OVERLAY>) % 16 == 0);
 
 class crawl_view_buffer;
 

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1590,12 +1590,7 @@ static void add_overlays(const coord_def& gc, screen_cell_t* cell)
            && tile_overlays[tile_overlay_i].gc == gc)
     {
         const auto &overlay = tile_overlays[tile_overlay_i];
-        if (cell->tile.num_dngn_overlay == 0
-            || cell->tile.dngn_overlay[cell->tile.num_dngn_overlay - 1]
-                                            != static_cast<int>(overlay.tile))
-        {
-            cell->tile.dngn_overlay[cell->tile.num_dngn_overlay++] = overlay.tile;
-        }
+        cell->tile.add_overlay(overlay.tile);
         tile_overlay_i++;
     }
 #endif


### PR DESCRIPTION
  In rare cases, you can exceed the 20 overlay limit.
  
  This leads to a crash.
  
  To fix this:
  * Deduplicate all overlays, not just the most recent
  * Reduce overlay cap to 16 instead of 20 for vectorization reasons
  * Make packed_cell fit into 196 bytes, because why not + cache alignment
  * Make add_overlay an instance method for convenience
  * Log instead of asserting if you do hit the limit; it's only a UI problem.
  
  Modern clang versions auto-vectorize and unroll this std::find nicely.
  GCC doesn't do quite as well, but at least clones/unrolls it
  4 wide. We'll see if it's a win or not.
