### PR TITLE
Rework robe of misfortune (again).

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -859,11 +859,15 @@ OBJ:      OBJ_ARMOUR/ARM_ROBE
 # try to make it bad, this is the only bad SPARM:
 FB_BRAND: SPARM_PONDEROUSNESS
 PLUS:     5
+INSCRIP:  Wiz+++ *Miscast
 COLOUR:   LIGHTMAGENTA
 TILE:     urand_misfortune
 TILE_EQ:  robe_misfortune
-EV:       5
-BOOL:     harm, slow, corrode
+EV:       3
+MP:       15
+DESCRIP:  Wiz+++:    It greatly improves the wearer's spellcasting success.
+ *Miscast:    The wearer will sometimes suffer miscast effects even
+ when they successfully cast a spell.
 
 # start TAG_MAJOR_VERSION == 34
 NAME:     cloak of Flash

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2042,7 +2042,8 @@ int player_wizardry()
 {
     return you.wearing_jewellery(RING_WIZARDRY)
            + (you.get_mutation_level(MUT_BIG_BRAIN) == 3 ? 1 : 0)
-           + you.scan_artefacts(ARTP_WIZARDRY);
+           + you.scan_artefacts(ARTP_WIZARDRY)
+           + you.unrand_equipped(UNRAND_MISFORTUNE) ? 3 : 0;
 }
 
 int player_channelling()

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -2248,6 +2248,12 @@ spret your_spells(spell_type spell, int powc, bool actual_spell,
                            you.experience_level,
                            "the malice of Vehumet");
         }
+        else if (you.unrand_equipped(UNRAND_MISFORTUNE) && one_chance_in(20))
+        {
+
+            mprf("You feel unlucky.");
+            miscast_effect(spell, 1 + random2(20) + random2(21));
+        }
 
         const int spfail_chance = raw_spell_fail(spell);
 


### PR DESCRIPTION
Based on a comment on a very old pr. Now provides triple wizardry and 15 MP, but has a flat 5% chance to give a miscast effect even if the spell succeeds. Bonuses were chosen to try and make it a casting item orthogonal to most of the existing casting armours, which tend to provide lots of spellpower. The other drawbacks of the robe are removed.