### PR TITLE
Don't let Jiyva ban attacking hostile slime-shaped shifters

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -5543,6 +5543,7 @@ bool bolt::at_blocking_monster() const
         return true;
     if (have_passive(passive_t::neutral_slimes)
         && mons_is_slime(*mon)
+        && mon->wont_attack()
         && flavour != BEAM_VILE_CLUTCH)
     {
         return true;
@@ -5562,7 +5563,8 @@ void bolt::affect_monster(monster* mon)
     if (agent()
         && flavour != BEAM_VILE_CLUTCH
         && have_passive(passive_t::neutral_slimes)
-        && mons_is_slime(*mon))
+        && mons_is_slime(*mon)
+        && mon->wont_attack())  // allow attacking slime-shaped shifters
     {
         if (!is_tracer() && you.see_cell(mon->pos()))
         {

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -5841,7 +5841,8 @@ bool never_harm_monster(const actor* agent, const monster& mon, bool do_message)
 
     if (agent && agent->is_player()
         && have_passive(passive_t::neutral_slimes)
-        && mons_is_slime(mon))
+        && mons_is_slime(mon)
+        && mon.wont_attack())
     {
         if (do_message && you.can_see(mon))
             simple_god_message(" protects your slime from harm.", false, GOD_JIYVA);


### PR DESCRIPTION
Jiyva currently doesn't turn slime-shaped shifters neutral, but she would previously prevent attacks on them anyway. This behaviour leaves the player (temporarily) with a monster they cannot attack.

I have elected to effect this by not banning attacks on hostile slimes. This may need to be adjusted if there are other ways for hostile slimes to appear under Jiyva; I am not aware of any.