### PR TITLE
Add baubles to "autopickup toggle" menu

### DIFF
--- a/crawl-ref/source/known-items.cc
+++ b/crawl-ref/source/known-items.cc
@@ -376,6 +376,7 @@ void check_item_knowledge(bool unknown_items)
 #endif
     vector<const item_def*> items_misc;
     vector<const item_def*> items_talismans;
+    vector<const item_def*> items_baubles;
     vector<const item_def*> items_other;   //List of other items should go after everything
     vector<SelItem> selected_items;
 
@@ -483,6 +484,9 @@ void check_item_knowledge(bool unknown_items)
         };
         for (auto e : misc_list)
             _add_fake_item(e.first, e.second, selected_items, items_other);
+
+        for (int i = 0; i < NUM_BAUBLES; i++)
+            _add_fake_item(OBJ_BAUBLES, i, selected_items, items_baubles);
     }
 
     sort(items.begin(), items.end(), _identified_item_names);
@@ -490,9 +494,10 @@ void check_item_knowledge(bool unknown_items)
 #if TAG_MAJOR_VERSION == 34
     sort(items_food.begin(), items_food.end(), _identified_item_names);
 #endif
-    sort(items_misc.begin(), items_misc.end(), _identified_item_names);
     // Intentionally don't sort talismans so that they're ordered by tier instead.
     // (This is dubious!)
+    sort(items_misc.begin(), items_misc.end(), _identified_item_names);
+    sort(items_baubles.begin(), items_baubles.end(), _identified_item_names);
 
     KnownMenu menu(unknown_items, all_items_known);
     string stitle;
@@ -520,6 +525,7 @@ void check_item_knowledge(bool unknown_items)
 #endif
     ml = menu.load_items(items_misc, known_item_mangle, ml, false);
     ml = menu.load_items(items_talismans, known_item_mangle, ml, false);
+    ml = menu.load_items(items_baubles, known_item_mangle, ml, false);
     if (!items_other.empty())
     {
         menu.add_entry(new MenuEntry("Other Items", MEL_SUBTITLE));
@@ -538,6 +544,7 @@ void check_item_knowledge(bool unknown_items)
 #endif
     deleteAll(items_misc);
     deleteAll(items_talismans);
+    deleteAll(items_baubles);
     deleteAll(items_other);
 
     if (!all_items_known && (last_char == '\\' || last_char == '-'))


### PR DESCRIPTION
> (Note: the autopickup toggle menu is primarily/internally intended for "known items" in comparison to unknown items)

Baubles were previously not in this menu, and it seemed logical to add them. In particular, the entire "Baubles" category is added, futureproofing if other baubles besides flux are created.

Closes #4619.