### PR TITLE
Sign and notarize app bundle on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+      - name: Install modern Bash on macOS
+        run: brew install bash
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # all history
@@ -368,8 +370,67 @@ jobs:
             macos-clang
       - name: "Setup ccache: prepend path"
         run: "echo $(brew --prefix)/opt/ccache/libexec >> $GITHUB_PATH"
-      - run: make -j$(sysctl -n hw.ncpu) mac-app-${{ matrix.build_type }} ${{matrix.build_opts }}
+      - run: make -j$(sysctl -n hw.ncpu) mac-app-${{ matrix.build_type }} ${{ matrix.build_opts }}
         working-directory: crawl-ref/source
+      - name: "Determine Filenames on macOS"
+        shell: bash
+        run: |
+          target=${{ matrix.build_type }}
+          target_type=${target%-universal}
+          BUNDLE_NAME="Dungeon Crawl Stone Soup - ${target_type^}"
+          MACOS_BINARY=$(if [[ "$target" == "console-universal" ]]; then echo "crawl"; else echo "${BUNDLE_NAME}"; fi)
+          echo "BUNDLE_NAME=$BUNDLE_NAME" >> $GITHUB_ENV
+          echo "MACOS_BINARY=$MACOS_BINARY" >> $GITHUB_ENV
+      - name: "Generate signed .app for macOS"
+        working-directory: crawl-ref/source
+        shell: bash
+        run: |
+          # Create p12 file
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          echo -n "${{ secrets.APPLE_BUILD_CERTIFICATE_BASE64 }}" | base64 --decode > $CERTIFICATE_PATH
+
+          # Configure Keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          security create-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # Import certificates on Keychain
+          security import $CERTIFICATE_PATH -P "${{ secrets.APPLE_P12_PASSWORD }}" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+
+          # Codesign files
+          APP_DIR="build/app-bundle-stage/${BUNDLE_NAME}.app"
+          CONSOLE_BINARY="$APP_DIR/Contents/Resources/$MACOS_BINARY"
+          test -f "$CONSOLE_BINARY" && \
+            codesign --options=runtime --entitlements mac/entitlements.xml --deep --keychain $KEYCHAIN_PATH --timestamp --force --sign "${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}" -v "$CONSOLE_BINARY"
+          codesign --options=runtime --entitlements mac/entitlements.xml --deep --keychain $KEYCHAIN_PATH --timestamp --force --sign "${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}" -v "$APP_DIR/Contents/MacOS/$BUNDLE_NAME"
+          codesign --options=runtime --entitlements mac/entitlements.xml --keychain $KEYCHAIN_PATH --timestamp --force --sign "${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}" -v "$APP_DIR"
+      - name: "Notarize Release Build for macOS"
+        uses: wpilibsuite/xcode-notarize@v3
+        with:
+          product-path: crawl-ref/source/build/app-bundle-stage/${{ env.BUNDLE_NAME }}.app
+          appstore-connect-username: ${{ secrets.APPLE_ACCOUNT_USERNAME }}
+          appstore-connect-password: ${{ secrets.APPLE_ACCOUNT_PASSWORD }}
+          appstore-connect-teamid: ${{ secrets.APPLE_ACCOUNT_TEAM_ID }}
+          primary-bundle-id: 'DCSS'
+      - name: "Staple Release Build for macOS"
+        uses: BoundfoxStudios/action-xcode-staple@v1
+        with:
+          product-path: crawl-ref/source/build/app-bundle-stage/${{ env.BUNDLE_NAME }}.app
+      - name: Clean up keychain and certificate
+        if: ${{ always() }}
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
+          rm $RUNNER_TEMP/build_certificate.p12
+      - name: "Create release zip for macOS"
+        working-directory: crawl-ref/source
+        shell: bash
+        run: |
+          mkdir mac-app-zips
+          rm -f mac-app-zips/latest.zip
+          ditto -c -k --sequesterRsrc --keepParent "build/app-bundle-stage/${BUNDLE_NAME}.app" "${BUNDLE_NAME}.zip"
+          mv "${BUNDLE_NAME}.zip" mac-app-zips/latest.zip
       - name: Add build to release
         if: github.event.release.tag_name != null
         uses: svenstaro/upload-release-action@v2

--- a/crawl-ref/source/mac/Makefile.app-bundle
+++ b/crawl-ref/source/mac/Makefile.app-bundle
@@ -4,16 +4,16 @@
 CRAWL_BASE=$(CURDIR)/../..
 CRAWL_SRC=$(CRAWL_BASE)/source
 
-ZIP_QUALIFIER :=
-ZIP_ARCH :=
+CRAWL_QUALIFIER :=
+CRAWL_ARCH :=
 
 ifdef BUILD_OLD_UNIVERSAL
-ZIP_ARCH := -universal
+CRAWL_ARCH := -universal
 endif
 
 ifdef BUILD_UNIVERSAL
 CRAWL_BIN=crawl-universal
-ZIP_ARCH := -universal
+CRAWL_ARCH := -universal
 else
 CRAWL_BIN=crawl
 endif
@@ -23,25 +23,22 @@ APP_NAME := Dungeon Crawl Stone Soup
 ifneq (,$(findstring tiles,$(MAKECMDGOALS)))
 BUNDLE_NAME := Dungeon\ Crawl\ Stone\ Soup\ -\ Tiles
 TILE_APP := y
