### PR TITLE
fix: show Dilettante debuff in skill menu

### DIFF
--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -594,6 +594,8 @@ string SkillMenuSwitch::get_help()
                 causes.push_back("Ashenzari's anger");
             if (_hermit_penalty())
                 causes.push_back("the Hermit's pendant");
+            if (you.has_bane(BANE_DILETTANTE))
+                causes.push_back("the Bane of the Dilettante");
             if (!result.empty())
                 result += "\n";
             result += "Skills reduced by "


### PR DESCRIPTION
Was just not added to SkillMenuSwitch::get_help.

Fixes #4674.


<img width="400"  alt="image" src="https://github.com/user-attachments/assets/c6c0a048-9c7b-49fe-9959-4faf44db5f47" />
