### PR TITLE
console: draw waypoints over other items and features

### DIFF
--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -313,6 +313,13 @@ static void _draw_level_map(int start_x, int start_y, bool travel_mode,
                 if (travel_mode && travel_colour_override(c))
                     cell->colour = _get_travel_colour(c);
 
+                // If we've a waypoint on the current square,
+                // show the waypoint number.
+                if (uint8_t waypoint_char = is_waypoint(c))
+                {
+                    cell->glyph = waypoint_char;
+                }
+
                 if (c == you.pos() && !crawl_state.arena_suspended && on_level)
                 {
                     // [dshaligram] Draw the @ symbol on the
@@ -321,18 +328,6 @@ static void _draw_level_map(int start_x, int start_y, bool travel_mode,
                     // directly.
                     cell->colour = WHITE;
                     cell->glyph  = mons_char(you.symbol);
-                }
-
-                // If we've a waypoint on the current square, *and* the
-                // square is a normal floor square with nothing on it,
-                // show the waypoint number.
-                // XXX: This is a horrible hack.
-                char32_t bc   = cell->glyph;
-                uint8_t ch = is_waypoint(c);
-                if (ch && (bc == _get_sightmap_char(DNGN_FLOOR)
-                           || bc == _get_magicmap_char(DNGN_FLOOR)))
-                {
-                    cell->glyph = ch;
                 }
 
                 if (Options.show_travel_trail && travel_trail_index(c) >= 0)

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -315,10 +315,9 @@ static void _draw_level_map(int start_x, int start_y, bool travel_mode,
 
                 // If we've a waypoint on the current square,
                 // show the waypoint number.
-                if (uint8_t waypoint_char = is_waypoint(c))
-                {
+                const uint8_t waypoint_char = is_waypoint(c);
+                if (waypoint_char)
                     cell->glyph = waypoint_char;
-                }
 
                 if (c == you.pos() && !crawl_state.arena_suspended && on_level)
                 {


### PR DESCRIPTION
Currently, waypoints are only displayed on otherwise empty squares on the level map view. In combination with them not being xv-able and not reporting any sort of coordinates other than what level they're on, this makes it so that if anything overrides them, they become impossible to find without actually traveling to their exact location.

For my use case, this is a very annoying problem - I use waypoints to track timed portals and mark encounters with monsters that indicate potential branch entrances (e.g. redback on L:3), and in general for annotations that are more location-sensitive where annotating the whole floor doesn't cut it. Especially when scouting portals, being able to see exactly where the waypoints are at all times is very important. I understand that x-marks-the-spot may not the intended use case for waypoints, but I suspect it to be by far the most common one.