### PR TITLE
ci: Add msvc build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,87 @@ jobs:
           file: ${{ steps.release-names.outputs.source }}
           asset_name: ${{ steps.release-names.outputs.dest }}
 
+  build_msvc:
+    # Note: since the project's code is GPLv2, which is an OSI approved license:
+    # https://opensource.org/license/gpl-2-0
+    # We can compile it with msvc under the terms of Microsoft's license
+    # This is true even if you consider the crawl dev team as "organization"
+    # See:
+    # https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/
+    # "b. Organizational License. If you are an organization, your users may use the software as follows
+    #  i. Any number of your users may use the software to develop and test applications released under Open Source Initiative (OSI) approved open source software licenses."
+    # This explicitly includes "Build Devices and Visual Studio Build Tools."
+    # under section 3.b.
+    name: msvc ${{ matrix.build_type }} ${{ matrix.build_arch }}
+    # TODO: switch to windows-2025
+    # windows-2019 is the last version to have v141 toolset pre-installed
+    # We probably should update it, but some of the project files
+    # are in vendored repos
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        build_type:
+          - "Debug Console"
+          - "Debug Tiles"
+          - "Release Console"
+          - "Release Tiles"
+        build_arch:
+          - x64
+          # TODO: do we really want the Win32 configurations to exist
+          # in the project files even? If so, should we build them here?
+          # TODO: consider ARM64?
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # all history
+      - name: Fix tags for release # work around https://github.com/actions/checkout/issues/882
+        if: github.event.release.tag_name != null
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # will break on a lightweight tag
+      # Step 1 from INSTALL.md's Visual Studio section:
+      - name: Checkout submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+      # Step 2 from INSTALL.md's Visual Studio section would be to install perl
+      # It's already installed, so we can skip this:
+      # https://github.com/actions/runner-images/blob/13666fe26513ca5e0e21f412b5d4c7fa0e8eb5a9/images/windows/Windows2025-Readme.md?plain=1#L25
+      #
+      # Step 3 from INSTALL.md's Visual Studio section is installing Python
+      # Python 3.9 is already installed. So we skip this too.
+      #
+      # Step 4 from INSTALL.md's Visual Studio section
+      - name: Install pyyaml
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+        working-directory: crawl-ref/source
+      # Msbuild is already installed:
+      # https://github.com/actions/runner-images/blob/13666fe26513ca5e0e21f412b5d4c7fa0e8eb5a9/images/windows/Windows2025-Readme.md?plain=1#L254
+      # But isn't in the path, so fix that:
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+      # From the troubleshooting tips:
+      # This link is Windows 8.1 SDK
+      # See e.g. https://github.com/actions/runner-images/issues/842#issuecomment-643382166
+      # and https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/
+      # TODO: Newer SDKs, such as Windows 10 and 11, are preinstalled
+      # Do we want to continue supporting 8.1?
+      - name: Install Windows 8.1 SDK
+        shell: powershell
+        run: |
+          Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
+          Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
+      # Step 5/6 from INSTALL.md's Visual Studio Section
+      # See https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022
+      - name: Build
+        run: |
+          msbuild /maxCpuCount /property:Configuration="${{ matrix.build_type }}" /p:Platform=${{ matrix.build_arch }} crawl-ref.sln
+        working-directory: crawl-ref/source/MSVC
+      # TODO: Consider uploading artifacts
+      # TODO: Header tests? unit tests?
+
   codecov_catch2:
     permissions:
       contents: read #  to fetch code (actions/checkout)
@@ -716,6 +797,7 @@ jobs:
       - build_linux
       - build_macos
       - build_mingw64_crosscompile
+      - build_msvc
       - codecov_catch2
       - webserver
       - build_monster

--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -39,144 +39,34 @@
     <RootNamespace>crawlref</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>NotSet</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>NotSet</CharacterSet>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Tiles.props" />
