### PR TITLE
allow using hive form under Oka; explicitly mention when bees would not spawn (Sac love and now Oka)

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -7568,7 +7568,11 @@ static string _describe_talisman(const item_def &item, bool verbose)
 
         if (is_useless_item(item, false))
             _uselessness_desc(description, item);
-        else if (item.sub_type != TALISMAN_PROTEAN)
+
+        if (item.sub_type == TALISMAN_HIVE && you.allies_forbidden())
+          description << "\n\n" << "The swarm will not protect you as you can not gain allies.";
+
+        if (item.sub_type != TALISMAN_PROTEAN)
         {
             if (crawl_state.need_save && item.is_identified())
                 description << _equipment_property_change(item);

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1086,9 +1086,6 @@ string cannot_evoke_item_reason(const item_def *item, bool temp, bool ident)
         if (you.form != you.default_form && temp)
             return "you need to leave your temporary form first.";
 
-        if (trans == transformation::hive && you_worship(GOD_OKAWARU))
-            return "you have forsworn all allies in Okawaru's name.";
-
         return "";
     }
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -3225,9 +3225,6 @@ static bool _transformed_player_can_join_god(god_type which_god)
     if (is_good_god(which_god) && you.form == transformation::death)
         return false;
 
-    if (which_god == GOD_OKAWARU && you.form == transformation::hive)
-        return false;
-
     return true;
 }
 


### PR DESCRIPTION
it doesn't make sense to me that Oka would make hive talisman unusable, because "no allies" is not really a conduct thing, just something he enforces as a matter of fact (cf. Ds w/ guardian mutation, Oka does not excommunicate you or prevent you from joining if you have it, nor does he prevent it if you already worship him), hence all ally makers being gray and not red. if Ru's Sac love interaction with hive talisman is intentional (can use hive and get regen, but will not get swarm), then it seems that nectar-making bees aren't really allies, so there's no reason for Oka to intervene with their work, only with the swarm spawning part.

not sure about the wording of "The swarm will not protect you as you can not gain allies.", feel free to change if it doesn't fit

