### PR TITLE
Put Rising Flame into its own piety rank category

### DIFF
--- a/crawl-ref/source/describe-god.cc
+++ b/crawl-ref/source/describe-god.cc
@@ -915,7 +915,7 @@ static formatted_string _describe_god_powers(god_type which_god)
 
         if (you_worship(which_god)
             && (power.rank <= 0
-                || power.rank == 7 && can_do_capstone_ability(which_god)
+                || power.rank >= 7 && can_do_capstone_ability(which_god)
                 || piety_rank(piety) >= power.rank)
             && (!player_under_penance()
                 || power.rank == -1))

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -428,7 +428,7 @@ const vector<vector<god_power>> & get_all_god_powers()
             { 0, "", "", "You are resistant to fire." },
             { 1, ABIL_IGNIS_FIERY_ARMOUR, "armour yourself in flame" },
             { 1, ABIL_IGNIS_FOXFIRE, "call a swarm of foxfires against your foes" },
-            { 7, ABIL_IGNIS_RISING_FLAME, "rocket upward and away, once" },
+            { 8, ABIL_IGNIS_RISING_FLAME, "rocket upward and away, once" },
         },
     };
     static bool god_powers_init = false;
@@ -2379,7 +2379,7 @@ static void _handle_piety_gain(int old_piety)
             for (const auto& power : get_god_powers(you.religion))
             {
                 if (power.rank == rank
-                    || power.rank == 7 && can_do_capstone_ability(you.religion))
+                    || power.rank >= 7 && can_do_capstone_ability(you.religion))
                 {
                     power.display(true, "You can now %s.");
     #ifdef USE_TILE_LOCAL
@@ -4934,7 +4934,7 @@ bool god_power_usable(const god_power& power, bool ignore_piety, bool ignore_pen
     ASSERT(abil != ABIL_NON_ABILITY);
     return power.god == you.religion
             && (power.rank <= 0
-                || power.rank == 7 && can_do_capstone_ability(you.religion)
+                || power.rank >= 7 && can_do_capstone_ability(you.religion)
                 || piety_rank() >= power.rank
                 || ignore_piety)
             && (!player_under_penance()

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -188,7 +188,8 @@ struct god_power
     // 1-6 means it unlocks at that many stars of piety;
     // 0 means it is always available when worshipping the god;
     // -1 means it is available even under penance;
-    // 7 means it is a capstone.
+    // 7 means it is a capstone;
+    // 8 means it is a capstone and usable at any piety.
     int rank;
     ability_type abil;
 


### PR DESCRIPTION
By joining Ignis's religion through a faded altar while being able to get the first-time piety bonus as a Monk, players could achieve 6 stars of piety with Ignis. Normal capstone abilities (strong, one-time god actions akin to "7 star" abilities) are temporarily lost if the player gets under 6 stars of piety, and there was no exception made for Rising Flame being a special type of capstone ability.

It's a bit of a hack, but let's make Rising Flame an "8 star" ability.

Closes #4681.