### PR TITLE
Fix moving into a tele trap not adding an item to the stash

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -2478,7 +2478,6 @@ static void _prep_input()
 
     viewwindow();
     update_screen(); // ???
-    maybe_update_stashes();
     if (check_for_interesting_features() && you.running.is_explore())
         stop_running();
 
@@ -2561,9 +2560,6 @@ void world_reacts()
         update_screen();
     }
 
-    // prevent monsters wandering into view and picking up an item before
-    // our next prep_input
-    maybe_update_stashes();
     update_monsters_in_view();
 
     reset_show_terrain();

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3379,6 +3379,7 @@ item_def* monster_die(monster& mons, killer_type killer,
     if (in_bounds(mwhere) && you.see_cell(mwhere))
     {
         view_update_at(mwhere);
+        StashTrack.update_stash(mwhere);
         update_screen();
     }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -616,7 +616,6 @@ void moveto_location_effects(dungeon_feature_type old_feat,
     bool was_running = you.running;
 
     update_monsters_in_view();
-    maybe_update_stashes();
     if (check_for_interesting_features() && you.running.is_explore())
         stop_running();
 
@@ -7905,10 +7904,6 @@ bool player::do_shaft()
             " the earth!");
         return false;
     }
-
-    // Ensure altars, items, and shops discovered at the moment
-    // the player gets shafted are correctly registered.
-    maybe_update_stashes();
 
     down_stairs(DNGN_TRAP_SHAFT);
 

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1079,7 +1079,6 @@ static bool _teleport_player(bool wizard_tele, bool teleportitis,
     // (like picking up/dropping an item).
     viewwindow();
     update_screen();
-    StashTrack.update_stash(you.pos());
 
     if (player_in_branch(BRANCH_ABYSS) && !wizard_tele)
     {

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -1123,8 +1123,6 @@ void floor_transition(dungeon_feature_type how,
     // There's probably a reason for this. I don't know it.
     if (going_up)
         seen_monsters_react();
-    else
-        maybe_update_stashes();
 
     autotoggle_autopickup(false);
     request_autopickup();

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1470,11 +1470,16 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a, view_renderer 
             if (!is_map_persistent())
                 ash_detect_portals(false);
 
-            // TODO: why on earth is this called from here? It seems like it
-            // should be called directly on changing location, or something
-            // like that...
             if (you.on_current_level)
+            {
+                // TODO: why on earth is this called from here? It seems like it
+                // should be called directly on changing location, or something
+                // like that...
                 show_init(_layers);
+
+                if (show_updates)
+                    maybe_update_stashes();
+            }
 
 #ifdef USE_TILE
             tile_draw_floor();

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -344,7 +344,10 @@ bool wizard_create_feature(dist &target, dungeon_feature_type feat, bool mimic)
             env.level_map_mask(pos) |= MMT_MIMIC;
 
         if (you.see_cell(pos))
+        {
             view_update_at(pos);
+            StashTrack.update_stash(pos);
+        }
     } while (targeting_mode && target.isEndpoint);
 
     return true;

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -222,9 +222,6 @@ void wizard_create_spec_object()
         if (class_wanted != OBJ_CORPSES)
             origin_acquired(env.item[thing_created], AQ_WIZMODE);
         canned_msg(MSG_SOMETHING_APPEARS);
-
-        // Tell the stash tracker.
-        maybe_update_stashes();
     }
 }
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -5365,13 +5365,11 @@ static void _xom_good_teleport(int /*sever*/)
     {
         count++;
         you_teleport_now();
-        maybe_update_stashes();
         more();
         if (one_chance_in(10) || count >= 7 + random2(5))
             break;
     }
     while (x_chance_in_y(3, 4) || player_in_a_dangerous_place());
-    maybe_update_stashes();
 
     // Take a note.
     const string note = make_stringf("%d-stop teleportation journey%s", count,
@@ -5396,13 +5394,11 @@ static void _xom_bad_teleport(int /*sever*/)
     do
     {
         you_teleport_now();
-        maybe_update_stashes();
         more();
         if (count++ >= 7 + random2(5))
             break;
     }
     while (x_chance_in_y(3, 4) && !player_in_a_dangerous_place());
-    maybe_update_stashes();
 
     // Take a note.
     const string note = make_stringf("%d-stop teleportation journey%s", count,


### PR DESCRIPTION
When moving into a teleport trap, If you revealed an item just before the trap was set off, the item would be missing from the stash tracker and its description when you examined the square that is was in would say it was the floor. This was because the map knowledge (which can be used to quickly lookup the top item the player remembers in any square) and the stash tracker (which stores all rememberd items) were getting updated at different times and were becoming out of sync.