### PR TITLE
make packed_cell smaller still

### DIFF
--- a/crawl-ref/source/tile-env.h
+++ b/crawl-ref/source/tile-env.h
@@ -7,8 +7,10 @@
 #include "externs.h"
 #include "fixedarray.h"
 #include "rltiles/tiledef_defines.h"
+#ifdef USE_TILE // TODO: separate out this stuff from crawl_environment
+#include "tilecell.h"
+#endif
 
-struct packed_icons;
 struct crawl_tile_environment
 {
     // indexed by grid coords

--- a/crawl-ref/source/tile-env.h
+++ b/crawl-ref/source/tile-env.h
@@ -8,6 +8,7 @@
 #include "fixedarray.h"
 #include "rltiles/tiledef_defines.h"
 
+struct packed_icons;
 struct crawl_tile_environment
 {
     // indexed by grid coords
@@ -22,7 +23,7 @@ struct crawl_tile_environment
     FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> fg;
     FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> bg;
     FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> cloud;
-    map<coord_def, set<tileidx_t>> icons;
+    FixedArray<packed_icons, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> icons;
 #endif
     tile_flavour default_flavour;
     std::vector<std::string> names;

--- a/crawl-ref/source/tilecell.h
+++ b/crawl-ref/source/tilecell.h
@@ -16,7 +16,7 @@ enum halo_type: uint8_t
 // for 8 bytes fixed on every cell
 // + 32 bytes on cells with icons.
 struct packed_icons {
-    unique_ptr<FixedBitVector<256>> icons;
+    unique_ptr<set<tileidx_t>> icons;
     // constructor
     packed_icons() = default;
     // destructor
@@ -25,20 +25,23 @@ struct packed_icons {
     // copy-construct the inner set
     packed_icons(const packed_icons& o): icons(nullptr) {
         if (o.icons)
-            this->icons = make_unique<FixedBitVector<256>>(o.icons);
+            this->icons = make_unique<set<tileidx_t>>(*o.icons);
     }
 
     // move constructor
     packed_icons(packed_icons&&) = default;
 
     // copy assignment
-    // copy the innser set, then assign that.
-    packed_icons operator=(const packed_icons& o)
+    // copy the inner set, then assign that.
+    packed_icons operator=(const packed_icons& other)
     {
-        if (o.icons)
-            this->icons = make_unique<FixedBitVector<256>>(o.icons);
-        else
-            this->icons.reset();
+        if (this != &other) {
+            if (other.icons)
+                this->icons = make_unique<set<tileidx_t>>(*other.icons);
+            else
+                this->icons.reset();
+        }
+        return *this;
     }
 
     // move assignment
@@ -48,7 +51,7 @@ struct packed_icons {
     void insert(tileidx_t icon);
 
     // Clear the icons
-    inline void reset() {
+    inline void clear() {
         icons.reset();
     }
 };

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -633,26 +633,28 @@ void DungeonCellBuffer::pack_foreground(int x, int y, const packed_cell &cell)
         }
     }
 
-    // We might want to enforce some explicit ordering on these.
-    // Currently, they default to iteration order.
-    for (auto icon : cell.icons)
-    {
-        int size = status_icon_sizes[icon];
-        if (size == FIXED_LOC_ICON)
+    if (cell.icons.icons) {
+        // We might want to enforce some explicit ordering on these.
+        // Currently, they default to iteration order.
+        for (auto icon : *cell.icons.icons)
         {
-            m_buf_icons.add(icon, x, y);
-            continue;
-        }
+            int size = status_icon_sizes[icon];
+            if (size == FIXED_LOC_ICON)
+            {
+                m_buf_icons.add(icon, x, y);
+                continue;
+            }
 
-        m_buf_icons.add(icon, x, y, -status_shift, 0);
-        if (!size)
-        {
-            dprf("unknown icon %" PRIu64, icon);
-            size = 7; // could maybe crash here?
+            m_buf_icons.add(icon, x, y, -status_shift, 0);
+            if (!size)
+            {
+                dprf("unknown icon %" PRIu64, icon);
+                size = 7; // could maybe crash here?
+            }
+            status_shift += size;
+            // Very large numbers of these can go off the edge of
+            // the tile. Oh well! (Could skip those..?)
         }
-        status_shift += size;
-        // Very large numbers of these can go off the edge of
-        // the tile. Oh well! (Could skip those..?)
     }
 
     if (bg & TILE_FLAG_UNSEEN && (bg != TILE_FLAG_UNSEEN || fg))

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2331,9 +2331,9 @@ tileidx_t tileidx_monster(const monster_info& mons)
 void packed_icons::insert(tileidx_t icon) {
     ASSERT_RANGE(icon, TILEG_GUI_MAX, TILEI_ICONS_MAX);
     if (!icons)
-        icons = make_unique<FixedBitVector<256>>();
+        icons = make_unique<set<tileidx_t>>();
 
-    icons->set(icon - TILEG_GUI_MAX);
+    icons->insert(icon);
 }
 
 static const map<monster_info_flags, tileidx_t> monster_status_icons = {

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2326,6 +2326,16 @@ tileidx_t tileidx_monster(const monster_info& mons)
 }
 #endif
 
+
+// Since this method is only used in tilepick.cc, it's best placed here.
+void packed_icons::insert(tileidx_t icon) {
+    ASSERT_RANGE(icon, TILEG_GUI_MAX, TILEI_ICONS_MAX);
+    if (!icons)
+        icons = make_unique<FixedBitVector<256>>();
+
+    icons->set(icon - TILEG_GUI_MAX);
+}
+
 static const map<monster_info_flags, tileidx_t> monster_status_icons = {
     { MB_CONFUSED, TILEI_CONFUSED },
     { MB_BURNING, TILEI_STICKY_FLAME },
@@ -2400,9 +2410,9 @@ static const map<monster_info_flags, tileidx_t> monster_status_icons = {
     { MB_PYRRHIC_RECOLLECTION, TILEI_PYRRHIC },
 };
 
-set<tileidx_t> status_icons_for(const monster_info &mons)
+packed_icons status_icons_for(const monster_info &mons)
 {
-    set<tileidx_t> icons;
+    packed_icons icons;
     if (mons.type == MONS_DANCING_WEAPON)
         icons.insert(TILEI_ANIMATED_WEAPON);
     if (mons.type == MONS_NAMELESS_REVENANT
@@ -2447,9 +2457,9 @@ static bool _should_show_player_status_icon(const string& name)
 }
 #endif
 
-set<tileidx_t> status_icons_for_player()
+packed_icons status_icons_for_player()
 {
-    set<tileidx_t> icons;
+    packed_icons icons;
 #ifdef USE_TILE
     if (you.is_constricted() && _should_show_player_status_icon("constr"))
         icons.insert(TILEI_CONSTRICTED);

--- a/crawl-ref/source/tilepick.h
+++ b/crawl-ref/source/tilepick.h
@@ -23,6 +23,7 @@ class monster;
 struct monster_info;
 struct shop_struct;
 struct show_type;
+struct packed_icons;
 
 bool is_door_tile(tileidx_t tile);
 
@@ -66,8 +67,8 @@ tileidx_t tileidx_known_brand(const item_def &item);
 
 tileidx_t tileidx_unseen_flag(const coord_def &gc);
 
-set<tileidx_t> status_icons_for(const monster_info &mon);
-set<tileidx_t> status_icons_for_player();
+packed_icons status_icons_for(const monster_info &mon);
+packed_icons status_icons_for_player();
 
 // Return the level of enchantment as an int. None is 0, Randart is 4.
 int enchant_to_int(const item_def &item);

--- a/crawl-ref/source/tilereg-mon.cc
+++ b/crawl-ref/source/tilereg-mon.cc
@@ -178,7 +178,7 @@ void MonsterRegion::pack_buffers()
                     cell.fg = tile_env.fg(ep);
                     cell.bg = tile_env.bg(ep);
                     cell.flv = tile_env.flv(gc);
-                    cell.icons = tile_env.icons[ep];
+                    cell.icons = tile_env.icons(ep);
                     tile_apply_properties(gc, cell);
 
                     m_buf.add(cell, x, y);

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -905,7 +905,7 @@ void tile_draw_floor()
             tile_env.bg(ep) = bg;
             tile_env.fg(ep) = 0;
             tile_env.cloud(ep) = 0;
-            tile_env.icons.erase(ep);
+            tile_env.icons(ep).reset();
         }
 }
 

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -905,7 +905,7 @@ void tile_draw_floor()
             tile_env.bg(ep) = bg;
             tile_env.fg(ep) = 0;
             tile_env.cloud(ep) = 0;
-            tile_env.icons(ep).reset();
+            tile_env.icons(ep).clear();
         }
 }
 
@@ -1028,7 +1028,7 @@ static void _tile_place_monster(const coord_def &gc, const monster_info& mon)
         return;
     }
     tile_env.fg(ep) = t;
-    tile_env.icons[ep] = status_icons_for(mon);
+    tile_env.icons(ep) = status_icons_for(mon);
 
     // Add name tags.
     if (!mons_class_gives_xp(mon.type))
@@ -1090,7 +1090,7 @@ void tile_draw_map_cell(const coord_def& gc, bool foreground_only)
         const coord_def ep = grid2show(gc);
         tile_env.fg(ep) = 0;
         tile_env.cloud(ep) = 0;
-        tile_env.icons.erase(ep);
+        tile_env.icons(ep).clear();
     }
 
     const map_cell& cell = env.map_knowledge(gc);

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -2498,7 +2498,7 @@ void TilesFramework::json_write_comma()
     write_message(",");
 }
 
