### PR TITLE
Fix swapping two-handed weapon with fly to one without

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1344,6 +1344,23 @@ bool try_equip_item(item_def& item)
         {
             vector<item_def*>& candidates = removal_candidates[i];
 
+            // If one of the candidates has already been removed to free
+            // another slot, we don't need to remove anything to free this slot
+            bool slot_freed_when_freeing_other_slot = false;
+            for (const item_def* removed_item : to_remove)
+            {
+                for (const item_def* item : candidates)
+                {
+                    if (item == removed_item)
+                    {
+                        slot_freed_when_freeing_other_slot = true;
+                        break;
+                    }
+                }
+            }
+            if (slot_freed_when_freeing_other_slot)
+                continue;
+
             // Check if some number of items are inscribed with {=R} (but less
             // than all of them), and remove them from the candidates.
             int num_inscribed = 0;


### PR DESCRIPTION
When trying to swap a two-handed weapon with the flight property on it with another two-handed weapon without flight while wearing another item of flight, you would get a message saying that you would drown and be unable to swap weapons if you were above deep water. This was caused by the item swapping code trying to unequip the two-handed weapon twice (once to free the primary hand and once to free the offhand) which would mess up the count of equipped flight items.

Fixes #4258
Fixes #4255