### PR TITLE
Give Command to scales of the Dragon King

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -1005,7 +1005,7 @@ PLUS:    +9
 COLOUR:  ETC_GOLD
 TILE:    urand_dragon_king
 TILE_EQ: dragonarm_golden
-WILL:    1
+BRAND:   SPARM_COMMAND
 
 NAME:    hat of the Alchemist
 OBJ:     OBJ_ARMOUR/ARM_HAT


### PR DESCRIPTION
I think the new Command heavy armour ego is fitting thematically since kings give commands and the Command ego would allow many characters to cast Dragon's Call in golden dragon scales with extreme training.

I removed will+ because it's boring. Although an identical artefact could be still be randomly generated, hopfully this is more interesting thematically and has more impact on players' strategic decisions.