### PR TITLE
equip_slot_by_name(): Remove duplicated list and catch "Body Armour"

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1999,17 +1999,17 @@ int update_monster_pane()
 }
 #endif
 
-static const char *s_equip_slot_names[] =
-{
-    "Weapon", "Offhand", "Armour", "Helmet", "Gloves", "Boots",
-    "Barding", "Cloak", "Ring", "Amulet", "Gizmo"
-};
-
 int equip_slot_by_name(const char *s)
 {
     for (int i = SLOT_FIRST_STANDARD; i <= SLOT_LAST_STANDARD; ++i)
-        if (!strcasecmp(s_equip_slot_names[i - SLOT_FIRST_STANDARD], s))
+    {
+        const equipment_slot slot = static_cast<equipment_slot>(i);
+        if (!strcasecmp(s, equip_slot_name(slot, true)) ||
+            !strcasecmp(s, equip_slot_name(slot, false)))
+        {
             return i;
+        }
+    }
 
     return -1;
 }


### PR DESCRIPTION
Allows Lua API's item.equip_type to work with:
- l_item_equipped_at()
- l_slot_is_available()

Previously didn't work for body armour. equip_type = "Body Armour",
Both functions only check for "Armour"

s_equip_slot_names was only created to support this function afaict,
and just duplicates `enum equipment_slot`

Backward compatible: equip_type returns the same strings, but functions
will now check for both varieties of names.

Tested locally and everything works as before but catches body armour.