### PR TITLE
Recommend Tab instead of ! in spell library

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -286,13 +286,14 @@ Apart from (de)selecting skills, you also have the following toggles:
 %%%%
 spell-library
 <h>Spell Library</h>
-<w>!</w>        : Cycle between <w>Memorise</w>, <w>Describe</w>, <w>Hide</w>, and <w>Show</w> pages.
-<w>Ctrl-F</w>   : Filter the list of spells shown with a regex.
-<w>?</w>        : Show this help.
+<w>Tab</w> or <w>!</w>  : Cycle rightward through <w>Memorise</w>, <w>Describe</w>, <w>Hide</w>, and <w>Show</w> pages.
+<w>Shift-Tab</w> : Cycle leftward through the pages.
+<w>Ctrl-F</w>    : Filter the list of spells shown with a regex.
+<w>?</w>         : Show this help.
 
 By default, the spell library opens to the <w>Memorise</w> page; to begin memorising a
 spell, just press its letter. To read a spell's description, first switch to
-the <w>Describe</w> page by pressing <w>!</w>, then press the spell's letter.
+the <w>Describe</w> page by pressing <w>Tab</w>, then press the spell's letter.
 
 Most characters will not be interested in memorising the majority of spells that
 accumulate in their spell library; this is where the <w>Show</w> and <w>Hide</w> pages come in

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -599,7 +599,7 @@ private:
         const string act = default_action == action::memorise ? "Memorise"
                            : default_action == action::imbue ? "Imbue" : "Cast";
         // line 2
-        desc << menu_keyhelp_cmd(CMD_MENU_CYCLE_MODE) << " ";
+        desc << menu_keyhelp_cmd(CMD_MENU_RIGHT) << " ";
         desc << ( current_action == action::cast
                             ? "<w>Cast</w>|Describe|Hide|Show"
                  : current_action == action::memorise


### PR DESCRIPTION
Pairing `!` with the spell library  is a rational decision, given that it is normally accessed via `M`, which is shift+m for most players. But the main flaw in pressing `!` for navigation is that one can only navigate forwards (i.e. to the right). For a screen with as many  submenus as the spell library, this is could be better.

The good news is that the `Tab` key performs the same function as `!` here, but does not require shift -- even more critically, `Shift+Tab` will navigate the spell library backwards. Along with being slightly more conveniently placed than `!`, the `Tab` key may encourage more active use of hiding and showing spells, as well as the `auto_hide_spells` option.

(Usefully for me and for players, there is no underlying change: `!` can still be used to navigate between the pages if you want)