### PR TITLE
Let single-tile exclusions block destination stairs. (CrawlOdds, Darby, riverfiend splats spriggans, Zewo)

### DIFF
--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -5324,15 +5324,12 @@ bool stairs_destination_is_excluded(const stair_info &si)
             return false;
         }
 
-        // Check for exclusions that cover the stair destination, but ignore
-        // those that have radius 1: those exclude travel in the _other_
-        // direction only (from the destination to here, not from here to the
-        // destination)
+        // Check for exclusions that cover the stair destination
         const exclude_set &excludes = dest_li->get_excludes();
         for (auto entry : excludes)
         {
             const travel_exclude &ex = entry.second;
-            if (ex.in_bounds(dest.pos) && ex.radius > 1)
+            if (ex.in_bounds(dest.pos))
                 return true;
         }
     }


### PR DESCRIPTION

For some reason single-tile exclusions on the destination side of stairs didn't give warnings or prevent autotravel while multi-tile exclusions did. This was done intentionally according to code comments but it's not clear what benefits this had.

On the other hand it caused several people confusion over the years when their exclusions didn't stop them from going into dangerous situations that they had marked.

Closes #3115 and #3415