### PR TITLE
bugfix: AUTOFIGHT while immotile should not wait a turn (CrawlOdds)

### DIFF
--- a/crawl-ref/source/dat/clua/autofight.lua
+++ b/crawl-ref/source/dat/clua/autofight.lua
@@ -204,12 +204,14 @@ local function move_towards(dx, dy)
   local move = choose_move_towards(0, 0, dx, dy, can_move_now)
   if move == nil then
     crawl.mpr("Failed to move towards target.")
-  else
-    if you.status("immotile") then
+  elseif you.status("immotile") then
+    if AUTOFIGHT_WAIT then
       crawl.do_commands({"CMD_WAIT"})
     else
-      crawl.do_commands({delta_to_cmd(move[1],move[2])})
+      crawl.mpr("Failed to move towards target because you cannot move.")
     end
+  else
+      crawl.do_commands({delta_to_cmd(move[1],move[2])})
   end
 end
 


### PR DESCRIPTION
If immotile (e.g. from -Move), we should not wait when you try to autofight by default.
No other case that I can see will wait unless AUTOFIGHT_WAIT is set - why is this one different?

This logic was added last year in 52037ea7a925a6ae6b1b67939267cd8f1f4837a4.
I'm guessing because it was confusing to hit tab and have nothing happen? but mpr would make more sense to me to solve that.
Gate the old behavior behind autofight_wait.

Could add another option for it instead, but it seems consistent with the behavior of the autofight_wait option in general.

Closes #4394