### PR TITLE
Don't waste a turn when summoning with no space (NormalPerson7)

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3460,11 +3460,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
     }
 
     case ABIL_TSO_SUMMON_DIVINE_WARRIOR:
-        if (stop_summoning_prompt(MR_RES_POISON, M_FLIES))
-            return spret::abort;
-        fail_check();
-        summon_holy_warrior(you.skill(SK_INVOCATIONS, 4), false);
-        break;
+        return cast_summon_holy_warrior(you.skill(SK_INVOCATIONS, 4), fail);
 
     case ABIL_TSO_BLESS_WEAPON:
         simple_god_message(" will bless one of your weapons.");
@@ -3474,9 +3470,7 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         break;
 
     case ABIL_KIKU_UNEARTH_WRETCHES:
-        fail_check();
-        kiku_unearth_wretches();
-        break;
+        return kiku_unearth_wretches(fail);
 
     case ABIL_KIKU_SIGN_OF_RUIN:
         fail_check();
@@ -3642,12 +3636,12 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         break;
 
     case ABIL_TROG_BROTHERS_IN_ARMS:
-        fail_check();
-        // Trog abilities don't use or train invocations.
-        summon_berserker(you.piety +
-                         random2(you.piety/4) - random2(you.piety/4),
-                         &you);
-        break;
+    {
+        int pow = you.piety + random2(you.piety / 4);
+        // force a sequence point between random calls
+        pow -= random2(you.piety / 4);
+        return cast_summon_berserker(pow, fail);
+    }
 
     case ABIL_SIF_MUNA_FORGET_SPELL:
         if (cast_selective_amnesia() <= 0)

--- a/crawl-ref/source/mon-place.h
+++ b/crawl-ref/source/mon-place.h
@@ -13,6 +13,7 @@
 #include "dungeon-feature-type.h"
 #include "level-id.h"
 #include "mgen-enum.h"
+#include "mon-enum.h"
 #include "monster-type.h"
 #include "tag-version.h"
 #include "trap-type.h"
@@ -29,7 +30,7 @@ struct mgen_data;
  * a "puff of smoke" message if the monster cannot be placed. This is usually
  * used for summons and other monsters that want to appear near a given
  * position like a summon.
- * Returns -1 on failure, index into env.mons otherwise.
+ * Returns null on failure, the monster otherwise.
  * *********************************************************************** */
 monster* create_monster(mgen_data mg, bool fail_msg = true);
 
@@ -97,9 +98,16 @@ void check_lovelessness(monster &mon);
 bool find_habitable_spot_near(const coord_def& where, monster_type mon_type,
                               int radius, coord_def& result, int exclude_radius = -1,
                               const actor* in_sight_of = nullptr);
+bool you_can_see_habitable_spot_near(coord_def pos, habitat_type habitat,
+                                     int max_radius, int exclude_radius = 0);
+bool you_can_see_habitable_spot_near(habitat_type habitat, int max_radius,
+                                     int exclude_radius = 0);
 
 monster_type random_demon_by_tier(int tier);
 monster_type summon_any_demon(monster_type dct, bool use_local_demons = false);
+
+habitat_type habitat_for_any(const monster_type* mon_types,
+                             std::size_t types_count);
 
 bool monster_habitable_feat(const monster* mon,
                             dungeon_feature_type feat);

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -52,7 +52,9 @@ spret cast_summon_hydra(actor *caster, int pow, bool fail = false);
 spret cast_summon_mana_viper(int pow, bool fail);
 bool summon_berserker(int pow, actor *caster,
                       monster_type override_mons = MONS_PROGRAM_BUG);
+spret cast_summon_berserker(int pow, bool fail);
 bool summon_holy_warrior(int pow, bool punish);
+spret cast_summon_holy_warrior(int pow, bool fail);
 
 bool tukima_affects(const actor &target);
 void cast_tukimas_dance(int pow, actor *target);
@@ -126,14 +128,14 @@ spret fedhas_grow_ballistomycete(const coord_def& target, bool fail);
 spret fedhas_overgrow(bool fail);
 spret fedhas_grow_oklob(const coord_def& target, bool fail);
 
-void kiku_unearth_wretches();
+spret kiku_unearth_wretches(bool fail);
 
 spret cast_foxfire(actor &agent, int pow, bool fail,
                    bool marshlight = false);
 spret foxfire_swarm();
 bool summon_hell_out_of_bat(const actor &agent, coord_def pos);
 bool summon_spider(const actor &agent, coord_def pos, spell_type spell, int pow);
-spret summon_spiders(actor &agent, int pow, bool fail = false);
+spret summon_spiders(monster &agent, int pow, bool fail = false);
 bool summon_swarm_clone(const monster& agent, coord_def target_pos);
 
 spret summon_butterflies();
@@ -183,7 +185,7 @@ spret cast_monarch_bomb(const actor& agent, int pow, bool fail);
 bool monarch_deploy_bomblet(monster& original, const coord_def& target,
                             bool quiet = false);
 vector<coord_def> get_monarch_detonation_spots(const actor& agent);
-spret monarch_detonation(const actor& agent, int pow);
+spret monarch_detonation(const actor& agent, int pow, bool fail);
 
 spret cast_splinterfrost_shell(const actor& agent, const coord_def& aim, int pow,
                              bool fail);


### PR DESCRIPTION
When trying to summon a creature where you can't see any available space to place it, don't spend a turn or any resources.

Fixes #3837