### PR TITLE
Minimal fix / demonstration of bug in reexperience

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -4171,7 +4171,8 @@ static void _builder_monsters()
         // of letting half the level spawn at the far reaches of deep water.
         if (in_shoals)
             mg.flags |= MG_PREFER_LAND;
-
+        // TODO: this probably needs to go get XP somehow? where should it come in?
+        mg.exp = 0;
         place_monster(mg);
     }
 

--- a/crawl-ref/source/mgen-data.h
+++ b/crawl-ref/source/mgen-data.h
@@ -19,6 +19,8 @@
 #define MGEN_BLOB_SIZE "blob_size"
 #define MGEN_TENTACLE_CONNECT "tentacle_connect"
 
+constexpr int UNINITIALIZED_EXP = -1;
+
 // A structure with all the data needed to whip up a new monster.
 struct mgen_data
 {
@@ -131,8 +133,9 @@ struct mgen_data
           summon_type(0), pos(p), foe(mfoe), flags(genflags), god(which_god),
           base_type(MONS_NO_MONSTER), colour(COLOUR_INHERIT),
           proximity(PROX_ANYWHERE), place(level_id::current()), hd(0), hp(0),
-          extra_flags(MF_NO_FLAGS), mname(""), non_actor_summoner(""),
-          initial_shifter(RANDOM_MONSTER), xp_tracking(XP_NON_VAULT)
+          exp(UNINITIALIZED_EXP), extra_flags(MF_NO_FLAGS), mname(""),
+          non_actor_summoner(""), initial_shifter(RANDOM_MONSTER),
+          xp_tracking(XP_NON_VAULT)
     { }
 
     mgen_data &set_non_actor_summoner(string nas)

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1088,8 +1088,10 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
         mon->props[KNOWN_MAX_HP_KEY] = mg.hp;
     }
 
-    if (mg.exp != 0)
+    if (mg.exp != 0) {
+        ASSERT(mg.exp != UNINITIALIZED_EXP);
         mon->exp = mg.exp;
+    }
 
     if (!crawl_state.game_is_arena())
     {


### PR DESCRIPTION
mgen_data did not zero-initialize or otherwise initialize exp in constructor.
Probably would be better to use RAII-style constructors rather than this "defaults + overwrite fields after" approach - less error prone.

For now, 
* use -1 as a sentinel
* assert if sentinel reaches the place mgen_data::exp transfers to monster::exp, and
* set mg.exp = 0in _builder_monsters; with this change, the assert doesn't trip at least in initial monster generation, so this is probalby our problem, but there could be other problems elsewhere.