### PR TITLE
Fix a webtiles desync when a spectator joins

### DIFF
--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -322,7 +322,7 @@ protected:
     void _mcache_ref(bool inc);
 
     void _send_cursor(cursor_type type);
-    void _send_map(bool force_full = false);
+    void _send_map(bool spectator_only = false);
     void _send_cell(const coord_def &gc,
                     const screen_cell_t &current_sc, const screen_cell_t &next_sc,
                     const map_cell &current_mc, const map_cell &next_mc,


### PR DESCRIPTION
When a spectactor joins we send the full map data to the spectator that just joined and record this map data is the last sent map data. However, the player and any pre-exiting spectators might not have received this map data yet and as we set it as the last sent map data it won't be sent again until it changes. To fix this, make sure all the pre-existing clients have the most up to date map data before sending the full map data to the new spectator.

Fixes #1474
Fixes #1637
Fixes #2473
Fixes #2499
Fixes #2704
Fixes #3153
Fixes #3222
Fixes #3489
Fixes #3974
Fixes #4013
Fixes #4169
Fixes #4536