### PR TITLE
Fix comes into view messages for named orcs (cfcfcfcfcfcfcfcfcfcf)

### DIFF
--- a/crawl-ref/source/dat/mons/cloud-mage.yaml
+++ b/crawl-ref/source/dat/mons/cloud-mage.yaml
@@ -1,6 +1,6 @@
 name: "Cloud Mage"
 glyph: {char: "@", colour: etc_silver}
-flags: [flies, see_invis, speaks, warm_blood, always_named]
+flags: [flies, see_invis, speaks, warm_blood]
 exp: 1937
 species: human
 will: 100

--- a/crawl-ref/source/dat/mons/headmaster.yaml
+++ b/crawl-ref/source/dat/mons/headmaster.yaml
@@ -1,7 +1,7 @@
 name: "Head Instructor"
 enum: headmaster
 glyph: {char: "@", colour: etc_iron}
-flags: [fighter, see_invis, speaks, warm_blood, two_weapons, always_named]
+flags: [fighter, see_invis, speaks, warm_blood, two_weapons]
 exp: 3034
 species: human
 will: 100

--- a/crawl-ref/source/dat/mons/hellbinder.yaml
+++ b/crawl-ref/source/dat/mons/hellbinder.yaml
@@ -1,6 +1,6 @@
 name: "Hellbinder"
 glyph: {char: "@", colour: etc_fire}
-flags: [see_invis, speaks, warm_blood, always_named]
+flags: [see_invis, speaks, warm_blood]
 exp: 2274
 species: human
 will: 100

--- a/crawl-ref/source/dat/mons/pandemonium-lord.yaml
+++ b/crawl-ref/source/dat/mons/pandemonium-lord.yaml
@@ -1,6 +1,6 @@
 name: "pandemonium lord"
 glyph: {char: "&", colour: colour_undef}
-flags: [fighter, see_invis, speaks, ghost_demon, tall_tile, always_named]
+flags: [fighter, see_invis, speaks, ghost_demon, tall_tile]
 resists: {poison: 1}
 exp: 80
 exp_is_mult: true

--- a/crawl-ref/source/dat/mons/player-ghost.yaml
+++ b/crawl-ref/source/dat/mons/player-ghost.yaml
@@ -1,6 +1,6 @@
 name: "player ghost"
 glyph: {char: "W", colour: white}
-flags: [flies, fighter, speaks, ghost_demon, insubstantial, no_poly_to, always_named]
+flags: [flies, fighter, speaks, ghost_demon, insubstantial, no_poly_to]
 exp: 65
 exp_is_mult: true
 genus: phantom

--- a/crawl-ref/source/mon-flags.h
+++ b/crawl-ref/source/mon-flags.h
@@ -120,8 +120,8 @@ enum monclass_flag_type : uint64_t
     /// An ancestor granted by Hepliaklqana
     M_ANCESTOR          = BIT(35),
 
-    /// Gets a special name, like the Hellbinder
-    M_ALWAYS_NAMED      = BIT(36),
+    // Was M_ALWAYS_NAMED and before that M_ALWAYS_CORPSE
+                       // BIT(36),
 
     /// prefer ranged attacks over melee
     M_PREFER_RANGED     = BIT(37),

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1423,13 +1423,6 @@ bool mons_is_or_was_unique(const monster& mon)
               && mons_is_unique((monster_type) mon.props[ORIGINAL_TYPE_KEY].get_int());
 }
 
-/// This monster isn't a unique per se, but it gets a name anyway.
-/// E.g., the Hellbinder.
-bool mons_is_specially_named(monster_type mc)
-{
-    return mons_class_flag(mc, M_ALWAYS_NAMED);
-}
-
 /**
  * Is the given type one of Hepliaklqana's granted ancestors?
  *

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -227,7 +227,6 @@ bool mons_can_shout(monster_type mclass);
 bool mons_is_ghost_demon(monster_type mc);
 bool mons_is_unique(monster_type mc);
 bool mons_is_or_was_unique(const monster& mon);
-bool mons_is_specially_named(monster_type mc);
 bool mons_is_pghost(monster_type mc);
 bool mons_is_draconian_job(monster_type mc);
 bool mons_is_hepliaklqana_ancestor(monster_type mc);

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -429,8 +429,7 @@ static string _describe_monsters_from_species(const vector<details> &species)
         [] (const details &det)
         {
             string name = det.name;
-            if (mons_is_unique(det.mon->type)
-                || mons_is_specially_named(det.mon->type)
+            if (det.mon->is_named() && det.count == 1
                 || !you.can_see(*det.mon))
             {
                 return name;


### PR DESCRIPTION
When Beogh wrath sent a named orc after you with other orcs, the "comes into view" message would have a stray 'a' or 'an' before the orc name, for example "An Olfrun and 2 orcs come into view."

Fixes #4724