### PR TITLE
Fix the tile_runrest_rate option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2296,7 +2296,7 @@ tile_update_rate = 1000
         number. If, on the other hand, response time is fine but it takes too
         long for redrawings to happen, set it to a lower value.
 
-tile_runrest_rate = 100
+tile_runrest_rate = 17
         The number of milliseconds that tick by before the screen is redrawn
         when running or resting. If Crawl is slow while running or resting,
         increase this number.

--- a/crawl-ref/docs/tiles_help.txt
+++ b/crawl-ref/docs/tiles_help.txt
@@ -151,8 +151,8 @@ tile_update_rate = 1000
     more often if you take actions that change the display. You could try
     cranking up this value, though this may lead to updating taking too long.
 
-tile_runrest_rate = 100
-    While running and resting the screen is redraw every 100 milliseconds.
+tile_runrest_rate = 17
+    While running and resting the screen is redrawn every 17 milliseconds.
     If Crawl is slow while running or resting, increase this number.
 
 tile_tooltip_ms = 0

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -409,8 +409,11 @@ static command_type _get_running_command()
         you.running.rest();
 
 #ifdef USE_TILE
-        if (Options.rest_delay >= 0 && tiles.need_redraw())
+        if (Options.rest_delay >= 0
+            && tiles.need_redraw(Options.tile_runrest_rate))
+        {
             tiles.redraw();
+        }
 #endif
 
         if (!is_resting() && you.running.hp == you.hp
@@ -425,7 +428,14 @@ static command_type _get_running_command()
         return CMD_WAIT;
     }
     else if (you.running.is_explore() && Options.explore_delay > -1)
-        delay(Options.explore_delay);
+    {
+#ifdef USE_TILE
+        if (tiles.need_redraw(Options.tile_runrest_rate))
+            tiles.redraw();
+#endif
+        if (Options.explore_delay > 0)
+            delay(Options.explore_delay);
+    }
     else if (Options.travel_delay > 0)
         delay(Options.travel_delay);
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -850,7 +850,7 @@ const vector<GameOption*> game_options::build_options_list()
         new IntGameOption(SIMPLE_NAME(tile_tooltip_ms), 0, 0, INT_MAX),
 #endif
         new IntGameOption(SIMPLE_NAME(tile_update_rate), 1000, 50, INT_MAX),
-        new IntGameOption(SIMPLE_NAME(tile_runrest_rate), 100, 0, INT_MAX),
+        new IntGameOption(SIMPLE_NAME(tile_runrest_rate), 17, 0, INT_MAX),
         // minimap colours
         new TileColGameOption(SIMPLE_NAME(tile_branchstairs_col), "#ff7788"),
         new TileColGameOption(SIMPLE_NAME(tile_deep_water_col), "#001122"),

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1492,19 +1492,20 @@ const coord_def &TilesFramework::get_cursor() const
     return m_region_tile->get_cursor();
 }
 
-void TilesFramework::set_need_redraw(unsigned int min_tick_delay)
+void TilesFramework::set_need_redraw()
 {
     if (in_headless_mode())
-        return;
-    unsigned int ticks = (wm->get_ticks() - m_last_tick_redraw);
-    if (min_tick_delay && ticks <= min_tick_delay)
         return;
 
     m_need_redraw = true;
 }
 
-bool TilesFramework::need_redraw() const
+bool TilesFramework::need_redraw(unsigned int min_tick_delay) const
 {
+    unsigned int ticks_passed = (wm->get_ticks() - m_last_tick_redraw);
+    if (ticks_passed < min_tick_delay)
+        return false;
+
     return m_need_redraw;
 }
 

--- a/crawl-ref/source/tilesdl.h
+++ b/crawl-ref/source/tilesdl.h
@@ -179,8 +179,8 @@ public:
     void toggle_inventory_display();
     void update_tabs();
 
-    void set_need_redraw(unsigned int min_tick_delay = 0);
-    bool need_redraw() const;
+    void set_need_redraw();
+    bool need_redraw(unsigned int min_tick_delay = 0) const;
     void redraw();
     bool update_dpi();
 

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -2294,17 +2294,17 @@ const coord_def &TilesFramework::get_cursor() const
     return m_cursor[CURSOR_MOUSE];
 }
 
-void TilesFramework::set_need_redraw(unsigned int min_tick_delay)
+void TilesFramework::set_need_redraw()
 {
-    unsigned int ticks = (get_milliseconds() - m_last_tick_redraw);
-    if (min_tick_delay && ticks <= min_tick_delay)
-        return;
-
     m_need_redraw = true;
 }
 
-bool TilesFramework::need_redraw() const
+bool TilesFramework::need_redraw(unsigned int min_tick_delay) const
 {
+    unsigned int ticks_passed = (get_milliseconds() - m_last_tick_redraw);
+    if (ticks_passed < min_tick_delay)
+        return false;
+
     return m_need_redraw;
 }
 

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -116,8 +116,8 @@ public:
     void update_tabs();
 
     void mark_for_redraw(const coord_def& gc);
-    void set_need_redraw(unsigned int min_tick_delay = 0);
-    bool need_redraw() const;
+    void set_need_redraw();
+    bool need_redraw(unsigned int min_tick_delay = 0) const;
     void redraw();
 
     void place_cursor(cursor_type type, const coord_def &gc);

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1177,7 +1177,14 @@ command_type travel()
 
         }
         else if (you.running.is_explore() && Options.explore_delay > -1)
-            delay(Options.explore_delay);
+        {
+#ifdef USE_TILE
+            if (tiles.need_redraw(Options.tile_runrest_rate))
+                tiles.redraw();
+#endif
+            if (Options.explore_delay > 0)
+                delay(Options.explore_delay);
+        }
         else if (Options.travel_delay > 0)
             delay(Options.travel_delay);
     }
@@ -4665,11 +4672,6 @@ void runrest::stop(bool clear_delays)
     // run/rest/travel on top of other delays.
     if (clear_delays)
         stop_delay();
-
-#ifdef USE_TILE_LOCAL
-    if (Options.tile_runrest_rate > 0)
-        tiles.set_need_redraw();
-#endif
 
     quiver::set_needs_redraw();
     if (need_redraw)

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1491,7 +1491,7 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a, view_renderer 
             UNUSED(tiles_only);
 #endif
 #ifdef USE_TILE
-            tiles.set_need_redraw(you.running ? Options.tile_runrest_rate : 0);
+            tiles.set_need_redraw();
             tiles.load_dungeon(vbuf, crawl_view.vgrdc);
             tiles.update_tabs();
 #endif


### PR DESCRIPTION
This option controls how often we render in milliseconds when resting, exploring, or travelling. However, it was being ignored resulting in large amounts of time being washed waiting for vsync or rendering updates that were never going to be visable. I also, reduced its default value from 100ms to 17ms as 10 fps felt choppy.