### PR TITLE
Remove some non-determinism

### DIFF
--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1100,7 +1100,7 @@ CFWARN := -wd383,810,869,981,1418 -we14,193,304
 CFWARN_L :=
 endif
 
-LINKER_LDFLAG=
+LINKER_LDFLAG=--build-id=none
 ifndef NO_TRY_LLD
 ifeq (,$(shell echo 'int main(){return 1;}'|$(GXX) -x c++ - -o /dev/null -fuse-ld=lld 2>&1))
  LINKER_LDFLAG = -fuse-ld=lld


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro.

Looking at the latest app report: https://verification.f-droid.org/packages/org.develz.crawl/

We can remove the build-id like this, or maybe you can move it to a better place as you see fit.