### PR TITLE
make Aphotic Marionette fail on illusions

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -3850,7 +3850,21 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         return dithmenos_shadowslip(fail);
 
     case ABIL_DITHMENOS_APHOTIC_MARIONETTE:
+    {
+        monster* mons = monster_at(beam.target);
+
+        if (mons && you.can_see(*mons) && mons->is_illusion())
+        {
+            fail_check();
+            mprf("You attempt to grasp %s shadow with your own, but %s is merely a clone!",
+                 mons->name(DESC_ITS).c_str(),
+                 mons->pronoun(PRONOUN_SUBJECTIVE).c_str());
+            // Still costs a turn to gain the information.
+            mons->add_ench(ENCH_SHADOWLESS);
+            return spret::success;
+        }
         return dithmenos_marionette(*monster_at(beam.target), fail);
+    }
 
     case ABIL_DITHMENOS_PRIMORDIAL_NIGHTFALL:
         return dithmenos_nightfall(fail);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2495,7 +2495,7 @@ bool targeter_marionette::valid_aim(coord_def a)
     if (mons->has_ench(ENCH_SHADOWLESS))
         return notify_fail("Their shadow is too faded to take hold of.");
 
-    if (mons->is_summoned())
+    if (mons->is_summoned() && !mons->is_illusion())
         return notify_fail("A summoned shadow is too ephemeral to take hold of.");
 
     if (mons->props[DITHMENOS_MARIONETTE_SPELLS_KEY].get_int() <= 0)


### PR DESCRIPTION
#4682 fix, instead of providing illusion info for free, make it auto-fail on illusions with custom message and apply shadowless status