### PR TITLE
Fix always invalidating the area grid when a monster dies

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3308,9 +3308,10 @@ void monster_cleanup(monster* mons)
     }
 
     // Monsters haloes should be removed when they die.
-    if (mons->halo_radius()
-        || mons->umbra_radius()
-        || mons->silence_radius())
+    if (mons->halo_radius() >= 0
+        || mons->umbra_radius() >= 0
+        || mons->silence_radius() >= 0
+        || mons->liquefying_radius() >= 0)
     {
         invalidate_agrid();
     }


### PR DESCRIPTION
We were checking if the radius of any of the monster's halo, umbra or silence were not equal to zero. However, they have a radius of -1 when they don't exist.