### PR TITLE
Make decorative altar monsters neutral

### DIFF
--- a/crawl-ref/source/dat/des/altar/kiku_cage.des
+++ b/crawl-ref/source/dat/des/altar/kiku_cage.des
@@ -69,7 +69,7 @@ local tm = TriggerableFunction:new{
 tm:add_triggerer(DgnTriggerer:new{type="monster_dies", target="dreplica"})
 lua_marker('_', tm)
 }}
-KMONS:   h = generate_awake human never_corpse hp:12 ; nothing
+KMONS:   h = generate_awake att:neutral human never_corpse hp:12 ; nothing
 KFEAT:   h = .
 : if you.depth() > 4 then
 MONS:    burial acolyte, zombie

--- a/crawl-ref/source/dat/des/altar/trog_wizard.des
+++ b/crawl-ref/source/dat/des/altar/trog_wizard.des
@@ -66,7 +66,7 @@ KFEAT:  1 = .
 # A terrified wizard whose spells have been taken away
 # (he refused to convert)
 MARKER: 1 = lua:portal_desc {replica_name="trog_wizard"}
-KMONS:  1 = arcanist name:wizard n_rpl n_des n_noc perm_ench:mute spells:. dbname:captured_wizard ; nothing
+KMONS:  1 = att:neutral arcanist name:wizard n_rpl n_des n_noc perm_ench:mute spells:. dbname:captured_wizard ; nothing
 KPROP:  1 = no_tele_into
 KFEAT:  # = iron_grate
 MAP


### PR DESCRIPTION
2 altar vaults have harmless monsters behind grates or transparent walls that are supposed to do nothing and die. However, you can dig them out and for a good chunk of xp if you find them early enough. This pr makes them neutral so that they don't give xp and there is no incentive to dig them out (works with sac love too)