### PR TITLE
Note Okawaru's joy of hard battles in Powers screen

### DIFF
--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -1098,6 +1098,9 @@ string get_god_likes(god_type which_god)
     case GOD_ZIN:
         likes.emplace_back("you donate money");
         break;
+    case GOD_OKAWARU:
+        really_likes.emplace_back("you kill challenging foes");
+        break;
     default:
         break;
     }


### PR DESCRIPTION
Piety gain for Okawaru scales with the difficulty of the monster faced; the gain is otherwise identical to that of other gods (which, I imagine, is why mention of its special scaling was omitted). This commit adds an acknowledgement that Okawaru "really likes" it when you kill tougher monsters.

Notes:

- Okawaru is placed at the end of the switch statement, specifically to line up with the comment that "unique/unusual piety gain methods [should go] first" -- killing stronger foes isn't *that* unusual or unintuitive.
- Also, the specific wording -- "challenging foes" -- is somewhat intended (if imperfect?). Objective mightiness is surprisingly not relevant; instead, the relative strength of the monster to your character is what matters.

Closes #4656.