### PR TITLE
Fix loading high evasion ghosts (OblivionHorseArmour)

### DIFF
--- a/crawl-ref/source/ghost.cc
+++ b/crawl-ref/source/ghost.cc
@@ -33,7 +33,6 @@
 
 #define MAX_GHOST_DAMAGE     50
 #define MAX_GHOST_HP        400
-#define MAX_GHOST_EVASION    50
 
 // Pan lord AOE conjuration spell list.
 static spell_type search_order_aoe_conj[] =

--- a/crawl-ref/source/ghost.h
+++ b/crawl-ref/source/ghost.h
@@ -25,6 +25,8 @@ using std::vector;
 #define APOSTLE_POWER_KEY "apostle_power"
 #define APOSTLE_BAND_POWER_KEY "apostle_band_power"
 
+#define MAX_GHOST_EVASION    50
+
 enum apostle_type
 {
     // Basic generation types

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -8069,6 +8069,8 @@ static ghost_demon _unmarshallGhost(reader &th)
     ghost.xl               = unmarshallShort(th);
     ghost.max_hp           = unmarshallShort(th);
     ghost.ev               = unmarshallShort(th);
+    if (ghost.ev > MAX_GHOST_EVASION)
+        ghost.ev = MAX_GHOST_EVASION;
     ghost.ac               = unmarshallShort(th);
     ghost.damage           = unmarshallShort(th);
     ghost.speed            = unmarshallShort(th);


### PR DESCRIPTION
The ghost evasion cap was lowered from 60 to 50, so we need to cap ghosts evasion to 50 when loading them.

Fixes #4198