### PR TITLE
Add a cachebusting key to lobby static assets

### DIFF
--- a/crawl-ref/source/webserver/static/scripts/app.js
+++ b/crawl-ref/source/webserver/static/scripts/app.js
@@ -6,7 +6,8 @@ require.config({
     paths: {
         'jquery': '/static/scripts/contrib/jquery'
     },
-    waitSeconds: 0
+    waitSeconds: 0,
+    urlArgs: game_version ? 'v=' + encodeURIComponent(game_version) : undefined,
 });
 
 require(['client']);

--- a/crawl-ref/source/webserver/templates/client.html
+++ b/crawl-ref/source/webserver/templates/client.html
@@ -5,9 +5,10 @@
     <link rel="icon" href="/static/stone_soup_icon-32x32.png" type="image/png">
     <script type="text/javascript">
       var socket_server = "{{ socket_server }}";
+      var game_version = "{{ game_version }}";
     </script>
-    <script src="/static/scripts/contrib/require.js" data-main="/static/scripts/app"></script>
-    <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <script src="/static/scripts/contrib/require.js?v={{ game_version }}" data-main="/static/scripts/app"></script>
+    <link rel="stylesheet" type="text/css" href="/static/style.css?v={{ game_version }}">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="viewport" content="width=860, initial-scale=1.0">

--- a/crawl-ref/source/webserver/webtiles/server.py
+++ b/crawl-ref/source/webserver/webtiles/server.py
@@ -60,6 +60,7 @@ class MainHandler(tornado.web.RequestHandler):
 
         with util.SlowWarning("Slow IO: render client.html"):
             self.render("client.html", socket_server = protocol + host + "/socket",
+                    game_version = _crawl_version,
                     username = None,
                     config = config,
                     reset_token = recovery_token, reset_token_error = recovery_token_error)


### PR DESCRIPTION
Adding a version string to all the lobby assets ensures that, if the server rebuilds and there is an update to client scripts, players will definitely get the update when they reload the browser, and not get a locally-cached copy of the file.

This enables use of more aggressive caching strategies, longer cache times, in-memory caching with nginx/Apache, or even pushing static assets over to CDN, if server admins wish to configure thing way, without worrying about the client browser potentially serving stale assets.