### PR TITLE
feat: Add selection menus for Gozag’s potion petition and call merchant abilities

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -111,7 +111,8 @@
 #include "traps.h"
 #include "viewchar.h"
 #include "view.h"
-
+#include "menu.h"
+#include "shopping.h"
 static bool _player_sacrificed_arcana();
 
 // Load the sacrifice_def definition and the sac_data array.
@@ -3343,39 +3344,23 @@ bool gozag_potion_petition()
         }
     }
 
-    int keyin = 0;
-
-    while (true)
+    std::vector<potion_group> groups;
+    for (int i = 0; i < GOZAG_MAX_POTIONS; ++i)
     {
-        if (crawl_state.seen_hups)
-            return false;
-
-        clear_messages();
-        for (int i = 0; i < GOZAG_MAX_POTIONS; i++)
-        {
-            string line = make_stringf("  [%c] - %d gold - ", i + 'a',
-                                       prices[i]);
-            vector<string> pot_names;
-            for (const CrawlStoreValue& store : *pots[i])
-                pot_names.emplace_back(potion_type_name(store.get_int()));
-            line += comma_separated_line(pot_names.begin(), pot_names.end());
-            mpr_nojoin(MSGCH_PLAIN, line);
-        }
-        mprf(MSGCH_PROMPT, "Purchase which effect?");
-        keyin = toalower(get_ch()) - 'a';
-        if (keyin < 0 || keyin > GOZAG_MAX_POTIONS - 1)
-            continue;
-
-        if (you.gold < prices[keyin])
-        {
-            mpr("You don't have enough gold for that!");
-            more();
-            continue;
-        }
-
-        break;
+        potion_group g;
+        g.price = prices[i];
+        for (const CrawlStoreValue &v : *pots[i])
+            g.potions.push_back(static_cast<potion_type>(v.get_int()));
+        groups.push_back(std::move(g));
     }
 
+    //Display the menu and get the player's choice.
+    int keyin = gozag_potion_petition_menu(groups);
+    if (keyin == -1)
+    {
+        canned_msg(MSG_OK);
+        return false;
+    }
     ASSERT(you.gold >= prices[keyin]);
     you.del_gold(prices[keyin]);
     you.attribute[ATTR_GOZAG_GOLD_USED] += prices[keyin];
@@ -3508,6 +3493,7 @@ static void _setup_gozag_shop(int index, vector<shop_type> &valid_shops)
         = gozag_price_for_shop();
 }
 
+static string _describe_gozag_shop_name(int index);
 /**
  * Build a string describing the name, price & type of the shop being offered
  * at the given index.
@@ -3519,8 +3505,16 @@ static void _setup_gozag_shop(int index, vector<shop_type> &valid_shops)
 static string _describe_gozag_shop(int index)
 {
     const int cost = _gozag_shop_price(index);
-
     const char offer_letter = 'a' + index;
+
+    return make_stringf("  [%c] %5d gold - %s",
+                        offer_letter,
+                        cost,
+                        _describe_gozag_shop_name(index).c_str());
+}
+
+static string _describe_gozag_shop_name(int index)
+{
     const string shop_name =
         apostrophise(you.props[make_stringf(GOZAG_SHOPKEEPER_NAME_KEY,
                                             index)].get_string());
@@ -3529,9 +3523,7 @@ static string _describe_gozag_shop(int index)
     const string suffix =
         you.props[make_stringf(GOZAG_SHOP_SUFFIX_KEY, index)].get_string();
 
-    return make_stringf("  [%c] %5d gold - %s %s %s",
-                        offer_letter,
-                        cost,
+    return make_stringf("%s %s %s",
                         shop_name.c_str(),
                         type_name.c_str(),
                         suffix.c_str());
@@ -3670,7 +3662,26 @@ bool gozag_call_merchant()
         if (!you.props.exists(make_stringf(GOZAG_SHOPKEEPER_NAME_KEY, i)))
             _setup_gozag_shop(i, valid_shops);
 
-    const int shop_index = _gozag_choose_shop();
+    // Convert shop data from props into a list of offers for the menu.
+    std::vector<shop_offer> offers;
+    offers.reserve(GOZAG_MAX_SHOPS);
+    for (int i = 0; i < GOZAG_MAX_SHOPS; ++i)
+    {
+        offers.emplace_back(shop_offer{
+            _gozag_shop_price(i),
+            _gozag_shop_type(i),
+            _describe_gozag_shop_name(i)
+        });
+    }
+
+    // Display the menu and let the player choose a merchant.
+    const int shop_index = gozag_shop_petition_menu(offers);
+    if (shop_index == -1) // Menu was escaped
+    {
+        canned_msg(MSG_OK);
+        return false;
+    }
+
     if (shop_index == -1) // hup!
         return false;
 

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -9,10 +9,24 @@
 #include <vector>
 
 #include "tag-version.h"
-
+#include "potion-type.h"
 using std::vector;
 
 struct shop_struct;
+
+struct potion_group
+{
+    int price;
+    vector<potion_type> potions;
+};
+
+/// A shop offered by Gozag's call merchant.
+struct shop_offer
+{
+    int               price;
+    shop_type         type;
+    string            shop_name;
+};
 
 int artefact_value(const item_def &item);
 
@@ -46,7 +60,8 @@ bool have_voucher();
 shop_type str_to_shoptype(const string &s);
 const char *shoptype_to_str(shop_type type);
 
-/////////////////////////////////////////////////////////////////////
+int gozag_potion_petition_menu(const vector<potion_group> &groups);
+int gozag_shop_petition_menu(const vector<shop_offer> &offers);
 
 struct level_pos;
 class  Menu;


### PR DESCRIPTION
Until now, both Gozag’s Potion Petition and Call Merchant abilities printed their choices directly to the message window and only accepted selection via hot-keys.
On tiles/web builds, long random shop names could be truncated (especially for Call Merchant) and mouse selection was impossible.
This patch introduces a proper shop-style menu for both abilities:

- Works like a one-time “pop-up shop”(Interface imitates ShopMenu)

- Supports both hot-keys and mouse clicks

- Guarantees all options remain visible regardless of font/screen size

Because the menu re-uses the existing icon, Call Merchant now also shows the shop-type icon next to each candidate, giving players an extra visual cue.
![gozag_petition](https://github.com/user-attachments/assets/c06a1dc3-d6a3-49f8-b60d-42ffd3ad2963)
