### PR TITLE
Don't hide items on decorative floor cells on console (croikle)

### DIFF
--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -328,7 +328,8 @@ show_class get_cell_show_class(const map_cell& cell,
            && feat != DNGN_ABANDONED_SHOP
            && feat != DNGN_STONE_ARCH
            && feat != DNGN_EXPIRED_PORTAL
-           && !feat_is_fountain(feat))
+           && !feat_is_fountain(feat)
+           && feat != DNGN_DECORATIVE_FLOOR)
     {
         return SH_FEATURE;
     }


### PR DESCRIPTION
Show the item glyth instead of the decorative floor glyph like we do with regular floors. This way items won't be hidden on garden patches and other decorative floors.

Fixes #4380