### PR TITLE
Revise the description from 'Max blocks/turn' to 'Max blocks/action'

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2372,7 +2372,7 @@ static string _describe_armour(const item_def &item, bool verbose, bool monster)
                         + to_string(property(item, PARM_AC));
             description += "     Encumbrance rating: "
                         + to_string(-property(item, PARM_EVASION) / 10);
-            description += "     Max blocks/turn: "
+            description += "     Max blocks/action: "
                         + to_string(shield_block_limit(item));
             if (is_unrandom_artefact(item, UNRAND_WARLOCK_MIRROR))
                 description += _warlock_mirror_reflect_desc();


### PR DESCRIPTION
I found that the reset of shield-blocks value occurs after each action, rather than after each turn (in my understanding, turn refers to the impression of 10 aut). I think the description should be modified from blocks/turn to blocks/action. This makes it easier for readers of the description to understand the working principle. @PleasingFungus I hope you can review it:)