### PR TITLE
Add projectile preservation effect to Cloak of Preservation(50% reduc…

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -2308,7 +2308,8 @@ static const char* _item_ego_desc(special_armour_type ego)
     case SPARM_ARCHMAGI:
         return "it increases the power of its wearer's magical spells.";
     case SPARM_PRESERVATION:
-        return "it protects its wearer from the effects of acid and corrosion.";
+        return "it protects its wearer from the effects of acid and corrosion, "
+               "and also halves the chance of thrown items being destroyed.";
     case SPARM_REFLECTION:
         return "it reflects blocked missile attacks back in the "
                "direction they came from.";

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -957,6 +957,9 @@ static bool _thrown_object_destroyed(const item_def &item)
     if (brand == SPMSL_CURARE)
         chance /= 2;
 
+    if (you.is_player() && you.wearing_ego(OBJ_ARMOUR, SPARM_PRESERVATION))
+        chance *= 2;
+
     dprf("mulch chance: %d in %d", mult, chance);
 
     return x_chance_in_y(mult, chance);


### PR DESCRIPTION
…ed chance of mulch)

Compared to other playstyles where a single artifact or spellbook encounter can dramatically shift the course of a run — such as a warrior finding an early spell of Ignite Poison and pivoting into a magic-warrior hybrid, or a conjurer acquiring Quicksilver Dragon Scales and adjusting their strategy — throwing lacks comparable incentives that might tempt players down a new path. While evocations (a somewhat similar niche) can feel varied due to mutations or artifact modifiers affecting the same item, throwing currently has only one related item of note: the Hurling gloves (+4 slaying for throwing only). This leads to a highly repetitive gameplay experience for throwers. To address this, I aim to introduce more equipment and talismans (or bubbles) that interact with throwing in meaningful ways, to help diversify the throwing playstyle. This change to the Cloak of Preservation is one step in that direction.

The reason I chose the Cloak of Preservation for this effect is twofold: It's unfortunate that such a great name as "Preservation" is currently used for an item that only grants corrosion resistance (rcorr). The old effect of reducing the chance of potion and scroll destruction feels thematically similar to reducing the chance of projectile destruction.