### PR TITLE
Fix no warning when rampaging over trap (CrawlOdds)

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -632,6 +632,21 @@ monster* get_rampage_target(coord_def move)
     return nullptr;
 }
 
+static bool _check_rampage(bool attacking, coord_def rampage_destination,
+                           coord_def rampage_target, const string& noun)
+{
+    if (attacking)
+    {
+        return check_moveto(rampage_destination, noun)
+               && wielded_weapon_check(you.weapon(), noun + " and attack");
+    }
+    // You won't always move over rampage_destination, sometimes an invisible
+    // monster will get in the way and stop you on it. But warning about this
+    // seems more annoying than useful --Wizard Ike
+    return check_move_over(rampage_destination, noun)
+           && check_moveto(rampage_target, noun);
+}
+
 /**
  * Rampages the player toward a hostile monster, if one exists in the direction
  * of the move input. Invalid things along the rampage path cancel the rampage.
@@ -698,9 +713,7 @@ static spret _rampage_forward(coord_def move)
     // * dangerous terrain/trap/cloud/exclusion prompt
     // * weapon check prompts;
     // messaging for this is handled by check_moveto().
-    if (attacking && !check_moveto(rampage_destination, noun)
-        || attacking && !wielded_weapon_check(you.weapon(), noun + " and attack")
-        || !attacking && !check_moveto(rampage_target, noun))
+    if (!_check_rampage(attacking, rampage_destination, rampage_target, noun))
     {
         stop_running();
         you.turn_is_over = false;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -250,15 +250,9 @@ static bool _check_moveto_dangerous(const coord_def& p, const string& msg)
     return false;
 }
 
-bool check_moveto_terrain(const coord_def& p, const string &move_verb,
-                          const string &msg, bool *prompted)
+static bool _check_moveto_binding_sigil(coord_def p, const string &move_verb,
+                                        const string &msg, bool *prompted)
 {
-    // Boldly go into the unknown (for ranged move prompts)
-    if (!env.map_knowledge(p).known())
-        return true;
-
-    if (!_check_moveto_dangerous(p, msg))
-        return false;
     if (env.grid(p) == DNGN_BINDING_SIGIL && !you.is_binding_sigil_immune())
     {
         string prompt;
@@ -277,6 +271,22 @@ bool check_moveto_terrain(const coord_def& p, const string &move_verb,
             return false;
         }
     }
+    return true;
+}
+
+bool check_moveto_terrain(const coord_def& p, const string &move_verb,
+                          const string &msg, bool *prompted)
+{
+    // Boldly go into the unknown (for ranged move prompts)
+    if (!env.map_knowledge(p).known())
+        return true;
+
+    if (!_check_moveto_dangerous(p, msg))
+        return false;
+
+    if (!_check_moveto_binding_sigil(p, move_verb, msg, prompted))
+        return false;
+
     if (!you.airborne() && !you.duration[DUR_NOXIOUS_BOG]
         && env.grid(you.pos()) != DNGN_TOXIC_BOG
         && env.grid(p) == DNGN_TOXIC_BOG)
@@ -386,6 +396,24 @@ bool check_moveto(const coord_def& p, const string &move_verb, bool physically)
            && check_moveto_cloud(p, move_verb)
            && check_moveto_trap(p, move_verb)
            && check_moveto_exclusion(p, move_verb);
+}
+
+static bool _check_move_over_terrain(coord_def p, const string& move_verb)
+{
+    // Boldly go into the unknown (for ranged move prompts)
+    if (!env.map_knowledge(p).known())
+        return true;
+
+    if (crawl_state.disables[DIS_CONFIRMATIONS])
+        return true;
+
+    return _check_moveto_binding_sigil(p, move_verb, "", nullptr);
+}
+
+bool check_move_over(coord_def p, const string& move_verb)
+{
+    return _check_move_over_terrain(p, move_verb)
+        && check_moveto_trap(p, move_verb);
 }
 
 // Returns true if this is a valid swap for this monster. If true, then

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -990,6 +990,8 @@ bool check_moveto_exclusion(const coord_def& p,
 bool check_moveto_trap(const coord_def& p, const string &move_verb = "step",
         bool *prompted = nullptr);
 
+bool check_move_over(coord_def p, const string& move_verb);
+
 bool swap_check(monster* mons, coord_def &loc, bool quiet = false);
 
 void move_player_to_grid(const coord_def& p, bool stepped);


### PR DESCRIPTION
When you rampage over a trap, the trap will be set off, so you should receive a warning. This was broken in 18e1206

Fixes #4459