-ZIP_QUALIFIER := -tiles
+CRAWL_QUALIFIER := -tiles
 else
 BUNDLE_NAME := Dungeon\ Crawl\ Stone\ Soup\ -\ Console
-ZIP_QUALIFIER := -console
+CRAWL_QUALIFIER := -console
 endif
 EXECUTABLE_PATH := $(CRAWL_SRC)/$(CRAWL_BIN)
 
-ZIP_NAME = stone_soup-$(SRC_VERSION)$(ZIP_QUALIFIER)-macosx$(ZIP_ARCH).zip
-
 STAGING_DIR := $(CRAWL_SRC)/build/app-bundle-stage
-ZIPPED_APP_DIR := $(CRAWL_SRC)/mac-app-zips
 BUNDLE_DIRNAME := $(STAGING_DIR)/$(BUNDLE_NAME).app
 RESOURCES := $(BUNDLE_DIRNAME)/Contents/Resources
 
 .PHONY: all clean clean-stage stage-dir copy-executable copy-resources \
 	copy-tiledata assemble-app-bundle create-bundle-directory
 
-all: $(STAGING_DIR) $(ZIPPED_APP_DIR) \
-	clean-stage assemble-app-bundle zip-app-bundle
+all: $(STAGING_DIR) \
+	clean-stage assemble-app-bundle
 
 clean:
 	rm -rf $(CRAWL_SRC)/build
@@ -51,22 +48,11 @@ tiles: all
 $(STAGING_DIR):
 	mkdir -p $@
 
-$(ZIPPED_APP_DIR):
-	mkdir -p $@
-
 clean-stage:
 	rm -rf $(STAGING_DIR)/*
 
 assemble-app-bundle: create-bundle-directory copy-executable copy-resources \
 		     copy-info-plist
-
-zip-app-bundle:
-	rm -f $(ZIPPED_APP_DIR)/$(ZIP_NAME)
-	cd $(STAGING_DIR) && \
-		zip -9r $(ZIPPED_APP_DIR)/$(ZIP_NAME) $(BUNDLE_NAME).app
-	cd $(STAGING_DIR) && \
-		if which advzip >/dev/null;then advzip -z3 $(ZIPPED_APP_DIR)/$(ZIP_NAME);fi
-	ln -sf $(ZIPPED_APP_DIR)/$(ZIP_NAME) $(ZIPPED_APP_DIR)/latest.zip
 
 create-bundle-directory: $(BUNDLE_DIRNAME)
 

--- a/crawl-ref/source/mac/entitlements.xml
+++ b/crawl-ref/source/mac/entitlements.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-executable-page-protection</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Overview

These additional steps and modifications allow for developers to sign (with an Apple Developer certificate), notarize (server-side virus check from Apple), and staple (attach notarization result to .app bundle) the .app bundles that are shipped for macOS for the software.

## Benefits

Users will no longer face Gatekeeper lockout when launching the app. In the current state of the released application, one must go into System Settings and manually override the current, invalid signature to load the application. They must be an administrator of the system to do this. In the future, software may be even harder to distribute on macOS without a valid signature. 

Users will be able to immediately launch the application on any supported Mac after download.

Users will have confidence the software does not contain malware per Apple's required server-side notarization process.

## Drawbacks

Without a current certificate, the build will fail. Reverting this PR would be required to restore functionality. The error messages in this scenario would explicitly inform developers the certificate has expired.

Certificates cost $100/yr.

## Removals

I have removed the .zip creation in the `mac/Makefile.app-bundle` script. A .zip for release can only be created on macOS after the signature is applied, notarization passes, and the attestation ticket is available to staple to the bundle. These steps are post-build steps and I've found it easiest to perform them in the GitHub action instead of segmenting the build.

## Additions

A number of GitHub Actions secrets must be added for this to function. I am willing and able to provide values for these secrets on my personal development account with Apple, which I do for [another large, FOSS video game project](https://apotris.com), as I trust in the goodwill of the development organization behind this repo and wish to help support the greater Roguelikes community. I would prefer (as may you) for you to provide your own values. You must have or obtain an Apple Developer license for this to function.

- `APPLE_ACCOUNT_USERNAME`: your Apple account ID, which is also found as your iCloud account email
- `APPLE_ACCOUNT_PASSWORD`: an app-specific password if you use 2FA, or your iCloud account password otherwise
- `APPLE_ACCOUNT_TEAM_ID`: the Team ID associated with your apple account, this may be different from your personal Team ID if the organization forms a team through the Apple Developer web interface
- `APPLE_BUILD_CERTIFICATE_BASE64`: a base64-encoded string of the contents of your development certificate
  - given the certificate is installed in your Keychain Access.app, you must expand it and highlight both the certificate and its associated key, and export it to .p12 format with a secure password
  - from there one can run e.g. `base64 -i Certificates.p12 | pbcopy` and paste it into the secret
- `APPLE_P12_PASSWORD`: the password used to encrypt the exported certificate from the secret above
- `APPLE_DEVELOPER_ID_INSTALLER`: the string identifier for your developer certificate, in my case: "Developer ID Application: Isaac Aronson"
- `APPLE_KEYCHAIN_PASSWORD`: any random, secure string -- only used briefly within the runner in-place
