### PR TITLE
Rephrase shadow dragon scales.

### DIFF
--- a/crawl-ref/source/dat/clua/stash.lua
+++ b/crawl-ref/source/dat/clua/stash.lua
@@ -135,7 +135,7 @@ function ch_stash_search_annotate_item(it)
       ["ice"] = "rC++ rF-",
       ["pearl"] = "rN+",
       ["storm"] = "rElec",
-      ["shadow"] = "Stlth++++",
+      ["shadow"] = "Stlth+",
       ["golden"] = "rF+ rC+ rPois"
     }
     local t = it.name("base"):match("%a+")

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -1606,8 +1606,8 @@ thrown to cause minor damage.
 shadow dragon scales
 
 The scales of a great umbral dragon. It is heavier than most dragon scale
-armours, but despite this, blends in so well with the shadows as to provide a
-substantial benefit to the wearer's stealth.
+armours, but its encumbrance does not penalize the wearer's stealth. It also
+grants additional stealth to the wearer.
 %%%%
 storm dragon scales
 

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -258,7 +258,7 @@ static const armour_def Armour_prop[] =
     DRAGON_ARMOUR(STORM,       "storm",                  10, -150,  650,
         ARMF_RES_ELEC),
     DRAGON_ARMOUR(SHADOW,      "shadow",                 11, -150,  650,
-        ard(ARMF_STEALTH, 4)),
+        ARMF_STEALTH),
     DRAGON_ARMOUR(GOLDEN,      "golden",                 12, -230,  800,
         ARMF_RES_FIRE | ARMF_RES_COLD | ARMF_RES_POISON),
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2073,6 +2073,16 @@ int player_armour_shield_spell_penalty()
     return max(total_penalty, 0) / scale;
 }
 
+int player_armour_stealth_penalty()
+{
+    const item_def *body_armour = you.body_armour();
+
+    if (body_armour && body_armour->sub_type == ARM_SHADOW_DRAGON_ARMOUR)
+        return 0;
+
+    return you.unadjusted_body_armour_penalty();
+}
+
 /**
  * How many spell-success-boosting ('wizardry') effects does the player have?
  *
@@ -3172,7 +3182,7 @@ int player_stealth()
     {
         // [ds] New stealth penalty formula from rob: SP = 6 * (EP^2)
         // Now 2 * EP^2 / 3 after EP rescaling.
-        const int evp = you.unadjusted_body_armour_penalty();
+        const int evp = player_armour_stealth_penalty();
         const int penalty = evp * evp * 2 / 3;
         stealth -= penalty;
 

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -1034,6 +1034,7 @@ bool player_effectively_in_light_armour();
 
 int player_shield_racial_factor();
 int player_armour_shield_spell_penalty();
+int player_armour_stealth_penalty();
 
 int player_movement_speed(bool check_terrain = true, bool temp = true);
 


### PR DESCRIPTION
Players don't intuitively know how much stealth ER 15 with stealth++++ is (it's equal to ER 0 with stealth+). Change shadow dragon scales to have no ER penalty for the purpose of stealth and stealth+ instead for clarity.