### PR TITLE
Fix far viewing

### DIFF
--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -13,10 +13,10 @@
 #include "tiles-build-specific.h"
 #include "travel.h"
 #include "viewgeom.h"
+#include "viewmap.h"
 
 MapRegion::MapRegion(int pixsz) :
-    m_dirty(true),
-    m_far_view(false)
+    m_dirty(true)
 {
     ASSERT(pixsz > 0);
 
@@ -204,12 +204,12 @@ int MapRegion::handle_mouse(wm_mouse_event &event)
 
     if (!inside(event.px, event.py))
     {
-        if (m_far_view)
+        if (is_far_viewing())
         {
-            m_far_view = false;
-            tiles.load_dungeon(crawl_view.vgrdc);
-            return 0;
+            update_far_viewing(crawl_view.vgrdc);
+            stop_far_viewing();
         }
+
         return 0;
     }
 
@@ -217,47 +217,51 @@ int MapRegion::handle_mouse(wm_mouse_event &event)
     mouse_pos(event.px, event.py, cx, cy);
     const coord_def gc(m_min_gx + cx, m_min_gy + cy);
 
-    tiles.place_cursor(CURSOR_MOUSE, gc);
+    if (!is_far_viewing())
+        tiles.place_cursor(CURSOR_MOUSE, gc);
 
     switch (event.event)
     {
     case wm_mouse_event::MOVE:
-        if (m_far_view)
-            tiles.load_dungeon(gc);
+        if (is_far_viewing())
+            update_far_viewing(gc);
         return 0;
     case wm_mouse_event::PRESS:
         if (event.button == wm_mouse_event::LEFT)
         {
+            if (tiles.get_map_display())
+                return 0;
+
             if (event.mod & TILES_MOD_SHIFT)
             {
                 // Start autotravel, or give an appropriate message.
                 do_explore_cmd();
                 return CK_MOUSE_CMD;
             }
-            else if (!tiles.get_map_display())
-            {
-                const int cmd = click_travel(gc, event.mod & TILES_MOD_CTRL);
-                if (cmd != CK_MOUSE_CMD)
-                    process_command((command_type) cmd);
 
-                return CK_MOUSE_CMD;
-            }
+            const int cmd = click_travel(gc, event.mod & TILES_MOD_CTRL);
+            if (cmd != CK_MOUSE_CMD)
+                process_command((command_type)cmd);
+
+            return CK_MOUSE_CMD;
         }
         else if (event.button == wm_mouse_event::RIGHT)
         {
-            m_far_view = true;
-            tiles.load_dungeon(gc);
             if (!tiles.get_map_display())
             {
                 process_command(CMD_DISPLAY_MAP);
-                m_far_view = false;
                 return CK_MOUSE_CMD;
             }
+            start_far_viewing(gc);
+            tiles.place_cursor(CURSOR_MOUSE, NO_CURSOR);
         }
         return 0;
     case wm_mouse_event::RELEASE:
-        if (event.button == wm_mouse_event::RIGHT && m_far_view)
-            m_far_view = false;
+        if (event.button == wm_mouse_event::RIGHT)
+        {
+            if (is_far_viewing())
+                stop_far_viewing();
+        }
         return 0;
     default:
         return 0;

--- a/crawl-ref/source/tilereg-map.h
+++ b/crawl-ref/source/tilereg-map.h
@@ -36,7 +36,6 @@ protected:
     ShapeBuffer m_buf_map;
     LineBuffer m_buf_lines;
     bool m_dirty;
-    bool m_far_view;
 };
 
 #endif

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -3612,6 +3612,7 @@ wm_mouse_event to_wm_event(const MouseEvent &ev)
     wm_mouse_event mev;
     mev.event = ev.type() == Event::Type::MouseMove ? wm_mouse_event::MOVE :
                 ev.type() == Event::Type::MouseDown ? wm_mouse_event::PRESS :
+                ev.type() == Event::Type::MouseUp ? wm_mouse_event::RELEASE :
                 wm_mouse_event::WHEEL;
     mev.button = static_cast<wm_mouse_event::mouse_event_button>(ev.button());
     int x = 0;

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -749,7 +749,8 @@ public:
 
 #ifdef USE_TILE_LOCAL
         if (ev.type() == ui::Event::Type::MouseMove
-            || ev.type() == ui::Event::Type::MouseDown)
+            || ev.type() == ui::Event::Type::MouseDown
+            || ev.type() == ui::Event::Type::MouseUp)
         {
             auto wm_event = to_wm_event(static_cast<const ui::MouseEvent&>(ev));
             int k = tiles.handle_mouse(wm_event);
@@ -873,6 +874,31 @@ public:
         return ret;
     }
 
