### PR TITLE
Fix a crash when zooming local tiles (sulla)

### DIFF
--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -1040,9 +1040,9 @@ void TilesFramework::zoom_dungeon(bool in)
     current_scale = min(ceil(max_zoom*10)/10, max(0.2,
                     current_scale + (in ? ZOOM_INC : -ZOOM_INC)));
     do_layout(); // recalculate the viewport setup
+    redraw_screen(false);
     if (current_scale != orig)
         mprf(MSGCH_PROMPT, "Zooming to %.2f", (float) current_scale);
-    redraw_screen(false);
     update_screen();
 #endif
 }


### PR DESCRIPTION
When zooming in local tiles we call `do_layout` to calculate the new size of the view buffer (as well as other things). however, we need to call `redraw_screen` to actually resize the view buffer before next rendering or the game will crash. We were calling `mprf` before `redraw_screen` which can lead to a force more which can sometimes result in rendering.

This change maybe should be applied to earlier versions to, as in at least version 0.32 zooming in map view mode causes force mores by default.