### PR TITLE
Fix player tracers not warning when path is blocked (staticshock)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -1297,7 +1297,7 @@ void bolt::do_fire()
             // and we're actually between you and the target...
             && !passed_target && pos() != target && pos() != source
             // ?
-            && tracer->has_hit_foe() && bounces == 0 && reflections == 0
+            && !tracer->has_hit_foe() && bounces == 0 && reflections == 0
             // and you aren't shooting out of LOS.
             && you.see_cell(target))
         {


### PR DESCRIPTION
When trying to shoot through a plant or transparent wall you should get a message such as "Your line of fire to the ogre is blocked by a plant". However, I broke this in commit 1564750