### PR TITLE
Fix a crash when casting phantom blitz (Colgate)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2827,6 +2827,8 @@ void bolt::affect_endpoint()
             bool obviousness; // dummy argument
             monster *mirror = clone_mons(blitzer, true, &obviousness,
                                          blitzer->attitude, spot);
+            if (!mirror)
+                break;
             mirror->mark_summoned(SPELL_PHANTOM_BLITZ, summ_dur(2), true, true);
             mirror->summoner = blitzer->mid;
             mirror->foe = blitzer->foe;


### PR DESCRIPTION
When a monster cast phantom blitz with all 700 monsters on a level, the game would crash.