### PR TITLE
Make the lua function dgn.vault_at return a pointer

### DIFF
--- a/crawl-ref/source/l-dgn.cc
+++ b/crawl-ref/source/l-dgn.cc
@@ -1569,7 +1569,10 @@ LUAFN(_dgn_map_parameters)
 
 static int _dgn_push_vault_placement(lua_State *ls, const vault_placement *vp)
 {
-    return dlua_push_object_type(ls, VAULT_PLACEMENT_METATABLE, *vp);
+    const vault_placement** ptr = clua_new_userdata<const vault_placement*>(ls,
+                                                    VAULT_PLACEMENT_METATABLE);
+    *ptr = vp;
+    return 1;
 }
 
 static int _dgn_push_vault_placement_uptr(lua_State *ls,
@@ -1961,8 +1964,7 @@ static void _dgn_register_metatables(lua_State *ls)
 {
     clua_register_metatable(ls,
                             VAULT_PLACEMENT_METATABLE,
-                            dgn_vaultplacement_ops,
-                            lua_object_gc<vault_placement>);
+                            dgn_vaultplacement_ops);
 }
 
 void dluaopen_dgn(lua_State *ls)


### PR DESCRIPTION
The lua function dgn.vault_at was returning a copy of the vault_placemnt at a location. Unfortunately, it is slow to copy a vault_placement and because the object returned to lua is a wrapper around a c++ object lua doesn't know how big it is and won't trigger garbage collection until you have about 8000 of them (about 17 MB).

The only place using dgn.vault_at is the disco Pan colour function which can work just fine with a pointer rather than a copy and runs considerably faster.

This is also consistent with the c++ equivalent that returns a pointer.