### PR TITLE
Fix resizing the console while in a menu on windows

### DIFF
--- a/crawl-ref/source/cio.h
+++ b/crawl-ref/source/cio.h
@@ -308,7 +308,6 @@ enum KEYS
     CK_MOUSE_CLICK,
     CK_TOUCH_DUMMY, // so a non-event can be passed from handle_mouse to the controlling code
     CK_REDRAW, // no-op to force redraws of things
-    CK_RESIZE,
 
     CK_NO_KEY, // so that the handle_mouse loop can be broken from early (for
               // popups), and otherwise for keys to ignore

--- a/crawl-ref/source/libconsole.h
+++ b/crawl-ref/source/libconsole.h
@@ -31,7 +31,6 @@ void cprintf(const char *format, ...);
 int wherex();
 int wherey();
 void putwch(char32_t c);
-void set_getch_returns_resizes(bool rr);
 int getch_ck();
 bool kbhit();
 void delay(unsigned int ms);

--- a/crawl-ref/source/libunix.cc
+++ b/crawl-ref/source/libunix.cc
@@ -550,18 +550,12 @@ static int _get_key_from_curses()
 static void unix_handle_resize_event()
 {
     crawl_state.last_winch = time(0);
-    if (crawl_state.waiting_for_command)
+    if (crawl_state.waiting_for_command || crawl_state.waiting_for_ui)
         handle_terminal_resize();
     else
         crawl_state.terminal_resized = true;
 }
 #endif
-
-static bool getch_returns_resizes;
-void set_getch_returns_resizes(bool rr)
-{
-    getch_returns_resizes = rr;
-}
 
 static int _headless_getchk()
 {
@@ -642,8 +636,7 @@ int getch_ck()
             // then scroll down one line. To fix this, we always sync termsz:
             crawl_view.init_geometry();
 
-            if (!getch_returns_resizes)
-                continue;
+            continue;
         }
 #endif
 
@@ -687,10 +680,6 @@ int getch_ck()
         case KEY_B2:        return CK_NUMPAD_5;
         case KEY_C1:        return CK_NUMPAD_1;
         case KEY_C3:        return CK_NUMPAD_3;
-
-#ifdef KEY_RESIZE
-        case KEY_RESIZE:    return CK_RESIZE;
-#endif
 
         // Undocumented ncurses control keycodes, here be dragons!!!
         case 515:           return CK_CTRL_DELETE; // Mac

--- a/crawl-ref/source/libw32c.cc
+++ b/crawl-ref/source/libw32c.cc
@@ -323,16 +323,12 @@ static void set_w32_screen_size()
     }
 
     screen = new CHAR_INFO[screensize.X * screensize.Y];
-
-    COORD topleft;
-    SMALL_RECT used;
-    topleft.X = topleft.Y = 0;
-    ::ReadConsoleOutputW(outbuf, screen, screensize, topleft, &used);
+    clrscr_sys();
 }
 
 static void w32_handle_resize_event()
 {
-    if (crawl_state.waiting_for_command)
+    if (crawl_state.waiting_for_command || crawl_state.waiting_for_ui)
         handle_terminal_resize();
     else
         crawl_state.terminal_resized = true;
@@ -850,13 +846,6 @@ static int w32_proc_mouse_event(const MOUSE_EVENT_RECORD &mer)
     }
 
     return 0;
-}
-
-
-void set_getch_returns_resizes(bool rr)
-{
-    UNUSED(rr);
-    // no-op on windows console: see mantis issue #11532
 }
 
 int getch_ck()

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -2045,7 +2045,6 @@ bool is_synthetic_key(int key)
     case CK_MOUSE_CMD:
     case CK_MOUSE_MOVE:
     case CK_REDRAW:
-    case CK_RESIZE:
         return true;
     default:
         return false;

--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -2030,7 +2030,6 @@ bool Menu::process_key(int keyin)
     {
     case CK_NO_KEY:
     case CK_REDRAW:
-    case CK_RESIZE:
         return true;
     case 0:
         return true;

--- a/crawl-ref/source/state.cc
+++ b/crawl-ref/source/state.cc
@@ -28,6 +28,7 @@
 game_state::game_state()
     : game_crashed(false), crash_debug_scans_safe(true),
       mouse_enabled(false), waiting_for_command(false),
+      waiting_for_ui(false),
       terminal_resized(false), last_winch(0),
       seed(0),
       io_inited(false),

--- a/crawl-ref/source/state.h
+++ b/crawl-ref/source/state.h
@@ -45,6 +45,7 @@ struct game_state
     bool mouse_enabled;     // True if mouse input is currently relevant.
 
     bool waiting_for_command; // True when the game is waiting for a command.
+    bool waiting_for_ui;     // True when waiting for input from the ui overlay
     bool terminal_resized;   // True if the term was resized and we need to
                              // take action to handle it.
     time_t last_winch;       // Time of last resize, for crash dumps.

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -3290,28 +3290,19 @@ void pump_events(int wait_event_timeout)
 #else
     if (wait_event_timeout <= 0) // resizing probably breaks this case
         return;
-    set_getch_returns_resizes(true);
-    int k = macro_key != -1 ? macro_key : getch_ck();
-    set_getch_returns_resizes(false);
 
-    if (k == CK_RESIZE)
+    int k;
     {
-        // This may be superfluous, since the resize handler may have already
-        // resized the screen
-        clrscr();
-        console_shutdown();
-        console_startup();
-        ui_root.resize(get_number_of_cols(), get_number_of_lines());
+        unwind_bool safe_resize(crawl_state.waiting_for_ui, true);
+        k = macro_key != -1 ? macro_key : getch_ck();
     }
-    else
-    {
-        wm_event ev = {0};
-        ev.type = WME_KEYDOWN;
-        ev.key.keysym.sym = k;
-        if (macro_key == -1)
-            remap_key(ev);
-        ui_root.on_event(ev);
-    }
+
+    wm_event ev = {0};
+    ev.type = WME_KEYDOWN;
+    ev.key.keysym.sym = k;
+    if (macro_key == -1)
+        remap_key(ev);
+    ui_root.on_event(ev);
 #endif
 }
 

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -77,6 +77,7 @@
 #include "transform.h"
 #include "traps.h"
 #include "travel.h"
+#include "ui.h"
 #include "unicode.h"
 #include "unwind.h"
 #include "viewchar.h"
@@ -1960,6 +1961,15 @@ void handle_terminal_resize()
     else
         crawl_view.init_geometry();
 
-    redraw_screen();
-    update_screen();
+    if (crawl_state.waiting_for_ui)
+    {
+        ui::resize(crawl_view.termsz.x, crawl_view.termsz.y);
+        // We always need a redraw as the console was cleared when resizing
+        ui::force_render();
+    }
+    else
+    {
+        redraw_screen();
+        update_screen();
+    }
 }


### PR DESCRIPTION
Responding to console resize events in menus was disabled in 9746042 as the way we were handling them lead to generating another resize event resulting in an infinite loop. However, this results in the menu becoming fairly unreadable until you exit it and go back in. With a slight adjustment we can use the normal resize handling code in menus as well which doesn't have this problem.