### PR TITLE
Fix bump attacks with range using a turn when cancelled (Kab)

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -440,7 +440,7 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
             if (Options.auto_switch && _autoswitch_to_melee())
                 return true; // Is this right? We did take time, but we didn't melee
             if (!simu && _autofire_at(defender))
-                return true;
+                return you.turn_is_over;
         }
 
         melee_attack attk(&you, defender);


### PR DESCRIPTION
If you attacked an enemy with a ranged weapon by trying to move into their space and it give you a warning prompt, saying no to the prompt would still spend a turn.