-void TilesFramework::json_write_icons(const set<tileidx_t> &icons)
+void TilesFramework::json_write_icons(const packed_icons &icons)
 {
     json_open_array("icons");
     for (const tileidx_t icon : icons)

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -195,7 +195,7 @@ public:
     void json_write_null(const string& name);
     void json_write_string(const string& value);
     void json_write_string(const string& name, const string& value);
-    void json_write_icons(const set<tileidx_t> &icons);
+    void json_write_icons(const packed_icons &icons);
     /* Causes the current object/array to be erased if it is closed
        with erase_if_empty without writing any other content after
        this call */

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1211,7 +1211,7 @@ static void _draw_player(screen_cell_t *cell,
     cell->tile.fg = tile_env.fg(ep) = tileidx_player();
     cell->tile.bg = tile_env.bg(ep);
     cell->tile.cloud = tile_env.cloud(ep);
-    cell->tile.icons = status_icons_for_player();
+    cell->tile.icons = std::move(status_icons_for_player());
     if (anim_updates)
         tile_apply_animations(cell->tile.bg, &tile_env.flv(gc));
 #else
@@ -1231,7 +1231,7 @@ static void _draw_los(screen_cell_t *cell,
     cell->tile.fg = tile_env.fg(ep);
     cell->tile.bg = tile_env.bg(ep);
     cell->tile.cloud = tile_env.cloud(ep);
-    cell->tile.icons = tile_env.icons[ep];
+    cell->tile.icons = tile_env.icons(ep);
     if (anim_updates)
         tile_apply_animations(cell->tile.bg, &tile_env.flv(gc));
 #else

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1211,7 +1211,7 @@ static void _draw_player(screen_cell_t *cell,
     cell->tile.fg = tile_env.fg(ep) = tileidx_player();
     cell->tile.bg = tile_env.bg(ep);
     cell->tile.cloud = tile_env.cloud(ep);
-    cell->tile.icons = std::move(status_icons_for_player());
+    cell->tile.icons = status_icons_for_player();
     if (anim_updates)
         tile_apply_animations(cell->tile.bg, &tile_env.flv(gc));
 #else


### PR DESCRIPTION
The typical case is zero icons. every single packed_cell uses 48 bytes nonetheless.