### PR TITLE
Add missing Zig pillar traps

### DIFF
--- a/crawl-ref/source/dat/des/portals/ziggurat.des
+++ b/crawl-ref/source/dat/des/portals/ziggurat.des
@@ -527,6 +527,76 @@ G.G
 G.G
 ENDMAP
 
+NAME:   ziggurat_pillar_centre_dissolved
+TAGS:   ziggurat_pillar centered unrand no_exits
+WEIGHT: 5
+KFEAT:  ^ = devourer's trap
+MONS:   entropy weaver
+: if (you.zigs_completed() < 1) then
+SUBST:  G = G.
+: else
+SUBST:  G = GG.^
+SUBST:  . = ...1^
+: end
+FTILE:  .1^G = floor_iron
+: vault_metal_statue_setup(_G, "G", "iron statue")
+: megazig_zot_traps(_G)
+MAP
+^GG^
+G.1G
+G..G
+^GG^
+ENDMAP
+
+NAME:   ziggurat_pillar_centre_exhaustion
+TAGS:   ziggurat_pillar centered unrand no_exits
+WEIGHT: 5
+KFEAT:  ^ = archmage's trap
+: if (you.zigs_completed() < 1) then
+MONS:   occultist / deep elf sorcerer
+: else
+MONS:   ancient lich / dread lich w:5
+SUBST:  . = ..^
+: end
+FTILE:  .1^G = floor_hall
+: vault_metal_statue_setup(_G, "G", "arcane conduit")
+: megazig_zot_traps(_G)
+MAP
+G1G
+.^.
+G.G
+ENDMAP
+
+NAME:   ziggurat_pillar_centre_mighty_misfortune
+TAGS:   ziggurat_pillar centered unrand no_exits
+WEIGHT: 5
+KFEAT:  ^ = tyrant's trap / harlequin's trap
+KPROP:  ^ = bloody
+FTILE:  ^FG. = floor_orc
+: decorative_floor(_G, 'F', "orcish standard")
+: vault_metal_statue_setup(_G, "G", "misfortune conduit")
+: megazig_zot_traps(_G)
+MAP
+F.G
+.^.
+G..
+ENDMAP
+
+NAME:   ziggurat_pillar_centre_nasty_nets
+TAGS:   ziggurat_pillar centered unrand no_exits
+DEPTH:  Zig:10-
+WEIGHT: 5
+KFEAT:  ^ = net trap
+KFEAT:  m = iron_grate
+SUBST:  m = mmmmm...^
+FTILE:  ^m. = floor_tomb
+: megazig_zot_traps(_G)
+MAP
+mmm
+m^m
+m.m
+ENDMAP
+
 #######################################################################
 
 NAME: ziggurat1


### PR DESCRIPTION
Adds zig pillars for the remaining traps that have yet to be used there. All pillars have a weight of 5 and megazig_zot_traps

* ziggurat_pillar_centre_dissolved: Places a few devourer's traps, as well as an entropy weaver. After the first zig, replaces more statues and empty floor with traps. Uses the rusted iron statues and iron floor tiles from Dis.

* ziggurat_pillar_centre_exhaustion: Places an archmage's trap, plus an occultist or deep elf sorcerer. Starting from zig+1, it instead places an ancient or dread lich and can put additional archmage traps. Uses floor tiles from Elf.

* ziggurat_pillar_centre_mighty_misfortune: Places a harlequin's trap or tyrant's trap. These were originally two separate pillars, but as they basically do the same thing I decided to merge them into one. Uses floor tiles from Orc.

* ziggurat_pillar_centre_nasty_nets: Places one or more net traps, surrounded by a variable amount of iron grates. Limited to only place after zig:10 to avoid zig dippers being instantly netted and killed by a pan lord or something. Uses floor tiles from Tomb.

Known issues:
* Pillars more than 4 tiles wide will fail to place in oval and cross-shaped ziggurats (even on zig:27), so these have all been limited to 4 or less in width.

* Decorative floors/metal statues will show up as their generic base type when inspected

* nasty_nets placing multiple net traps before zig+1 might be a little too mean

I thought about putting a hydra or oni incarcerator next to the trap in mighty_misfortune but they often weren't positioned in a way where they would actually step on the trap and get the effects. Also it's only really funny if they're next to a harlequin trap (which won't always be the case). Not very on-theme either IMO