### PR TITLE
Fix harmless beams prompting when hitting allies (cool 3)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -7845,6 +7845,9 @@ void player_beam_tracer::monster_hit(const bolt& beam, const monster& mon)
     if (!you.can_see(mon))
         return;
 
+    if (beam.is_harmless(&mon))
+        return;
+
     bool penance = false;
     string adj, suffix;
     if (bad_attack(&mon, adj, suffix, penance))


### PR DESCRIPTION
There shouldn't be a prompt warning you that you will hit your allies with a beam if the beam is harmless to your allies. I accidentally broke this in commit 1564750