### PR TITLE
Rebalance Reaver starting attributes and skills, give them robes instead of leather

### DIFF
--- a/crawl-ref/source/dat/jobs/reaver.yaml
+++ b/crawl-ref/source/dat/jobs/reaver.yaml
@@ -2,8 +2,8 @@ enum: JOB_REAVER
 name: "Reaver"
 category: Warrior-mage
 category_priority: 70
-str: 4
-int: 5
+str: 3
+int: 6
 dex: 3
 spells:
   - SPELL_KISS_OF_DEATH
@@ -11,7 +11,7 @@ spells:
   - SPELL_HAILSTORM
   - SPELL_RENDING_BLADE
 equipment:
-  - "leather armour"
+  - "robe"
 weapon_choice: plain
 recommended_species:
   - gnoll
@@ -21,9 +21,10 @@ recommended_species:
   - draconian
   - mountain dwarf
 skills:
-  fighting: 2
-  dodging: 2
+  fighting: 3
+  stealth: 2
   spellcasting: 2
   conjurations: 3
-  weapon: 3
+  necromancy: 1
+  weapon: 2
 create_enum: false


### PR DESCRIPTION
this is mostly intended to fix the outrageous fail% on their starting spell. an average (i.e. Human) book start can expect to have starting spell fail% of 3-6 for single school spells, up to around 10 for double school spells. a HuRe starts with **_17%_** failure, on a spell you want to use as late as possible (1-2 turns from death) or you risk entering a negative feedback loop and draining yourself to death. that's almost 3% to fail twice and just die. even the absolute best start (GnRe) has 9% fail. 

at the same time it's not like Re start is stretched so thin as to have no starting xp to spare, some skill allocations are very questionable - 3 weapon skill on a warrior-mage start, 2 dodging on a +3 dex start (second lowest bg dex bonus in the game), no secondary school skill with double school starting spell (the only instance of this in the game - all other double school starting spells have starting skills in both schools, in fact if there's secondary skill for a lv1-2 spell in the starting book, it's very likely to have the appropriate training even if the starting spell doesn't use it, cf. EE, Hs, Al*)

by simply swapping leathers for robe and reshuffling the starting allocation as below, you can get fail% down to 4 for GnRe and 11 for HuRe, and prepare the start a bit better for what it needs:

* 1 point from str to int, resulting in 3/6/3 SID. would rather lose 1 str than 1 dex on start, especially with robe;
* swap fighting and weapon skill, from 2/3 to 3/2 - only other starts that get 3 weapon are Be, Mo, CK, CA & Gl - all except CA entirely martial and/or starting with improved weapons, 2 is more in line with starts like Wr/Hs and personally i'd rather have 3 fighting for this start because it gives a larger margin for error;
* replace 2 dodging with 2 stealth - as mentioned above, dodging with +3 starting dex doesn't make a whole lot of sense, not that it's a stellar starting skill otherwise. you really can't afford to bite off more than you can chew on Re, stealth is a natural fit;
* add 1 necro - this is "over budget" (although you could view it as a compensation for swapping to robe), but it's needed, and it's not a big xp investment. starts don't have exactly the same xp anyway, e.g. IE has more starting xp than FE because 4 > 3+1

this also brings down their momentum strike fail%, which is not insignificant

------
\* that one is just plain stupid - the starting spell is double school alch/air, but the starting skills are 3 alch 1 conj 0 air, it has to be a post-rework oversight