### PR TITLE
feat: Add selection menus for Gozag’s potion petition and call merchant abilities

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -111,8 +111,8 @@
 #include "traps.h"
 #include "viewchar.h"
 #include "view.h"
-#include "menu.h"          // InvMenu 等
-#include "shopping.h"      // 只是为了复用 InvEntry 风格，不需要改 shopping.cc
+#include "menu.h"
+#include "shopping.h"
 static bool _player_sacrificed_arcana();
 
 // Load the sacrifice_def definition and the sac_data array.

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2823,7 +2823,7 @@ int gozag_shop_petition_menu(const vector<shop_offer> &offers)
 {
     GozagPetitionMenu<shop_offer> menu(
         offers, &_shop_line, &_shop_tile, "gozag-shop",
-        "Which merchant should call?");
+        "Fund which merchant?");
     menu.show();
     return menu.selected_index();
 }

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2729,18 +2729,94 @@ class GozagPetitionMenu : public InvMenu
     const vector<T> &_items;
     string (*_line_func)(const T &);
     tileidx_t (*_tile_func)(const T &);
+    int (*_price_func)(const T &);
+    bool _confirmed = false;
+
+    void _update_footer()
+    {
+        string top_line;
+        const int total_cost = selected_entries().empty() ? 0 :
+            _price_func(_items[selected_index(true)]);
+
+        if (total_cost > 0)
+        {
+            if (total_cost > you.gold)
+            {
+                top_line = make_stringf(
+                    "<yellow>You have %d gold.</yellow> "
+                    "<lightred>You are short %d gold for this.</lightred>",
+                    you.gold, total_cost - you.gold);
+            }
+            else
+            {
+                top_line = make_stringf(
+                    "<yellow>You have %d gold. After purchase, you will have %d.</yellow>",
+                    you.gold, you.gold - total_cost);
+            }
+        }
+        else
+        {
+            top_line = make_stringf("<yellow>You have %d gold piece%s.</yellow>",
+                                     you.gold, you.gold != 1 ? "s" : "");
+        }
+
+        string help;
+        help += "<lightgrey>";
+        if (item_count() > 0)
+        {
+            help += hyphenated_hotkey_letters(item_count(), 'a');
+            help += " select item";
+        }
+
+        if (!selected_entries().empty())
+        {
+            if (item_count() > 0)
+                help += "      ";
+            help += menu_keyhelp_cmd(CMD_MENU_ACCEPT_SELECTION);
+            help += " confirm purchase";
+        }
+        help += "</lightgrey>";
+
+        string full_help = top_line + "\n" + help;
+        set_more(formatted_string::parse_string(pad_more_with_esc(full_help)));
+    }
+
+    // Logic to handle purchase confirmation.
+    bool _confirm_purchase()
+    {
+        if (selected_entries().empty())
+        {
+            // No selection, do nothing, stay in menu.
+            return false;
+        }
+
+        const int selection_idx = selected_index(true);
+        const int cost = _price_func(_items[selection_idx]);
+
+        if (cost > you.gold)
+        {
+            mpr("You cannot afford that.");
+            return false;
+        }
+
+        _confirmed = true;
+        return true;
+    }
 
 public:
     GozagPetitionMenu(const vector<T> &offered_items,
                       string (*line_func)(const T &),
                       tileidx_t (*tile_func)(const T &),
+                      int (*price_func)(const T &),
                       const string &title_tag,
                       const string &menu_title)
-        : InvMenu(MF_SINGLESELECT | MF_ALLOW_FORMATTING | MF_INIT_HOVER),
-          _items(offered_items), _line_func(line_func), _tile_func(tile_func)
+        : InvMenu(MF_MULTISELECT | MF_ALLOW_FORMATTING | MF_INIT_HOVER),
+          _items(offered_items), _line_func(line_func), _tile_func(tile_func),
+          _price_func(price_func)
     {
         set_tag(title_tag);
         menu_action = ACT_EXECUTE;
+        action_cycle = CYCLE_TOGGLE;
         set_title(menu_title);
         menu_letter key = 'a';
 
@@ -2751,17 +2827,74 @@ public:
             entry->data = reinterpret_cast<void *>(idx);
             if (_tile_func)
                 entry->add_tile(tile_def(_tile_func(it)));
+
+            if (_price_func(it) > you.gold)
+                entry->colour = DARKGREY;
+
             add_entry(std::move(entry));
         }
