### PR TITLE
Let Lua check the type of an ident

### DIFF
--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -404,8 +404,6 @@ static string _item_name(lua_State *ls, item_def* item)
     description_level_type ndesc = DESC_PLAIN;
     if (lua_isstring(ls, 1))
         ndesc = description_type_by_name(lua_tostring(ls, 1));
-    else if (lua_isnumber(ls, 1))
-        ndesc = static_cast<description_level_type>(luaL_safe_checkint(ls, 1));
     const bool terse = lua_toboolean(ls, 2);
     return item->name(ndesc, terse);
 }

--- a/crawl-ref/source/libutil.cc
+++ b/crawl-ref/source/libutil.cc
@@ -87,6 +87,8 @@ description_level_type description_type_by_name(const char *desc)
         return DESC_BASENAME;
     else if (!strcmp("qual", desc))
         return DESC_QUALNAME;
+    else if (!strcmp("db", desc))
+        return DESC_DBNAME;
 
     return DESC_PLAIN;
 }


### PR DESCRIPTION
Crawl didn't offer a way to check which subtype an identified item has. `item.subtype()` returned the same name ("body") for robes as for plate mail. `item.name("base")` returned different names for artefact and non-artefact items. Change each function as follows:

* Give `item.subtype()` a way to return the item type for armour.
* Give `item.name()` a way to return the `DBNAME` of an item.

Also delete the "choose the description level by number" code from `item.name()`. It doesn't work, and I don't know if it ever has. It could be made to work, but I don't know if anyone would actually find that useful.