### PR TITLE
fix: 'program bug' death attribution for blazeheart golem flame clouds

### DIFF
--- a/crawl-ref/source/hiscores.cc
+++ b/crawl-ref/source/hiscores.cc
@@ -1423,6 +1423,9 @@ void scorefile_entry::init_death_cause(int dam, mid_t dsrc,
         if (mons->mid == MID_YOU_FAULTLESS)
             death_source_name = "themself";
 
+        if (mons->mid == MID_ANON_FRIEND)
+            death_source_name = "a friend";
+
         if (mons->has_ench(ENCH_SHAPESHIFTER))
             death_source_name += " (shapeshifter)";
         else if (mons->has_ench(ENCH_GLOWING_SHAPESHIFTER))


### PR DESCRIPTION
It will now claim the player was "engulfed by a friend's flame" rather than "engulfed by a program bug's flame".