### PR TITLE
Fix imp _suck_up_adj2_ syntax

### DIFF
--- a/crawl-ref/source/dat/database/monspeak.txt
+++ b/crawl-ref/source/dat/database/monspeak.txt
@@ -347,7 +347,7 @@ if you.race() == "Mummy" then
     return "velvet-covered"
 elseif you.mutation('beak') > 0 then
     return "pearl-beaked"
-elseif you.transform() == "death"
+elseif you.transform() == "death" then
     return "well-preserved"
 elseif you.transform() == "statue" then
     return "marble-toed"


### PR DESCRIPTION
Imp speech `_suck_up_adj2_` throws an error because of a missing `then`. Restore correct syntax.

Should fix https://github.com/crawl/crawl/issues/4344.