### PR TITLE
fix: make '[X] to wear' text coloring gray

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -636,9 +636,10 @@ void UseItemMenu::update_sections()
         floor_header->text = "Floor Items";
         if (easy_floor)
         {
-            floor_header->text += make_stringf(" (%s to %s)",
-                    menu_keyhelp_cmd(CMD_MENU_CYCLE_HEADERS).c_str(),
-                        _oper_name(oper).c_str());
+            floor_header->text += make_stringf(
+                "<lightgray> (%s to %s)</lightgray>",
+                menu_keyhelp_cmd(CMD_MENU_CYCLE_HEADERS).c_str(),
+                _oper_name(oper).c_str());
         }
         else if (is_inventory)
             floor_header->text += cycle_hint;


### PR DESCRIPTION
The text for `easy_floor_use` in the case of floor items didn't have any explicit color information set, causing the color of the nearby cyan text to partially overlap.  This fixes that by just explicitly setting it as lightgray.

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2d16a73a-3be9-478f-babf-5a977b4e5976" />
After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/1f2ff243-8542-4873-9a4e-edbf5a9f931c" />
