### PR TITLE
Fix spells being greyed out on forget/adjust/quiver spell lists

### DIFF
--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -86,7 +86,7 @@ static void _adjust_spell()
 
     // Select starting slot
     mprf(MSGCH_PROMPT, "Adjust which spell? ");
-    int keyin = list_spells(false, false, false, "adjust");
+    int keyin = list_spells(false, false, false, false, "adjust");
 
     if (!isaalpha(keyin))
     {
@@ -123,7 +123,7 @@ static void _adjust_spell()
         // XX this does not really work well with new menu code
         if (keyin == '?' || keyin == '*')
         {
-            keyin = list_spells(true, false, false, "adjust it to");
+            keyin = list_spells(true, false, false, false, "adjust it to");
             if (keyin < 'a' || keyin > 'Z')
                 continue;
         }

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -2827,7 +2827,7 @@ namespace quiver
                 return _choose_from_inv();
             else if (key == '&' && any_spells)
             {
-                const int skey = list_spells(false, false, false,
+                const int skey = list_spells(false, false, false, false,
                                                     "quiver");
                 if (skey == 0)
                     return true;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -116,11 +116,11 @@ void surge_power_wand(const int mp_cost)
     }
 }
 
-static string _spell_base_description(spell_type spell, bool viewing)
+static string _spell_base_description(spell_type spell, bool transient)
 {
     ostringstream desc;
 
-    int highlight =  spell_highlight_by_utility(spell, COL_UNKNOWN, !viewing);
+    int highlight =  spell_highlight_by_utility(spell, COL_UNKNOWN, transient);
     if (you.duration[DUR_ENKINDLED] && highlight == COL_UNKNOWN
         && spell_can_be_enkindled(spell))
     {
@@ -157,11 +157,11 @@ static string _spell_base_description(spell_type spell, bool viewing)
     return desc.str();
 }
 
-static string _spell_extra_description(spell_type spell, bool viewing)
+static string _spell_extra_description(spell_type spell, bool transient)
 {
     ostringstream desc;
 
-    int highlight =  spell_highlight_by_utility(spell, COL_UNKNOWN, !viewing);
+    int highlight =  spell_highlight_by_utility(spell, COL_UNKNOWN, transient);
     if (you.duration[DUR_ENKINDLED] && spell_can_be_enkindled(spell) && highlight == COL_UNKNOWN)
         highlight = LIGHTCYAN;
 
@@ -246,8 +246,8 @@ protected:
 // selector is a boolean function that filters spells according
 // to certain criteria. Currently used for Tiles to distinguish
 // spells targeted on player vs. spells targeted on monsters.
-int list_spells(bool toggle_with_I, bool viewing, bool allow_preselect,
-                const string &action)
+int list_spells(bool toggle_with_I, bool transient, bool viewing,
+                bool allow_preselect, const string &action)
 {
     if (toggle_with_I && get_spell_by_letter('I') != SPELL_NO_SPELL)
         toggle_with_I = false;
@@ -297,10 +297,10 @@ int list_spells(bool toggle_with_I, bool viewing, bool allow_preselect,
             continue;
 
         SpellMenuEntry* me =
-            new SpellMenuEntry(_spell_base_description(spell, viewing),
-                               _spell_extra_description(spell, viewing),
+            new SpellMenuEntry(_spell_base_description(spell, transient),
+                               _spell_extra_description(spell, transient),
                                MEL_ITEM, 1, letter);
-        me->colour = spell_highlight_by_utility(spell, COL_UNKNOWN, !viewing);
+        me->colour = spell_highlight_by_utility(spell, COL_UNKNOWN, transient);
         // TODO: maybe fill this from the quiver if there's a quivered spell and
         // no last cast one?
         if (allow_preselect && you.last_cast_spell == spell)
@@ -649,7 +649,7 @@ void inspect_spells()
         return;
     }
 
-    list_spells(true, true);
+    list_spells(true, false, true);
 }
 
 /**
@@ -862,7 +862,7 @@ spret cast_a_spell(bool check_range, spell_type spell, dist *_target,
 
             if (keyin == '?' || keyin == '*' || Options.spell_menu)
             {
-                keyin = list_spells(true, false);
+                keyin = list_spells(true, true, false);
                 if (!keyin)
                     keyin = ESCAPE;
 

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -92,8 +92,8 @@ enum class spret
 void surge_power(const int enhanced);
 void surge_power_wand(const int mp_cost);
 
-int list_spells(bool toggle_with_I = true, bool viewing = false,
-                bool allow_preselect = true,
+int list_spells(bool toggle_with_I = true, bool transient = false,
+                bool viewing = false, bool allow_preselect = true,
                 const string &title = "cast");
 int raw_spell_fail(spell_type spell, bool enkindled = false);
 int calc_spell_power(spell_type spell);

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -132,7 +132,7 @@ int cast_selective_amnesia(const string &pre_msg)
     int slot;
 
     // Pick a spell to forget.
-    keyin = list_spells(false, false, false, "forget");
+    keyin = list_spells(false, false, false, false, "forget");
     redraw_screen();
     update_screen();
 


### PR DESCRIPTION
Spells which were not currently useful because there was no targetable monster in sight would be greyed out on the forget/adjust/quiver spell lists.

This will fix #4397.