### PR TITLE
Fix the mouse doing incorrect commands when keys are rebound

### DIFF
--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -1481,3 +1481,16 @@ void show_help(int section, string highlight_string)
     // from the help main menu.
     _show_help_special(key);
 }
+
+int encode_command_as_key(command_type cmd) noexcept
+{
+    // Don't accept buggy commands
+    if (cmd < CMD_NO_CMD || cmd >= CMD_MAX_CMD)
+        cmd = CMD_NO_CMD;
+
+    // There should be room between the internal keys
+    // (CK_MIN_INTERNAL == -1021) and keys with alt set
+    // (about -3000 + 255) for command_type to fit
+    // (currently 2000 through 2287).
+    return -(int)cmd;
+}

--- a/crawl-ref/source/command.h
+++ b/crawl-ref/source/command.h
@@ -34,3 +34,7 @@ int show_keyhelp_menu(const vector<formatted_string> &lines);
 
 // XXX: Actually defined in main.cc; we may want to move this to command.cc.
 void process_command(command_type cmd, command_type prev_cmd = CMD_NO_CMD);
+
+// This is an ugly hack to return a command where a keycode is expected
+// e.g. when returning mouse input from the getch_ck function
+int encode_command_as_key(command_type cmd) noexcept;

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -589,10 +589,7 @@ void macro_buf_add_cmd(command_type cmd, bool reverse)
 {
     ASSERT_RANGE(cmd, CMD_NO_CMD + 1, CMD_MIN_SYNTHETIC);
 
-    // There should be plenty of room between the synthetic keys
-    // (KEY_MACRO_MORE_PROTECT == -10) and USERFUNCBASE (-10000) for
-    // command_type to fit (currently 1000 through 2069).
-    macro_buf_add(-((int) cmd), reverse, true);
+    macro_buf_add(encode_command_as_key(cmd), reverse, true);
 }
 
 /*

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -567,14 +567,15 @@ int DungeonRegion::handle_mouse(wm_mouse_event &event)
                 {
                     // if on stairs, travel them
                     const dungeon_feature_type feat = env.grid(gc);
-                    switch (feat_stair_direction(feat))
+                    const command_type cmd = feat_stair_direction(feat);
+                    switch (cmd)
                     {
                     case CMD_GO_DOWNSTAIRS:
                     case CMD_GO_UPSTAIRS:
-                        return command_to_key(feat_stair_direction(feat));
+                        return encode_command_as_key(cmd);
                     default:
                         // otherwise wait
-                        return command_to_key(CMD_WAIT);
+                        return encode_command_as_key(CMD_WAIT);
                     }
                 }
                 else
@@ -590,26 +591,32 @@ int DungeonRegion::handle_mouse(wm_mouse_event &event)
                         update_screen();
                         return CK_MOUSE_CMD;
                     }
-                    return command_to_key(CMD_PICKUP);
+                    return encode_command_as_key(CMD_PICKUP);
                 }
             }
 
             const dungeon_feature_type feat = env.grid(gc);
-            switch (feat_stair_direction(feat))
+            const command_type cmd = feat_stair_direction(feat);
+            switch (cmd)
             {
             case CMD_GO_DOWNSTAIRS:
             case CMD_GO_UPSTAIRS:
-                return command_to_key(feat_stair_direction(feat));
+                return encode_command_as_key(cmd);
             default:
                 return 0;
             }
         }
         case wm_mouse_event::RIGHT:
             if (!(event.mod & TILES_MOD_SHIFT))
-                return command_to_key(CMD_RESISTS_SCREEN); // Character overview.
+            {
+                // Character overview.
+                return encode_command_as_key(CMD_RESISTS_SCREEN);
+            }
             if (!you_worship(GOD_NO_GOD))
-                return command_to_key(CMD_DISPLAY_RELIGION); // Religion screen.
-
+            {
+                // Religion screen.
+                return encode_command_as_key(CMD_DISPLAY_RELIGION);
+            }
             // fall through...
         default:
             return 0;

--- a/crawl-ref/source/tilereg-msg.cc
+++ b/crawl-ref/source/tilereg-msg.cc
@@ -4,6 +4,7 @@
 
 #include "tilereg-msg.h"
 
+#include "command.h"
 #include "libutil.h"
 #include "format.h"
 #include "macro.h"
@@ -35,7 +36,7 @@ int MessageRegion::handle_mouse(wm_mouse_event &event)
     if (mouse_control::current_mode() != MOUSE_MODE_COMMAND)
         return 0;
 
-    return command_to_key(CMD_REPLAY_MESSAGES);
+    return encode_command_as_key(CMD_REPLAY_MESSAGES);
 }
 
 bool MessageRegion::update_tip_text(string& tip)

--- a/crawl-ref/source/tilereg-stat.cc
+++ b/crawl-ref/source/tilereg-stat.cc
@@ -4,6 +4,7 @@
 
 #include "tilereg-stat.h"
 
+#include "command.h"
 #include "libutil.h"
 #include "macro.h"
 #include "tiles-build-specific.h"
@@ -29,7 +30,7 @@ int StatRegion::handle_mouse(wm_mouse_event &event)
 #endif
 
     // clicking on stats should show all the stats
-    return command_to_key(CMD_RESISTS_SCREEN);
+    return encode_command_as_key(CMD_RESISTS_SCREEN);
 }
 
 bool StatRegion::update_tip_text(string& tip)

--- a/crawl-ref/source/tilereg-tab.cc
+++ b/crawl-ref/source/tilereg-tab.cc
@@ -5,6 +5,7 @@
 #include "options.h"
 #include "tilereg-tab.h"
 
+#include "command.h"
 #include "command-type.h"
 #include "cio.h"
 #include "english.h"
@@ -408,7 +409,7 @@ int TabbedRegion::handle_mouse(wm_mouse_event &event)
                 return CK_NO_KEY; // prevent clicking on tab from 'bubbling up' to other regions
             }
             else
-                return command_to_key(m_tabs[m_mouse_tab].cmd);
+                return encode_command_as_key(m_tabs[m_mouse_tab].cmd);
         }
     }
 


### PR DESCRIPTION
We were converting some mouse commands into the key press that would result in that command with default key bindings. For example, if the '<' key was rebound to open the read scrolls menu, clicking on an up staircase you were standing on would open the read scrolls menu.

Fixes #3799