### PR TITLE
Give Demigods Clarity at XL 13

### DIFF
--- a/crawl-ref/source/dat/descript/species.txt
+++ b/crawl-ref/source/dat/descript/species.txt
@@ -22,7 +22,7 @@ They regenerate magical power rapidly.
 Demigod
 
 Demigods refuse to worship any god, but make up for this with divine attributes,
-mutation resistance and high reserves of health and magic.
+clarity of mind and high reserves of health and magic.
 %%%%
 Demonspawn
 

--- a/crawl-ref/source/dat/descript/species.txt
+++ b/crawl-ref/source/dat/descript/species.txt
@@ -21,8 +21,8 @@ They regenerate magical power rapidly.
 %%%%
 Demigod
 
-Demigods refuse to worship any god, but make up for this with divine attributes
-and high reserves of health and magic.
+Demigods refuse to worship any god, but make up for this with divine attributes,
+mutation resistance and high reserves of health and magic.
 %%%%
 Demonspawn
 

--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -49,7 +49,8 @@ mutations:
     MUT_HIGH_MAGIC: 1
     MUT_FORLORN: 1
     MUT_DIVINE_ATTRS: 1
-    MUT_MUTATION_RESISTANCE: 1
+  13:
+    MUT_CLARITY: 1
 recommended_jobs:
   - shapeshifter
   - conjurer

--- a/crawl-ref/source/dat/species/demigod.yaml
+++ b/crawl-ref/source/dat/species/demigod.yaml
@@ -49,6 +49,7 @@ mutations:
     MUT_HIGH_MAGIC: 1
     MUT_FORLORN: 1
     MUT_DIVINE_ATTRS: 1
+    MUT_MUTATION_RESISTANCE: 1
 recommended_jobs:
   - shapeshifter
   - conjurer


### PR DESCRIPTION
Demigods now start with innate Mutation Resistance 1.

Since Halflings were removed back in 0.27, no species has had built-in mutation resistance. Demigods feel like a good candidate for it thematically, they’re made in a divine image and should be less vulnerable to chaotic corruption than ordinary mortals.

On the gameplay side, it also fits their role as a straightforward “big stats, no god” species — solid and reliable, but still an advanced challenge. Mutation resistance doesn’t really come into play until the mid- to late game, so it shouldn't strengthen them too much.

This idea was discussed earlier in #1728, where ideas for the last Demigod rework came from.