### PR TITLE
feat: Adjust Body Armour acquirement

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -219,7 +219,7 @@ static armour_type _acquirement_shield_type()
 /**
  * Determine the weight (likelihood) to acquire a specific type of body armour.
  *
- * Weighted by Armour skill, though not particularly strongly.
+ * Weighted by Armour skill.
  *
  * @param armour    The type of armour in question. (E.g. ARM_ROBE.)
  * @return          A weight for the armour.
@@ -228,7 +228,8 @@ static int _body_acquirement_weight(armour_type armour)
 {
     const int base_weight = armour_acq_weight(armour);
     const int ac = armour_prop(armour, PARM_AC);
-    return base_weight * (300 + (_skill_rdiv(SK_ARMOUR) - 6) * ac);
+    return base_weight +
+            (_skill_rdiv(SK_ARMOUR) * _skill_rdiv(SK_ARMOUR) * ac * ac / 27);
 }
 
 /**

--- a/crawl-ref/source/item-prop.cc
+++ b/crawl-ref/source/item-prop.cc
@@ -129,9 +129,9 @@ static const armour_def Armour_prop[] =
     { ARM_LEATHER_ARMOUR,       "leather armour",         3,  -40,   20,
         SLOT_BODY_ARMOUR, SIZE_SMALL, SIZE_MEDIUM, true, 10, BASIC_BODY_EGOS },
     { ARM_RING_MAIL,            "ring mail",              5,  -70,   40,
-        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 100, BASIC_BODY_EGOS },
+        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 80, BASIC_BODY_EGOS },
     { ARM_SCALE_MAIL,           "scale mail",             6, -100,   40,
-        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 10, {
+        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 60, {
             { SPARM_FIRE_RESISTANCE,   20 },
             { SPARM_COLD_RESISTANCE,   20 },
             { SPARM_POISON_RESISTANCE, 10 },
@@ -143,11 +143,11 @@ static const armour_def Armour_prop[] =
             { SPARM_RESONANCE,          7 },
     }},
     { ARM_CHAIN_MAIL,           "chain mail",             8, -140,   60,
-        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 10, HEAVY_BODY_EGOS },
+        SLOT_BODY_ARMOUR, SIZE_SMALL,  SIZE_MEDIUM, true, 60, HEAVY_BODY_EGOS },
     { ARM_PLATE_ARMOUR,         "plate armour",          10, -180,   180,
-        SLOT_BODY_ARMOUR, SIZE_SMALL, SIZE_MEDIUM, true, 150, HEAVY_BODY_EGOS },
+        SLOT_BODY_ARMOUR, SIZE_SMALL, SIZE_MEDIUM, true, 100, HEAVY_BODY_EGOS },
     { ARM_CRYSTAL_PLATE_ARMOUR, "crystal plate armour",  14, -230,   600,
-        SLOT_BODY_ARMOUR, SIZE_SMALL, SIZE_MEDIUM, false, 150 },
+        SLOT_BODY_ARMOUR, SIZE_SMALL, SIZE_MEDIUM, false, 100 },
 
 #if TAG_MAJOR_VERSION == 34
     { ARM_TROLL_HIDE, "removed troll hide",              0,    0,      0,


### PR DESCRIPTION
Currently body armour acqurement is dominated by robes, ring mails,
troll leather, plate and crystal plate. Higher armour skill makes plate
and crystal plate more likely, but the chance to get one of those five
is about the same even at 27 skill.
Additionally scale mail and chain mail are very rare. This version
brings several new body armour egos that spawn on scale, chain or plate
so it makes sense to make those slightly more likely.
Okawaru gifts also tend to leave a bad feeling after being offered a
robe or troll leather on your heavy armour using char.

This commit changes the weights of ring, scale, chain, plate and cpa.
It also changes the formula for body armour acquirement so low base AC
body armours become significantly less likely at higher armour skill.
For example: Body size restricted species still had ~27% to acquire
robes or TLA at 27 Armour skill. With the new formula at 27 skill
that chance is ~2.5%. For normal size species robe + tla + ring
mail went from ~23% at 27 with the old formula to ~4% with the new
formula.
