### PR TITLE
Fix shape shifters losing their thrall status icon (Monkooky)

### DIFF
--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -325,6 +325,7 @@ void change_monster_type(monster* mons, monster_type targetc, bool do_seen)
     mon_enchant insanity  = mons->get_ench(ENCH_FRENZIED);
     mon_enchant vengeance = mons->get_ench(ENCH_VENGEANCE_TARGET);
     mon_enchant tempered  = mons->get_ench(ENCH_TEMPERED);
+    mon_enchant thrall    = mons->get_ench(ENCH_VAMPIRE_THRALL);
 
     mons->number       = 0;
 
@@ -366,6 +367,7 @@ void change_monster_type(monster* mons, monster_type targetc, bool do_seen)
     mons->add_ench(insanity);
     mons->add_ench(vengeance);
     mons->add_ench(tempered);
+    mons->add_ench(thrall);
 
     mons->ench_countdown = old_ench_countdown;
 


### PR DESCRIPTION
When shape shifter vampire thralls changed shape they would incorrectly lose their thrall status icon.

Fixes #4386