### PR TITLE
Don't become a religious traitor when switching good gods (A0rika)

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -618,7 +618,10 @@ god_iterator god_iterator::operator++(int)
 
 void maybe_clear_traitor(god_type god)
 {
-    if (static_cast<god_type>(you.attribute[ATTR_TRAITOR]) == god)
+    const god_type betrayed_god = static_cast<god_type>(
+                                    you.attribute[ATTR_TRAITOR]);
+    if (betrayed_god == god ||
+        is_good_god(betrayed_god) && is_good_god(god))
     {
         you.attribute[ATTR_TRAITOR] = 0;
         you.redraw_title = true;


### PR DESCRIPTION
Good gods are usually fine with you switching to another good god, so it doesn't make sense for you to get the traiter title from the religion you left in this case.

Resolves #4329