### PR TITLE
feat: Add staff of earth's ac bonus and update description

### DIFF
--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -362,7 +362,7 @@ static void _populate_staff_intrinsic_artps(stave_type staff,
     if (prop)
     {
         // Staffs of earth give AC, not resistance.
-        if(*prop == ARTP_AC)
+        if (*prop == ARTP_AC)
             proprt[*prop] += 3;
         else
             proprt[*prop] += 1;

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -341,7 +341,8 @@ static map<stave_type, artefact_prop_type> staff_resist_artps = {
     { STAFF_ALCHEMY, ARTP_POISON },
     { STAFF_DEATH,   ARTP_NEGATIVE_ENERGY },
     { STAFF_AIR,     ARTP_ELECTRICITY },
-    // nothing for conj or earth
+    { STAFF_EARTH,   ARTP_AC },
+    // nothing for conj
 };
 
 static map<stave_type, artefact_prop_type> staff_enhancer_artps = {
@@ -359,7 +360,13 @@ static void _populate_staff_intrinsic_artps(stave_type staff,
 {
     artefact_prop_type *prop = map_find(staff_resist_artps, staff);
     if (prop)
-        proprt[*prop] += 1;
+    {
+        // Staffs of earth give AC, not resistance.
+        if(*prop == ARTP_AC)
+            proprt[*prop] += 3;
+        else
+            proprt[*prop] += 1;
+    }
     prop = map_find(staff_enhancer_artps, staff);
     if (prop)
         proprt[*prop] = 1;

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1487,10 +1487,10 @@ dealing negative energy damage which bypasses armour.
 %%%%
 staff of earth
 
-A staff that increases the power of earth spells cast by its wielder. If the
-wielder is skilled in Evocations and Earth magic, they can fracture the ground
-beneath those struck by it, dealing substantial damage - though much less to
-creatures which fly.
+A staff that increases the power of earth spells cast by its wielder, and protects
+them from less sources of damage. If the wielder is skilled in Evocations and Earth
+magic, they can fracture the ground beneath those struck by it, dealing substantial
+damage - though much less to creatures which fly.
 %%%%
 staff of fire
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -3240,6 +3240,10 @@ int monster::armour_class() const
     // check for protection-brand weapons
     ac += 5 * _weapons_with_prop(this, SPWPN_PROTECTION);
 
+    // check for staves of earth
+    const item_def *w = primary_weapon();
+    if (w && w->is_type(OBJ_STAVES, STAFF_EARTH))
+        ac += 3;
     // armour from ac
     const item_def *armour = mslot_item(MSLOT_ARMOUR);
     if (armour)

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6209,6 +6209,9 @@ int player::base_ac(int scale) const
 
     AC += ac_changes_from_mutations();
 
+    if (you.wearing(OBJ_STAVES,STAFF_EARTH))
+        AC += 300;
+
     return AC * scale / 100;
 }
 


### PR DESCRIPTION
The Staff of Earth currently lacks distinctiveness. Its special physical damage doesn't offer any standout advantages, and players instead fixate on its trivial weakness against flying creatures (a largely irrelevant concern). As one of the four elemental magic schools' foundational staff types, it lacks the signature resistance to basic elemental damage—a feature present in the Elemental Staff. I propose repurposing this resistance mechanic for the base Staff of Earth. Given the staff's inherent rarity in early gameplay, I don't anticipate this adjustment significantly altering early-game balance or progression.