### PR TITLE
Don't hang on SIGHUP in wizard_mod_tide().

### DIFF
--- a/crawl-ref/source/dgn-shoals.cc
+++ b/crawl-ref/source/dgn-shoals.cc
@@ -1123,7 +1123,7 @@ void wizard_mod_tide()
         const int res =
             cancellable_get_line(buf, sizeof buf, nullptr, _tidemod_keyfilter);
         clear_messages(true);
-        if (key_is_escape(res))
+        if (key_is_escape(res) || crawl_state.seen_hups)
             break;
         if (!res)
         {

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -3394,6 +3394,11 @@ void delay(unsigned int ms)
             pump_events();
     }
 #endif
+    if (crawl_state.seen_hups)
+    {
+        macro_buf_add(CK_ESCAPE, true); // Let the caller respond to seen_hups.
+        pump_events();
+    }
 }
 
 /**


### PR DESCRIPTION
Make Crawl shut down correctly in some situations where it didn't already.

Make wizard_mod_tide() respond to seen_hups, rather than ignore it.
Make ui::delay() treat seen_hups as if the user had pressed the Escape key.
