### PR TITLE
Fix tile mismatch on monster lookup menu

### DIFF
--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -1071,6 +1071,7 @@ static int _describe_monster(const string &key, const string &suffix,
     // Avoid slime creature being described as "buggy"
     if (mi.type == MONS_SLIME_CREATURE)
         mi.slime_size = 1;
+    mi.props[FAKE_MON_KEY] = true;
     return describe_monster(mi, footer);
 }
 


### PR DESCRIPTION
When typing part of a monster's type into the ?/m menu, it will list all monsters who's type is similar to what you typed in. In this list, monsters that usually have a randomized tile will always show the same tile. However, after selecting one of these monsters to view its description, it will have a randomized tile. To fix this tile mismatch, also don't randomize the tile when viewing the description.