### PR TITLE
Webtiles Perf Improvements, part 1

### DIFF
--- a/crawl-ref/source/webserver/webtiles/terminal.py
+++ b/crawl-ref/source/webserver/webtiles/terminal.py
@@ -113,6 +113,10 @@ class TerminalRecorder(object):
             if self.game_cwd:
                 os.chdir(self.game_cwd)
             try:
+                # If using CFS scheduler or similar,
+                # we really want the webserver to be higher priority than the individual crawl processes
+                # So make the crawl process a little bit nicer after fork and before exec
+                os.nice(2)
                 os.execvpe(self.command[0], self.command, env)
             except OSError:
                 sys.exit(1)


### PR DESCRIPTION
- Default (likely 6 if version of Python is new enough) for ZLIB compression appears to be too much CPU for too little benefit - 2 should be better
- Avoid a try-except where we could use an if
- Avoid some intermediate buffers living longer than they need to (probably won't help much)
- Add __slots__ to a class
- Simplify some if not None
- Don't capture a backtrace in a happy path, it's expensive
- Make the children a bit nicer to hopefully ensure the main webserver takes priority over them if there's contention (maybe should make configurable? not sure)