### PR TITLE
fix: overflow of overlays with Qazlal's Disaster area (prawnwizard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
             pip install -r webserver/requirements/dev.py3.txt # use this until we have a repo-wide requirements.txt
         working-directory: crawl-ref/source
       - name: Install dependencies
-        run: ./deps.py --coverage
+        run: ./deps.py --coverage --build-opts TILES=1
         working-directory: .github/workflows
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -479,7 +479,7 @@ jobs:
         run: "echo /usr/lib/ccache >> $GITHUB_PATH"
       - name: "Setup ccache: update symlinks"
         run: "/usr/sbin/update-ccache-symlinks"
-      - run: make -j$(nproc) catch2-tests
+      - run: make -j$(nproc) catch2-tests TILES=1
         working-directory: crawl-ref/source
       - name: Generate LCOV data
         working-directory: crawl-ref/source

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -319,6 +319,7 @@ catch2-tests/test_randbook.o \
 catch2-tests/test_stringutil.o \
 catch2-tests/test_species.o \
 catch2-tests/test_tags.o \
+catch2-tests/test_tilecell.o \
 catch2-tests/test_ui.o \
 catch2-tests/test_viewmap.o \
 catch2-tests/test_spl-util.o

--- a/crawl-ref/source/catch2-tests/test_tilecell.cc
+++ b/crawl-ref/source/catch2-tests/test_tilecell.cc
@@ -1,0 +1,36 @@
+#include "catch_amalgamated.hpp"
+#include "AppHdr.h"
+#ifdef USE_TILE
+#include "tilecell.h"
+
+
+TEST_CASE( "add_overlay deduplication", "[single-file]")
+{
+    packed_cell cell;
+    cell.add_overlay(5);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.num_dngn_overlay == 1);
+
+    // Adding the same overlay twice in a row gets deduplicated
+    cell.add_overlay(5);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.num_dngn_overlay == 1);
+
+    // Adding the same overlay separately gets deduplicated
+    cell.add_overlay(6);
+    cell.add_overlay(7);
+    cell.add_overlay(6);
+    REQUIRE(cell.dngn_overlay[0] == 5);
+    REQUIRE(cell.dngn_overlay[1] == 6);
+    REQUIRE(cell.dngn_overlay[2] == 7);
+    REQUIRE(cell.num_dngn_overlay == 3);
+
+    cell.clear();
+    REQUIRE(cell.dngn_overlay[0] == 0);
+    REQUIRE(cell.dngn_overlay[1] == 0);
+    REQUIRE(cell.dngn_overlay[2] == 0);
+    REQUIRE(cell.num_dngn_overlay == 0);
+}
+#endif

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1352,8 +1352,7 @@ static void _draw_ray_cell(screen_cell_t& cell, coord_def p, bool on_target,
 {
 #ifdef USE_TILE
     UNUSED(on_target, p);
-    cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-        _tileidx_aff_type(aff);
+    cell.tile.add_overlay(_tileidx_aff_type(aff));
 #endif
     const auto bcol = _colour_aff_type(aff, on_target);
     const auto mbcol = on_target ? bcol : bcol | COLFLAG_REVERSE;
@@ -1419,8 +1418,7 @@ void direction_chooser::draw_beam(crawl_view_buffer &vbuf)
         const bool inrange = in_range(p);
         auto& cell = vbuf(grid2view(p) - 1);
 #ifdef USE_TILE
-        cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-            inrange ? TILE_RAY : TILE_RAY_OUT_OF_RANGE;
+        cell.tile.add_overlay(inrange ? TILE_RAY : TILE_RAY_OUT_OF_RANGE);
 #endif
         const auto bcol = inrange ? MAGENTA : DARKGREY;
         const auto cglyph = _get_ray_glyph(p, bcol, '*', bcol| COLFLAG_REVERSE);
@@ -1432,8 +1430,8 @@ void direction_chooser::draw_beam(crawl_view_buffer &vbuf)
     // Only draw the ray over the target on tiles.
 #ifdef USE_TILE
     auto& cell = vbuf(grid2view(target()) - 1);
-    cell.tile.dngn_overlay[cell.tile.num_dngn_overlay++] =
-        in_range(ray.pos()) ? TILE_RAY : TILE_RAY_OUT_OF_RANGE;
+    cell.tile.add_overlay(in_range(ray.pos()) ? TILE_RAY :
+                                                TILE_RAY_OUT_OF_RANGE);
 #endif
 }
 

--- a/crawl-ref/source/tilecell.h
+++ b/crawl-ref/source/tilecell.h
@@ -4,7 +4,7 @@
 #include "map-cell.h"
 #include "tag-version.h"
 
-enum halo_type
+enum halo_type: uint8_t
 {
     HALO_NONE = 0,
     HALO_RANGE = 1,
@@ -15,71 +15,84 @@ struct packed_cell
 {
     // For anything that requires multiple dungeon tiles (such as waves)
     // These tiles will be placed directly on top of the bg tile.
-    enum { MAX_DNGN_OVERLAY = 20 };
-    int num_dngn_overlay;
+    static constexpr size_t MAX_DNGN_OVERLAY = 16;
     FixedVector<int, MAX_DNGN_OVERLAY> dngn_overlay;
-
-    tileidx_t fg;
-    tileidx_t bg;
-    tile_flavour flv;
-    tileidx_t cloud;
-    set<tileidx_t> icons;
+    // SSE2 / XMM registers = 128 bits or 16 bytes
+    // Current size of 16x int32 == 512 bits aligns nicely
+    COMPILE_CHECK(sizeof(FixedVector<int, MAX_DNGN_OVERLAY>) % 16 == 0);
 
     // This is directly copied from env.map_knowledge by viewwindow()
+    // Here for packing / alignment purposes
     map_cell map_knowledge;
+    // Logically should go with dngn_overlay, but that would pack worse
+    short int num_dngn_overlay;
+    halo_type halo;
+    bool quad_glow: 1;
+    bool old_blood: 1;
+    bool is_highlighted_summoner: 1;
+    bool is_bloody: 1;
+    bool is_silenced: 1;
+    bool is_sanctuary: 1;
+    bool is_blasphemy: 1;
+    bool is_liquefied: 1;
+    bool mangrove_water: 1;
+    bool awakened_forest: 1;
+    bool has_bfb_corpse: 1;
 
-    bool is_highlighted_summoner;
-    bool is_bloody;
-    bool is_silenced;
-    char halo;
-    bool is_sanctuary;
-    bool is_blasphemy;
-    bool is_liquefied;
-    bool mangrove_water;
-    bool awakened_forest;
+    // Note: placed here to pack better
     uint8_t orb_glow;
     char blood_rotation;
-    bool old_blood;
     uint8_t travel_trail;
-    bool quad_glow;
     uint8_t disjunct;
-    bool has_bfb_corpse;
+
+    tile_flavour flv;
+    tileidx_t fg;
+    tileidx_t bg;
+    tileidx_t cloud;
+    set<tileidx_t> icons;
 
     bool operator ==(const packed_cell &other) const;
     bool operator !=(const packed_cell &other) const { return !(*this == other); }
 
-    packed_cell() : num_dngn_overlay(0), fg(0), bg(0), cloud(0),
-                    is_highlighted_summoner(false), is_bloody(false),
-                    is_silenced(false), halo(HALO_NONE), is_sanctuary(false),
-                    is_blasphemy(false), is_liquefied(false), mangrove_water(false),
-                    awakened_forest(false), orb_glow(0), blood_rotation(0),
-                    old_blood(false), travel_trail(0),
-                    quad_glow(false), disjunct(false), has_bfb_corpse(false)
-                    {}
+    packed_cell() : num_dngn_overlay(0), halo(HALO_NONE), quad_glow(false),
+                    old_blood(false), is_highlighted_summoner(false),
+                    is_bloody(false), is_silenced(false), is_sanctuary(false),
+                    is_blasphemy(false), is_liquefied(false),
+                    mangrove_water(false), awakened_forest(false),
+                    has_bfb_corpse(false), orb_glow(0), blood_rotation(0),
+                    travel_trail(0), disjunct(false), fg(0), bg(0), cloud(0)
+                    {
+                        dngn_overlay.fill(0);
+                    }
 
-    packed_cell(const packed_cell* c) : num_dngn_overlay(c->num_dngn_overlay),
-                                        fg(c->fg), bg(c->bg), flv(c->flv),
-                                        cloud(c->cloud),
+    packed_cell(const packed_cell* c) : dngn_overlay(c->dngn_overlay),
                                         map_knowledge(c->map_knowledge),
+                                        num_dngn_overlay(c->num_dngn_overlay),
+                                        halo(c->halo),
+                                        quad_glow(c->quad_glow),
+                                        old_blood(c->old_blood),
                                         is_highlighted_summoner(c->is_highlighted_summoner),
                                         is_bloody(c->is_bloody),
                                         is_silenced(c->is_silenced),
-                                        halo(c->halo),
                                         is_sanctuary(c->is_sanctuary),
                                         is_blasphemy(c->is_blasphemy),
                                         is_liquefied(c->is_liquefied),
                                         mangrove_water(c->mangrove_water),
                                         awakened_forest(c->awakened_forest),
+                                        has_bfb_corpse(c->has_bfb_corpse),
                                         orb_glow(c->orb_glow),
                                         blood_rotation(c->blood_rotation),
-                                        old_blood(c->old_blood),
                                         travel_trail(c->travel_trail),
-                                        quad_glow(c->quad_glow),
                                         disjunct(c->disjunct),
-                                        has_bfb_corpse(c->has_bfb_corpse)
+                                        flv(c->flv),
+                                        fg(c->fg),
+                                        bg(c->bg),
+                                        cloud(c->cloud)
                                         {}
 
     void clear();
+    // Add an overlay if not already present
+    void add_overlay(int tileidx);
 };
 
 class crawl_view_buffer;

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1630,12 +1630,7 @@ static void add_overlays(const coord_def& gc, screen_cell_t* cell)
            && tile_overlays[tile_overlay_i].gc == gc)
     {
         const auto &overlay = tile_overlays[tile_overlay_i];
-        if (cell->tile.num_dngn_overlay == 0
-            || cell->tile.dngn_overlay[cell->tile.num_dngn_overlay - 1]
-                                            != static_cast<int>(overlay.tile))
-        {
-            cell->tile.dngn_overlay[cell->tile.num_dngn_overlay++] = overlay.tile;
-        }
+        cell->tile.add_overlay(overlay.tile);
         tile_overlay_i++;
     }
 #endif


### PR DESCRIPTION
In rare cases, you can exceed the 20 overlay limit.

This leads to a crash.

To fix this:
* Deduplicate all overlays, not just the most recent
* Reduce overlay cap to 16 instead of 20 for vectorization reasons
* Make packed_cell fit into 196 bytes, because why not + cache alignment
* Make add_overlay an instance method for convenience

Modern clang versions auto-vectorize and unroll this std::find nicely. GCC doesn't do quite as well, but at least clones/unrolls it 4 wide. We'll see if it's a win or not.
