### PR TITLE
Fix malign gateway not spawning its tentacle (caiman-dorohedoro)

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -3346,7 +3346,7 @@ habitat_type mons_class_habitat(monster_type mc, bool core_only)
         if (ht == HT_LAND && st >= SIZE_GIANT)
             ht = HT_AMPHIBIOUS;
         if (me && monster_class_flies(mc))
-            ht = HT_FLYER;
+            ht = (habitat_type)(ht | HT_FLYER);
     }
     return ht;
 }


### PR DESCRIPTION
We where giving eldritch tenacles a habitat of HT_FLYER instead of HT_FLYER | HT_MALIGN_GATEWAY which was preventing them from spawning on the tile containing the malign gateway.

Fixes #4464