### PR TITLE
Fix blood for blood spawning orcs faster the faster your turns

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -2711,7 +2711,7 @@ void beogh_blood_for_blood_tick(int delay)
     if (count * 3 <= max)
         rate *= 2;
 
-    int num_to_summon = div_rand_round(rate, delay * 5);
+    int num_to_summon = div_rand_round(rate * delay, 500);
 
     for (int i = 0; i < num_to_summon; ++i)
         _place_orcish_reinforcement();


### PR DESCRIPTION
A turn that took 5 auts would spawn in twice the number of orcs that a 10 aut turn would spawn, resulting in 4 times as any orcs spawning per aut. This change makes the average number of orcs spawned per aut the same no matter how long your turns take. It keeps the same spawn rate if you are taking turns of length 10 auts although this might need adjusting as many melee characters can have an attack delay closer to 7 auts when getting blood for blood online which would spawn at about twice the rate with the old system.

This also fixes a crash that would sometimes occur as sometimes turns can be cut short to 0 auts (e.g. when resting is interupted).