### PR TITLE
Adjust revenant dummy monster

### DIFF
--- a/crawl-ref/source/dat/mons/revenant.yaml
+++ b/crawl-ref/source/dat/mons/revenant.yaml
@@ -1,16 +1,16 @@
 name: "revenant"
 glyph: {char: "z", colour: magenta}
 flags: [see_invis, speaks]
-resists: {cold: 2}
-exp: 1335
+resists: {cold: 1}
+exp: 200
 holiness: [undead]
 will: invuln
 attacks:
- - {type: claw, damage: 26}
-hd: 18
-hp_10x: 810
-ac: 8
-ev: 12
+ - {type: claw, damage: 12}
+hd: 6
+hp_10x: 360
+ac: 4
+ev: 10
 shout: shout
 intelligence: human
 uses: open_doors


### PR DESCRIPTION
Changes the stats of revenant monsters to be more in line with other dummy monsters. Also changes their cold resist to match the player default (rC+).
This only (barely) affects a few player-themed vaults.