### PR TITLE
Fix krakens not flopping around on land

### DIFF
--- a/crawl-ref/source/mon-ench.cc
+++ b/crawl-ref/source/mon-ench.cc
@@ -1470,7 +1470,7 @@ void monster::apply_enchantment(const mon_enchant &me)
 
     case ENCH_AQUATIC_LAND:
         // Aquatic monsters lose hit points every turn they spend on dry land.
-        ASSERT(mons_habitat(*this) == HT_WATER || mons_habitat(*this) == HT_LAVA);
+        ASSERT(!(mons_habitat(*this) & HT_DRY_LAND));
         if (monster_habitable_grid(this, pos()))
         {
             del_ench(ENCH_AQUATIC_LAND);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5355,7 +5355,7 @@ void monster::apply_location_effects(const coord_def &oldpos,
         dungeon_events.fire_position_event(DET_MONSTER_MOVED, pos());
 
     if (alive()
-        && (mons_habitat(*this) == HT_WATER || mons_habitat(*this) == HT_LAVA)
+        && !(mons_habitat(*this) & HT_DRY_LAND)
         && !monster_habitable_grid(this, pos())
         && type != MONS_HELLFIRE_MORTAR
         && !has_ench(ENCH_AQUATIC_LAND))


### PR DESCRIPTION
A kraken can move into temporary deep water such as that created by the summon forest spell and then be left on land when the water reverts back. This should result in the kraken flopping around on land taking damage. However, the check for this was checking if the monster's habitat was HT_WATER and krakens are HT_DEEP_WATER now.