### PR TITLE
Track runed doors in stashes again (#4533)

### DIFF
--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -226,6 +226,7 @@ static bool _grid_is_interesting(const coord_def& pos)
     const auto feat = env.grid(pos);
     if (feat_is_staircase(feat)
        || feat_is_escape_hatch(feat)
+       || feat_is_runed(feat)
        || (is_notable_terrain(feat)
             // Count shops as boring features, because they are
             // handled separately.


### PR DESCRIPTION
This was broken by 01fb971, which made runed doors no longer be considered notable features.

Resolves #4533.