### PR TITLE
Fix wizmode not being able to place electric eels

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -127,7 +127,7 @@ bool monster_inherently_flies(const monster &mons)
 dungeon_feature_type preferred_feature_type(monster_type mt)
 {
     const habitat_type ht = mons_class_habitat(mt);
-    if (ht & HT_LAND)
+    if (ht & HT_DRY_LAND)
         return DNGN_FLOOR;
     if (ht & HT_LAVA)
         return DNGN_LAVA;


### PR DESCRIPTION
When placing an electric eel using wizard mode, if there isn't any water near by it should place water and then place the eel in the water. However, it was placing a floor tile instead.