### PR TITLE
Fix random blinks not interrupting delays

### DIFF
--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -152,6 +152,7 @@ void uncontrolled_blink(bool override_stasis, int max_distance)
     const coord_def origin = you.pos();
     move_player_to_grid(target, false);
     _place_tloc_cloud(origin);
+    stop_delay(true);
 
     crawl_state.potential_pursuers.clear();
 }


### PR DESCRIPTION
Previously, (among other issues), the player could continue to pass through a wall with Passwall after being blinked away from that wall (e.g. from a monster with a distortion weapon).

This will fix #4430.