### PR TITLE
Fix arrow animation sometimes sticking around to long

### DIFF
--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -243,7 +243,11 @@ int MapRegion::handle_mouse(wm_mouse_event &event)
                 const command_type cmd =
                     click_travel(gc, event.mod & TILES_MOD_CTRL, false);
                 if (cmd != CMD_NO_CMD)
+                {
                     process_command(cmd);
+                    redraw_screen();
+                    update_screen();
+                }
             }
 
             return CK_MOUSE_CMD;


### PR DESCRIPTION
When ctrl-clicking a spot on the map adjacent to you in local tiles, you perform an attack. If this attack was with a ranged weapon, the arrow animation would stick around until you took a different action.

Fixes #4381