### PR TITLE
Fix erroneous warning when firing at enemy in front of friendly (dilly)

### DIFF
--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -366,7 +366,7 @@ private:
     // for monsters
     void affect_monster(monster* m);
     void kill_monster(monster &m);
-    void check_for_friendly_past_target(monster* mon);
+    bool check_for_friendly_past_target(monster* mon);
     bool attempt_block(monster* mon);
     void update_hurt_or_helped(monster* mon);
     void enchantment_affect_monster(monster* mon);


### PR DESCRIPTION
The beam would stop at the enemies, so the warning was incorrect. This was broken in commit 1564750