+#ifdef USE_TILE_LOCAL
+    // This function should not be called while a map command is processing
+    void start_far_viewing(coord_def viewed_location)
+    {
+        m_far_view = true;
+        update_far_viewing(viewed_location);
+    }
+
+    void stop_far_viewing()
+    {
+        m_far_view = false;
+    }
+
+    bool is_far_viewing()
+    {
+        return m_far_view;
+    }
+
+    // This function should not be called while a map command is processing
+    void update_far_viewing(coord_def viewed_location)
+    {
+        m_state.lpos.pos = viewed_location.clamped(known_map_bounds());
+    }
+#endif
+
 private:
     map_control_state m_state;
 
@@ -888,8 +914,12 @@ private:
 
 #ifdef USE_TILE_LOCAL
     bool first_run = true;
+
+    bool m_far_view = false;
 #endif
 };
+
+static shared_ptr<UIMapView> map_view = nullptr;
 
 // show_map() now centers the known map along x or y. This prevents
 // the player from getting "artificial" location clues by using the
@@ -897,8 +927,6 @@ private:
 // to get that. This function is still a mess, though. -- bwr
 bool show_map(level_pos &lpos, bool travel_mode, bool allow_offlevel)
 {
-    static shared_ptr<UIMapView> map_view = nullptr;
-
     if (map_view)
     {
         ASSERT(map_view->is_alive());
@@ -975,11 +1003,34 @@ level_pos map_follow_stairs(bool up, const coord_def &pos)
 
 void process_map_command(command_type cmd)
 {
-    // XX cleaner API for this
-    shared_ptr<ui::Widget> l = ui::top_layout();
-    if (UIMapView *mv = dynamic_cast<UIMapView *>(l.get()))
-        mv->process_command(cmd);
+    if (map_view)
+        map_view->process_command(cmd);
 }
+
+#ifdef USE_TILE_LOCAL
+void start_far_viewing(coord_def viewed_location)
+{
+    if (map_view)
+        map_view->start_far_viewing(viewed_location);
+}
+
+void stop_far_viewing()
+{
+    if (map_view)
+        map_view->stop_far_viewing();
+}
+
+bool is_far_viewing()
+{
+    return map_view && map_view->is_far_viewing();
+}
+
+void update_far_viewing(coord_def viewed_location)
+{
+    if (map_view)
+        map_view->update_far_viewing(viewed_location);
+}
+#endif
 
 map_control_state process_map_command(command_type cmd, const map_control_state& prev_state)
 {

--- a/crawl-ref/source/viewmap.h
+++ b/crawl-ref/source/viewmap.h
@@ -84,6 +84,12 @@ bool is_feature(char32_t feature, const coord_def& where);
 bool show_map(level_pos &spec_place,
               bool travel_mode, bool allow_offlevel);
 void process_map_command(command_type cmd);
+#ifdef USE_TILE_LOCAL
+void start_far_viewing(coord_def viewed_location);
+void stop_far_viewing();
+bool is_far_viewing();
+void update_far_viewing(coord_def viewed_location);
+#endif
 level_pos map_follow_stairs(bool up, const coord_def &pos);
 
 bool emphasise(const coord_def& where);


### PR DESCRIPTION
In local tiles while in map view mode, you should be able to right click and drag the mini map to view those parts of the map. However, in version 0.26 dragging the mouse stopped doing anything and in version 0.28 right clicking the map stopped doing anything.

Fixes #3804
Fixes #3802