### PR TITLE
Changes with display of current attack delay in weapon descriptions

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1372,16 +1372,13 @@ static int _get_delay(const item_def &item)
 
 static string _desc_attack_delay(const item_def &item)
 {
-    const int base_delay = property(item, PWPN_SPEED);
-
     // Hide speed/heavy brand from unidentified weapons.
     item_def dummy = item;
     if (!item.is_identified())
         dummy.brand = SPWPN_NORMAL;
 
     const int cur_delay = _get_delay(dummy);
-    if (weapon_adjust_delay(item, base_delay, false) == cur_delay)
-        return "";
+    
     return make_stringf("\n    Current attack delay: %.1f.", (float)cur_delay / 10);
 }
 


### PR DESCRIPTION
2 commits, one to display weapon delay in item descriptions (even if you're at the base delay) and one to include your current delay on throwing weapons as well.

---
https://github.com/crawl/crawl/blob/3cd4677b91f90b0ed0b777eed8f9afef84451c52/crawl-ref/source/describe.cc#L2254

I wanted to ask about this `crawl_state.needsave`. This check was performed elsewhere https://github.com/crawl/crawl/blob/3cd4677b91f90b0ed0b777eed8f9afef84451c52/crawl-ref/source/describe.cc#L1506 and I copied it over but I am not sure what it's guarding against exactly. I thought it would be easier to ask about it if I provided the context. Needs attention!