### PR TITLE
Don't let Blorkula cheat banishment (#4205)

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -864,7 +864,7 @@ static bool _beogh_maybe_convert_orc(monster &mons, killer_type killer,
 static bool _blorkula_bat_split(monster& blorkula, killer_type ktype)
 {
     // Can't recover from these
-    if (RESET_KILL(ktype))
+    if (RESET_KILL(ktype) || ktype == KILL_BANISHED)
         return false;
 
     // XXX: Summoned Blorkulas (ie: from phantom mirror) will cease to be when


### PR DESCRIPTION
Previously, Blorkula would split into vampire bats when banished, and if they reformed, trying to banish them again would cause a crash.

Will fix #4205.