### PR TITLE
fix: undisplayable spell failure changes in talisman description

### DIFF
--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -3724,7 +3724,7 @@ bool is_usable_talisman(const item_def& item)
     if (item.sub_type == TALISMAN_PROTEAN)
         return false;
 
-    return cannot_put_on_talisman_reason(item).empty();
+    return cannot_put_on_talisman_reason(item, false).empty();
 }
 
 bool ring_plusses_matter(int ring_subtype)

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -3724,7 +3724,7 @@ bool is_usable_talisman(const item_def& item)
     if (item.sub_type == TALISMAN_PROTEAN)
         return false;
 
-    return cannot_evoke_item_reason(&item, false, false).empty();
+    return cannot_put_on_talisman_reason(item).empty();
 }
 
 bool ring_plusses_matter(int ring_subtype)


### PR DESCRIPTION
Talismans were changed from evokable to wearable but there was still a check to see if the talisman was evokable before players could preview spell failure rates. Now it checks if the talisman is wearable when determining if spell failure changes should be shown.

Fixes #4756.