### PR TITLE
Fix trolls not keeping claws with fungal fisticloak

### DIFF
--- a/crawl-ref/source/player-equip.h
+++ b/crawl-ref/source/player-equip.h
@@ -79,7 +79,7 @@ struct player_equip_set
     item_def* get_first_slot_item(equipment_slot slot, bool include_melded = false) const;
     player_equip_entry& get_entry_for(const item_def& item);
 
-    bool slot_is_fully_covered(equipment_slot slot) const;
+    bool innate_slot_is_covered(equipment_slot slot) const;
     bool has_compatible_slot(equipment_slot slot, bool include_form = false) const;
 
     // Basic mutators
@@ -120,7 +120,8 @@ private:
 };
 
 int get_player_equip_slot_count(equipment_slot slot, string* zero_reason = nullptr,
-                                bool count_melded_unrands = false);
+                                bool count_melded_unrands = false,
+                                bool count_items = true);
 FixedVector<int, NUM_EQUIP_SLOTS> get_total_player_equip_slots();
 const vector<equipment_slot>& get_alternate_slots(equipment_slot slot);
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -7350,7 +7350,7 @@ int player::has_claws(bool allow_tran) const
 bool player::has_usable_claws(bool allow_tran) const
 {
     return has_claws(allow_tran)
-           && !you.equipment.slot_is_fully_covered(SLOT_GLOVES);
+           && !you.equipment.innate_slot_is_covered(SLOT_GLOVES);
 }
 
 int player::has_talons(bool allow_tran) const
@@ -7365,7 +7365,7 @@ int player::has_talons(bool allow_tran) const
 bool player::has_usable_talons(bool allow_tran) const
 {
     return has_talons(allow_tran)
-           && !you.equipment.slot_is_fully_covered(SLOT_BOOTS);
+           && !you.equipment.innate_slot_is_covered(SLOT_BOOTS);
 }
 
 int player::has_hooves(bool allow_tran) const
@@ -7380,7 +7380,7 @@ int player::has_hooves(bool allow_tran) const
 bool player::has_usable_hooves(bool allow_tran) const
 {
     return has_hooves(allow_tran)
-           && !you.equipment.slot_is_fully_covered(SLOT_BOOTS);
+           && !you.equipment.innate_slot_is_covered(SLOT_BOOTS);
 }
 
 int player::has_fangs(bool allow_tran) const
@@ -7431,8 +7431,8 @@ bool player::has_tail(bool allow_tran) const
 // purpose of punching.
 bool player::has_usable_offhand() const
 {
-    return !you.equipment.slot_is_fully_covered(SLOT_OFFHAND)
-            && !you.equipment.slot_is_fully_covered(SLOT_WEAPON_OR_OFFHAND);
+    return !you.equipment.innate_slot_is_covered(SLOT_OFFHAND)
+            && !you.equipment.innate_slot_is_covered(SLOT_WEAPON_OR_OFFHAND);
 }
 
 bool player::has_usable_tentacle() const


### PR DESCRIPTION
While wearing the fungal fisticloak with gloves on it, trolls would lose the damage from their claws.

Fixes #4598