### PR TITLE
Fix merfolk fish-tail clipping in Quill form

### DIFF
--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -1193,6 +1193,13 @@ void tilep_calc_flags(const dolls_data &doll, int flag[])
         flag[TILEP_PART_DRCWING] = TILEP_FLAG_HIDE;
         flag[TILEP_PART_BODY]    = TILEP_FLAG_CUT_BOTTOM;
     }
+    // when merfolk in quill form, hide the quill legs to show the fishtail.
+    if (you.species == SP_MERFOLK && you.fishtail
+        && doll.parts[TILEP_PART_HELM] == TILEP_BODY_QUILL_HUMANOID
+        && flag[TILEP_PART_HELM] == TILEP_FLAG_NORMAL)   // No hide by other rules
+    {
+        flag[TILEP_PART_HELM] = TILEP_FLAG_CUT_BOTTOM;
+    }
 
     if (doll.parts[TILEP_PART_ARM] == TILEP_ARM_OCTOPODE_SPIKE
         && !is_player_tile(doll.parts[TILEP_PART_BASE], TILEP_BASE_OCTOPODE))


### PR DESCRIPTION
Quill form is not a full-body polymorph like Dragon or Fortress Crab; it only alters certain body parts, similar to Hive or Maw. Therefore the tile should preserve the player's original species silhouette.
Genies and nagas already have bespoke lower-body tiles for this purpose, but merfolk were left wearing a humanoid "legs" layer on top of their fish tail. Copy the approach used for Hive: when a merfolk is in water (fishtail active) simply crop the bottom of the Quill armour tile so the tail remains the only visible lower extremity. This produces a clean, species-consistent sprite.

After fix:
<img width="96" height="96" alt="quill_merfolk_on_land" src="https://github.com/user-attachments/assets/acc641ea-0c6a-42a9-a338-1002e8f99275" />
_on land_
<img width="96" height="96" alt="quill_merfolk_in_water" src="https://github.com/user-attachments/assets/a0e0827e-06e0-4801-8a98-6b81df9ce8c9" />
_in water_
