### PR TITLE
Make diamond sawblades splatter more blood (GnomeSayin)

### DIFF
--- a/crawl-ref/source/bloodspatter.cc
+++ b/crawl-ref/source/bloodspatter.cc
@@ -185,14 +185,15 @@ void bleed_onto_floor(const coord_def& where, monster_type montype,
     _maybe_bloodify_square(where, damage, spatter, from, old_blood);
 }
 
-void blood_spray(const coord_def& origin, monster_type montype, int level)
+void blood_spray(const coord_def& origin, monster_type montype, int level,
+                 int max_ranged)
 {
     int tries = 0;
     for (int i = 0; i < level; ++i)
     {
         // Blood drops are small and light and suffer a lot of wind
         // resistance.
-        int range = random2(8) + 1;
+        int range = random2(max_ranged) + 1;
 
         while (tries < 5000)
         {

--- a/crawl-ref/source/bloodspatter.h
+++ b/crawl-ref/source/bloodspatter.h
@@ -9,7 +9,8 @@ void bleed_onto_floor(const coord_def& where, monster_type mon, int damage,
                       bool spatter = false,
                       const coord_def& from = INVALID_COORD,
                       const bool old_blood = false);
-void blood_spray(const coord_def& where, monster_type mon, int level);
+void blood_spray(const coord_def& where, monster_type mon, int level,
+                 int max_ranged = 8);
 void generate_random_blood_spatter_on_level(
                                             const map_bitmask *susceptible_area = nullptr);
 void bleed_for_makhleb(const actor& actor);

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -863,7 +863,8 @@ static const map<spell_type, mons_spell_logic> spell_to_logic = {
 
                 if (final)
                 {
-                    bleed_onto_floor(victim->pos(), victim->type, final, true);
+                    if (victim->has_blood())
+                        blood_spray(victim->pos(), victim->type, final / 5, 2);
                     victim->hurt(&caster, final);
                 }
             }


### PR DESCRIPTION
Shredding enemies with sawblades feels like it should result in a lot of blood, which it wasn't producing before. I limited each sawblade to only spraying blood in a small area around its victims as its hard to tell where the blood is coming from otherwise.