### PR TITLE
Fix rampage hints showing on levels you aren't on

### DIFF
--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -1558,7 +1558,7 @@ void tile_apply_properties(const coord_def &gc, packed_cell &cell)
     if (mc.flags & MAP_BFB_CORPSE)
         cell.has_bfb_corpse = true;
 
-    if (you.rampage_hints.count(gc) > 0)
+    if (you.on_current_level && you.rampage_hints.count(gc) > 0)
         cell.bg |= TILE_FLAG_RAMPAGE;
 
     if (Options.show_travel_trail)


### PR DESCRIPTION
When examining a level that you weren't on, rampage hints would still show up leaking information about where you were relative to the map borders.