### PR TITLE
Rework habitats

### DIFF
--- a/crawl-ref/source/catch2-tests/test_mon-util.cc
+++ b/crawl-ref/source/catch2-tests/test_mon-util.cc
@@ -49,9 +49,16 @@ TEST_CASE("mons_habitat_type returns correct habitats", "[single-file]")
 
     SECTION("Water monsters should be HT_WATER")
     {
-        const auto habitat = mons_habitat_type(MONS_KRAKEN, MONS_KRAKEN);
+        const auto habitat = mons_habitat_type(MONS_ELECTRIC_EEL, MONS_ELECTRIC_EEL);
 
         REQUIRE(habitat == HT_WATER);
+    }
+
+    SECTION("Deep water monsters should be HT_DEEP_WATER")
+    {
+        const auto habitat = mons_habitat_type(MONS_KRAKEN, MONS_KRAKEN);
+
+        REQUIRE(habitat == HT_DEEP_WATER);
     }
 
     SECTION("Amphibious monsters should be HT_AMPHIBIOUS")

--- a/crawl-ref/source/dat/mons/eldritch-tentacle-segment.yaml
+++ b/crawl-ref/source/dat/mons/eldritch-tentacle-segment.yaml
@@ -11,7 +11,7 @@ hp_10x: 1200
 ac: 13
 ev: 0
 intelligence: animal
-habitat: amphibious
+habitat: eldritch_tentacle
 speed: 12
 size: giant
 shape: misc

--- a/crawl-ref/source/dat/mons/eldritch-tentacle.yaml
+++ b/crawl-ref/source/dat/mons/eldritch-tentacle.yaml
@@ -12,7 +12,7 @@ hp_10x: 1200
 ac: 13
 ev: 0
 intelligence: animal
-habitat: amphibious
+habitat: eldritch_tentacle
 speed: 12
 size: giant
 shape: snake

--- a/crawl-ref/source/dat/mons/kraken.yaml
+++ b/crawl-ref/source/dat/mons/kraken.yaml
@@ -12,7 +12,7 @@ ev: 0
 spells: kraken
 has_corpse: true
 intelligence: animal
