### PR TITLE
Fix an invalid comparator being passed to std::sort

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -815,7 +815,7 @@ static bool _forced_removal_goodness(player_equip_entry* entry1, player_equip_en
         return true;
     }
 
-    return true;
+    return false;
 }
 
 /**


### PR DESCRIPTION
In `player_equip_set::get_forced_removal_list` we were passing a comparator to std::sort that returns true for equal items, however, it should return false.