### PR TITLE
Fix quote for microbat

### DIFF
--- a/crawl-ref/source/dat/descript/quotes.txt
+++ b/crawl-ref/source/dat/descript/quotes.txt
@@ -2521,7 +2521,6 @@ mad acolyte of Lugonu
 microbat
 
 <bat>
-
 %%%%
 phase bat
 


### PR DESCRIPTION
An extra blank line caused the microbat's quote to be literal `<bat>` rather than copying the basic bat quote.