### PR TITLE
Correct Lua Regex:matches() doc/name

### DIFF
--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -785,9 +785,9 @@ static int crawl_regex(lua_State *ls)
  * passed.
  * @tparam string s
  * @treturn boolean|nil
- * @function Regex:find
+ * @function Regex:matches
  */
-static int crawl_regex_find(lua_State *ls)
+static int crawl_regex_matches(lua_State *ls)
 {
     text_pattern **pattern =
             clua_get_userdata< text_pattern* >(ls, REGEX_METATABLE);
@@ -830,7 +830,7 @@ static int crawl_regex_equals(lua_State *ls)
 }
 static const luaL_reg crawl_regex_ops[] =
 {
-    { "matches",        crawl_regex_find },
+    { "matches",        crawl_regex_matches },
     { "equals",         crawl_regex_equals },
     { nullptr, nullptr }
 };


### PR DESCRIPTION
Lua API lists `Regex:find()` when it's actually `Regex:matches()`.  Updated the docstring to reflect this. Updated cpp function name to follow existing pattern.

Built and tested with `make -j4 TILES=y BUILD_PCRE=y` on MacOS tiles.

Tested in lua interpreter. Works as intended.
<img width="454" height="103" alt="Screenshot 2025-09-24 at 10 09 55 PM" src="https://github.com/user-attachments/assets/cfdacc94-4e59-4eb0-996f-03e5fdecdc0a" />

<img width="444" height="105" alt="Screenshot 2025-09-24 at 10 10 57 PM" src="https://github.com/user-attachments/assets/e05e5a4e-7648-42fd-9e6f-45ab3f05743e" />
