### PR TITLE
Let Percussive Tempering target splinterfrost barricades by default

### DIFF
--- a/crawl-ref/source/dat/mons/splinterfrost-barricade.yaml
+++ b/crawl-ref/source/dat/mons/splinterfrost-barricade.yaml
@@ -1,6 +1,6 @@
 name: "splinterfrost barricade"
 glyph: {char: "I", colour: lightcyan}
-flags: [stationary, no_exp_gain, no_threat]
+flags: [stationary, no_exp_gain]
 resists: {fire: -1, cold: 3}
 holiness: [nonliving]
 will: invuln


### PR DESCRIPTION
...by removing the M_NO_THREAT monster flag from splinterfrost barricades. Unfortunately this will make targeting more awkward against player ghosts with Splinterfrost Barricade, as it will cause most beams to consider them to be default valid targets. However, such ghosts are rare. So hopefully this is an improvement to the status quo.

This will resolve #4343.