### PR TITLE
Fix unexpected "Okay, then" when swapping weapons (projectNoob)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1218,11 +1218,10 @@ static item_def* _item_swap_prompt(const vector<item_def*>& candidates)
                 || c == _item_swap_keys[i])
             {
                 chosen = i;
-                c = ' ';
                 break;
             }
         }
-    } while (!key_is_escape(c) && c != ' ' && c != '?');
+    } while (!key_is_escape(c) && c != ' ' && c != '?' && chosen < 0);
 
     clear_messages();
 


### PR DESCRIPTION
When swapping weapons as a coglin, you would get the message "Okay, then" after selecting which weapon to swap out. This is incorrect as you should only get that message when cancelling the action.

Fixes #4267