### PR TITLE
Remove random items from alpha shops

### DIFF
--- a/crawl-ref/source/dat/des/builder/alphashops.des
+++ b/crawl-ref/source/dat/des/builder/alphashops.des
@@ -200,7 +200,7 @@
 
       end
 
-      return i
+      return util.filter(items.pickable, i)
    end
 
    -- Automatically determine which letters have sufficient variety for a shop,


### PR DESCRIPTION
When alphashops selects an excluded item from an item set (e.g. Wand of Light in a Wand of Acid game), the shop will fill the slot with a random item instead, which will probably not match the theme.

Filter out excluded items to preserve purity.