### PR TITLE
bugfix: Zong text was ambiguous as to the equipment slot

### DIFF
--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -834,10 +834,10 @@ power to carry them out, no matter the adversity.
 %%%%
 skull of Zonguldrok
 
-The skull of a legendary necromancer, seemingly parted from the rest of his
-body. When held, it seems disinclined to explain the precise circumstances of 
-its ending up in this state, but offers no objection to others siphoning what 
-considerable necromantic power still remains in his ancient bones.
+The skull of a legendary necromancer, seemingly parted from the rest of its
+body. When held, it seems disinclined to explain the precise circumstances of
+its ending up in this state, but offers no objection to others siphoning what
+considerable necromantic power still remains in its ancient bones.
 %%%%
 fungal fisticloak
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -835,9 +835,10 @@ power to carry them out, no matter the adversity.
 skull of Zonguldrok
 
 The skull of a legendary necromancer, seemingly parted from the rest of his
-body. It seems disinclined to explain the precise circumstances of its ending up
-in this state, but offers no objection to others siphoning what considerable
-necromantic power still remains in his ancient bones.
+body. When held, it seems disinclined to explain the precise circumstances of 
+its ending up in this state, but offers no objection to others siphoning what 
+considerable necromantic power still remains in his ancient bones
+
 %%%%
 fungal fisticloak
 

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -837,7 +837,7 @@ skull of Zonguldrok
 The skull of a legendary necromancer, seemingly parted from the rest of his
 body. When held, it seems disinclined to explain the precise circumstances of 
 its ending up in this state, but offers no objection to others siphoning what 
-considerable necromantic power still remains in his ancient bones
+considerable necromantic power still remains in his ancient bones.
 
 %%%%
 fungal fisticloak

--- a/crawl-ref/source/dat/descript/unrand.txt
+++ b/crawl-ref/source/dat/descript/unrand.txt
@@ -838,7 +838,6 @@ The skull of a legendary necromancer, seemingly parted from the rest of his
 body. When held, it seems disinclined to explain the precise circumstances of 
 its ending up in this state, but offers no objection to others siphoning what 
 considerable necromantic power still remains in his ancient bones.
-
 %%%%
 fungal fisticloak
 


### PR DESCRIPTION
One of the players noticed that the Skull of Zonguldrok's artefact text was unclear as to the equip slot which caused some problems with the 2H they were using.  This adds a "When held" to the second sentence to clarify.