### PR TITLE
style: fix a few warnings

### DIFF
--- a/crawl-ref/source/delay.h
+++ b/crawl-ref/source/delay.h
@@ -269,7 +269,6 @@ private:
 class EquipOffDelay : public Delay
 {
     item_def& equip;
-    bool primary_weapon;
     bool was_prompted = false;
 
     void start() override;
@@ -284,8 +283,8 @@ class EquipOffDelay : public Delay
 
     void finish() override;
 public:
-    EquipOffDelay(int dur, item_def& item, bool primary = false) :
-                   Delay(dur), equip(item), primary_weapon(primary)
+    EquipOffDelay(int dur, item_def& item) :
+                   Delay(dur), equip(item)
     { }
 
     bool try_interrupt(bool force = false) override;
@@ -739,8 +738,6 @@ private:
 
 class ImprintDelay : public Delay
 {
-    bool was_prompted = false;
-
     void start() override;
 
     void tick() override

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -961,7 +961,9 @@ static bool _dgn_fill_zone(
     bool ret = false;
     list<coord_def> points[2];
     int cur = 0;
+#ifdef DEBUG_DIAGNOSTICS
     int found_points = 0;
+#endif
 
     // No bounds checks, assuming the level has at least one layer of
     // rock border.
@@ -971,7 +973,9 @@ static bool _dgn_fill_zone(
         for (const auto &c : points[cur])
         {
             travel_point_distance[c.x][c.y] = zone;
+#ifdef DEBUG_DIAGNOSTICS
             found_points++;
+#endif
 
             if (iswanted && iswanted(c))
                 ret = true;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1448,7 +1448,7 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
                                                    diamond_sawblade_spots(false));
 
     case SPELL_SPLINTERFROST_SHELL:
-        return make_unique<targeter_wall_arc>(&you, 5);
+        return make_unique<targeter_wall_arc>(&you, 4);
 
     case SPELL_PERCUSSIVE_TEMPERING:
         return make_unique<targeter_tempering>();

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2572,8 +2572,8 @@ aff_type targeter_surprising_crocodile::is_affected(coord_def loc)
     return AFF_NO;
 }
 
-targeter_wall_arc::targeter_wall_arc(const actor* caster, int size)
-    : targeter_smite(caster, 1, 0, 0, true, true), wall_num(size)
+targeter_wall_arc::targeter_wall_arc(const actor* caster, int count)
+    : targeter_smite(caster, 1, 0, 0, true, true), num_walls(count)
 {
 }
 
@@ -2583,7 +2583,7 @@ bool targeter_wall_arc::set_aim(coord_def a)
     if (!targeter_smite::set_aim(a) || !valid_aim(a) || a == agent->pos())
         return false;
 
-    spots = get_splinterfrost_block_spots(*agent, a, 4);
+    spots = get_splinterfrost_block_spots(*agent, a, num_walls);
 
     return true;
 }

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -691,12 +691,12 @@ private:
 class targeter_wall_arc : public targeter_smite
 {
 public:
-    targeter_wall_arc(const actor* caster, int size);
+    targeter_wall_arc(const actor* caster, int num_walls);
     bool set_aim(coord_def a) override;
     aff_type is_affected(coord_def loc) override;
 private:
-    int wall_num;
     vector<coord_def> spots;
+    int num_walls;
 };
 
 class targeter_tempering : public targeter_smite


### PR DESCRIPTION
Fixes #4262

* Removes unused fields where it make sense
* In the case of targeter_wall_arc, put field back into use (and move where the hard-coded value is)
* Also fixes one other warning that only occurs in debug-lite or release configurations