### PR TITLE
Fix uninitialized variables in beam.h (#4491)

### DIFF
--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -220,10 +220,10 @@ struct bolt
     mon_attitude_type attitude = ATT_HOSTILE; // attitude of whoever fired the bolt
     int foe_ratio = 0;           // 100* foe ratio (see mons_should_fire())
     map<mid_t, int> hit_count;   // how many times targets were affected
-    int foes_hurt;               // number of foes actually hurt
-    int foes_helped;             // number of foes actually helped
-    int friends_hurt;            // number of friends actually hurt
-    int friends_helped;          // number of friends actually helped
+    int foes_hurt = 0;               // number of foes actually hurt
+    int foes_helped = 0;             // number of foes actually helped
+    int friends_hurt = 0;            // number of friends actually hurt
+    int friends_helped = 0;          // number of friends actually helped
 
     beam_tracer* tracer = nullptr;
 


### PR DESCRIPTION
Fixes #4491 