### PR TITLE
Fix crash on looking up Nobody

### DIFF
--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -1532,7 +1532,8 @@ vector<string> monster_info::attributes() const
         }
     }
 
-    if (type == MONS_NAMELESS_REVENANT)
+    if (type == MONS_NAMELESS_REVENANT
+        && props.exists(NOBODY_MEMORIES_KEY))
     {
         const int num_memories = props[NOBODY_MEMORIES_KEY].get_vector().size();
         v.push_back(make_stringf("%d %s left", num_memories,


### PR DESCRIPTION
Closes #4766.

This one is a bit more complicated than it looks. The underlying cause appears to be that lookup-help eventually calls for monster attributes despite (seemingly?) not using that data.

(The exact-ish issue, I *think*, is the line `const formatted_string status_desc = _get_monster_status_descriptions(mi);` in the `describe_monster` function in describe.cc. I'm too amateur to think of a good fix, but I *think* status_desc should get an empty value if `describe_monster` is called from the monster lookup functions (there will never be "active" statuses that we care about from `?/m`, since that's what `xv` is for). Overall, unsure if this warrants more refactoring/fixing)