### PR TITLE
Fix closing doors with the mouse

### DIFF
--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -238,10 +238,13 @@ int MapRegion::handle_mouse(wm_mouse_event &event)
                 do_explore_cmd();
                 return CK_MOUSE_CMD;
             }
-
-            const int cmd = click_travel(gc, event.mod & TILES_MOD_CTRL);
-            if (cmd != CK_MOUSE_CMD)
-                process_command((command_type)cmd);
+            if (!tiles.get_map_display())
+            {
+                const command_type cmd =
+                    click_travel(gc, event.mod & TILES_MOD_CTRL, false);
+                if (cmd != CMD_NO_CMD)
+                    process_command(cmd);
+            }
 
             return CK_MOUSE_CMD;
         }

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -393,11 +393,11 @@ static int _handle_cell_click(const coord_def &gc, int button, bool force)
     // click travel
     if (mouse_control::current_mode() == MOUSE_MODE_COMMAND && button == 1)
     {
-        int c = click_travel(gc, force);
-        if (c != CK_MOUSE_CMD)
+        command_type c = click_travel(gc, force, false);
+        if (c != CMD_NO_CMD)
         {
             clear_messages();
-            process_command((command_type) c);
+            process_command(c);
         }
         return CK_MOUSE_CMD;
     }

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -5105,17 +5105,18 @@ void do_interlevel_travel()
 
 #ifdef USE_TILE
 // (0,0) = same position is handled elsewhere.
-const int dir_dx[8] = {-1, 0, 1, -1, 1, -1,  0,  1};
-const int dir_dy[8] = { 1, 1, 1,  0, 0, -1, -1, -1};
+static const int dir_dx[8] = {-1, 0, 1, -1, 1, -1,  0,  1};
+static const int dir_dy[8] = { 1, 1, 1,  0, 0, -1, -1, -1};
 
-const int cmd_array[8] =
+static const command_type cmd_array[8] =
 {
     CMD_MOVE_DOWN_LEFT,  CMD_MOVE_DOWN,  CMD_MOVE_DOWN_RIGHT,
     CMD_MOVE_LEFT,                       CMD_MOVE_RIGHT,
     CMD_MOVE_UP_LEFT,    CMD_MOVE_UP,    CMD_MOVE_UP_RIGHT,
 };
 
-static int _adjacent_cmd(const coord_def &gc, bool force)
+static command_type _adjacent_cmd(const coord_def &gc, bool attack,
+    bool close_door)
 {
     const coord_def dir = gc - you.pos();
     for (int i = 0; i < 8; i++)
@@ -5123,19 +5124,15 @@ static int _adjacent_cmd(const coord_def &gc, bool force)
         if (dir_dx[i] != dir.x || dir_dy[i] != dir.y)
             continue;
 
-        int cmd = cmd_array[i];
-        if (!force)
-            return cmd;
-        const dungeon_feature_type feat = env.grid(gc);
-        if ((feat == DNGN_OPEN_DOOR || feat == DNGN_OPEN_CLEAR_DOOR)
-            && !env.map_knowledge(gc).monsterinfo())
-        {
-            return CMD_CLOSE_DOOR_LEFT - CMD_MOVE_LEFT;
-        }
-        return cmd + CMD_ATTACK_LEFT - CMD_MOVE_LEFT;
+        command_type cmd = cmd_array[i];
+        if (attack)
+            return (command_type)(cmd + CMD_ATTACK_LEFT - CMD_MOVE_LEFT);
+        if (close_door)
+            return (command_type)(cmd + CMD_CLOSE_DOOR_LEFT - CMD_MOVE_LEFT);
+        return cmd;
     }
 
-    return CK_MOUSE_CMD;
+    return CMD_NO_CMD;
 }
 
 bool click_travel_safe(const coord_def &gc)
@@ -5145,14 +5142,16 @@ bool click_travel_safe(const coord_def &gc)
         && i_feel_safe(false, false, false, false);
 }
 
-int click_travel(const coord_def &gc, bool force)
+command_type click_travel(const coord_def &gc, bool force_attack,
+                          bool force_close_doors)
 {
     if (!in_bounds(gc))
-        return CK_MOUSE_CMD;
+        return CMD_NO_CMD;
 
-    const int cmd = _adjacent_cmd(gc, force);
-    if (cmd != CK_MOUSE_CMD)
-        return cmd;
+    const command_type adj_cmd = _adjacent_cmd(gc, force_attack,
+                                               force_close_doors);
+    if (adj_cmd != CMD_NO_CMD)
+        return adj_cmd;
 
     if (click_travel_safe(gc))
     {
@@ -5162,7 +5161,7 @@ int click_travel(const coord_def &gc, bool force)
         if (!_monster_blocks_travel(cell.monsterinfo()))
         {
             start_travel(gc);
-            return CK_MOUSE_CMD;
+            return CMD_NO_CMD;
         }
     }
 
@@ -5173,9 +5172,11 @@ int click_travel(const coord_def &gc, bool force)
     const coord_def dest = tp.pathfind(RMODE_TRAVEL);
 
     if (!dest.x && !dest.y)
-        return CK_MOUSE_CMD;
+        return CMD_NO_CMD;
 
-    return _adjacent_cmd(dest, force);
+    // Don't pass on the force_attack and force_close_doors flags because
+    // the player didn't click on this square
+    return _adjacent_cmd(dest, false, false);
 }
 #endif
 

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -584,7 +584,8 @@ void do_interlevel_travel();
 // If force is true, then the player will attack empty squares/open doors.
 #ifdef USE_TILE
 bool click_travel_safe(const coord_def &gc);
-int click_travel(const coord_def &gc, bool force);
+command_type click_travel(const coord_def &gc, bool force_attack,
+                          bool force_close_doors);
 #endif
 
 bool check_for_interesting_features();


### PR DESCRIPTION
Control left mouse clicking an open door would result in an unknown command message instead of attacking in the direction of the door. The reason for this is that the game would try to close an open door if you control left clicked it and couldn't see a monster on it, but generate the command to do so incorrectly. This is a bad idea as control left clicking is almost always used to attack invisible monsters. This change moves closing doors to shift left clicking and fixes the generation of the command.

Fixes #3801