### PR TITLE
Stop Summon Holies trying to summon too many monsters

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -7489,6 +7489,9 @@ void mons_cast(monster* mons, bolt pbolt, spell_type spell_cast,
         sumcount2 = 1 + random2(2); // sequence point
         sumcount2 += random2(mons->spell_hd(spell_cast) / 4 + 1);
 
+        // Spell has a summon cap of 4
+        sumcount2 = min(sumcount2, 4);
+
         duration  = min(2 + mons->spell_hd(spell_cast) / 5, 6);
         for (int i = 0; i < sumcount2; ++i)
         {


### PR DESCRIPTION
Summon Holies has a summon cap of 4, but the code previously allowed seraphs to make up to at least 8 at once, causing the excess to immediately disappear.

This will fix #4288.