### PR TITLE
Create chop_string_ignore_tags() for colourized inscriptions.

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -2097,7 +2097,7 @@ static void _append_overview_screen_item(column_composer& cols,
                     equip_char,
                     colname.c_str(),
                     melded ? "melded " : "",
-                    chop_string(item.name(DESC_PLAIN, true),
+                    chop_string_ignore_tags(item.name(DESC_PLAIN, true),
                             melded ? sw - 32 : sw - 25, false).c_str(),
                     colname.c_str());
     equip_chars.push_back(equip_char);

--- a/crawl-ref/source/unicode.h
+++ b/crawl-ref/source/unicode.h
@@ -9,6 +9,8 @@ int strwidth(const char *s);
 int strwidth(const string &s);
 string chop_string(const char *s, int width, bool spaces = true);
 string chop_string(const string &s, int width, bool spaces = true);
+string chop_string_ignore_tags(const char *s, int width, bool spaces);
+string chop_string_ignore_tags(const string &s, int width, bool spaces);
 
 int wctoutf8(char *d, char32_t s);
 int utf8towc(char32_t *d, const char *s);


### PR DESCRIPTION
Color tags are functional in item inscriptions, but have a couple issues in chop_string():
- Tags are included in the width count, when they don't actually contribute to the length of the visible string.
- Tags can be chopped in half, resulting in formatting errors like:
<img width="791" height="457" alt="cur" src="https://github.com/user-attachments/assets/bd2b45d1-6d3a-407f-9bb3-0dacff3f678f" />

This PR creates `chop_string_ignore_tags()` to address both issues.
- Proper tags are not included in the width count. (If the tag is not a color, or is an unmatched closing tag, it is treated as displayed text, which it is).
- Opening tags are always closed

Result:
<img width="787" height="433" alt="new" src="https://github.com/user-attachments/assets/42cfd9c9-7d14-43e4-b6d8-e327354f3f02" />

Some debugging messages showing function behavior:
<img width="1102" height="199" alt="tests" src="https://github.com/user-attachments/assets/6f6983b8-7f68-4813-ad45-63f7d2541f09" />
