### PR TITLE
Mark maxed out misc evokers as useless if not in player's inventory

### DIFF
--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3317,15 +3317,15 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
     }
 
     case OBJ_MISCELLANY:
-        // Try to discourage players from wasting money on a useless evoker in a
-        // shop (which will vanish immediately when they buy it).
-        if (is_shop_item(item) && is_xp_evoker(item)
-            && evoker_plus(item.sub_type) >= MAX_EVOKER_ENCHANT)
+        if (is_xp_evoker(item) && evoker_plus(item.sub_type) >= MAX_EVOKER_ENCHANT)
         {
             for (const item_def &inv_item : you.inv)
             {
                 if (inv_item.base_type == OBJ_MISCELLANY
-                    && inv_item.sub_type == item.sub_type)
+                    && inv_item.sub_type == item.sub_type
+                    // Have to check this way because stash passes item with pos == you.pos()
+                    // instead of pos == ITEM_IN_INVENTORY so in_inventory check doesn't work
+                    && inv_item.pos != item.pos && inv_item.link != item.link)
                 {
                     return true;
                 }


### PR DESCRIPTION
Existing code only marks useless misc evokers as such if they're in shops, but if they're just laying on the floor they are currently not considered useless. This is a nuisance in zigs, which have one or more evokers on almost every floor, quickly maxing them out and adding more visual noise to an already overloaded ctrl-X menu.

The hacky inventory check is not ideal, but I couldn't come up with a better solution without going out of my depth and messing with core functions. I checked all edge cases I could think of like standing on +5 evo while having a copy in your inventory