### PR TITLE
Don't ask which trap to make if already specified (and fix some minor issues)

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -6490,7 +6490,8 @@ static void _place_specific_trap(const coord_def& where, trap_spec* spec,
 
     if (spec_type == TRAP_SHAFT && !is_valid_shaft_level())
     {
-        mprf(MSGCH_ERROR, "Vault %s tried to place a shaft at a branch end",
+        mprf(MSGCH_ERROR, "%s%s tried to place a shaft at a branch end.",
+                env.placing_vault.empty() ? "Something" : "Vault ",
                 env.placing_vault.c_str());
     }
 

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -1233,6 +1233,8 @@ trap_type trap_type_from_feature(dungeon_feature_type type)
         return TRAP_ARCHMAGE;
     case DNGN_TRAP_HARLEQUIN:
         return TRAP_HARLEQUIN;
+    case DNGN_TRAP_DEVOURER:
+        return TRAP_DEVOURER;
     case DNGN_TRAP_ALARM:
         return TRAP_ALARM;
     case DNGN_TRAP_ZOT:

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -17,7 +17,6 @@
 #include "directn.h"
 #include "dgn-overview.h"
 #include "dungeon.h"
-#include "dungeon-feature-type.h"
 #include "tile-env.h"
 #include "files.h"
 #include "libutil.h"
@@ -321,7 +320,7 @@ bool wizard_create_feature(dist &target, dungeon_feature_type feat, bool mimic)
             return debug_make_shop(pos);
 
         if (feat_is_trap(feat))
-            return debug_make_trap(pos, feat);
+            return debug_make_trap(pos, trap_type_from_feature(feat));
 
         tile_env.flv(pos).feat = 0;
         tile_env.flv(pos).special = 0;
@@ -451,16 +450,16 @@ void wizard_map_level()
     }
 }
 
-bool debug_make_trap(const coord_def& pos, dungeon_feature_type feat)
+bool debug_make_trap(const coord_def& pos, trap_type trap)
 {
     if (env.grid(pos) != DNGN_FLOOR)
     {
-        mpr("You need to be on a floor square to make a trap.");
+        mprf("You can only make a %s on a floor square.",
+             trap == TRAP_UNASSIGNED ? "trap" : full_trap_name(trap).c_str());
         return false;
     }
 
-    trap_type trap = TRAP_UNASSIGNED;
-    if (!feat_is_trap(feat))
+    if (trap == TRAP_UNASSIGNED)
     {
         vector<WizardEntry> options;
         for (int i = TRAP_FIRST_TRAP; i < NUM_TRAPS; ++i)
@@ -477,8 +476,6 @@ bool debug_make_trap(const coord_def& pos, dungeon_feature_type feat)
 
         trap = static_cast<trap_type>(menu.result());
     }
-    else
-        trap = trap_type_from_feature(feat);
     place_specific_trap(pos, trap);
 
     mprf("Created %s.",

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -479,12 +479,12 @@ bool debug_make_trap(const coord_def& pos, dungeon_feature_type feat)
     }
     else
         trap = trap_type_from_feature(feat);
-    place_specific_trap(you.pos(), trap);
+    place_specific_trap(pos, trap);
 
     mprf("Created %s.",
          (trap == TRAP_RANDOM)
             ? "a random trap"
-            : trap_at(you.pos())->name(DESC_A).c_str());
+            : trap_at(pos)->name(DESC_A).c_str());
 
     if (trap == TRAP_SHAFT && !is_valid_shaft_level())
         mpr("NOTE: Shaft traps aren't valid on this level.");

--- a/crawl-ref/source/wiz-dgn.h
+++ b/crawl-ref/source/wiz-dgn.h
@@ -12,8 +12,8 @@
 // it immediately exits the builder so that you can see what happened.
 //#define DEBUG_VETO_RESUME
 
-#include "dungeon-feature-type.h"
 #include "player.h"
+#include "trap-type.h"
 
 #define WIZ_LAST_FEATURE_TYPE_PROP "last_created_feature"
 dungeon_feature_type wizard_select_feature(bool mimic, bool allow_fprop=false);
@@ -29,7 +29,8 @@ void wizard_interlevel_travel();
 void wizard_list_levels();
 void wizard_recreate_level();
 void wizard_clear_used_vaults();
-bool debug_make_trap(const coord_def& pos = you.pos(), dungeon_feature_type feat = DNGN_FLOOR);
+bool debug_make_trap(const coord_def& pos = you.pos(),
+                     trap_type trap = TRAP_UNASSIGNED);
 bool debug_make_shop(const coord_def& pos = you.pos());
 void debug_place_map(bool primary);
 void wizard_primary_vault();

--- a/crawl-ref/source/wiz-dgn.h
+++ b/crawl-ref/source/wiz-dgn.h
@@ -12,6 +12,7 @@
 // it immediately exits the builder so that you can see what happened.
 //#define DEBUG_VETO_RESUME
 
+#include "dungeon-feature-type.h"
 #include "player.h"
 
 #define WIZ_LAST_FEATURE_TYPE_PROP "last_created_feature"
@@ -28,7 +29,7 @@ void wizard_interlevel_travel();
 void wizard_list_levels();
 void wizard_recreate_level();
 void wizard_clear_used_vaults();
-bool debug_make_trap(const coord_def& pos = you.pos());
+bool debug_make_trap(const coord_def& pos = you.pos(), dungeon_feature_type feat = DNGN_FLOOR);
 bool debug_make_shop(const coord_def& pos = you.pos());
 void debug_place_map(bool primary);
 void wizard_primary_vault();


### PR DESCRIPTION
In wizmode, don't ask which trap to make if the type is already specified. Also, fix trap always made at the character's tile even when told to make at another place.

Fixes #4757.