### PR TITLE
Don't leak the location of invis monsters as a fungus

### DIFF
--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -156,8 +156,11 @@ static void _update_feat_at(const coord_def &gp)
     if (you.get_fearmonger(gp))
         env.map_knowledge(gp).flags |= MAP_WITHHELD;
 
-    if (you.is_nervous() && you.see_cell(gp) && !monster_at(gp))
+    if (you.is_nervous() && you.see_cell(gp)
+        && (!monster_at(gp) || !monster_at(gp)->visible_to(&you)))
+    {
         env.map_knowledge(gp).flags |= MAP_WITHHELD;
+    }
 
     if ((feat_is_stone_stair(feat)
          || feat_is_escape_hatch(feat))


### PR DESCRIPTION
When in fungus form and nervous (there is a non confused, non asleep, non batty etc monster in view), the locations without monster's are greyed out. This lets you know which locations have invisible monsters without having see invisible as they aren't greyed out. Instead, grey out locations without visible monsters only.

This does make it harder for players in fungus form to attack invisible enemies as they will be told that they cannot move when pressing a direction key, but this problem already exists for tree form and you can still attack with ctrl-direction.