+    <Import Project="Tiles.props" Condition="'$(Configuration)'=='Debug Tiles' Or '$(Configuration)'=='Release Tiles'"/>
+    <Import Project="Console.props" Condition="'$(Configuration)'=='Debug Console' Or '$(Configuration)'=='Release Console'"/>
     <Import Project="Release.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Console.props" />
-    <Import Project="Release.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Tiles.props" />
-    <Import Project="Debug.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Console.props" />
-    <Import Project="Debug.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Tiles.props" />
-    <Import Project="Release.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Console.props" />
-    <Import Project="Release.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Tiles.props" />
-    <Import Project="Debug.props" />
-    <Import Project="Common.props" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="Console.props" />
-    <Import Project="Debug.props" />
     <Import Project="Common.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <_ProjectFileVersion>11.0.60315.1</_ProjectFileVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
     <OutDir>$(SolutionDir)\..\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug Tiles' Or '$(Configuration)'=='Debug Console'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
+  <PropertyGroup Condition="'$(Configuration)'=='Release Tiles' Or '$(Configuration)'=='Release Console'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-    <OutDir>$(SolutionDir)\..\</OutDir>
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
+  <ItemDefinitionGroup>
     <PreBuildEvent>
       <Message>Generating build-specific headers...</Message>
       <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
