### PR TITLE
fix: Ash "Shatter the Chains" not giving unequip_item a chance to do its job

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -2410,12 +2410,13 @@ bool ashenzari_uncurse_item()
         canned_msg(MSG_OK);
         return false;
     }
-
     mprf("You shatter the curse binding %s!", item.name(DESC_THE).c_str());
     item_skills(item, you.skills_to_hide);
-
     vector<item_def*> to_remove = {&item};
+    // TODO: this probably works, but it's definitely weird that we're ignoring
+    // the return value. It might be better to make this interactive?
     handle_chain_removal(to_remove, false);
+
     for (item_def* _item : to_remove)
     {
         if (_item-> link != item_slot)

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1422,13 +1422,7 @@ bool unequip_item(item_def& item, bool msg, bool skip_effects)
     you.equipment.update();
 
     if (!skip_effects)
-    {
-        // Cursed items should always be destroyed on unequip.
-        if (item.cursed())
-            destroy_item(item);
-
         unequip_effect(item_slot, false, msg);
-    }
 
     ash_check_bondage();
     you.last_unequip = item_slot;
@@ -1506,6 +1500,7 @@ void unequip_effect(int item_slot, bool meld, bool msg)
     else if (item.base_type == OBJ_JEWELLERY)
         _unequip_jewellery_effect(item, meld);
 
+    // Cursed items should always be destroyed on unequip.
     if (item.cursed() && !meld)
         destroy_item(item);
 }


### PR DESCRIPTION
The item was being destroyed before unequip_item was called.
As a result, the call to unequip_item did nothing at all.
Because the item was already OBJ_UNASSIGNED,
rather than being the specific item that unequip_item
needed to handle.

This resulted in several bugs:
* Visual artifacts (halo/umbra/etc)
* Likely various messages not being printed
* Possibly other persistent issues?
E.g. update_vision_range not being called.
as well as potentially other bugs.
For example, update_vision_range would not be called.

Closes https://github.com/crawl/crawl/issues/4309