### PR TITLE
Make invis indicators accurate

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4308,7 +4308,11 @@ void bolt::affect_player()
     // Visible beams reveal invisible monsters; otherwise animations confer
     // an information advantage for sighted players
     if (visible() && agent() && agent()->is_monster())
-        agent()->as_monster()->unseen_pos = agent()->pos();
+    {
+        monster* mons = agent()->as_monster();
+        mons->revealed_this_turn = true;
+        mons->revealed_at_pos = mons->pos();
+    }
 
     if (misses_player())
         return;

--- a/crawl-ref/source/map-cell.h
+++ b/crawl-ref/source/map-cell.h
@@ -22,7 +22,6 @@
 #define MAP_SILENCED           0x800
 #define MAP_BLOODY            0x1000
 #define MAP_CORRODING         0x2000
-#define MAP_INVISIBLE_UPDATE  0x4000 // Used for invis redraws by show_init()
 #define MAP_ICY               0x8000
 
 /* these flags require more space to serialize: put infrequently used ones there */
@@ -149,8 +148,7 @@ struct map_cell
     // Clear prior to show update. Need to retain at least "seen" flag.
     void clear_data()
     {
-        const uint32_t f = flags & (MAP_SEEN_FLAG | MAP_CHANGED_FLAG
-                                    | MAP_INVISIBLE_UPDATE);
+        const uint32_t f = flags & (MAP_SEEN_FLAG | MAP_CHANGED_FLAG);
         clear();
         flags = f;
     }

--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -330,10 +330,13 @@ void monster::add_enchantment_effect(const mon_enchant &ench, bool quiet)
         break;
 
     case ENCH_INVIS:
+        // Reveal a monster that goes invisible so that if it has just entered
+        // view but the screen hasn't redrawn with it in view, the player won't
+        // be confused by their auto explore stopping etc.
         if (testbits(flags, MF_WAS_IN_VIEW))
         {
-            went_unseen_this_turn = true;
-            unseen_pos = pos();
+            revealed_this_turn = true;
+            revealed_at_pos = pos();
         }
         break;
 

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -99,8 +99,8 @@ monster::monster()
     constricting = 0;
 
     clear_constricted();
-    went_unseen_this_turn = false;
-    unseen_pos = coord_def(0, 0);
+    revealed_this_turn = false;
+    revealed_at_pos = coord_def(0, 0);
 }
 
 // Empty destructor to keep unique_ptr happy with incomplete ghost_demon type.
@@ -149,8 +149,8 @@ void monster::reset()
     shield_blocks   = 0;
     foe_memory      = 0;
     god             = GOD_NO_GOD;
-    went_unseen_this_turn = false;
-    unseen_pos = coord_def(0, 0);
+    revealed_this_turn = false;
+    revealed_at_pos = coord_def(0, 0);
 
     mons_remove_from_grid(*this);
     target.reset();

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -123,8 +123,8 @@ public:
     uint32_t client_id;                // for ID of monster_info between turns
     static uint32_t last_client_id;
 
-    bool went_unseen_this_turn;
-    coord_def unseen_pos;
+    bool revealed_this_turn;
+    coord_def revealed_at_pos;
 
 public:
     void set_new_monster_id();

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -2684,8 +2684,8 @@ static void _mark_unseen_monsters()
     {
         if (testbits((*mi)->flags, MF_WAS_IN_VIEW) && !you.can_see(**mi))
         {
-            (*mi)->went_unseen_this_turn = true;
-            (*mi)->unseen_pos = (*mi)->pos();
+            (*mi)->revealed_this_turn = true;
+            (*mi)->revealed_at_pos = (*mi)->pos();
         }
 
     }

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -334,6 +334,7 @@ enum tag_minor_version
     TAG_MINOR_EQUIP_TALISMAN,      // Make talismans equipment you put on.
     TAG_MINOR_EXCLUSIVE_ROLLPAGE,  // Don't give inhibited regen mutation to rollpage characters.
     TAG_MINOR_ATTACK_ACTION_COUNTS, // Add tracking for attack action count sources
+    TAG_MINOR_ACCURATE_INVIS_INDICATORS, // Invis indicators now always show at the monsters position
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6506,8 +6506,8 @@ void marshallMonster(writer &th, const monster& m)
     marshallInt(th, m.foe_memory);
     marshallShort(th, m.damage_friendly);
     marshallShort(th, m.damage_total);
-    marshallByte(th, m.went_unseen_this_turn);
-    marshallCoord(th, m.unseen_pos);
+    marshallByte(th, m.revealed_this_turn);
+    marshallCoord(th, m.revealed_at_pos);
 
     if (parts & MP_GHOST_DEMON)
     {
@@ -7597,14 +7597,14 @@ void unmarshallMonster(reader &th, monster& m)
 #if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() < TAG_MINOR_UNSEEN_MONSTER)
     {
-        m.went_unseen_this_turn = false;
-        m.unseen_pos = coord_def(0, 0);
+        m.revealed_this_turn = false;
+        m.revealed_at_pos = coord_def(0, 0);
     }
     else
     {
 #endif
-    m.went_unseen_this_turn = unmarshallByte(th);
-    m.unseen_pos = unmarshallCoord(th);
+        m.revealed_this_turn = unmarshallByte(th);
+        m.revealed_at_pos = unmarshallCoord(th);
 #if TAG_MAJOR_VERSION == 34
     }
 #endif


### PR DESCRIPTION
Usually, when we show invis indicators we show them where the monster is. However, when a monster turns invisible and then moves in just one player turn, we would show the invis indicator at the square where the monster went invisible (or an adjacent square if there is now a monster in this square). This happened rarely enough that players usually thought that it was a bug. Instead, when showing an invis indicator, we should always show it on the square with the monster.

This also brings some sanity to the `show_update_at` function as it now only affects the location that we told it to affect.