### PR TITLE
Protect chk_lua_save from functions returning nil.

### DIFF
--- a/crawl-ref/source/dat/dlua/userbase.lua
+++ b/crawl-ref/source/dat/dlua/userbase.lua
@@ -78,7 +78,7 @@ function c_save()
 
     local res = ""
     for i, fn in ipairs(chk_lua_save) do
-        res = res .. fn(file)
+        res = res .. (fn(file) or "")
     end
     return res
 end


### PR DESCRIPTION
One bad value will break everything in chk_lua_save. This small patch addresses the most common scenario; a function returning nil.