-habitat: water
+habitat: deep_water
 speed: 14
 size: giant
 shape: misc

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -1125,9 +1125,10 @@ static inline bool _monster_warning(activity_interrupt ai,
         else if (at.context == SC_FISH_SURFACES)
         {
             text += " bursts forth from the ";
-            if (mons_primary_habitat(*mon) == HT_LAVA)
+            const habitat_type habitat = mons_habitat(*mon);
+            if (habitat & HT_LAVA)
                 text += "lava";
-            else if (mons_primary_habitat(*mon) == HT_WATER)
+            else if (habitat & HT_WATER)
                 text += "water";
             else
                 text += "realm of bugdom";

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -4014,7 +4014,7 @@ static void _place_aquatic_in(vector<coord_def> &places, const vector<pop_entry>
         mg.pos = places[i];
 
         // Amphibious creatures placed with water should hang around it
-        if (mons_class_primary_habitat(mon) == HT_LAND)
+        if (mons_class_habitat(mon) & HT_DRY_LAND)
             mg.flags |= MG_PATROLLING;
 
         if (allow_zombies
@@ -5211,10 +5211,8 @@ monster* dgn_place_monster(mons_spec &mspec, coord_def where,
                                      ? fixup_zombie_type(type, mspec.monbase)
                                      : type;
 
-        const habitat_type habitat = mons_class_primary_habitat(montype);
-
         if (in_bounds(where) && !monster_habitable_grid(montype, where))
-            dungeon_terrain_changed(where, habitat2grid(habitat));
+            dungeon_terrain_changed(where, preferred_feature_type(montype));
     }
 
     if (type == RANDOM_MONSTER)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -6609,8 +6609,7 @@ spret okawaru_duel(const coord_def& target, bool fail)
     }
 
     if (mons->is_peripheral()
-        || mons_primary_habitat(*mons) == HT_LAVA
-        || mons_primary_habitat(*mons) == HT_WATER
+        || !(mons_habitat(*mons) & HT_DRY_LAND)
         || mons->wont_attack())
     {
         mpr("You cannot duel that!");

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -144,7 +144,7 @@ static void _monster_regenerate(monster* mons)
     }
 
     // Non-land creatures out of their element cannot regenerate.
-    if (mons_primary_habitat(*mons) != HT_LAND
+    if (!(mons_habitat(*mons) & HT_DRY_LAND)
         && !monster_habitable_grid(mons, mons->pos()))
     {
         return;
@@ -3148,7 +3148,6 @@ bool mon_can_move_to_pos(const monster* mons, const coord_def& delta,
         return false;
 
     const dungeon_feature_type target_grid = env.grid(targ);
-    const habitat_type habitat = mons_primary_habitat(*mons);
 
     // No monster may enter the open sea.
     if (feat_is_endless(target_grid))
@@ -3272,7 +3271,7 @@ bool mon_can_move_to_pos(const monster* mons, const coord_def& delta,
     // [dshaligram] Monsters now prefer to head for deep water only if
     // they're low on hitpoints. No point in hiding if they want a
     // fight.
-    if (habitat == HT_WATER
+    if (!(mons_habitat(*mons) & HT_DRY_LAND)
         && targ != you.pos()
         && target_grid != DNGN_DEEP_WATER
         && env.grid(mons->pos()) == DNGN_DEEP_WATER
@@ -3750,7 +3749,7 @@ static bool _monster_move(monster* mons, coord_def& delta)
     ASSERT(mons); // XXX: change to monster &mons
     move_array good_move;
 
-    const habitat_type habitat = mons_primary_habitat(*mons);
+    const habitat_type habitat = mons_habitat(*mons);
     bool deep_water_available = false;
 
     // TODO: move the below logic out of move code.
@@ -3776,8 +3775,8 @@ static bool _monster_move(monster* mons, coord_def& delta)
             if (!cell_is_solid(*ai))
             {
                 adj_move.push_back(*ai);
-                if (habitat == HT_WATER && feat_is_water(env.grid(*ai))
-                    || habitat == HT_LAVA && feat_is_lava(env.grid(*ai)))
+                if ((habitat & HT_DEEP_WATER) && feat_is_water(env.grid(*ai))
+                    || (habitat & HT_LAVA) && feat_is_lava(env.grid(*ai)))
                 {
                     adj_water.push_back(*ai);
                 }

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -1408,8 +1408,9 @@ static string _derived_undead_message(const monster &mons, monster_type which_z,
         return "A buggy dead thing appears!";
     }
 
-    const auto habitat = mons_class_primary_habitat(mons.type);
-    if (habitat == HT_WATER || habitat == HT_LAVA)
+    const habitat_type habitat = mons_class_habitat(mons.type);
+    const habitat_type swimming_habitats = (habitat_type)(HT_WATER | HT_LAVA);
+    if ((habitat & swimming_habitats) == habitat)
         return "The dead are swimming!";
 
     if (mons_class_flag(mons.type, M_FLIES))

--- a/crawl-ref/source/mon-enum.h
+++ b/crawl-ref/source/mon-enum.h
@@ -196,14 +196,21 @@ enum mon_intel_type             // Must be in increasing intelligence order
 
 enum habitat_type
 {
-    // Flying monsters will appear in all categories except rock walls
-    HT_LAND = 0,         // Land critters
-    HT_AMPHIBIOUS,       // Amphibious creatures
-    HT_WATER,            // Water critters
-    HT_LAVA,             // Lava critters
-    HT_AMPHIBIOUS_LAVA,  // Amphibious w/ lava (salamanders)
 
-    NUM_HABITATS
+    HT_NONE = 0,
+    HT_DRY_LAND = 1 << 0,
+    HT_SHALLOW_WATER = 1 << 1,
+    HT_DEEP_WATER = 1 << 2,
+    HT_LAVA = 1 << 3,
+    HT_MALIGN_GATEWAY = 1 << 4,
+
+    HT_LAND = HT_DRY_LAND | HT_SHALLOW_WATER,
+    HT_AMPHIBIOUS = HT_LAND | HT_DEEP_WATER,
+    HT_WATER = HT_SHALLOW_WATER | HT_DEEP_WATER,
+    HT_AMPHIBIOUS_LAVA = HT_LAND | HT_LAVA,
+    HT_ELDRITCH_TENTACLE = HT_AMPHIBIOUS | HT_MALIGN_GATEWAY,
+    // Flying monsters will appear in all categories except HT_MALIGN_GATEWAY
+    HT_FLYER = HT_LAND | HT_WATER | HT_LAVA,
 };
 
 // order of these is important:

--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -432,23 +432,8 @@ static bool _habitat_matches(bool orig_flies, habitat_type orig_hab,
         return false;
 
     const habitat_type new_hab = mons_habitat_type(new_type, new_type, false);
-    switch (orig_hab)
-    {
-        case HT_AMPHIBIOUS:
-        case HT_AMPHIBIOUS_LAVA:
-            return new_hab == orig_hab;
-        case HT_WATER:
-            return new_hab == orig_hab || new_hab == HT_AMPHIBIOUS;
-        case HT_LAVA:
-            return new_hab == orig_hab || new_hab == HT_AMPHIBIOUS_LAVA;
-        case HT_LAND:
-            return new_hab == orig_hab
-                || new_hab == HT_AMPHIBIOUS
-                || new_hab == HT_AMPHIBIOUS_LAVA;
-        case NUM_HABITATS:
-            break;
-    }
-    return false; // should never happen
+
+    return (new_hab & orig_hab) == orig_hab;
 }
 
 static int _goal_hd(int orig_hd, poly_power_type ppt)

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -89,9 +89,18 @@ struct mon_display
 
 static mon_display monster_symbols[NUM_MONSTERS];
 
+enum primary_habitat_type
+{
+    PHT_LAND = 0,
+    PHT_WATER,
+    PHT_LAVA,
+
+    NUM_PRIMARY_HABITATS
+};
+
 static bool initialised_randmons = false;
-static vector<monster_type> monsters_by_habitat[NUM_HABITATS];
-static vector<monster_type> species_by_habitat[NUM_HABITATS];
+static vector<monster_type> monsters_by_habitat[NUM_PRIMARY_HABITATS];
+static vector<monster_type> species_by_habitat[NUM_PRIMARY_HABITATS];
 
 #include "mon-spell.h"
 #include "mon-data.h"
@@ -129,43 +138,60 @@ bool monster_inherently_flies(const monster &mons)
         || mons.has_facet(BF_BAT);
 }
 
-static habitat_type _grid2habitat(dungeon_feature_type grid)
+static primary_habitat_type _grid_2_primary_habitat(dungeon_feature_type grid)
 {
     if (feat_is_water(grid))
-        return HT_WATER;
+        return PHT_WATER;
 
     switch (grid)
     {
     case DNGN_LAVA:
-        return HT_LAVA;
+        return PHT_LAVA;
     case DNGN_FLOOR:
     default:
-        return HT_LAND;
+        return PHT_LAND;
     }
 }
 
-dungeon_feature_type habitat2grid(habitat_type ht)
+dungeon_feature_type _primary_habitat_2_grid(primary_habitat_type ht)
 {
     switch (ht)
     {
-    case HT_WATER:
+    case PHT_WATER:
         return DNGN_DEEP_WATER;
-    case HT_LAVA:
+    case PHT_LAVA:
         return DNGN_LAVA;
-    case HT_LAND:
-    case HT_AMPHIBIOUS:
-    case HT_AMPHIBIOUS_LAVA:
+    case PHT_LAND:
     default:
         return DNGN_FLOOR;
     }
 }
 
+static primary_habitat_type _primary_habitat(habitat_type ht)
+{
+    if (ht & HT_LAND)
+        return PHT_LAND;
+    if (ht & HT_LAVA)
+        return PHT_LAVA;
+    if (ht & HT_DEEP_WATER)
+        return PHT_WATER;
+
+    return PHT_LAND;
+}
+
+dungeon_feature_type preferred_feature_type(monster_type mt)
+{
+    const habitat_type ht = mons_class_habitat(mt);
+    return _primary_habitat_2_grid(_primary_habitat(ht));
+}
+
 static void _initialise_randmons()
 {
-    for (int i = 0; i < NUM_HABITATS; ++i)
+    for (int i = 0; i < NUM_PRIMARY_HABITATS; ++i)
     {
         set<monster_type> tmp_species;
-        const dungeon_feature_type feat = habitat2grid(habitat_type(i));
+        const primary_habitat_type habitat = primary_habitat_type(i);
+        const dungeon_feature_type feat = _primary_habitat_2_grid(habitat);
 
         for (monster_type mt = MONS_0; mt < NUM_MONSTERS; ++mt)
         {
@@ -192,7 +218,7 @@ monster_type random_monster_at_grid(const coord_def& p, bool species)
     if (!initialised_randmons)
         _initialise_randmons();
 
-    const habitat_type ht = _grid2habitat(env.grid(p));
+    const primary_habitat_type ht = _grid_2_primary_habitat(env.grid(p));
     const vector<monster_type> &valid_mons = species ? species_by_habitat[ht]
                                                      : monsters_by_habitat[ht];
 
@@ -3384,8 +3410,7 @@ mon_intel_type mons_intel(const monster& m)
     return mons_class_intel(mon.type);
 }
 
-static habitat_type _mons_class_habitat(monster_type mc,
-                                        bool real_amphibious = false)
+habitat_type mons_class_habitat(monster_type mc, bool real_amphibious)
 {
     const monsterentry *me = get_monster_data(mc);
     habitat_type ht = (me ? me->habitat
@@ -3404,8 +3429,8 @@ static habitat_type _mons_class_habitat(monster_type mc,
 habitat_type mons_habitat_type(monster_type t, monster_type base_t,
                                bool real_amphibious)
 {
-    return _mons_class_habitat(fixup_zombie_type(t, base_t),
-                               real_amphibious);
+    return mons_class_habitat(fixup_zombie_type(t, base_t),
+                              real_amphibious);
 }
 
 habitat_type mons_habitat(const monster& mon, bool real_amphibious)
@@ -3414,32 +3439,6 @@ habitat_type mons_habitat(const monster& mon, bool real_amphibious)
         ? draconian_subspecies(mon) : mon.type;
 
     return mons_habitat_type(type, mons_base_type(mon), real_amphibious);
-}
-
-habitat_type mons_class_primary_habitat(monster_type mc)
-{
-    habitat_type ht = _mons_class_habitat(mc);
-    if (ht == HT_AMPHIBIOUS || ht == HT_AMPHIBIOUS_LAVA)
-        ht = HT_LAND;
-    return ht;
-}
-
-habitat_type mons_primary_habitat(const monster& mon)
-{
-    const monster_type type = mons_is_draconian_job(mon.type)
-        ? draconian_subspecies(mon) : mons_base_type(mon);
-
-    return mons_class_primary_habitat(type);
-}
-
-habitat_type mons_class_secondary_habitat(monster_type mc)
-{
-    habitat_type ht = _mons_class_habitat(mc);
-    if (ht == HT_AMPHIBIOUS)
-        ht = HT_WATER;
-    if (ht == HT_AMPHIBIOUS_LAVA)
-        ht = HT_LAVA;
-    return ht;
 }
 
 int mons_power(monster_type mc)

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -188,7 +188,7 @@ static inline int get_resist(resists_t all, mon_resist_flags res)
     return v;
 }
 
-dungeon_feature_type habitat2grid(habitat_type ht);
+dungeon_feature_type preferred_feature_type(monster_type mt);
 
 monsterentry *get_monster_data(monster_type mc) IMMUTABLE;
 int get_mons_class_ac(monster_type mc) IMMUTABLE;
@@ -287,15 +287,12 @@ bool should_attract_mons(const monster &m);
 mon_intel_type mons_class_intel(monster_type mc);
 mon_intel_type mons_intel(const monster& mon);
 
-// Use mons_habitat() and mons_primary_habitat() wherever possible,
-// since the class variants do not handle zombies correctly.
+// Use mons_habitat() wherever possible, since the class variants do not
+// handle zombies correctly.
 habitat_type mons_habitat_type(monster_type t, monster_type base_t,
                                bool real_amphibious = false);
+habitat_type mons_class_habitat(monster_type t, bool real_amphibious = false);
 habitat_type mons_habitat(const monster& mon, bool real_amphibious = false);
-
-habitat_type mons_class_primary_habitat(monster_type mc);
-habitat_type mons_primary_habitat(const monster& mon);
-habitat_type mons_class_secondary_habitat(monster_type mc);
 
 bool mons_skeleton(monster_type mc);
 

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -514,15 +514,30 @@ bool feat_is_trap(dungeon_feature_type feat)
     return get_feature_def(feat).flags & FFT_TRAP;
 }
 
+/** Is this feature a type of water that is too deep for most creatures to
+*   wade through?
+*/
+bool feat_is_deep_water(dungeon_feature_type feat)
+{
+    return feat == DNGN_DEEP_WATER
+           || feat == DNGN_OPEN_SEA;
+}
+
+/** Is this feature a type of water that is shallow enough to wade through?
+*/
+bool feat_is_shallow_water(dungeon_feature_type feat)
+{
+    return feat == DNGN_SHALLOW_WATER
+           || feat == DNGN_TOXIC_BOG
+           || feat == DNGN_MANGROVE;
+}
+
 /** Is this feature a type of water, with the concomitant dangers/bonuses?
  */
 bool feat_is_water(dungeon_feature_type feat)
 {
-    return feat == DNGN_SHALLOW_WATER
-           || feat == DNGN_DEEP_WATER
-           || feat == DNGN_OPEN_SEA
-           || feat == DNGN_TOXIC_BOG
-           || feat == DNGN_MANGROVE;
+    return feat_is_shallow_water(feat)
+           || feat_is_deep_water(feat);
 }
 
 /** Is this feature a kind of lava?

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -73,6 +73,8 @@ string feat_preposition(dungeon_feature_type feat, bool active = false,
                         const actor* who = nullptr);
 string stair_climb_verb(dungeon_feature_type feat);
 
+bool feat_is_deep_water(dungeon_feature_type feat);
+bool feat_is_shallow_water(dungeon_feature_type feat);
 bool feat_is_water(dungeon_feature_type feat);
 bool feat_is_lava(dungeon_feature_type feat);
 god_type feat_altar_god(dungeon_feature_type feat);

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -439,9 +439,9 @@ static void _catchup_monster_moves(monster* mon, int turns)
         return;
 
     // Don't move non-land or stationary monsters around.
-    if (mons_primary_habitat(*mon) != HT_LAND
+    if (!(mons_habitat(*mon) & HT_DRY_LAND)
         || mons_is_zombified(*mon)
-           && mons_class_primary_habitat(mon->base_monster) != HT_LAND
+           && !(mons_class_habitat(mon->base_monster) & HT_DRY_LAND)
         || mon->is_stationary())
     {
         return;

--- a/crawl-ref/source/util/mon-gen.py
+++ b/crawl-ref/source/util/mon-gen.py
@@ -322,7 +322,8 @@ HOLINESSES = {'holy', 'natural', 'undead', 'demonic', 'nonliving', 'plant'}
 def parse_holiness(s):
     return [parse_enum(h, "MH_", HOLINESSES) for h in s]
 
-HABITATS = {'land', 'amphibious', 'water', 'lava', 'amphibious_lava'}
+HABITATS = {'land', 'amphibious', 'water', 'lava', 'amphibious_lava',
+            'deep_water', 'eldritch_tentacle'}
 def parse_habitat(s):
     return parse_enum(s, "HT_", HABITATS)
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -301,14 +301,26 @@ void debug_list_monsters()
     }
 }
 
-static const char* ht_names[] =
+static string _habitat_debug_name(habitat_type ht)
 {
-    "land",
-    "amphibious",
-    "water",
-    "lava",
-    "amphibious_lava",
-};
+    string result;
+    if (ht & HT_DRY_LAND)
+        result += "dry_land|";
+    if (ht & HT_SHALLOW_WATER)
+        result += "shallow_water|";
+    if (ht & HT_DEEP_WATER)
+        result += "deep_water|";
+    if (ht & HT_LAVA)
+        result += "lava|";
+    if (ht & HT_LAVA)
+        result += "malign_gateway|";
+    if (ht >= (HT_LAVA << 1))
+        result += "INVALID|";
+    if (result.empty())
+        return "none";
+    result.pop_back();
+    return result;
+}
 
 // Prints a number of useful (for debugging, that is) stats on monsters.
 void debug_stethoscope(int mon)
@@ -387,14 +399,11 @@ void debug_stethoscope(int mon)
     }
 
     // Print habitat and behaviour information.
-    const habitat_type hab = mons_habitat(mons);
-
-    COMPILE_CHECK(ARRAYSZ(ht_names) == NUM_HABITATS);
     const actor * const summoner = actor_by_mid(mons.summoner);
     mprf(MSGCH_DIAGNOSTICS,
          "hab=%s beh=%s(%d) foe=%s(%d) mem=%d target=(%d,%d) "
          "firing_pos=(%d,%d) patrol_point=(%d,%d) god=%s%s",
-         (hab >= 0 && hab < NUM_HABITATS) ? ht_names[hab] : "INVALID",
+         _habitat_debug_name(mons_habitat(mons)).c_str(),
          mons.asleep()                    ? "sleep"
          : mons.behaviour == BEH_BATTY   ? "flitting"
          : mons_is_wandering(mons)       ? "wander"


### PR DESCRIPTION
Store habitats as a bit mask of the different terrain categories monsters of that habitat can survive on. This lets us easily check of one habitat is more restrictive than another or if a monster can survive on a category of terrain e.g. land, water, shallow water or deep water etc.