### PR TITLE
Fix Examine mode cycling

### DIFF
--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -1465,7 +1465,7 @@ bool direction_chooser::in_range(const coord_def& p) const
 // (When just looking around, this is typically any monster. For specific
 // spells, it will be restricted to those in range which can be affected by the
 // spell in question.)
-void direction_chooser::cycle_target(int dir, vector<coord_def> &cycle_throgh_pos)
+void direction_chooser::cycle_target(int dir, const vector<coord_def> &cycle_throgh_pos)
 {
     if (cycle_throgh_pos.empty())
         return;

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -160,7 +160,7 @@ private:
     // range. (This is usually a monster, but may be a cell near a monster if
     // that is the only way to hit them, ie: a fireball hitting something just
     // out of range.)
-    void cycle_target(int dir, vector<coord_def> &cycle_throgh_pos);
+    void cycle_target(int dir, const vector<coord_def> &cycle_throgh_pos);
 
     void cycle_feature(char feature_class);
 


### PR DESCRIPTION
* Add an argument to `cycle_target` member function to provide coords we are cycling through
* Introduce new data member `items_cycle_pos` to `direction_chooser` for storing positions of items we can cycle though
* Remove condition within calculate_target_info to always calculate items coords
* Add handling for `CMD_TARGET_OBJ_CYCLE_BACK` and `CMD_TARGET_OBJ_CYCLE_FORWARD` commands to `direction_chooer::process_command`

Fixes [4577](https://github.com/crawl/crawl/issues/4577)
