### PR TITLE
Fix the moncast.lua test sometimes failing

### DIFF
--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -463,6 +463,8 @@ LUAFN(debug_check_moncasts)
         dprf("Forcing %s to cast %s", m1->name(DESC_THE, true).c_str(),
                                                 spell_title(spell));
         handle_mon_spell(m1);
+        if (m2)
+            m2->heal(10000);
     }
     return 1;
 }


### PR DESCRIPTION
The statue used as a spell target was sometimes dying and then still being used as a target resulting in a crash.