### PR TITLE
Spend a turn when failing to rampage over blastemotes (Hellmonk)

### DIFF
--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -1025,7 +1025,7 @@ void move_player_action(coord_def move)
         {
             // Don't allow the player to freely locate invisible monsters
             // with confirmation prompts.
-            if (!you.can_see(*targ_monst) && !you.is_motile())
+            if (!rampaged && !you.can_see(*targ_monst) && !you.is_motile())
             {
                 canned_msg(MSG_CANNOT_MOVE);
                 you.turn_is_over = false;
@@ -1055,6 +1055,13 @@ void move_player_action(coord_def move)
             you.berserk_penalty = 0;
             attacking = true;
         }
+    }
+    else if (rampaged && !you.is_motile())
+    {
+        // We rampaged onto something that has stopped us moving and we
+        // don't have a target to hit.
+        _finalize_cancelled_rampage_move();
+        return;
     }
     else if (you.form == transformation::fungus && moving && !you.confused())
     {


### PR DESCRIPTION
When you to rampage over blastemotes, still spend a turn on the move even though you only moved one space instead of two due to the -move from the blastemotes.