### PR TITLE
Fix fortress talisman description in small screens

### DIFF
--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -1701,7 +1701,10 @@ void Popup::_allocate_region()
             m_region.x + m_region.width, m_region.y + m_region.height,
             VColour(0, 0, 0, 150));
     const int pad = base_margin() + m_padding;
-    region.width -= 2*pad;
+    if (tiles.is_using_small_layout())
+        region.width -= 2*m_padding;
+    else
+        region.width -= 2*pad;
     region.height -= 2*pad + m_depth*m_depth_indent*(!m_centred);
 
     SizeReq hsr = m_child->get_preferred_size(HORZ, -1);


### PR DESCRIPTION
The fortress talisman description popup breaks with narrow screen size. Smartphones are most affected by this, but also any other device with the default configuration when the game window is shrunk.

I have shortened the Rust Breath Size column title and also reduced the columns spacing, but of course it's not the only valid solution.

BEFORE
<img width="720" height="400" alt="before" src="https://github.com/user-attachments/assets/b449f0f5-a5d4-449e-a9aa-c328c9fc9c85" />

AFTER
<img width="720" height="720" alt="after" src="https://github.com/user-attachments/assets/f940ca83-b54f-4bff-95d4-8096c1336eff" />
