### PR TITLE
Show failure rates of abilities in chardump

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -908,9 +908,9 @@ string print_abilities()
     {
         for (unsigned int i = 0; i < talents.size(); ++i)
         {
-            if (i)
-                text += ", ";
-            text += ability_name(talents[i].which);
+            text += make_stringf("%s%s (%s)", i ? ", " : "",
+                        ability_name(talents[i].which).c_str(),
+                        failure_rate_to_string(talents[i].fail).c_str());
         }
     }
 


### PR DESCRIPTION
Shows failure rates of abilities in the chardump `a:` list, e.g. `a: Oozemancy (3%), Slimify (12%)`, similar to the passive effects list in format.

There were a couple of times that either me or my friends wanted to know the failure rates of some abilities. I'm not sure if its intuitive enough so that most people won't mistake it for success rate. Maybe showing a table like the spell library can be better?