### PR TITLE
Webtiles Perf improvements

### DIFF
--- a/crawl-ref/source/webserver/webtiles/terminal.py
+++ b/crawl-ref/source/webserver/webtiles/terminal.py
@@ -113,6 +113,9 @@ class TerminalRecorder(object):
             if self.game_cwd:
                 os.chdir(self.game_cwd)
             try:
+                # If using CFS scheduler or similar, we really want the webserver to be higher priority
+                # than the individual crawl processes
+                os.nice(2)
                 os.execvpe(self.command[0], self.command, env)
             except OSError:
                 sys.exit(1)

--- a/crawl-ref/source/webserver/webtiles/ws_handler.py
+++ b/crawl-ref/source/webserver/webtiles/ws_handler.py
@@ -1421,7 +1421,6 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             # handle any exceptions lingering in the Future
             # TODO: this whole call chain should be converted to use coroutines
 
-            start = time.perf_counter_ns()
             # extreme back-compat `f` should be None in ancient tornado versions
             if f is not None:
                 #TODO: would partial application be faster?
@@ -1448,14 +1447,14 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
         if self.client_closed or len(self.message_queue) == 0:
             return False
 
-        start = time.perf_counter_ns()
+        # start = time.perf_counter_ns()
         batch = ("{\"msgs\":["
             + ",".join(self.message_queue)
             + "]}")
         self.message_queue = [] # always empty the queue
         result = self._send_raw_message(batch)
 
-        self.logger.info("Message duration: %d ns", time.perf_counter_ns() - start)
+        # self.logger.info("Message duration: %d ns", time.perf_counter_ns() - start)
         return result
 
     # n.b. this looks a lot like superclass write_message, but has a static

--- a/crawl-ref/source/webserver/webtiles/ws_handler.py
+++ b/crawl-ref/source/webserver/webtiles/ws_handler.py
@@ -1386,22 +1386,23 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             if self.failed_messages == 0:
                 self.logger.warning("Connection closed during async write_message")
             self.failed_messages += 1
-            if self.ws_connection is not None:
+            if self.ws_connection:
                 self.ws_connection._abort()
         except tornado.websocket.WebSocketClosedError as e:
             if self.failed_messages == 0:
                 self.logger.warning("Connection closed during async write_message")
             self.failed_messages += 1
-            if self.ws_connection is not None:
+            if self.ws_connection:
                 self.ws_connection._abort()
         except Exception as e:
-            # Not necessarily as helpful, but getting the current stack is too expensive to do in the happy path
+            # Not necessarily as helpful, but getting the current stack is
+            # too expensive to do in the happy path
             cur_stack = traceback.format_stack()
             self.logger.warning("Exception during async write_message, stack at call:")
             self.logger.warning("".join(cur_stack))
             self.logger.warning(e, exc_info=True)
             self.failed_messages += 1
-            if self.ws_connection is not None:
+            if self.ws_connection:
                 self.ws_connection._abort()
 
     # send a single message batch, encoding and compressing it if necessary
@@ -1422,7 +1423,7 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             # TODO: this whole call chain should be converted to use coroutines
 
             # extreme back-compat `f` should be None in ancient tornado versions
-            if f is not None:
+            if f:
                 #TODO: would partial application be faster?
                 f.add_done_callback(lambda x: self.after_write_callback(x))
             # true means that something was queued up to send, but it may be
@@ -1432,12 +1433,12 @@ class CrawlWebSocket(tornado.websocket.WebSocketHandler):
             if self.failed_messages == 0:
                 self.logger.warning("Connection closed during write_message")
             self.failed_messages += 1
-            if self.ws_connection is not None:
+            if self.ws_connection:
                 self.ws_connection._abort()
         except:
             self.logger.warning("Exception trying to send message.", exc_info = True)
             self.failed_messages += 1
-            if self.ws_connection is not None:
+            if self.ws_connection:
                 self.ws_connection._abort()
             return False
 


### PR DESCRIPTION
- Default (likely 6 if version of Python is new enough) for ZLIB compression is likely more aggressive than makes sense for us - 1 or 2 seems to be plenty
- Avoid a needless try /except in _encode_for_send (any weird cases that throw here, can be caught by the handler higher up now)
- Avoid keeping both the uncompressed and compressed buffers when we only need one.
- Don't use a large local function for the after_write_callback. Does it matter? not sure. But doesn't seem slower and it's cleaner.
- Don't use a try/except where an if statement would do