### PR TITLE
Fix monsters not getting shield and orb egos (yrdzrfxndfvh)

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -528,6 +528,13 @@ int monster::wearing_ego(object_class_type obj_type, int special) const
         break;
 
     case OBJ_ARMOUR:
+        item = mslot_item(MSLOT_SHIELD);
+        if (item && item->base_type == OBJ_ARMOUR
+            && get_armour_ego_type(*item) == special)
+        {
+            ret++;
+        }
+
         item = mslot_item(MSLOT_ARMOUR);
         if (item && item->base_type == OBJ_ARMOUR
             && get_armour_ego_type(*item) == special)


### PR DESCRIPTION
After equipment slots were reworked in commit 2dbd7c1, the `monster::wearing_ego` function stopped checking the shield slot for egos when checking armour for egos leaving monsters unable to benefit from shield and orb egos.

Fixes #4324