### PR TITLE
fix: unistd.h inclusion for macOS 10.14

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -88,9 +88,7 @@
 #include <shlobj.h>
 #elif defined(TARGET_OS_MACOSX)
 extern char **NXArgv;
-#ifndef DATA_DIR_PATH
 #include <unistd.h>
-#endif
 #elif defined(UNIX) || defined(TARGET_COMPILER_MINGW)
 #include <unistd.h>
 #endif


### PR DESCRIPTION
Hopefully fix #4299.

I'm not entirely convinced all usage of unlink should not be unlink_u. But that's a separate discussion.