### PR TITLE
Fix the Orb card

### DIFF
--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -1177,13 +1177,13 @@ static void _damaging_card(card_type card, int power,
 
     if (ztype == ZAP_IOOD)
     {
-        if (power_level == 1)
+        if (power_level == 0)
         {
-            cast_iood(&you, power/6, &beam, 0, 0,
+            cast_iood(&you, power/10, &beam, 0, 0,
                       env.mgrid(beam.target), false, false);
         }
         else
-            cast_iood_burst(power/6, beam.target);
+            cast_iood_burst(power/6, power_level, beam.target);
     }
     else
         zapping(ztype, power/6, beam);

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -213,14 +213,14 @@ static int _burst_iood_target(double iood_angle, int preferred_foe)
     return foe;
 }
 
-void cast_iood_burst(int pow, coord_def target)
+void cast_iood_burst(int pow, int power_level, coord_def target)
 {
     const monster* mons = monster_at(target);
     const int preferred_foe = mons && you.can_see(*mons) ?
                               mons->mindex() :
                               MHITNOT;
 
-    const int n_orbs = random_range(3, 7);
+    const int n_orbs = power_level == 1 ? random_range(1, 2) : random_range(3, 7);
     dprf("Bursting %d orbs.", n_orbs);
     // 2097152 = 2^21. 21 is the greatest n s.t. `(2 ** n) * PI * 2` does not
     // exceed 2 ** 24; 24 bits is where `float` (`PI` is a float constant)

--- a/crawl-ref/source/mon-project.h
+++ b/crawl-ref/source/mon-project.h
@@ -12,7 +12,7 @@ spret cast_iood(actor *caster, int pow, bolt *beam,
                      float vx = 0, float vy = 0, int foe = MHITNOT,
                      bool fail = false, bool needs_tracer = true,
                      monster_type orb_type = MONS_ORB_OF_DESTRUCTION);
-void cast_iood_burst(int pow, coord_def target);
+void cast_iood_burst(int pow, int power_level, coord_def target);
 bool iood_act(monster& mon, bool no_trail = false);
 void iood_catchup(monster* mon, int turns);
 dice_def iood_damage(int pow, int dist, bool random = true);


### PR DESCRIPTION
Ever since 45c4a97, the Orb card has had the same effect at its lowest power level (power level 0) as at its highest (level 2), specifically a circle of 4-8 orbs of destruction around the player. At power level 1, it has always just fired a single orb of destruction. Prior to that commit, power level 0 instead cast the old version of Iskenderun's Mystic Blast.

With no suitable pure-conjurations-based replacement for orb of destruction these days, I have elected to keep the orb of destruction theme at power level 0. The effects are now:

power level 0: single orb of destruction using
               spell power = card power/10
power level 1: 2-3 orbs of destruction around you using
               spell power = card power/6
power level 2: 4-8 orbs of destruction (same as current) using
               spell power = card power/6

This should very much be a nerf to the Orb card compared to the last five years, and nobody has complained that the card is too strong in that time, so I think this should be fine. In any case, it's easy to fine-tune.

Resolves #4550.