-
-        set_more(formatted_string::parse_string(
-            make_stringf("<yellow>You have %d gold piece%s.</yellow>",
-                         you.gold, you.gold == 1 ? "" : "s")));
-        set_flags(get_flags() | MF_USE_TWO_COLUMNS);
+        _update_footer();
     }
 
-    int selected_index() const
+    bool process_key(int keyin) override
     {
+        auto old_selection = selected_entries();
+        bool ret = InvMenu::process_key(keyin);
+
+        if (old_selection != selected_entries())
+        {
+            if (selected_entries().size() > 1)
+            {
+                for (auto entry : old_selection)
+                    entry->selected_qty = 0;
+            }
+            _update_footer();
+            update_menu(true);
+        }
+        return ret;
+    }
+
+    bool process_command(command_type cmd) override
+    {
+        if (menu_action == ACT_EXECUTE && cmd == CMD_MENU_ACCEPT_SELECTION)
+        {
+            if (_confirm_purchase())
+                return false; // Close menu.
+            return true;
+        }
+        return InvMenu::process_command(cmd);
+    }
+
+    bool cycle_mode(bool) override
+    {
+        if (menu_action == ACT_EXECUTE)
+            menu_action = ACT_EXAMINE;
+        else
+            menu_action = ACT_EXECUTE;
+        _update_footer();
+        update_menu(true);
+        return true;
+    }
+
+    // bool examine_index(int /*i*/) override
+    // {
+    //     // In examine mode, selecting an item does nothing but show its info.
+    //     // We don't have detailed info, so just prevent the menu from closing.
+    //     return true;
+    // }
+
+    /**
+     * Returns the index of the selected item.
+     *
+     * @param force   If true, returns the index regardless of whether the
+     *                purchase was confirmed. Used internally for UI updates.
+     * @return The selected index if confirmed, otherwise -1.
+     */
+    int selected_index(bool force = false) const
+    {
+        if (!_confirmed && !force)
+            return -1;
+
         return selected_entries().empty()
                ? -1
                : static_cast<int>(reinterpret_cast<intptr_t>(
@@ -2778,6 +2911,12 @@ static string _potion_line(const potion_group &g)
     return make_stringf("%d gold - %s", g.price, names.c_str());
 }
 
+/// Returns the price for a potion group.
+static int _potion_price(const potion_group &g)
+{
+    return g.price;
+}
+
 /// Generates the tile for a potion petition menu entry.
 static tileidx_t _potion_tile(const potion_group &)
 {
@@ -2788,6 +2927,12 @@ static tileidx_t _potion_tile(const potion_group &)
 static string _shop_line(const shop_offer &o)
 {
     return make_stringf("%d gold - %s", o.price, o.shop_name.c_str());
+}
+
+/// Returns the price for a shop offer.
+static int _shop_price(const shop_offer &o)
+{
+    return o.price;
 }
 
 /// Generates the tile for a shop petition menu entry.
@@ -2807,7 +2952,7 @@ static tileidx_t _shop_tile(const shop_offer &o)
 int gozag_potion_petition_menu(const vector<potion_group> &groups)
 {
     GozagPetitionMenu<potion_group> menu(
-        groups, &_potion_line, &_potion_tile, "gozag-potion",
+        groups, &_potion_line, &_potion_tile, &_potion_price, "gozag-potion",
         "Purchase which effect?");
     menu.show();
     return menu.selected_index();
@@ -2822,7 +2967,7 @@ int gozag_potion_petition_menu(const vector<potion_group> &groups)
 int gozag_shop_petition_menu(const vector<shop_offer> &offers)
 {
     GozagPetitionMenu<shop_offer> menu(
-        offers, &_shop_line, &_shop_tile, "gozag-shop",
+        offers, &_shop_line, &_shop_tile, &_shop_price, "gozag-shop",
         "Fund which merchant?");
     menu.show();
     return menu.selected_index();

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -2876,13 +2876,6 @@ public:
         return true;
     }
 
-    // bool examine_index(int /*i*/) override
-    // {
-    //     // In examine mode, selecting an item does nothing but show its info.
-    //     // We don't have detailed info, so just prevent the menu from closing.
-    //     return true;
-    // }
-
     /**
      * Returns the index of the selected item.
      *

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -9,10 +9,24 @@
 #include <vector>
 
 #include "tag-version.h"
-
+#include "potion-type.h"
 using std::vector;
 
 struct shop_struct;
+
+struct potion_group
+{
+    int price;
+    vector<potion_type> potions;
+};
+
+/// A shop offered by Gozag's call merchant.
+struct shop_offer
+{
+    int               price;
+    shop_type         type;
+    string            shop_name;
+};
 
 int artefact_value(const item_def &item);
 
@@ -46,7 +60,8 @@ bool have_voucher();
 shop_type str_to_shoptype(const string &s);
 const char *shoptype_to_str(shop_type type);
 
-/////////////////////////////////////////////////////////////////////
+int gozag_potion_petition_menu(const vector<potion_group> &groups);
+int gozag_shop_petition_menu(const vector<shop_offer> &offers);
 
 struct level_pos;
 class  Menu;

--- a/crawl-ref/source/tiledoll.cc
+++ b/crawl-ref/source/tiledoll.cc
@@ -291,6 +291,7 @@ void fill_doll_equipment(dolls_data &result)
         result.parts[TILEP_PART_SHADOW]  = 0;
         break;
     case transformation::quill:
+        result.parts[TILEP_PART_HAIR] = 0;
         if (you.species == SP_FELID)
             result.parts[TILEP_PART_BASE] = TILEP_TRAN_QUILL_FELID;
         else if (you.species == SP_OCTOPODE)
@@ -345,9 +346,11 @@ void fill_doll_equipment(dolls_data &result)
         {
         case SP_OCTOPODE:
             result.parts[TILEP_PART_BASE] = TILEP_TRAN_FLUX_OCTOPODE;
+            result.parts[TILEP_PART_HAIR] = 0;
             break;
         case SP_FELID:
             result.parts[TILEP_PART_BASE] = TILEP_TRAN_FLUX_FELID;
+            result.parts[TILEP_PART_HAIR] = 0;
             break;
         default:
             result.parts[TILEP_PART_BODY] = TILEP_TRAN_FLUX_HUMANOID;
@@ -367,6 +370,7 @@ void fill_doll_equipment(dolls_data &result)
             result.parts[TILEP_PART_BODY] = TILEP_BODY_HIVE_FORM;
             break;
         }
+        result.parts[TILEP_PART_HAIR] = 0;
         break;
     case transformation::medusa:
         switch (you.species)
@@ -386,6 +390,7 @@ void fill_doll_equipment(dolls_data &result)
             result.parts[TILEP_PART_CLOAK] = TILEP_CLOAK_MEDUSA_FORM_HUMANOID;
             break;
         }
+        result.parts[TILEP_PART_HAIR] = 0;
         break;
     case transformation::statue:
         switch (you.species)


### PR DESCRIPTION
Until now, both Gozag’s Potion Petition and Call Merchant abilities printed their choices directly to the message window and only accepted selection via hot-keys.
On tiles/web builds, long random shop names could be truncated (especially for Call Merchant) and mouse selection was impossible.
This patch introduces a proper shop-style menu for both abilities:

1. Works like a one-time “pop-up shop”

2. Supports both hot-keys and mouse clicks

3. Guarantees all options remain visible regardless of font/screen size

Because the menu re-uses the existing icon, Call Merchant now also shows the shop-type icon next to each candidate, giving players an extra visual cue.

<img width="1586" height="958" alt="potions" src="https://github.com/user-attachments/assets/e1e3df30-c4b0-471d-8705-6bf2d2226d69" />
potion petition

<img width="1587" height="943" alt="shop" src="https://github.com/user-attachments/assets/294325c7-a761-4821-a91f-f43b3311b1b3" />
call merchant