@@ -186,6 +76,8 @@ perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(Pr
 python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
 python.exe util/gen-all.py</Command>
     </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -210,15 +102,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>./include;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -243,15 +126,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <Midl>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
@@ -278,15 +152,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <Midl>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
@@ -313,15 +178,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>./include;../sdl2;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;USE_TILE;USE_TILE_LOCAL;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";USE_FT;FT_FREETYPE_H="freetype.h";USE_GL;USE_SDL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -346,15 +202,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <ClCompile>
       <AdditionalIncludeDirectories>./include;../sdl2;.;..;../contrib/lua/src;../contrib/sqlite;../contrib/pcre;../rltiles;../contrib/sdl2/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES;_ALLOW_KEYWORD_MACROS;WIZARD;PROPORTIONAL_FONT="..\\..\\contrib\\fonts\\DejaVuSans.ttf";MONOSPACED_FONT="..\\..\\contrib\\fonts\\DejaVuSansMono.ttf";FT_FREETYPE_H="freetype.h";USE_GL;CLUA_BINDINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -379,15 +226,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <Midl>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
@@ -414,15 +252,6 @@ python.exe util/gen-all.py</Command>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-    <PreBuildEvent>
-      <Message>Generating build-specific headers...</Message>
-      <Command>set PATH=c:\cygwin\bin%3bc:\msysgit\mingw\bin%3bc:\msysgit\bin%3bc:\mingw\bin%3b%25PATH%25
-cd $(SolutionDir)\..\
-perl.exe "util/gen_ver.pl" build.h "" "nul"
-perl.exe "util/gen-cflg.pl" compflag.h "&lt;UNKNOWN&gt;" "&lt;UNKNOWN&gt;" "$(PreferredToolArchitecture)-Windows-msvc$(VCToolsVersion)" $(ProcessorArchitecture)-$(SDKIdentifier)-msvc$(VCToolsVersion)"
-python.exe "util/configure-msvc.py" "$(VCInstallDir)Tools\MSVC\$(VCToolsVersion)\bin\Host$(PreferredToolArchitecture)\$(PlatformTargetAsMSBuildArchitecture)\cl.exe" "$(VC_IncludePath);$(WindowsSDK_IncludePath)"
-python.exe util/gen-all.py</Command>
-    </PreBuildEvent>
     <Midl>
       <TargetEnvironment>X64</TargetEnvironment>
     </Midl>
@@ -457,14 +286,7 @@ python.exe util/gen-all.py</Command>
     <ClCompile Include="..\actor.cc" />
     <ClCompile Include="..\adjust.cc" />
     <ClCompile Include="..\AppHdr.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">Create</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\areas.cc" />
     <ClCompile Include="..\arena.cc" />
@@ -492,22 +314,7 @@ python.exe util/gen-all.py</Command>
     <ClCompile Include="..\ctest.cc" />
     <ClCompile Include="..\dactions.cc" />
     <ClCompile Include="..\database.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-      </PrecompiledHeader>
+      <PrecompiledHeader></PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\dbg-asrt.cc" />
     <ClCompile Include="..\dbg-maps.cc" />
@@ -627,58 +434,18 @@ python.exe util/gen-all.py</Command>
     <ClCompile Include="..\player-stats.cc" />
     <ClCompile Include="..\potion.cc" />
     <ClCompile Include="..\prebuilt\levcomp.lex.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-      </PrecompiledHeader>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader></PrecompiledHeader>
+      <PreprocessorDefinitions>YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <ClCompile Include="..\prebuilt\levcomp.tab.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-      </PrecompiledHeader>
+      <PrecompiledHeader></PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\precision-menu.cc" />
     <ClCompile Include="..\prompt.cc" />
     <ClCompile Include="..\libgui.cc" />
     <ClCompile Include="..\libutil.cc" />
     <ClCompile Include="..\libw32c.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">Use</PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">Use</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\loading-screen.cc" />
     <ClCompile Include="..\los.cc" />
@@ -786,22 +553,7 @@ python.exe util/gen-all.py</Command>
     <ClCompile Include="..\throw.cc" />
     <ClCompile Include="..\tilebuf.cc" />
     <ClCompile Include="..\rltiles\tiledef-unrand.cc">
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug Console|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|Win32'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Tiles|x64'">
-      </PrecompiledHeader>
-      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release Console|x64'">
-      </PrecompiledHeader>
+      <PrecompiledHeader></PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\tilecell.cc" />
     <ClCompile Include="..\tiledgnbuf.cc" />

--- a/crawl-ref/source/util/gen-all.py
+++ b/crawl-ref/source/util/gen-all.py
@@ -26,11 +26,11 @@ def needs_running(generated_files, input_files):
 
 def run_if_needed(generated_files, input_files, command):
     needs_to_run = needs_running(generated_files, input_files)
-    if(not needs_to_run):
+    if not needs_to_run:
         return
 
     result = subprocess.call(command)
-    if(result != 0):
+    if result != 0:
         sys.exit(result)
 
 def copy_if_needed(source, destination):
@@ -47,13 +47,13 @@ def gen_all(perl):
     #
     generated_files = ['species-data.h', 'aptitudes.h', 'species-groups.h', 'species-type.h']
     input_files = (['util/species-gen.py'] + glob.glob('dat/species/*.yaml') +
-        glob.glob('util/species-gen/*.txt'))
+                   glob.glob('util/species-gen/*.txt'))
     command = [python, input_files[0], 'dat/species/', 'util/species-gen/'] + generated_files
     run_if_needed(generated_files, input_files, command)
 
     generated_files = ['job-data.h', 'job-groups.h', 'job-type.h']
     input_files = (['util/job-gen.py'] + glob.glob('dat/jobs/*.yaml') +
-        glob.glob('util/job-gen/*.txt'))
+                   glob.glob('util/job-gen/*.txt'))
     command = [python, input_files[0], 'dat/jobs/', 'util/job-gen/'] + generated_files
     run_if_needed(generated_files, input_files, command)
 
@@ -62,13 +62,13 @@ def gen_all(perl):
     #
     generated_files = ['../docs/aptitudes.txt']
     input_files = ['util/gen-apt.pl', '../docs/template/apt-tmpl.txt',
-        'species-data.h', 'aptitudes.h']
+                   'species-data.h', 'aptitudes.h']
     command = [perl, input_files[0]] + generated_files + input_files[1:]
     run_if_needed(generated_files, input_files, command)
 
     generated_files = ['../docs/aptitudes-wide.txt']
     input_files = ['util/gen-apt.pl', '../docs/template/apt-tmpl-wide.txt',
-        'species-data.h', 'aptitudes.h']
+                   'species-data.h', 'aptitudes.h']
     command = [perl, input_files[0]] + generated_files + input_files[1:]
     run_if_needed(generated_files, input_files, command)
 
