### PR TITLE
Don't allow Command armour in Okawaru capstone gifts (55-ENN)

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1156,6 +1156,10 @@ static string _why_reject(const item_def &item, int agent)
     if (agent == GOD_OKAWARU && get_weapon_brand(item) == SPWPN_REAPING)
         return "Destroying Oka-gifted reaping weapon.";
 
+    // Oka does not gift command armour.
+    if (agent == GOD_OKAWARU && get_armour_ego_type(item) == SPARM_COMMAND)
+        return "Destroying Oka-gifted command armour.";
+
     // Pain brand is useless if you've sacrificed Necromancy.
     if (you.get_mutation_level(MUT_NO_NECROMANCY_MAGIC)
         && get_weapon_brand(item) == SPWPN_PAIN)


### PR DESCRIPTION
Okawaru worshipers cannot make use of this armour ego without abandoning Okawaru. Surely Oka wouldn't encourage the player to abandon!