### PR TITLE
Fix a crash when describing an untrainable skill

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4414,8 +4414,11 @@ string get_skill_description(skill_type skill, bool need_title)
 
     result += getLongDescription(lookup);
 
-    if (skill == SK_ARMOUR || skill == SK_DODGING || skill == SK_SHIELDS)
+    if ((skill == SK_ARMOUR || skill == SK_DODGING || skill == SK_SHIELDS)
+        && you.skills[skill] < MAX_SKILL_LEVEL && !is_useless_skill(skill))
+    {
         result += _get_skill_defense_change(skill);
+    }
     if (skill == SK_INVOCATIONS)
     {
         if (you.has_mutation(MUT_FORLORN))


### PR DESCRIPTION
The ?/ menu can be used to describe all skills including those that you can't train. However, it would crash when trying to calculate how much your AC/EV/SH would increase by when training the corresponding skill if it wasn't trainable.