### PR TITLE
Add several new skill titles

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1938,6 +1938,8 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
                 result = "Pharaoh";
             else if (species == SP_FELID)
                 result = claw_and_tooth_titles[skill_rank];
+            else if (species == SP_OCTOPODE && skill_rank == 4)
+                result = "Crusher";
             else if (species == SP_OCTOPODE && skill_rank == 5)
                 result = "Kraken";
             else if (species == SP_ONI && skill_rank == 5)
@@ -2129,11 +2131,6 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
                 result = "Abyssopelagic";
             else if (species == SP_OCTOPODE && skill_rank == 5 && is_evil_god(god))
                 result = "Leviathan";
-            else if (species == SP_MINOTAUR && skill_rank == 5 && god == GOD_ASHENZARI)
-            {
-                // navigating through mazes seems like the sort of thing Ash helps one with
-                result = "Lord of the Labyrinth";
-            }
             else if (god != GOD_NO_GOD)
                 result = god_title(god, species, piety);
             else if (species == SP_BARACHI)

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1924,6 +1924,8 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
         case SK_FIGHTING:
             if (species == SP_HUMAN && skill_rank == 5 && god == GOD_MAKHLEB)
                 result = "Hell Knight";
+            else if (species == SP_HUMAN && skill_rank == 5 && god == GOD_YREDELEMNUL)
+                result = "Death Knight";
             break;
 
         case SK_POLEARMS:
@@ -1937,7 +1939,7 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
             else if (species == SP_FELID)
                 result = claw_and_tooth_titles[skill_rank];
             else if (species == SP_OCTOPODE && skill_rank == 5)
-                result = "Crusher";
+                result = "Kraken";
             else if (species == SP_ONI && skill_rank == 5)
                 result = "Yokozuna";
             else if (!dex_better && (species == SP_DJINNI || species == SP_POLTERGEIST)
@@ -1996,6 +1998,8 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
                 result = "Wishgranter";
             else if (species == SP_COGLIN && skill_rank == 5)
                 result = "Cogmind";
+            else if (species == SP_DEMIGOD && skill_rank == 5)
+                result = "Ascendant";
             break;
 
         case SK_CONJURATIONS:
@@ -2009,6 +2013,8 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
         case SK_HEXES:
             if (species::is_draconian(species) && skill_rank == 5)
                 result = "Faerie Dragon";
+            else if (species == SP_MERFOLK && skill_rank == 5)
+                result = "Siren";
             break;
 
         case SK_NECROMANCY:
@@ -2086,6 +2092,11 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
                 result = "Iron Dragon";
             break;
 
+        case SK_STEALTH:
+            if (species == SP_DEMIGOD && skill_rank == 5)
+                result = "Thief of Divinity";
+            break;
+
         case SK_INVOCATIONS:
             if (species == SP_MUMMY && skill_rank == 5 && god == GOD_GOZAG)
                 result = "Royal Mummy";
@@ -2113,6 +2124,16 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
                 result = "Laughing Skull";
             else if (species == SP_REVENANT && skill_rank == 5 && god == GOD_USKAYAW)
                 result = "Danse Macabre";
+            else if ((species == SP_MERFOLK || species == SP_OCTOPODE)
+                && skill_rank == 5 && god == GOD_LUGONU)
+                result = "Abyssopelagic";
+            else if (species == SP_OCTOPODE && skill_rank == 5 && is_evil_god(god))
+                result = "Leviathan";
+            else if (species == SP_MINOTAUR && skill_rank == 5 && god == GOD_ASHENZARI)
+            {
+                // navigating through mazes seems like the sort of thing Ash helps one with
+                result = "Lord of the Labyrinth";
+            }
             else if (god != GOD_NO_GOD)
                 result = god_title(god, species, piety);
             else if (species == SP_BARACHI)


### PR DESCRIPTION
Listing them all here for ease of viewing:

Octopode 27 UC from Crusher to Kraken to feel more epic and more unique to Op
Octopode/Merfolk 27 Invo Lugonu gets Abyssopelagic (https://en.wikipedia.org/wiki/Abyssal_zone)
Minotaur 27 Invo Ash gets Lord of the Labyrinth (Navigating a labyrinth feels very appropriate for Ash to me)
Merfolk 27 Hexes gets Siren
Octopode 27 Invo with an evil god gets Leviathan (Leviathan is one of those loosely defined mythological creatures, but is definitely a sea monster of some sort, was considered demonic pretty often. Crawl's tainted leviathans are not aquatic at all, so I would understand if this adds unwanted confusion.)
Human of Yred 27 Fighting gets Death Knight (Hell Knight is also specifically a Fighting title, not an Invocations title, so I kept symmetry)
Demigod 27 Spellcasting gets Ascendant
Demigod 27 Stealth gets Thief of Immortality
