### PR TITLE
Fix clear_to_end_of_line for windows console builds

### DIFF
--- a/crawl-ref/source/libconsole.h
+++ b/crawl-ref/source/libconsole.h
@@ -62,10 +62,8 @@ struct save_cursor_pos
     save_cursor_pos()
         : region(get_cursor_region()), pos(cgetpos(region))
     {
-#ifndef TARGET_OS_WINDOWS
         ASSERTM(valid_cursor_pos(pos.x, pos.y, region),
             "invalid cursor position %d,%d in region %d", pos.x, pos.y, region);
-#endif
     };
     ~save_cursor_pos()
     {

--- a/crawl-ref/source/libutil.cc
+++ b/crawl-ref/source/libutil.cc
@@ -380,7 +380,6 @@ bool valid_cursor_pos(int x, int y, GotoRegion region)
     return x >= 1 && y >= 1 && x <= sz.x && y <= sz.y;
 }
 
-#ifndef TARGET_OS_WINDOWS
 static GotoRegion _find_correct_region()
 {
     for (int r = GOTO_MSG; r < GOTO_MLIST; r++)
@@ -394,25 +393,22 @@ static GotoRegion _find_correct_region()
     // should probably fail for entirely invalid coords somehow
     return GOTO_CRT;
 }
-#endif
 
 void assert_valid_cursor_pos()
 {
-#ifndef TARGET_OS_WINDOWS
     GotoRegion region(get_cursor_region());
     coord_def pos(cgetpos(region));
     ASSERTM(valid_cursor_pos(pos.x, pos.y, region),
         "invalid cursor position %d,%d in region %d, should be %d,%d in region %d",
         pos.x, pos.y, region, cgetpos(_find_correct_region()).x,
         cgetpos(_find_correct_region()).y, _find_correct_region());
-#endif
 }
 
 static GotoRegion _current_region = GOTO_CRT;
 
 void cgotoxy(int x, int y, GotoRegion region)
 {
-#if defined(ASSERTS) && !defined(TARGET_OS_WINDOWS)
+#if defined(ASSERTS)
     if (!valid_cursor_pos(x, y, region))
     {
         const coord_def sz = cgetsize(region);

--- a/crawl-ref/source/libw32c.cc
+++ b/crawl-ref/source/libw32c.cc
@@ -488,9 +488,11 @@ void set_cursor_enabled(bool curstype)
         gotoxy_sys(cx+1, cy+1);
 }
 
-// This will force the cursor down to the next line.
 void clear_to_end_of_line()
 {
+    // We shouldn't move cursor pos
+    save_cursor_pos save;
+
     const int pos = wherex();
     const int cols = get_number_of_cols();
     if (pos <= cols)

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -910,7 +910,11 @@ string terse_mutation_list()
 string describe_mutations(bool drop_title)
 {
 #ifdef DEBUG
+#ifndef USE_TILE_LOCAL
+    validate_mutations(!crawl_state.smallterm);
+#else
     validate_mutations(true);
+#endif
 #endif
     string result;
 


### PR DESCRIPTION
It isn't meant to change the cursor position. However, it was changing it which meant we had to disable some asserts on windows in b0d7ede