### PR TITLE
Allow manifold assault with the Sword of Power

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3196,23 +3196,9 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
                 return spret::abort;
             }
 
-            static const vector<int> forbidden_unrands =
-            {
-                UNRAND_POWER,
-            };
-
-            // Currently excluding the same weapons that Manifold Assault does
-            // (because they work weirdly for projected attacks), though a
-            // larger number than that are *unsafe*. Is it okay if the player
-            // knowingly imprints something dangerous-but-fun? Maybe?
-            for (int urand : forbidden_unrands)
-            {
-                if (is_unrandom_artefact(*wpn, urand))
-                {
-                    mprf(MSGCH_WARN, "That weapon cannot be imprinted.");
-                    return spret::abort;
-                }
-            }
+            // Currently allowing all unrand weapons, though some are *unsafe*.
+            // Is it okay if the player knowingly imprints something
+            // dangerous-but-fun? Maybe?
 
             if (monster* paragon = find_player_paragon())
                 paragon->del_ench(ENCH_SUMMON_TIMER);

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -47,7 +47,7 @@
 #include "player-stats.h"
 #include "showsymb.h"      // For Cigotuvi's Embrace
 #include "spl-cast.h"      // For evokes
-#include "spl-damage.h"    // For the Singing Sword.
+#include "spl-damage.h"    // For the Singing Sword and the Sword of Power.
 #include "spl-goditem.h"   // For Sceptre of Torment tormenting
 #include "spl-miscast.h"   // For Spellbinder and plutonium sword miscasts
 #include "spl-monench.h"   // For Zhor's aura
@@ -296,17 +296,7 @@ static void _POWER_melee_effects(item_def* /*weapon*/, actor* attacker,
     coord_def targ = defender->pos();
 
     for (int i = 0; i < num_beams; i++)
-    {
-        bolt beam;
-        beam.thrower   = attacker->is_player() ? KILL_YOU : KILL_MON;
-        beam.source    = attacker->pos();
-        beam.source_id = attacker->mid;
-        beam.attitude  = attacker->temp_attitude();
-        beam.range = 4;
-        beam.target = targ;
-        zappy(ZAP_SWORD_BEAM, 100, false, beam);
-        beam.fire();
-    }
+        fire_life_bolt(*attacker, targ);
 }
 
 ////////////////////////////////////////////////////

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1010,7 +1010,9 @@ bool player_unrand_bad_target(const item_def &weapon,
     if (is_unrandom_artefact(weapon, UNRAND_POWER))
     {
         targeter_beam hitfunc(&you, 4, ZAP_SWORD_BEAM, 100, 0, 0);
+        hitfunc.beam.chose_ray = true;
         hitfunc.beam.aimed_at_spot = false;
+        find_life_bolt_ray(hitfunc.beam.source, defender.pos(), hitfunc.beam.ray);
         hitfunc.set_aim(defender.pos());
 
         return stop_attack_prompt(hitfunc, "attack",

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -5287,3 +5287,40 @@ dice_def fortress_blast_damage(int AC, bool is_monster)
     int power = min(200, (int)pow(AC, 1.343) * 2 / 3);
     return zap_damage(ZAP_FORTRESS_BLAST, power, is_monster, false);
 }
+
+bool find_life_bolt_ray(coord_def& source, coord_def target, ray_def& ray)
+{
+    bool has_ray = find_ray(source, target, ray, opc_no_trans);
+    if (!has_ray)
+        return false;
+    while (true)
+    {
+        ray_def next_ray = ray;
+        next_ray.advance();
+        if (next_ray.pos() == target)
+        {
+            source = ray.pos();
+            break;
+        }
+        ray = next_ray;
+    }
+    return true;
+}
+
+void fire_life_bolt(actor& attacker, coord_def target)
+{
+    bolt beam;
+    beam.thrower = attacker.is_player() ? KILL_YOU : KILL_MON;
+    beam.source = attacker.pos();
+    beam.source_id = attacker.mid;
+    beam.attitude = attacker.temp_attitude();
+    beam.range = 4;
+    beam.target = target;
+    beam.chose_ray = true;
+    zappy(ZAP_SWORD_BEAM, 100, false, beam);
+    bool has_ray = find_life_bolt_ray(beam.source, beam.target, beam.ray);
+    if (!has_ray)
+        return;
+
+    beam.fire();
+}

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -184,3 +184,6 @@ void gain_grave_claw_soul(bool silent = false, bool wizard = false);
 spret cast_fortress_blast(actor& caster, int pow, bool fail);
 void unleash_fortress_blast(actor& caster);
 dice_def fortress_blast_damage(int AC, bool is_monster);
+
+bool find_life_bolt_ray(coord_def& source, coord_def target, ray_def& ray);
+void fire_life_bolt(actor& attacker, coord_def target);

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1370,27 +1370,6 @@ spret cast_dimensional_bullseye(int pow, monster *target, bool fail)
     return spret::success;
 }
 
-string weapon_unprojectability_reason(const item_def* wpn)
-{
-    if (!wpn)
-        return "";
-
-    // These don't work properly when performing attacks against non-adjacent
-    // targets. Maybe support them in future?
-    static const vector<int> forbidden_unrands = {
-        UNRAND_POWER,
-    };
-    for (int urand : forbidden_unrands)
-    {
-        if (is_unrandom_artefact(*wpn, urand))
-        {
-            return make_stringf("%s would react catastrophically with paradoxical space!",
-                                you.weapon()->name(DESC_THE, false, false, false, false).c_str());
-        }
-    }
-    return "";
-}
-
 // Mildly hacky: If this was triggered via Autumn Katana, katana_defender is the
 //               target it first triggered on. If nullptr, this is a normal cast.
 spret cast_manifold_assault(actor& agent, int pow, bool fail, bool real,
@@ -1451,17 +1430,6 @@ spret cast_manifold_assault(actor& agent, int pow, bool fail, bool real,
                 mpr("You can't see anything you can safely attack.");
         }
         return spret::abort;
-    }
-
-    if (real && !katana_defender)
-    {
-        const string unproj_reason = weapon_unprojectability_reason(weapon);
-        if (unproj_reason != "")
-        {
-            if (agent.is_player())
-                mpr(unproj_reason);
-            return spret::abort;
-        }
     }
 
     if (!real)

--- a/crawl-ref/source/spl-transloc.h
+++ b/crawl-ref/source/spl-transloc.h
@@ -45,7 +45,6 @@ spret cast_dimensional_bullseye(int pow, monster *target, bool fail);
 
 spret cast_manifold_assault(actor& agent, int pow, bool fail, bool real = true,
                             actor* katana_defender = nullptr);
-string weapon_unprojectability_reason(const item_def* wpn);
 
 struct bolt;
 spret cast_apportation(int pow, bolt& beam, bool fail);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1459,15 +1459,6 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
             return "you have no body armour to summon the spirit of.";
         break;
 
-    case SPELL_MANIFOLD_ASSAULT:
-        if (temp)
-        {
-            const string unproj_reason = weapon_unprojectability_reason(you.weapon());
-            if (unproj_reason != "")
-                return unproj_reason;
-        }
-        break;
-
     case SPELL_MOMENTUM_STRIKE:
         if (temp && !you.is_motile())
             return "you cannot redirect your momentum while unable to move.";


### PR DESCRIPTION
When the Sword of Power shoots a bolt, start the bolt from one space before the defender in the direction from the attacker to defender instead of always starting from the attacker. This allows it to make attacks it a distance with manifold assault.