### PR TITLE
only deploy docs and try to send IRC notification on the main repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
   deploy_docs:
     name: Deploy docs
     needs: build_docs
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' && github.repository == 'crawl/crawl' && github.ref == 'refs/heads/master' }}
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
       pages: write      # to deploy to Pages
@@ -721,7 +721,7 @@ jobs:
       - build_monster
       - build_docs
       - deploy_docs
-    if: failure() && github.event_name == 'push'
+    if: failure() && github.event_name == 'push' && github.repository == 'crawl/crawl'
     runs-on: ubuntu-22.04
     steps:
       - name: Build message


### PR DESCRIPTION
As currently written, the `deploy_docs` action runs on forks, which means anyone with a fork of the crawl repo gets a build failure when updating the fork. This patch makes it only run on the main crawl repo (hopefully).