### PR TITLE
Fix the area grid not being updated on monster item unequip

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5063,8 +5063,9 @@ static void _dgn_give_mon_spec_items(mons_spec &mspec, monster *mon)
     // Get rid of existing equipment.
     for (mon_inv_iterator ii(*mon); ii; ++ii)
     {
-        mon->unequip(*ii, false, true);
-        destroy_item(ii->index(), true);
+        item_def &item = *ii;
+        mon->unequip(ii.slot(), false, true);
+        destroy_item(item, true);
     }
 
     item_list &list = mspec.items;

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -380,8 +380,7 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
         const int new_index = get_mitm_slot(0);
         if (new_index == NON_ITEM)
         {
-            mons->unequip(env.item[old_index], false, true);
-            mons->inv[ii.slot()] = NON_ITEM;
+            mons->unequip(ii.slot(), false, true);
             continue;
         }
 

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -310,7 +310,8 @@ public:
     void      swap_weapons(maybe_bool msg = maybe_bool::maybe);
     bool      pickup_item(item_def &item, bool msg, bool force);
     bool      drop_item(mon_inv_type eslot, bool msg);
-    bool      unequip(item_def &item, bool msg, bool force = false);
+    bool      do_unequip_effects(item_def &item, bool msg, bool force = false);
+    bool      unequip(mon_inv_type slot, bool msg, bool force = false);
     void      steal_item_from_player();
     item_def* take_item(int steal_what, mon_inv_type mslot,
                         bool is_stolen = false);

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -788,8 +788,7 @@ static void _animate_weapon(int pow, actor* target)
     ASSERT(montarget->inv[wp_slot] != NON_ITEM);
     ASSERT(&env.item[montarget->inv[wp_slot]] == wpn);
 
-    montarget->unequip(*(montarget->mslot_item(wp_slot)), false, true);
-    montarget->inv[wp_slot] = NON_ITEM;
+    montarget->unequip(wp_slot, false, true);
 
     // Find out what our god thinks before killing the item.
     conduct_type why = god_hates_item_handling(*wpn);

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -1646,8 +1646,7 @@ static void _xom_animate_monster_weapon(int sever)
         return;
 
     // Make the monster unwield its weapon.
-    mon->unequip(*(mon->mslot_item(MSLOT_WEAPON)), false, true);
-    mon->inv[MSLOT_WEAPON] = NON_ITEM;
+    mon->unequip(MSLOT_WEAPON, false, true);
 
     mprf("%s %s dances into the air!",
          apostrophise(mon->name(DESC_THE)).c_str(),


### PR DESCRIPTION
The `monster::unquip` function was checking if it changed the monster's halo and umbra radii and invalidateding the area grid if it did. However, because it only runs any effects that need to happen on unequip and doesn't actually remove the item from the monsters equipment slots, it doesn't change the halo or umbra radii. Instead we should check if the halo and umbra radii have changed in the places that actually remove the items.