### PR TITLE
Stop debug_xom_effects() (&^X) from trying to run -1 times.

### DIFF
--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -5676,7 +5676,7 @@ void debug_xom_effects()
     const int N = prompt_for_int("How many iterations over the "
                                  "entire piety range? ", true);
 
-    if (N == 0)
+    if (N <= 0)
     {
         canned_msg(MSG_OK);
         return;


### PR DESCRIPTION
prompt_for_int() signals an error to debug_xom_effects() by returning -1, which caused it to create a nonsensical xom_debug.stat file.

Fix this by only generating a file if the user requests a positive number of iterations.