### PR TITLE
Fix agony not saying when you are immune

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -9107,6 +9107,8 @@ bool player::immune_to_hex(const spell_type hex) const
         return !actor::can_sleep();
     case SPELL_HIBERNATION:
         return !can_hibernate();
+    case SPELL_AGONY:
+        return res_torment();
     default:
         return false;
     }


### PR DESCRIPTION
When examining an enemy with the agony spell as a torment immune character, it would show the chance of the spell effecting you instead of saying that you are immune. Change it to say that you are immune for consistency with the sleep and confusion spells.