@@ -99,6 +99,12 @@ def gen_all(perl):
     command = [perl, input_files[0]]
     run_if_needed(generated_files, input_files, command)
 
+    generated_files = ['mon-data.h']
+    input_files = (['util/mon-gen.py'] + glob.glob('dat/mons/*.yaml') +
+                   glob.glob('util/mon-gen/*.txt'))
+    command = [python, input_files[0], 'dat/mons/', 'util/mon-gen/'] + generated_files
+    run_if_needed(generated_files, input_files, command)
+
     generated_files = ['mon-mst.h']
     input_files = ['util/gen-mst.pl', 'mon-spell.h', 'mon-data.h']
     command = [perl, input_files[0]]
@@ -119,12 +125,6 @@ def gen_all(perl):
     command = [perl, input_files[0]]
     run_if_needed(generated_files, input_files, command)
 
-    generated_files = ['mon-data.h']
-    input_files = (['util/mon-gen.py'] + glob.glob('dat/mons/*.yaml') +
-        glob.glob('util/mon-gen/*.txt'))
-    command = [python, input_files[0], 'dat/mons/', 'util/mon-gen/'] + generated_files
-    run_if_needed(generated_files, input_files, command)
-
     build_rtiles()
 
 def build_rtiles():
@@ -136,32 +136,32 @@ def build_rtiles():
         sys.exit(1)
 
     inputs = ['main', 'dngn', 'floor', 'wall', 'feat', 'player',
-        'gui', 'icons']
+              'gui', 'icons']
     extra_dependencies = {
         'main': ['dc-item.txt', 'dc-unrand.txt', 'dc-corpse.txt',
-            'dc-misc.txt'],
+                 'dc-misc.txt'],
 
         'player': ['dc-mon.txt', 'dc-tentacles.txt', 'dc-zombie.txt',
-            'dc-demon.txt'],
+                   'dc-demon.txt'],
 
         'gui': ['dc-spells.txt', 'dc-skills.txt', 'dc-commands.txt',
-            'dc-abilities.txt', 'dc-invocations.txt', 'dc-mutations.txt']
+                'dc-abilities.txt', 'dc-invocations.txt', 'dc-mutations.txt']
     }
 
     for tile_type in inputs:
         generated_files = [tile_type + '.png',
-            'tiledef-' + tile_type + '.h',
-            'tiledef-' + tile_type + '.cc',
-            'tileinfo-' + tile_type + '.js']
+                           'tiledef-' + tile_type + '.h',
+                           'tiledef-' + tile_type + '.cc',
+                           'tileinfo-' + tile_type + '.js']
         input_files = ([tile_gen, 'dc-' + tile_type + '.txt']
-            + extra_dependencies.get(tile_type, []))
+                       + extra_dependencies.get(tile_type, []))
         command = input_files[:2]
         should_run = False
         try:
             should_run = needs_running(generated_files, input_files)
         except FileNotFoundError as e:
             print('Error: missing file rltiles/', e.filename, '"', sep='',
-                file=sys.stderr)
+                  file=sys.stderr)
             sys.exit(1)
         if should_run:
             print('Generating', generated_files[0])
@@ -174,7 +174,7 @@ def build_rtiles():
 
     for tile_type in inputs:
         copy_if_needed('rltiles/' + tile_type + '.png',
-            'dat/tiles/' + tile_type + '.png')
+                       'dat/tiles/' + tile_type + '.png')
 
 def main():
     perl = shutil.which('perl')


### PR DESCRIPTION
* Add msvc build job covering all x64 build configurations           
* Fix gen-all.py to run targets in the correct order so that a clean msvc build works
* clean up vcxproj - Visual Studio can be repetitive for no reason
* YY_NO_UNISTD_H needs to be defined for all msvc configurations after wheals' latest cleanup.
