### PR TITLE
Change how flayed duration increases when a flayed ghost is in view

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -827,7 +827,7 @@ static void _decrement_durations()
                 heal_flayed_effect(&you);
         }
         else if (you.duration[DUR_FLAYED] < 80)
-            you.duration[DUR_FLAYED] += div_rand_round(50, delay);
+            you.duration[DUR_FLAYED] += div_rand_round(delay, 2);
     }
 
     if (you.duration[DUR_TOXIC_RADIANCE])


### PR DESCRIPTION
It used to increase by more per turn if your turns were quicker e.g. taking a turn of length 10 auts would increase it by 5 auts but taking a turn of length 1 aut would increase it by 50 auts and a turn being cut short to 0 auts by your rest being interrupted would result in a crash. After this change the increase is equal to half the time your turn took.