### PR TITLE
Fix fungal fisticloak popping off poltergeist when taking stairs

### DIFF
--- a/crawl-ref/source/player-equip.h
+++ b/crawl-ref/source/player-equip.h
@@ -97,8 +97,13 @@ struct player_equip_set
                                                  const item_def& new_item) const;
     equipment_slot find_equipped_slot(const item_def& item) const;
     equipment_slot find_slot_to_equip_item(const item_def& item,
-                                           vector<vector<item_def*>>& to_replace,
+                                           bool& requires_replace,
                                            bool ignore_curses = false) const;
+    equipment_slot find_free_slot(equipment_slot base_slot) const;
+    void find_removable_items_for_slot(equipment_slot base_slot,
+                                       vector<item_def*>& to_replace,
+                                       bool ignore_curses = false,
+                                       bool quite = true) const;
 
     int needs_chain_removal(const item_def& item, vector<item_def*>& to_replace,
                             bool cursed_okay = false);
@@ -107,11 +112,6 @@ struct player_equip_set
                                               bool is_save_cleanup = false);
 
 private:
-    equipment_slot find_slot_to_equip_item(equipment_slot base_slot,
-                                           vector<item_def*>& to_replace,
-                                           FixedVector<int, NUM_EQUIP_SLOTS>& slot_count,
-                                           bool ignore_curses) const;
-
     void handle_unmelding(vector<item_def*>& to_unmeld, bool skip_effects);
 };
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -4599,7 +4599,7 @@ static void _cleanup_book_ids(reader &th, int n_subtypes)
 // hopefully 'just work' in basically all normal cases.
 static void _convert_old_player_equipment()
 {
-    vector<vector<item_def*>> dummy;
+    bool dummy;
     // Calculate current player slots first.
     you.equipment.update();
     for (int i = 0; i < (int)old_eq.size(); ++i)


### PR DESCRIPTION
If you had all 6 aux slots filled, equipping the fungal fisticloak should remove two of them. However, it was only removing one leaving you with too many aux slots filled which would be fixed up by removing one of them when taking a staircase.

Fixes #4445 reported by alexbeloi