### PR TITLE
Make `more_gem_info` show unacquired gems

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -962,10 +962,11 @@ static void _describe_gem(status_info& inf)
     if (time_taken >= limit)
         return; // already lost...
 
-    if (!gem_clock_active())
+    if (!gem_clock_active() && !you.gems_found[gem])
     {
         // player has picked up the orb, but the gem has not yet shattered
-        inf.light_text = "Gem not acquired";
+        inf.light_text = "No Gem";
+        inf.light_colour = CYAN;
         return;
     }
     const int d_aut_left = (limit - time_taken + 9) / 10;

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -947,7 +947,7 @@ static colour_t _gem_light_colour(int d_aut_left)
 
 static void _describe_gem(status_info& inf)
 {
-    if (!Options.always_show_gems || !gem_clock_active())
+    if (!Options.always_show_gems)
         return;
 
     const gem_type gem = gem_for_branch(you.where_are_you);
@@ -962,6 +962,12 @@ static void _describe_gem(status_info& inf)
     if (time_taken >= limit)
         return; // already lost...
 
+    if (!gem_clock_active())
+    {
+        // player has picked up the orb, but the gem has not yet shattered
+        inf.light_text = "Gem not acquired";
+        return;
+    }
     const int d_aut_left = (limit - time_taken + 9) / 10;
     inf.light_text = make_stringf("Gem (%d)", d_aut_left);
     inf.light_colour = _gem_light_colour(d_aut_left);

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -965,7 +965,7 @@ static void _describe_gem(status_info& inf)
     if (!gem_clock_active() && !you.gems_found[gem])
     {
         // player has picked up the orb, but the gem has not yet shattered
-        inf.light_text = " Gem*";
+        inf.light_text = " Gem (*)";
         inf.light_colour = CYAN;
         return;
     }

--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -965,7 +965,7 @@ static void _describe_gem(status_info& inf)
     if (!gem_clock_active() && !you.gems_found[gem])
     {
         // player has picked up the orb, but the gem has not yet shattered
-        inf.light_text = "No Gem";
+        inf.light_text = " Gem*";
         inf.light_colour = CYAN;
         return;
     }


### PR DESCRIPTION
... so that *ahem* [certain people](https://crawl.project357.org/morgue/DispaterIsMyDaddy/morgue-DispaterIsMyDaddy-20250518-155010.txt), do not forget to pick them up once they have the orb of zot.

~~Please let me know if I need to assign to `inf.light_colour` here as well~~ done.