### PR TITLE
Fix foxfire swarm using the wrong tile and power

### DIFF
--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -2631,7 +2631,7 @@ spret foxfire_swarm()
     bool unknown_unseen = false;
     for (radius_iterator ri(you.pos(), 2, C_SQUARE, LOS_NO_TRANS); ri; ++ri)
     {
-        if (_create_foxfire(you, *ri, GOD_NO_GOD, 20))
+        if (_create_foxfire(you, *ri, 20))
         {
             created = true;
             continue;


### PR DESCRIPTION
The foxfire swarm ability was creating foxfire with a power of GOD_NO_GOD (0) instead of 20 and marshlight set to 20 instead of its default value of false.