### PR TITLE
Fix a crash when shooting a ranged weapon

### DIFF
--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -606,7 +606,7 @@ void throw_it(quiver::action &a)
 {
     const item_def *primary = a.get_launcher();
     const item_def *offhand = you.offhand_weapon();
-    if (!primary || !is_range_weapon(*offhand))
+    if (offhand && (!primary || !is_range_weapon(*offhand)))
         offhand = nullptr;
     const item_def *launcher = primary;
     const item_def *alt_launcher = offhand;


### PR DESCRIPTION
In commit 2b4b8e2 I introduced a crash when firing a ranged weapon with no weapon in your offhand