### PR TITLE
fix: a trove map appearing about half as often

### DIFF
--- a/crawl-ref/source/dat/des/portals/trove.des
+++ b/crawl-ref/source/dat/des/portals/trove.des
@@ -1140,7 +1140,6 @@ TAGS:   no_species_fe
 veto {{ return crawl.game_started() and you.god() == "Elyvilon"
           or you.god() == "the Shining One" or you.god() == "Zin" }}
 : trove_setup(_G)
-WEIGHT: 5
 {{
 local scroll = {"silence q:3 w:3"}
 local weap = trove_weap_brand(_G, "draining")


### PR DESCRIPTION
Dread Knight's Derelict Chapel was the only trove with a weight set. Without the weight, mapstat suggests it now spawns as often as other troves.