### PR TITLE
More zig adjustments

### DIFF
--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -463,7 +463,7 @@ mset(with_props(spec_fn(function ()
          "yaktaur captain w:" .. d .. " / satyr w:" .. d .. " / " ..
          "cherub w:" .. d .. " / naga sharpshooter w:" .. e .. " / " ..
          "merfolk javelineer w:" .. e .. " / deep elf master archer w:" .. e .. " / " ..
-         "stone giant w:" .. e .. " / "nekomata w:" .. e
+         "stone giant w:" .. e .. " / nekomata w:" .. e
 end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()

--- a/crawl-ref/source/dat/dlua/ziggurat.lua
+++ b/crawl-ref/source/dat/dlua/ziggurat.lua
@@ -193,7 +193,7 @@ end
 -- Orc, Elf, Vaults, Crypt, Tomb,
 -- Abyss, Gehenna, Cocytus, Dis, Tartarus,
 -- Fire, Ice, Air, Earth, Negative Energy, Holy, Chaos,
--- Giants, Dragons, Draconians, Archers, Conjurers,
+-- Giants, Dragons, Draconians, Archers, Conjurers, Summoners,
 -- Pan, Lair Roulette, Vestibule / all Hells
 -- By using spec_fn to wrap monster-spec functions, monster weights
 -- are adjusted per-set, sometimes scaling by depth and always by zig completion.
@@ -233,6 +233,7 @@ mset(with_props(spec_fn(function ()
   local e = 10 + you.zigs_completed() * 12
   return "place:Shoals:$ w:" .. d .. " / merfolk impaler w:5 / " ..
          "merfolk javelineer / merfolk aquamancer / " ..
+         "sphinx marauder / formless jellyfish / " ..
          "water nymph w:" .. e
 end), { weight = 5 }))
 
@@ -258,7 +259,7 @@ mset(spec_fn(function ()
   local f = math.max(0, math.floor(you.depth() * 1.5 + you.zigs_completed() * 3 - 35))
   return "place:Orc:$ w:" .. d .. " / orc warlord w:" .. e .. " / " ..
          "orc high priest w:" .. e .. " / orc sorcerer / " ..
-         "stone giant / iron troll / juggernaut w:" .. e - 24 .. " / " ..
+         "stone giant / ettin / juggernaut w:" .. e - 24 .. " / " ..
          "moth of wrath w:" .. f .. " / undying armoury w:" .. f
 end))
 
@@ -283,8 +284,9 @@ mset(spec_fn(function ()
   local e = 10 + you.zigs_completed() * 6
   local f = 10 + you.zigs_completed() * 9
   return "place:Crypt:$ 9 w:250 / vampire bloodprince w:" .. d .. " / " ..
-         "curse skull w:" .. e .. " / revenant soulmonger w:" .. f .. " / " ..
-         "ancient lich w:" .. e .. " / dread lich w:" .. f
+         "ancient champion w:" .. d .. " / cognitogaunt w:" .. e .. " / " ..
+         "curse skull w:" .. e .. " / ancient lich w:" .. e .. " / " ..
+         "revenant soulmonger w:" .. f .. " / dread lich w:" .. f
 end))
 
 mset(spec_fn(function ()
@@ -349,13 +351,15 @@ end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()
   local d = 10 + you.zigs_completed() * 6
-  local e = 10 + you.zigs_completed() * you.zigs_completed() * 10
+  local e = 10 + you.zigs_completed() * 18
+  local f = 10 + you.zigs_completed() * you.zigs_completed() * 10
   return "ice devil w:5 / rime drake w:5 / azure jelly / " ..
          "caustic shrike simulacrum w:5 / spriggan defender simulacrum w:5 / " ..
          "juggernaut simulacrum w:5 / ironbound frostheart w:5 / " ..
          "walking frostbound tome w:" .. d .. " / frost giant w:" .. d .. " / " ..
          "blizzard demon w:" .. d .. " / white draconian knight w:" .. e .. " / " ..
-         "shard shrike w:" .. e .. " / ice fiend w:" .. e
+         "shard shrike w:" .. e .. " / ice fiend w:" .. e .. " / " ..
+         "orb of winter w:" .. f
 end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()
@@ -373,13 +377,14 @@ mset(with_props(spec_fn(function ()
   local d = 20 + you.zigs_completed() * 5
   local e = 20 + you.zigs_completed() * 8
   local f = 20 + you.zigs_completed() * you.zigs_completed() * 3
-  return "gargoyle w:20 / earth elemental w:20 / boulder beetle w:20 / " ..
+  return "obsidian bat w:20 / earth elemental w:20 / boulder beetle w:20 / " ..
          "torpor snail w:" .. d .. " / iron golem w:" .. d .. " / " ..
          "war gargoyle w:" .. d .. " / stone giant w:" .. d .. " / " ..
          "caustic shrike w:" .. d .. " / entropy weaver w:" .. d .. " / " ..
-         "iron dragon w:" .. d .. " / crystal guardian w:" .. e .. " / " ..
-         "undying armoury w:" .. e .. " / iron giant w:" .. f .. " / " ..
-         "hell sentinel w:" .. f
+         "iron dragon w:" .. d .. " / iron troll w:" .. d .. " / " ..
+         "walking crystal tome w:" .. d .. " / walking earthen tome w:" .. d - 10 .. " / " ..
+         "crystal guardian w:" .. e .. " / undying armoury w:" .. e .. " / " ..
+         "iron giant w:" .. f .. " / hell sentinel w:" .. f
 end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()
@@ -387,10 +392,11 @@ mset(with_props(spec_fn(function ()
   local e = math.min(8, math.floor((you.depth()) / 5) + 4 + you.zigs_completed())
   local f = math.max(1, you.depth() + you.zigs_completed() * 2 - 4)
   return "soul eater w:" .. d .. " / laughing skull w:" .. d .. " / " ..
-         "deep elf death mage w:2 / shadow dragon w:8 / ghost crab w:4 / " ..
-         "eidolon w:4 / revenant soulmonger w:" .. e .. " / " ..
-         "demonspawn soul scholar w:4 / curse skull w:4 / curse toe w:2 / " ..
-         "halazid warlock w:" .. e .. " / player ghost w:" .. f
+         "deep elf death mage w:2 / curse toe w:2 / ghost crab w:4 / " ..
+         "demonspawn soul scholar w:4 / curse skull w:4 / eidolon w:4 / " ..
+         "alderking w:4 / shadow dragon w:8 / revenant soulmonger w:" .. e .. " / " ..
+         "halazid warlock w:" .. e .. " / player ghost w:" .. f .. " / " ..
+         "orb of entropy w:" .. f / 2
 end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()
@@ -409,8 +415,9 @@ mset(spec_fn(function ()
   local e = math.min(8, math.floor((you.depth()) / 5) + 4)
   local f = math.max(1, you.depth() + you.zigs_completed() * 2 - 4)
   return "chaos spawn w:" .. d .. " / very ugly thing w:" .. d .. " / " ..
-         "apocalypse crab w:4 / killer klown w:8 / " ..
-         "crawling flesh cage w:2 / chonchon w:8 / " ..
+         "crawling flesh cage w:2 / kobold fleshcrafter w:4 / " ..
+         "apocalypse crab w:4 / demonspawn blood saint w:4 / " ..
+         "zykzyl w:4 / killer klown w:8 / chonchon w:8 / " ..
          "shapeshifter hd:16 w:" .. e .. " / " ..
          "glowing shapeshifter w:" .. e / 3 .. " / " ..
          "protean progenitor w:" .. e .. " / " ..
@@ -454,9 +461,9 @@ mset(with_props(spec_fn(function ()
   return "centaur w:5 / centaur warrior / yaktaur w:15 / cyclops w:15 / " ..
          "kobold blastminer w:" .. d .. " / faun w:" .. d .. " / " ..
          "yaktaur captain w:" .. d .. " / satyr w:" .. d .. " / " ..
-         "stone giant w:" .. e .. " / naga sharpshooter w:" .. e .. " / " ..
+         "cherub w:" .. d .. " / naga sharpshooter w:" .. e .. " / " ..
          "merfolk javelineer w:" .. e .. " / deep elf master archer w:" .. e .. " / " ..
-         "nekomata w:" .. e
+         "stone giant w:" .. e .. " / "nekomata w:" .. e
 end), { weight = 2 }))
 
 mset(with_props(spec_fn(function ()
@@ -482,7 +489,7 @@ mset(with_props(spec_fn(function ()
          "boggart w:" .. d .. " / worldbinder w:" .. d .. " / " ..
          "rakshasa / broodmother / shadow demon / deep elf demonologist w:5 / " ..
          "dread lich w:5 / fravashi w:5 / oblivion hound w:5 / " ..
-         "glowing orange brain w:" .. e .. " / " ..
+         "elemental wellspring w:5 / glowing orange brain w:" .. e .. " / " ..
          "demonspawn corrupter w:" .. e .. " / " ..
          "halazid warlock w:" .. f .. " / nekomata w:" .. f
 end), { weight = 2 }))


### PR DESCRIPTION
This got a little too big for the vault collection PR it was originally a part of. Adds some new monsters to Zig

Shoals: Small boost to formless jellyfish and sphinx marauders (two of the more dangerous enemies in the branch)
Orc: Loses iron trolls (which don't really spawn in there) and gains ettins
Crypt: Cognitogaunts and ancient champions
Ice: Orbs of winter, reduces scaling for (former) top tier monsters so they can be more prominent
Earth: Obsidian bats replace gargoyles (which are harmless in Zig), gain walking crystal/earthen tomes and the iron trolls that Orc lost. 
Negative energy: Alderkings and orbs of entropy (OoEs only get half weight compared to player ghosts so they don't overshadow them)
Chaos: Blood saints, fleshcrafters and zykzyl
Archers: Cherubim
Summoners: Elemental wellsprings

Also some minor formatting tweaks