### PR TITLE
Fix crash with Jiyva spawning slimes on damage (code2828)

### DIFF
--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -756,10 +756,10 @@ void _maybe_blood_hastes_allies()
 static void _maybe_spawn_monsters(int dam, kill_method_type death_type,
                                   mid_t death_source)
 {
-    monster* damager = monster_by_mid(death_source);
+    monster* damager = monster_by_mid(death_source, true);
     // We need to exclude acid damage and similar things or this function
     // will crash later.
-    if (!damager || death_source == MID_YOU_FAULTLESS)
+    if (!damager)
         return;
 
     monster_type mon;


### PR DESCRIPTION
When Jiyva creates slime creatures as a result of taking damage, they are meant to target the creature that caused damage to you. However, if the damage was from a cloud placed by a dead ally (e.g. fire clouds from a blaze-heart golem), the target would be set to ANON_FRIENDLY_MONSTER which isn't a valid target and resulted in a crash. To fix this, don't spawn slime creatures when damaged by a dead ally (we already don't when damaged by a dead enemy).

Fixes #4733