### PR TITLE
Dismiss monsters that are lured too far.

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5403,6 +5403,8 @@ monster* dgn_place_monster(mons_spec &mspec, coord_def where,
     for (const mon_enchant &ench : mspec.ench)
         mons->add_ench(ench);
 
+    mons->origin_level = level_id::current();
+
     return mons;
 }
 

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1482,6 +1482,8 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
         mon->add_ench(mon_enchant(ENCH_REGENERATION, 0, &you, random_range(300, 500)));
     }
 
+    mon->origin_level = level_id::current();
+
     return mon;
 }
 

--- a/crawl-ref/source/mon-transit.h
+++ b/crawl-ref/source/mon-transit.h
@@ -67,3 +67,4 @@ void transport_followers_from(const coord_def &from);
 
 void apply_daction_to_transit(daction_type act);
 int count_daction_in_transit(daction_type act);
+bool far_from_origin(level_id origin, level_id current = level_id::current());

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -101,6 +101,7 @@ monster::monster()
     clear_constricted();
     went_unseen_this_turn = false;
     unseen_pos = coord_def(0, 0);
+    origin_level = level_id::current();
 }
 
 // Empty destructor to keep unique_ptr happy with incomplete ghost_demon type.
@@ -209,6 +210,7 @@ void monster::init_with(const monster& mon)
     damage_friendly   = mon.damage_friendly;
     damage_total      = mon.damage_total;
     xp_tracking       = mon.xp_tracking;
+    origin_level      = mon.origin_level;
 
     if (mon.ghost)
         ghost.reset(new ghost_demon(*mon.ghost));

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -125,6 +125,7 @@ public:
 
     bool went_unseen_this_turn;
     coord_def unseen_pos;
+    level_id origin_level;
 
 public:
     void set_new_monster_id();

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -330,6 +330,7 @@ enum tag_minor_version
     TAG_MINOR_ZOT_ORB_ROTATION,    // Add multiple rotating orb monster types to Zot
     TAG_MINOR_GHOST_TITLE,         // Store ghost titles instead of generating them
     TAG_MINOR_ZOT_ORB_MEMORY,      // Fix whether the player has learned the Zot orb type not being saved
+    TAG_MINOR_TRACK_ORIGIN_LEVEL,  // Track the original level on which a monster was generated
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6446,6 +6446,7 @@ void marshallMonster(writer &th, const monster& m)
     marshallShort(th, m.damage_total);
     marshallByte(th, m.went_unseen_this_turn);
     marshallCoord(th, m.unseen_pos);
+    marshall_level_id(th, m.origin_level);
 
     if (parts & MP_GHOST_DEMON)
     {
@@ -7544,6 +7545,10 @@ void unmarshallMonster(reader &th, monster& m)
     m.went_unseen_this_turn = unmarshallByte(th);
     m.unseen_pos = unmarshallCoord(th);
 #if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() < TAG_MINOR_TRACK_ORIGIN_LEVEL)
+        m.origin_level = level_id::current();
+    else
+        unmarshall_level_id(th);
     }
 #endif
 


### PR DESCRIPTION
Experimental change. Store the origin level of each monster in its structure, and track how far away from the origin we are on transit to a new floor. If the monster is 3 or more floors away after transit, it goes away forever, yielding no items or exp. This only applies to hostile monsters in connected branches, and is turned off for the orbrun.

This is a thing that shouldn't be noticeable for most players. It prevents the sort of degenerate exploits that happened with eg. silent spectres, without having to either tag every monster with an exploitable mechanic to not use stairs or to avoid using those mechanics altogether. So now making an earlygame digging monster, or monsters with double-edged auras or other symmetrical mechanics should be possible.

I left in a bunch of testing messages for easier debugging. Those should be removed and an actual message should be added before merge.