### PR TITLE
Fix a vault failing to place an orb of light

### DIFF
--- a/crawl-ref/source/dat/des/altar/lugonu_bribe.des
+++ b/crawl-ref/source/dat/des/altar/lugonu_bribe.des
@@ -51,7 +51,7 @@ function callback.tgw_lugonu_bribe_lugonu_item (data, triggerable,
          ["the Shining One"] = "good_item " .. weapon .. " ego:pain pre_id /\
               good_item " .. weapon .. " ego:draining pre_id /\
               good_item " .. weapon .. " ego:vampirism pre_id /\
-              potion of invisibility pre_id q:3 / orb of light",
+              potion of invisibility pre_id q:3 / orb ego:light",
     }
     data.triggered = true
     if item[you.god()] ~= nil then


### PR DESCRIPTION
The lugonu_bribe vault is supposed to place an orb of light on its alter when the player first sees it if the player worships The Shining One, however, it was using the wrong item spec for creating one which resulted in an error showing up in the player's message log instead.