### PR TITLE
Fix the cloud targeter avoiding immune players

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3376,10 +3376,8 @@ bool bolt::harmless_to_player() const
     case BEAM_PETRIFY:
         return you.res_petrify() || you.petrified();
 
-#if TAG_MAJOR_VERSION == 34
     case BEAM_COLD:
-        return is_big_cloud() && you.has_mutation(MUT_FREEZING_CLOUD_IMMUNITY);
-#endif
+        return is_big_cloud() && actor_cloud_immune(you, CLOUD_COLD);
 
     case BEAM_VIRULENCE:
         return player_res_poison(false) >= 3;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1149,6 +1149,11 @@ aff_type targeter_cloud::is_affected(coord_def loc)
     return AFF_NO;
 }
 
+bool targeter_cloud::harmful_to_player()
+{
+    return !actor_cloud_immune(you, ctype);
+}
+
 
 targeter_splash::targeter_splash(const actor *act, int r, int pow)
     : targeter_beam(act, r, ZAP_COMBUSTION_BREATH, pow, 0, 0)

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -230,6 +230,7 @@ public:
     bool valid_aim(coord_def a) override;
     bool can_affect_outside_range() override;
     aff_type is_affected(coord_def loc) override;
+    bool harmful_to_player() override;
     cloud_type ctype;
     int range;
     int cnt_min, cnt_max;


### PR DESCRIPTION
When casting a cloud spell such as freezing cloud, the targeter would try to avoid hitting the player even when they were immune to the cloud.

Fixes #4592