### PR TITLE
ci: Generate docs in CI and publish to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,46 @@ jobs:
       - run: make -j$(nproc) monster
         working-directory: crawl-ref/source
 
+  build_docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Produce FAQ.html et cetera
+      - name: Generate non-Lua docs
+        run: make -j$(nproc) docs
+        working-directory: crawl-ref/source
+      # Installing everything to be able to do make api would be annoying.
+      # The action uses a docker container, which should make it less fragile.
+      - name: Lua LDoc
+        uses: lunarmodules/ldoc@v1.5.0
+        with:
+          args: --config crawl-ref/source/util/config.ld --dir $GITHUB_WORKSPACE/crawl-ref/docs/lua/ .
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3 # or specific "vX.X.X" version tag for this action
+        with:
+          path: crawl-ref/docs/
+  deploy_docs:
+    name: Deploy docs
+    needs: build_docs
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   notify_irc:
     name: "Notify #crawl-dev of build failure"
     needs:
@@ -679,6 +719,8 @@ jobs:
       - codecov_catch2
       - webserver
       - build_monster
+      - build_docs
+      - deploy_docs
     if: failure() && github.event_name == 'push'
     runs-on: ubuntu-22.04
     steps:

--- a/crawl-ref/docs/index.html
+++ b/crawl-ref/docs/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+        "http://www.w3.org/TR/html4/strict.dtd">
+<head>
+ <title>
+Dungeon Crawl Stone Soup - Index
+</title>
+ <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+ <style type="text/css">
+dt {font-weight:bold; margin-bottom:1em}
+dd {margin-left:0}
+ul {margin-top:0.5em}
+ </style>
+</head>
+<body>
+<p><a name="top"></a>
+ <h4>
+Dungeon Crawl Stone Soup - Documentation Index (under construction!)
+</h4>
+ <ul style='list-style-type:none; padding-left:0'>
+<li><a href="FAQ.html">Frequently Asked Questions</a>
+<li><a href="lua/index.html">Lua API documentation</a>
+</ul>
+<hr>
+
+<p><a href="#top">Back to top</a></p>
+</body>


### PR DESCRIPTION
* Generate Lua docs with ldoc
* Generate FAQ.html with make docs
* When on master, publish generated artifact to GitHub Pages
* Add a very rudimentary index.html to serve as landing page
* Once merged, https://crawl.github.io/crawl/ should show the new index.html
* With working links to FAQ.html and lua/index.html :)

One less task to do manually :)