### PR TITLE
Fix "Aiming Wall Jump instantly removes constriction"

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -6527,8 +6527,6 @@ spret wu_jian_wall_jump_ability()
         return spret::abort;
     }
 
-    you.stop_being_constricted(false, "jump");
-
     // query for location:
     dist beam;
 
@@ -6569,6 +6567,8 @@ spret wu_jian_wall_jump_ability()
 
     if (!wu_jian_do_wall_jump(beam.target))
         return spret::abort;
+
+    you.stop_being_constricted(false, "jump");
 
     crawl_state.cancel_cmd_again();
     crawl_state.cancel_cmd_repeat();


### PR DESCRIPTION
For Issue https://github.com/crawl/crawl/issues/4456

The constriction removal now happens after the targeting and checking for exclusions.