### PR TITLE
Don't display short lived frames in console

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -4260,10 +4260,7 @@ int choose_ability_menu(const vector<talent>& talents)
     };
     abil_menu.show(false);
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
     return ret;
 }
 

--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -614,7 +614,6 @@ public:
     {
         // Update known terrain
         viewwindow();
-        update_screen();
 
         const bool exit_is_near = abyss_exit_nearness();
         const bool rune_is_near = abyss_rune_nearness();
@@ -2387,7 +2386,6 @@ void abyss_maybe_spawn_xp_exit()
     env.grid(you.pos()) = stairs ? DNGN_ABYSSAL_STAIR : DNGN_EXIT_ABYSS;
     big_cloud(CLOUD_TLOC_ENERGY, &you, you.pos(), 3 + random2(3), 3, 3);
     redraw_screen(); // before the force-more
-    update_screen();
     mprf(MSGCH_BANISHMENT,
          "The substance of the Abyss twists violently,"
          " and a gateway leading %s appears!", stairs ? "down" : "out");

--- a/crawl-ref/source/arena.cc
+++ b/crawl-ref/source/arena.cc
@@ -826,7 +826,6 @@ namespace arena
     static void do_fight()
     {
         viewwindow();
-        update_screen();
         clear_messages(true);
 
         {
@@ -857,10 +856,7 @@ namespace arena
                 ASSERT(you.pet_target == MHITNOT);
             }
             if (!contest_cancelled)
-            {
                 viewwindow();
-                update_screen();
-            }
         }
 
         if (contest_cancelled)
@@ -1022,7 +1018,6 @@ namespace arena
             virtual void _render() override {};
             virtual void _allocate_region() override {
                 // XX sometimes this gets called spuriously?
-                update_screen();
                 display_message_window();
             };
             virtual bool on_event(const Event& ev) override {

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -1483,7 +1483,6 @@ static int _harvest_corpses()
                 beam.draw_delay = 3;
                 beam.fire();
                 viewwindow();
-                update_screen();
             }
 
             destroy_item(item.index());

--- a/crawl-ref/source/cio.cc
+++ b/crawl-ref/source/cio.cc
@@ -1050,7 +1050,6 @@ int line_reader::process_key(int ch)
         return -1;
     case CK_REDRAW:
         redraw_screen();
-        update_screen();
         return -1;
     default:
         if (mode == EDIT_MODE_OVERWRITE)

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -588,10 +588,7 @@ static deck_type _choose_deck(const string title = "Draw")
     };
     deck_menu.show(false);
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
     return (deck_type) ret;
 }
 
@@ -974,7 +971,6 @@ bool draw_three()
         {
             _describe_cards(draws);
             redraw_screen();
-            update_screen();
             need_prompt_redraw = true;
         }
         else if (keyin >= 'a' && keyin < 'a' + draws.size())
@@ -1461,7 +1457,6 @@ static void _storm_card(int power)
 
     wind_blast(&you, (power_level + 1) * 66, coord_def());
     redraw_screen(); // Update monster positions
-    update_screen();
 
     // 1-3, 4-6, 7-9
     const int max_explosions = random_range((power_level * 3) + 1, (power_level + 1) * 3);

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -413,13 +413,14 @@ static command_type _get_running_command()
     {
         you.running.rest();
 
-#ifdef USE_TILE
-        if (Options.rest_delay >= 0
-            && tiles.need_redraw(Options.tile_runrest_rate))
+        if (Options.rest_delay >= 0)
         {
-            tiles.redraw();
-        }
+#ifdef USE_TILE
+            update_screen(Options.tile_runrest_rate);
+#else
+            update_screen();
 #endif
+        }
 
         if (!is_resting() && you.running.hp == you.hp
             && you.running.mp == you.magic_points)
@@ -435,9 +436,11 @@ static command_type _get_running_command()
     else if (you.running.is_explore() && Options.explore_delay > -1)
     {
 #ifdef USE_TILE
-        if (tiles.need_redraw(Options.tile_runrest_rate))
-            tiles.redraw();
+        update_screen(Options.tile_runrest_rate);
+#else
+        update_screen();
 #endif
+
         if (Options.explore_delay > 0)
             delay(Options.explore_delay);
     }
@@ -702,7 +705,6 @@ void Delay::handle()
         you.wield_change = true;
         _pop_delay();
         print_stats();  // force redraw of the stats
-        update_screen();
 #ifdef USE_TILE
         tiles.update_tabs();
 #endif
@@ -784,7 +786,6 @@ void PasswallDelay::finish()
             mpr("...yet there is something new on the other side. "
                 "You quickly turn back.");
             redraw_screen();
-            update_screen();
             return;
         }
         break;
@@ -806,7 +807,6 @@ void PasswallDelay::finish()
         {
             mpr("...and sense your way blocked. You quickly turn back.");
             redraw_screen();
-            update_screen();
             return;
         }
 

--- a/crawl-ref/source/dgn-shoals.cc
+++ b/crawl-ref/source/dgn-shoals.cc
@@ -1135,7 +1135,6 @@ void wizard_mod_tide()
         {
             _shoals_force_tide(you.props, res == '+'? 2 : -2);
             viewwindow();
-            update_screen();
         }
     }
 }

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -722,7 +722,6 @@ static coord_def _full_describe_menu(vector<monster_info> const &list_mons,
             // View database entry.
             describe_monster(*m);
             redraw_screen();
-            update_screen();
             clear_messages();
         }
         else if (quant == 2)
@@ -791,7 +790,6 @@ static coord_def _full_describe_menu(vector<monster_info> const &list_mons,
     };
     desc_menu.show();
     redraw_screen();
-    update_screen();
 
 
 #ifndef USE_TILE_LOCAL
@@ -951,7 +949,6 @@ monster_view_annotator::monster_view_annotator(vector<monster *> *monsters)
     {
         crawl_state.flash_monsters = monsters;
         viewwindow(false);
-        update_screen();
     }
 }
 
@@ -962,7 +959,6 @@ monster_view_annotator::~monster_view_annotator()
     {
         crawl_state.flash_monsters = nullptr;
         viewwindow(false);
-        update_screen();
     }
 }
 
@@ -2097,7 +2093,6 @@ void direction_chooser::handle_wizard_command(command_type key_command,
         {
             set_hp(1);
             print_stats();
-            update_screen();
         }
         break;
 
@@ -2166,7 +2161,6 @@ void direction_chooser::handle_wizard_command(command_type key_command,
         return;
     }
     redraw_screen();
-    update_screen();
 #endif
 }
 
@@ -2313,7 +2307,6 @@ void direction_chooser::show_help()
 {
     show_targeting_help();
     redraw_screen();
-    update_screen();
     clear_messages(true);
     need_all_redraw = true;
 }
@@ -2837,7 +2830,6 @@ bool full_describe_square(const coord_def &c, bool cleanup)
     if (cleanup)
     {
         redraw_screen();
-        update_screen();
         clear_messages();
     }
     return action_taken;

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5025,7 +5025,6 @@ static void _extra_sacrifice_code(ability_type sac)
         }
 
         redraw_screen();
-        update_screen();
         break;
     }
     case ABIL_RU_SACRIFICE_FORMS:
@@ -5230,7 +5229,6 @@ bool ru_do_sacrifice(ability_type sac)
     _ru_expire_sacrifices();
     ru_reset_sacrifice_timer(true);
     redraw_screen(); // pretty much everything could have changed
-    update_screen();
     return true;
 }
 

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -1728,7 +1728,6 @@ void learned_something_new(hints_event_type seen_what, coord_def gc)
 
     case HINT_YOU_SILENCE:
         redraw_screen();
-        update_screen();
         print_hint("HINT_YOU_SILENCE");
         break;
 

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -1488,10 +1488,7 @@ void display_inventory()
 
     menu.show(true);
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
 }
 
 static string _drop_menu_titlefn(const Menu*, const string &)

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1775,7 +1775,6 @@ operation_types use_an_item_menu(item_def *&target, operation_types oper, int it
         }
 
         redraw_screen();
-        update_screen();
 
         // equip cases are handled in followup calls
         // TODO: cleanup

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1058,7 +1058,6 @@ void pickup_menu(int item_link)
     if (selected.empty())
         canned_msg(MSG_OK);
     redraw_screen();
-    update_screen();
 
     string pickup_warning;
     for (const SelItem &sel : selected)

--- a/crawl-ref/source/l-crawl.cc
+++ b/crawl-ref/source/l-crawl.cc
@@ -202,7 +202,6 @@ LUAFN(crawl_redraw_screen)
     UNUSED(ls);
 
     redraw_screen();
-    update_screen();
     return 0;
 }
 
@@ -1627,7 +1626,6 @@ LUAFN(_crawl_redraw_view)
     UNUSED(ls);
 
     viewwindow();
-    update_screen();
     return 0;
 }
 
@@ -1654,7 +1652,6 @@ LUAFN(_crawl_redraw_stats)
 
 
     print_stats();
-    update_screen();
     return 0;
 }
 

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -348,7 +348,6 @@ LUAFN(debug_check_uniques)
 LUAFN(debug_viewwindow)
 {
     viewwindow(lua_toboolean(ls, 1));
-    update_screen();
     return 0;
 }
 

--- a/crawl-ref/source/l-dgn.cc
+++ b/crawl-ref/source/l-dgn.cc
@@ -779,10 +779,7 @@ static int dgn_change_floor_colour(lua_State *ls)
     env.floor_colour = colour;
 
     if (crawl_state.need_save && update_now)
-    {
         viewwindow();
-        update_screen();
-    }
     return 0;
 }
 
@@ -794,10 +791,7 @@ static int dgn_change_rock_colour(lua_State *ls)
     env.rock_colour = colour;
 
     if (crawl_state.need_save && update_now)
-    {
         viewwindow();
-        update_screen();
-    }
     return 0;
 }
 

--- a/crawl-ref/source/libconsole.h
+++ b/crawl-ref/source/libconsole.h
@@ -35,7 +35,7 @@ int getch_ck();
 bool kbhit();
 void delay(unsigned int ms);
 void puttext(int x, int y, const crawl_view_buffer &vbuf);
-void update_screen();
+void update_screen(unsigned int min_delay_ms = 0);
 
 void set_cursor_enabled(bool enabled);
 bool is_cursor_enabled();

--- a/crawl-ref/source/libgui.cc
+++ b/crawl-ref/source/libgui.cc
@@ -217,16 +217,16 @@ void delay(unsigned int ms)
     if (crawl_state.disables[DIS_DELAY])
         return;
 
-    tiles.redraw();
+    update_screen();
+
     if (wm)
         wm->delay(ms);
 }
 
-void update_screen()
+void update_screen(unsigned int min_delay_ms)
 {
-    if (crawl_state.tiles_disabled)
-        return;
-    tiles.set_need_redraw();
+    if (tiles.need_redraw(min_delay_ms))
+        tiles.redraw();
 }
 
 bool kbhit()

--- a/crawl-ref/source/libw32c.cc
+++ b/crawl-ref/source/libw32c.cc
@@ -931,6 +931,8 @@ void delay(unsigned int ms)
     if (crawl_state.disables[DIS_DELAY])
         return;
 
+    update_screen();
+
     Sleep((DWORD)ms);
 }
 
@@ -951,8 +953,10 @@ void puttext(int x1, int y1, const crawl_view_buffer &vbuf)
     textcolour(WHITE);
 }
 
-void update_screen()
+void update_screen(unsigned int min_delay_ms)
 {
+    UNUSED(min_delay_ms);
+
     // see if we have a dirty area
     if (dirty_area_start.X == dirty_area_end.X)
         return;

--- a/crawl-ref/source/macro.cc
+++ b/crawl-ref/source/macro.cc
@@ -1674,7 +1674,6 @@ void macro_menu()
     menu.show();
 
     redraw_screen();
-    update_screen();
 }
 
 /*

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -450,7 +450,6 @@ NORETURN static void _launch_game()
 
 #ifdef USE_TILE
     viewwindow();
-    update_screen();
 #endif
 
     if (game_start)
@@ -1079,7 +1078,6 @@ static void _input()
         revive();
         bring_to_safety();
         redraw_screen();
-        update_screen();
     }
 
     if (you.props.exists(DREAMSHARD_KEY))
@@ -1309,7 +1307,6 @@ static void _input()
         // This else will be triggered by instantaneous actions, such as
         // Chei's temporal distortion.
         viewwindow();
-        update_screen();
     }
 
     update_can_currently_train();
@@ -2245,28 +2242,23 @@ void process_command(command_type cmd, command_type prev_cmd)
     case CMD_DISPLAY_COMMANDS:
         show_help();
         redraw_screen();
-        update_screen();
         break;
     case CMD_DISPLAY_INVENTORY:        display_inventory();            break;
     case CMD_DISPLAY_KNOWN_OBJECTS:
         check_item_knowledge();
         redraw_screen();
-        update_screen();
         break;
     case CMD_DISPLAY_MUTATIONS:
         display_mutations();
         redraw_screen();
-        update_screen();
         break;
     case CMD_DISPLAY_RUNES:
         display_runes();
         redraw_screen();
-        update_screen();
         break;
     case CMD_DISPLAY_SKILLS:
         skill_menu();
         redraw_screen();
-        update_screen();
         break;
     case CMD_EXPERIENCE_CHECK:         _experience_check();            break;
     case CMD_FULL_VIEW:                full_describe_view();           break;
@@ -2278,7 +2270,6 @@ void process_command(command_type cmd, command_type prev_cmd)
     case CMD_REPLAY_MESSAGES:
         replay_messages();
         redraw_screen();
-        update_screen();
         break;
     case CMD_RESISTS_SCREEN:           print_overview_screen();        break;
     case CMD_LOOKUP_HELP:
@@ -2290,7 +2281,6 @@ void process_command(command_type cmd, command_type prev_cmd)
     {
         describe_god(you.religion);
         redraw_screen();
-        update_screen();
         break;
     }
 
@@ -2374,7 +2364,6 @@ void process_command(command_type cmd, command_type prev_cmd)
         // Game commands.
     case CMD_REDRAW_SCREEN:
         redraw_screen();
-        update_screen();
         break;
 
 #ifdef USE_UNIX_SIGNALS
@@ -2389,7 +2378,6 @@ void process_command(command_type cmd, command_type prev_cmd)
         console_startup();
 #endif
         redraw_screen();
-        update_screen();
         break;
 #endif
 
@@ -2478,10 +2466,9 @@ static void _prep_input()
         you.refresh_rampage_hints();
     }
     print_stats();
-    update_screen();
 
     viewwindow();
-    update_screen(); // ???
+
     if (check_for_interesting_features() && you.running.is_explore())
         stop_running();
 
@@ -2561,7 +2548,6 @@ void world_reacts()
         crawl_state.viewport_monster_hp = false;
         crawl_state.viewport_weapons = false;
         viewwindow();
-        update_screen();
     }
 
     update_monsters_in_view();
@@ -2644,7 +2630,6 @@ void world_reacts()
     _check_trapped();
 
     viewwindow();
-    update_screen();
 
     if ((you.cannot_act() || you.duration[DUR_DAZED] || you.duration[DUR_VEXED])
         && any_messages()
@@ -2754,10 +2739,7 @@ static keycode_type _get_next_keycode()
     {
         keyin = unmangle_direction_keys(getch_with_command_macros());
         if (keyin == CK_REDRAW)
-        {
             redraw_screen();
-            update_screen();
-        }
         else
             break;
     }

--- a/crawl-ref/source/message.cc
+++ b/crawl-ref/source/message.cc
@@ -610,9 +610,6 @@ public:
         for (size_t i = diff; i < lines.size(); ++i)
             out_line(lines[i], i - diff);
         place_cursor();
-#ifdef USE_TILE
-        tiles.set_need_redraw();
-#endif
     }
 
     // temporary: to be overwritten with next item, e.g. new turn
@@ -687,12 +684,10 @@ public:
         {
             mouse_control mc(MOUSE_MODE_MORE);
             redraw_screen();
-            update_screen();
         }
         else
         {
             print_stats();
-            update_screen();
             show();
         }
 
@@ -1896,7 +1891,6 @@ static void readkey_more(bool user_forced)
         if (keypress == CK_REDRAW)
         {
             redraw_screen();
-            update_screen();
             continue;
         }
     }

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -3111,7 +3111,6 @@ static void _mons_open_door(monster& mons, const coord_def &pos)
     if (was_seen)
     {
         viewwindow();
-        update_screen();
 
         // XXX: should use custom verbs
         string open_str = broken ? "breaks down the " : "opens the ";
@@ -3810,7 +3809,6 @@ static bool _do_move_monster(monster& mons, const coord_def& delta)
             if (you.see_cell(f))
             {
                 viewwindow();
-                update_screen();
 
                 if (!you.can_see(mons))
                 {
@@ -3836,7 +3834,6 @@ static bool _do_move_monster(monster& mons, const coord_def& delta)
             if (you.see_cell(f))
             {
                 viewwindow();
-                update_screen();
 
                 if (!you.can_see(mons))
                 {

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -1151,7 +1151,6 @@ static void _fire_simple_beam(monster &/*caster*/, mon_spell_slot, bolt &pbolt)
     // If a monster just came into view and immediately cast a spell,
     // we need to refresh the screen before drawing the beam.
     viewwindow();
-    update_screen();
     pbolt.fire();
 }
 
@@ -1167,7 +1166,6 @@ static void _fire_direct_explosion(monster &caster, mon_spell_slot, bolt &pbolt)
     // If a monster just came into view and immediately cast a spell,
     // we need to refresh the screen before drawing the beam.
     viewwindow();
-    update_screen();
     const actor* foe = caster.get_foe();
     const bool need_more = foe && (foe->is_player()
                                    || you.see_cell(foe->pos()));

--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -395,7 +395,6 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
     {
         handle_seen_interrupt(mons);
         viewwindow();
-        update_screen();
     }
 
     if (crawl_state.game_is_arena())

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3624,7 +3624,6 @@ item_def* monster_die(monster& mons, killer_type killer,
     {
         view_update_at(mwhere);
         StashTrack.update_stash(mwhere);
-        update_screen();
     }
 
     if (!mons_reset)

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -319,7 +319,6 @@ void spawn_random_monsters()
 
     mons_place(mg);
     viewwindow();
-    update_screen();
 }
 
 static bool _is_random_monster(monster_type mt)

--- a/crawl-ref/source/mon-project.cc
+++ b/crawl-ref/source/mon-project.cc
@@ -426,7 +426,6 @@ static bool _iood_hit(monster& mon, const coord_def &pos, bool big_boom = false)
         // Update orb position so that the explosion looks centered in the
         // right place.
         redraw_screen();
-        update_screen();
         beam.explode(true, false);
     }
     else

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5457,7 +5457,6 @@ void monster::check_redraw(const coord_def &old, bool clear_tiles) const
             UNUSED(clear_tiles);
 #endif
         }
-        update_screen();
     }
 }
 

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -2083,7 +2083,6 @@ bool mutate(mutation_type which_mutation, const string &reason, bool failMsg,
     {
         tiles.layout_statcol();
         redraw_screen();
-        update_screen();
     }
 #endif
 #ifdef DEBUG

--- a/crawl-ref/source/ouch.cc
+++ b/crawl-ref/source/ouch.cc
@@ -473,7 +473,6 @@ void lose_level()
     // In case of intrinsic ability changes.
     tiles.layout_statcol();
     redraw_screen();
-    update_screen();
 #endif
 
     xom_is_stimulated(200);
@@ -1218,7 +1217,6 @@ static void _print_endgame_messages(scorefile_entry &se)
 
     flush_prev_message();
     viewwindow(); // don't do for leaving/winning characters
-    update_screen();
 
     if (crawl_state.game_is_hints())
         hints_death_screen();

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1689,6 +1689,7 @@ void smallterm_warning()
     CGOTOXY(1,1, GOTO_CRT);
     clrscr();
     CPRINTF("Your terminal window is too small; please resize to at least %d,%d", MIN_COLS, MIN_LINES);
+    update_screen();
 }
 #endif
 

--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1549,7 +1549,6 @@ void equip_item(equipment_slot slot, int item_slot, bool msg, bool skip_effects)
     {
         tiles.layout_statcol();
         redraw_screen();
-        update_screen();
     }
 #endif
 
@@ -1588,7 +1587,6 @@ bool unequip_item(item_def& item, bool msg, bool skip_effects)
     {
         tiles.layout_statcol();
         redraw_screen();
-        update_screen();
     }
 #endif
 
@@ -2421,7 +2419,6 @@ static void _change_wildshape_status()
     calc_hp();
     calc_mp();
     redraw_screen();
-    update_screen();
 }
 
 static void _handle_regen_item_equip(const item_def& item)

--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -630,10 +630,7 @@ static void _handle_recitation(int step)
                          you.attribute[ATTR_RECITE_TYPE], step).c_str());
 
     if (apply_area_visible(zin_recite_to_single_monster, you.pos()))
-    {
         viewwindow();
-        update_screen();
-    }
 
     // Recite trains more than once per use, because it has a
     // long timer in between uses and actually takes up multiple

--- a/crawl-ref/source/player-stats.cc
+++ b/crawl-ref/source/player-stats.cc
@@ -114,10 +114,7 @@ bool attribute_increase()
         else
         {
             while ((keyin = getchm()) == CK_REDRAW)
-            {
                 redraw_screen();
-                update_screen();
-            }
         }
         tried_lua = true;
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -681,7 +681,6 @@ void move_player_to_grid(const coord_def& p, bool stepped)
     // Move the player to new location.
     you.moveto(p, true);
     viewwindow();
-    update_screen();
 
     moveto_location_effects(old_grid, stepped, old_pos);
 }
@@ -2922,7 +2921,6 @@ void level_change(bool skip_attribute_increase)
         {
             // Don't want to see the dead creature at the prompt.
             redraw_screen();
-            update_screen();
 
             if (new_exp == 27)
                 mprf(MSGCH_INTRINSIC_GAIN, "You have reached level 27, the final one!");
@@ -2956,7 +2954,6 @@ void level_change(bool skip_attribute_increase)
             // In case of intrinsic ability changes.
             tiles.layout_statcol();
             redraw_screen();
-            update_screen();
 #endif
             if (!skip_attribute_increase)
                 species_stat_gain(you.species);
@@ -3041,7 +3038,6 @@ void level_change(bool skip_attribute_increase)
                     tiles.layout_statcol();
 #endif
                     redraw_screen();
-                    update_screen();
                 }
                 break;
 
@@ -8141,7 +8137,6 @@ bool player::do_shaft_ability()
     {
         canned_msg(MSG_NOTHING_HAPPENS);
         redraw_screen();
-        update_screen();
         return false;
     }
 }
@@ -8805,7 +8800,6 @@ void player_open_door(coord_def doorpos)
 
     update_exclusion_los(excludes);
     viewwindow();
-    update_screen();
     you.turn_is_over = true;
 }
 

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -725,7 +725,6 @@ void dec_penance(god_type god, int val)
             {
                 simple_god_message(" restores the support of your attributes.");
                 redraw_screen();
-                update_screen();
                 notify_stat_change();
             }
             if (have_passive(passive_t::storm_shield))
@@ -899,7 +898,6 @@ static void _inc_penance(god_type god, int val)
         if (will_have_passive(passive_t::stat_boost))
         {
             redraw_screen();
-            update_screen();
             notify_stat_change();
         }
 
@@ -2387,7 +2385,6 @@ static void _handle_piety_gain(int old_piety)
     #ifdef USE_TILE_LOCAL
                     tiles.layout_statcol();
                     redraw_screen();
-                    update_screen();
     #endif
                     learned_something_new(HINT_NEW_ABILITY_GOD);
                 }
@@ -2642,7 +2639,6 @@ static void _handle_piety_loss(int old_piety)
 #ifdef USE_TILE_LOCAL
         tiles.layout_statcol();
         redraw_screen();
-        update_screen();
 #endif
 
         if (will_have_passive(passive_t::frail) && !have_passive(passive_t::frail))
@@ -2940,7 +2936,6 @@ void excommunication(bool voluntary, god_type new_god)
     if (had_stat_boost)
     {
         redraw_screen();
-        update_screen();
         notify_stat_change();
     }
 
@@ -3183,7 +3178,6 @@ void excommunication(bool voluntary, god_type new_god)
 #ifdef USE_TILE_LOCAL
     tiles.layout_statcol();
     redraw_screen();
-    update_screen();
 #endif
 
     // Evil hack.
@@ -3657,7 +3651,6 @@ static void _join_gozag()
 #ifdef USE_TILE_LOCAL
         tiles.layout_statcol();
         redraw_screen();
-        update_screen();
 #else
         ;
 #endif
@@ -3828,7 +3821,6 @@ void join_religion(god_type which_god)
     ASSERT(!you.has_mutation(MUT_FORLORN));
 
     redraw_screen();
-    update_screen();
 
     const god_type old_god = you.religion;
     if (you.previous_good_god == GOD_NO_GOD)
@@ -3910,7 +3902,6 @@ void join_religion(god_type which_god)
 #ifdef USE_TILE_LOCAL
     tiles.layout_statcol();
     redraw_screen();
-    update_screen();
 #endif
 
     learned_something_new(HINT_CONVERT);
@@ -3953,7 +3944,6 @@ void god_pitch(god_type which_god)
     {
         you.turn_is_over = false;
         redraw_screen();
-        update_screen();
     }
 }
 

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1565,7 +1565,6 @@ void shop()
     // finally it is safe to catch up on any off-level id stuff that is needed
     shopping_list.do_excursion_work();
     redraw_screen();
-    update_screen();
     if (menu.bought_something)
         mprf("Thank you for shopping at %s!", shopname.c_str());
     if (any_on_list)
@@ -2540,7 +2539,6 @@ void ShoppingList::display(bool view_only)
 
     shopmenu.show();
     redraw_screen();
-    update_screen();
 }
 
 static bool _compare_shopping_things(const CrawlStoreValue& a,

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -792,7 +792,6 @@ void SkillMenu::finish_experience(bool experience_change)
         if (experience_change)
         {
             redraw_screen();
-            update_screen();
             unwind_bool change_xp_for_real(crawl_state.simulating_xp_gain, false);
             train_skills();
         }

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -828,7 +828,6 @@ bool check_selected_skills()
     reset_training();
     skill_menu();
     redraw_screen();
-    update_screen();
     return true;
 }
 

--- a/crawl-ref/source/species.cc
+++ b/crawl-ref/source/species.cc
@@ -780,7 +780,6 @@ void change_species_to(species_type sp)
     init_player_doll();
 #endif
     redraw_screen();
-    update_screen();
 
     you.equipment.update();
 }

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -942,10 +942,7 @@ static spell_type _choose_mem_spell(spell_list &spells)
 
     const vector<MenuEntry*> sel = spell_menu.show();
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
     if (sel.empty())
         return SPELL_NO_SPELL;
     const spell_type spell = *static_cast<spell_type*>(sel[0]->data);
@@ -1175,10 +1172,7 @@ spret divine_exegesis(bool fail)
 
     const vector<MenuEntry*> sel = spell_menu.show();
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
 
     if (sel.empty())
         return spret::abort;
@@ -1215,10 +1209,7 @@ spret imbue_servitor()
 
     const vector<MenuEntry*> sel = spell_menu.show();
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
 
     if (sel.empty())
         return spret::abort;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -342,10 +342,7 @@ int list_spells(bool toggle_with_I, bool transient, bool viewing,
 
     spell_menu.show();
     if (!crawl_state.doing_prev_cmd_again)
-    {
         redraw_screen();
-        update_screen();
-    }
     return choice;
 }
 
@@ -941,10 +938,7 @@ spret cast_a_spell(bool check_range, spell_type spell, dist *_target,
                     keyin = ESCAPE;
 
                 if (!crawl_state.doing_prev_cmd_again)
-                {
                     redraw_screen();
-                    update_screen();
-                }
 
                 if (isaalpha(keyin) || key_is_escape(keyin))
                     break;
@@ -1052,7 +1046,6 @@ spret cast_a_spell(bool check_range, spell_type spell, dist *_target,
             refund_hp(hp_cost);
 
         redraw_screen();
-        update_screen();
         return cast_result;
     }
 

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -145,7 +145,6 @@ spret cast_fire_storm(int pow, bolt &beam, bool fail)
     beam.explode(false);
 
     viewwindow();
-    update_screen();
     return spret::success;
 }
 

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -134,7 +134,6 @@ int cast_selective_amnesia(const string &pre_msg)
     // Pick a spell to forget.
     keyin = list_spells(false, false, false, false, "forget");
     redraw_screen();
-    update_screen();
 
     if (isaalpha(keyin))
     {

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1003,7 +1003,6 @@ static void _handle_teleport_update(bool large_change, const coord_def old_pos)
     if (large_change)
     {
         viewwindow();
-        update_screen();
         for (monster_iterator mi; mi; ++mi)
         {
             const bool see_cell = you.see_cell(mi->pos());
@@ -1081,7 +1080,6 @@ static bool _teleport_player(bool wizard_tele, bool teleportitis,
     // in case something happened in the exact turn that we teleported
     // (like picking up/dropping an item).
     viewwindow();
-    update_screen();
 
     if (player_in_branch(BRANCH_ABYSS) && !wizard_tele)
     {
@@ -1106,7 +1104,6 @@ static bool _teleport_player(bool wizard_tele, bool teleportitis,
             bool chose = show_map(lpos, false, false);
             pos = lpos.pos;
             redraw_screen();
-            update_screen();
 
             // If we've received a HUP signal then the user can't choose a
             // location, so cancel the teleport.
@@ -2630,7 +2627,6 @@ spret do_bestial_takedown(coord_def target)
     const coord_def old_pos = you.pos();
     you.moveto(landing, true);
     viewwindow();
-    update_screen();
 
     melee_attack atk(&you, targ);
     atk.dmg_mult = get_form()->get_takedown_multiplier();

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -393,7 +393,6 @@ bool add_spell_to_memory(spell_type spell)
 #ifdef USE_TILE_LOCAL
     tiles.layout_statcol();
     redraw_screen();
-    update_screen();
 #endif
 
     return true;
@@ -421,7 +420,6 @@ bool del_spell_from_memory_by_slot(int slot)
 #ifdef USE_TILE_LOCAL
     tiles.layout_statcol();
     redraw_screen();
-    update_screen();
 #endif
 
     return true;

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -432,7 +432,6 @@ static void _rune_effect(dungeon_feature_type ftype)
 #ifdef USE_TILE_LOCAL
         view_add_tile_overlay(you.pos(), tileidx_zap(rune_colour(runes[2])));
         viewwindow(false);
-        update_screen();
 #else
         flash_view(UA_BRANCH_ENTRY, rune_colour(runes[2]));
 #endif
@@ -442,7 +441,6 @@ static void _rune_effect(dungeon_feature_type ftype)
         mprf("You insert the %s rune into the lock.", rune_type_name(runes[1]));
         big_cloud(CLOUD_BLUE_SMOKE, &you, you.pos(), 20, 7 + random2(7));
         viewwindow();
-        update_screen();
         mpr("Heavy smoke blows from the lock!");
         // included in default force_more_message
     }
@@ -1118,7 +1116,6 @@ void floor_transition(dungeon_feature_type how,
     env.map_seen.set(you.pos());
 
     viewwindow();
-    update_screen();
 
     // There's probably a reason for this. I don't know it.
     if (going_up)

--- a/crawl-ref/source/startup.cc
+++ b/crawl-ref/source/startup.cc
@@ -394,9 +394,7 @@ static void _post_init(bool newc)
     you.redraw_title = true;
     you.redraw_status_lights = true;
     print_stats();
-    update_screen();
     viewwindow();
-    update_screen();
 
     activate_notes(true);
 

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -1381,7 +1381,6 @@ void StashTracker::search_stashes(string search_term)
             {
                 show_stash_search_help();
                 redraw_screen();
-                update_screen();
             }
             else
                 break;
@@ -1856,7 +1855,6 @@ bool StashTracker::display_search_results(
 
     vector<MenuEntry*> sel = stashmenu.show();
     redraw_screen();
-    update_screen();
     default_execute = stashmenu.menu_action == Menu::ACT_EXECUTE;
     if (stashmenu.request_toggle_sort_method)
     {

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1657,14 +1657,12 @@ bool swap_features(const coord_def &pos1, const coord_def &pos2,
         you.set_position(pos2);
         you.clear_invalid_constrictions();
         viewwindow();
-        update_screen();
     }
     else if (pos2 == you.pos())
     {
         you.set_position(pos1);
         you.clear_invalid_constrictions();
         viewwindow();
-        update_screen();
     }
 
     set_terrain_changed(pos1);

--- a/crawl-ref/source/throw.cc
+++ b/crawl-ref/source/throw.cc
@@ -187,7 +187,6 @@ void fire_target_behaviour::display_help()
 {
     show_targeting_help();
     redraw_screen();
-    update_screen();
     need_redraw = true;
     set_prompt();
 }
@@ -846,7 +845,6 @@ static void _player_shoot(bolt &pbolt, item_def &item, item_def const *launcher)
         // Fire beam in reverse.
         pbolt.setup_retrace();
         viewwindow();
-        update_screen();
         pbolt.fire();
     }
 
@@ -922,7 +920,6 @@ bool mons_throw(monster* mons, bolt &beam, bool teleport)
     // Redraw the screen before firing, in case the monster just
     // came into view and the screen hasn't been updated yet.
     viewwindow();
-    update_screen();
     const coord_def target = beam.target;
     if (teleport)
     {

--- a/crawl-ref/source/tilereg-abl.cc
+++ b/crawl-ref/source/tilereg-abl.cc
@@ -77,7 +77,6 @@ int AbilityRegion::handle_mouse(wm_mouse_event &event)
     {
         describe_ability(ability);
         redraw_screen();
-        update_screen();
         return CK_MOUSE_CMD;
     }
     return 0;

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -588,7 +588,6 @@ int DungeonRegion::handle_mouse(wm_mouse_event &event)
                         pickup_menu(o);
                         flush_prev_message();
                         redraw_screen();
-                        update_screen();
                         return CK_MOUSE_CMD;
                     }
                     return encode_command_as_key(CMD_PICKUP);

--- a/crawl-ref/source/tilereg-inv.cc
+++ b/crawl-ref/source/tilereg-inv.cc
@@ -187,13 +187,11 @@ int InventoryRegion::handle_mouse(wm_mouse_event &event)
         {
             describe_item(env.item[idx]);
             redraw_screen();
-            update_screen();
         }
         else // in inventory
         {
             describe_item(you.inv[idx]);
             redraw_screen();
-            update_screen();
         }
         return CK_MOUSE_CMD;
     }

--- a/crawl-ref/source/tilereg-map.cc
+++ b/crawl-ref/source/tilereg-map.cc
@@ -246,7 +246,6 @@ int MapRegion::handle_mouse(wm_mouse_event &event)
                 {
                     process_command(cmd);
                     redraw_screen();
-                    update_screen();
                 }
             }
 

--- a/crawl-ref/source/tilereg-mem.cc
+++ b/crawl-ref/source/tilereg-mem.cc
@@ -79,7 +79,6 @@ int MemoriseRegion::handle_mouse(wm_mouse_event &event)
     {
         describe_spell(spell);
         redraw_screen();
-        update_screen();
         return CK_MOUSE_CMD;
     }
     return 0;

--- a/crawl-ref/source/tilereg-mon.cc
+++ b/crawl-ref/source/tilereg-mon.cc
@@ -89,7 +89,6 @@ int MonsterRegion::handle_mouse(wm_mouse_event &event)
     {
         full_describe_square(gc);
         redraw_screen();
-        update_screen();
         return CK_MOUSE_CMD;
     }
 

--- a/crawl-ref/source/tilereg-skl.cc
+++ b/crawl-ref/source/tilereg-skl.cc
@@ -95,7 +95,6 @@ int SkillRegion::handle_mouse(wm_mouse_event &event)
     {
         describe_skill(skill);
         redraw_screen();
-        update_screen();
         return CK_MOUSE_CMD;
     }
     return 0;

--- a/crawl-ref/source/tilereg-spl.cc
+++ b/crawl-ref/source/tilereg-spl.cc
@@ -75,7 +75,6 @@ int SpellRegion::handle_mouse(wm_mouse_event &event)
     {
         describe_spell(spell);
         redraw_screen();
-        update_screen();
         return CK_MOUSE_CMD;
     }
     return 0;

--- a/crawl-ref/source/tilereg-text.cc
+++ b/crawl-ref/source/tilereg-text.cc
@@ -5,6 +5,7 @@
 #include "tilereg-text.h"
 
 #include "tilefont.h"
+#include "tiles-build-specific.h"
 #include "unicode.h"
 
 int TextRegion::print_x;
@@ -110,6 +111,8 @@ void TextRegion::addstr(const char *buffer)
 
 void TextRegion::addstr_aux(const char32_t *buffer, int len)
 {
+    tiles.set_need_redraw();
+
     int x = print_x - cx_ofs;
     int y = print_y - cy_ofs;
     int adrs = y * mx;
@@ -126,6 +129,8 @@ void TextRegion::addstr_aux(const char32_t *buffer, int len)
 
 void TextRegion::clear_to_end_of_line()
 {
+    tiles.set_need_redraw();
+
     int cx = print_x - cx_ofs;
     int cy = print_y - cy_ofs;
     int col = text_col;
@@ -243,6 +248,8 @@ void TextRegion::render()
 
 void TextRegion::clear()
 {
+    tiles.set_need_redraw();
+
     for (int i = 0; i < mx * my; i++)
     {
         cbuf[i] = ' ';
@@ -252,6 +259,8 @@ void TextRegion::clear()
 
 void TextRegion::scroll()
 {
+    tiles.set_need_redraw();
+
     for (int idx = 0; idx < mx*(my-1); idx++)
     {
         cbuf[idx] = cbuf[idx + mx];

--- a/crawl-ref/source/tilesdl.cc
+++ b/crawl-ref/source/tilesdl.cc
@@ -251,7 +251,6 @@ void TilesFramework::set_map_display(const bool display)
         m_region_tab->activate_tab(TAB_ITEM);
     do_layout(); // recalculate the viewport setup for zoom levels
     redraw_screen(false);
-    update_screen();
 }
 
 bool TilesFramework::get_map_display()
@@ -264,7 +263,6 @@ void TilesFramework::do_map_display()
     m_map_mode_enabled = true;
     do_layout(); // recalculate the viewport setup for zoom levels
     redraw_screen(false);
-    update_screen();
     if (!tiles.is_using_small_layout() && m_region_tab)
         m_region_tab->activate_tab(TAB_NAVIGATION);
 }
@@ -483,6 +481,8 @@ FontWrapper* TilesFramework::load_font(const char *font_file, int font_size,
 void TilesFramework::load_dungeon(const crawl_view_buffer &vbuf,
                                   const coord_def &gc)
 {
+    set_need_redraw();
+
     m_active_layer = LAYER_NORMAL;
 
     if (m_region_tile)
@@ -1040,7 +1040,6 @@ void TilesFramework::zoom_dungeon(bool in)
     redraw_screen(false);
     if (current_scale != orig)
         mprf(MSGCH_PROMPT, "Zooming to %.2f", (float) current_scale);
-    update_screen();
 #endif
 }
 
@@ -1054,7 +1053,6 @@ void TilesFramework::toggle_tab_icons()
     m_region_tab->toggle_tab_icons();
     resize();
     redraw_screen();
-    update_screen();
 }
 
 void TilesFramework::autosize_minimap()
@@ -1364,10 +1362,7 @@ void TilesFramework::maybe_redraw_screen()
 {
     // need to call with show_updates=false, which is passed to viewwindow
     if (m_active_layer == LAYER_NORMAL && !crawl_state.game_is_arena())
-    {
         redraw_screen(false);
-        update_screen();
-    }
 }
 
 void TilesFramework::render_current_regions()

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -2030,6 +2030,8 @@ void TilesFramework::_send_monster(const coord_def &gc, const monster_info* m,
 void TilesFramework::load_dungeon(const crawl_view_buffer &vbuf,
                                   const coord_def &gc)
 {
+    set_need_redraw();
+
     if (vbuf.size().equals(0, 0))
         return;
 

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1251,9 +1251,11 @@ command_type travel()
         else if (you.running.is_explore() && Options.explore_delay > -1)
         {
 #ifdef USE_TILE
-            if (tiles.need_redraw(Options.tile_runrest_rate))
-                tiles.redraw();
+            update_screen(Options.tile_runrest_rate);
+#else
+            update_screen();
 #endif
+
             if (Options.explore_delay > 0)
                 delay(Options.explore_delay);
         }
@@ -2758,7 +2760,6 @@ static level_pos _travel_depth_munge(int munge_method, const string &s,
     case '?':
         show_interlevel_travel_depth_help();
         redraw_screen();
-        update_screen();
         return level_pos(targ); // no change
     case '<':
         result.id = find_up_level(result.id);
@@ -4770,7 +4771,6 @@ void runrest::stop(bool clear_delays)
     {
         viewwindow();
         print_stats();
-        update_screen();
     }
 }
 

--- a/crawl-ref/source/ui.cc
+++ b/crawl-ref/source/ui.cc
@@ -2578,10 +2578,7 @@ void UIRoot::render()
     if (m_root.num_children() > 0)
         m_root.get_child(m_root.num_children()-1)->render();
     else
-    {
         redraw_screen(false);
-        update_screen();
-    }
 
     if (!cursor_pos.origin())
     {

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1007,7 +1007,6 @@ bool view_update()
     if (you.num_turns > you.last_view_update)
     {
         viewwindow();
-        update_screen();
         return true;
     }
     return false;
@@ -1018,10 +1017,7 @@ void animation_delay(unsigned int ms, bool do_refresh)
     // this leaves any Options.use_animations & UA_BEAM checks to the caller;
     // but maybe it could be refactored into here
     if (do_refresh)
-    {
         viewwindow(false);
-        update_screen();
-    }
     scaled_delay(ms);
 }
 
@@ -1034,7 +1030,6 @@ static void _flash_view(colour_t colour, targeter* where)
     you.flash_colour = colour;
     you.flash_where = where;
     viewwindow(false);
-    update_screen();
 }
 
 void flash_view(use_animation_type a, colour_t colour, targeter *where)
@@ -1042,9 +1037,7 @@ void flash_view(use_animation_type a, colour_t colour, targeter *where)
     if (crawl_state.need_save && Options.use_animations & a)
     {
         _flash_view(colour, where);
-#ifdef USE_TILE
-        tiles.redraw();
-#endif
+        update_screen();
     }
 }
 
@@ -1380,21 +1373,16 @@ void run_animation(animation_type anim, use_animation_type type, bool cleanup)
         animation *a = animations[anim];
 
         viewwindow();
-        update_screen();
 
         for (int i = 0; i < a->frames; ++i)
         {
             a->init_frame(i);
             viewwindow(false, false, a);
-            update_screen();
             delay(a->frame_delay);
         }
 
         if (cleanup)
-        {
             viewwindow();
-            update_screen();
-        }
     }
 }
 
@@ -1452,7 +1440,6 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a, view_renderer 
         if (crawl_state.smallterm)
         {
             smallterm_warning();
-            update_screen();
             return;
         }
 #endif
@@ -1516,7 +1503,6 @@ void viewwindow(bool show_updates, bool tiles_only, animation *a, view_renderer 
             UNUSED(tiles_only);
 #endif
 #ifdef USE_TILE
-            tiles.set_need_redraw();
             tiles.load_dungeon(vbuf, crawl_view.vgrdc);
             tiles.update_tabs();
 #endif
@@ -1871,7 +1857,6 @@ static void _config_layers_menu()
     while (!exit)
     {
         viewwindow();
-        update_screen();
         mprf(MSGCH_PROMPT, "Select layers to display:\n"
                            "<%s>(m)onsters</%s>|"
                            "<%s>(p)layer</%s>|"
@@ -1986,8 +1971,5 @@ void handle_terminal_resize()
         ui::force_render();
     }
     else
-    {
         redraw_screen();
-        update_screen();
-    }
 }

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -1327,7 +1327,6 @@ map_control_state process_map_command(command_type cmd, const map_control_state&
     case CMD_MAP_ANNOTATE_LEVEL:
         state.excursion->go_to(state.original);
         redraw_screen();
-        update_screen();
         state.excursion->go_to(state.lpos.id);
 
         if (!is_map_persistent())

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -168,7 +168,6 @@ static void _wizard_go_to_level(const level_pos &pos)
     new_level();
     seen_monsters_react();
     viewwindow();
-    update_screen();
 
     // Tell stash-tracker and travel that we've changed levels.
     trackers_init_new_level();
@@ -689,7 +688,6 @@ static void _debug_kill_traps()
 static int _debug_time_explore()
 {
     viewwindow();
-    update_screen();
     start_explore(false);
 
     unwind_var<int> es(Options.explore_stop, 0);
@@ -838,7 +836,6 @@ void wizard_recreate_level()
     new_level();
     seen_monsters_react();
     viewwindow();
-    update_screen();
 
     trackers_init_new_level();
 }

--- a/crawl-ref/source/wiz-fsim.cc
+++ b/crawl-ref/source/wiz-fsim.cc
@@ -267,7 +267,6 @@ static bool _fsim_kit_equip(const string &kit, string &error)
     }
 
     redraw_screen();
-    update_screen();
     return true;
 }
 
@@ -347,7 +346,6 @@ static monster* _init_fsim()
     mon->behaviour = BEH_SEEK;
 
     redraw_screen();
-    update_screen();
 
     return mon;
 }

--- a/crawl-ref/source/wiz-item.cc
+++ b/crawl-ref/source/wiz-item.cc
@@ -874,7 +874,6 @@ static void _debug_acquirement_stats()
             clear_messages();
             mprf("%d%% done.", 100 * (i + 1) / num_itrs);
             viewwindow();
-            update_screen();
         }
     }
 
@@ -1266,7 +1265,6 @@ static void _debug_randart_stats()
             clear_messages();
             mprf("%d%% done.", 100 * (i + 1) / num_itrs);
             viewwindow();
-            update_screen();
         }
     }
 

--- a/crawl-ref/source/wiz-mon.cc
+++ b/crawl-ref/source/wiz-mon.cc
@@ -820,7 +820,6 @@ void debug_pathfind(int idx)
     bool chose = show_map(ldest, false, false);
     dest = ldest.pos;
     redraw_screen();
-    update_screen();
     if (!chose)
     {
         canned_msg(MSG_OK);
@@ -865,7 +864,6 @@ static void _miscast_screen_update()
 
     you.redraw_status_lights = true;
     print_stats();
-    update_screen();
 
 #ifndef USE_TILE_LOCAL
     update_monster_pane();

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -100,7 +100,6 @@ void wizard_suppress()
     tiles.layout_statcol();
 #endif
     redraw_screen();
-    update_screen();
 }
 
 void wizard_change_job_to(job_type job)
@@ -924,7 +923,6 @@ void wizard_toggle_xray_vision()
     you.wizard_vision = !you.wizard_vision;
     mprf("X-ray vision %s.", you.wizard_vision ? "enabled" : "disabled");
     viewwindow(true);
-    update_screen();
 }
 
 void wizard_freeze_time()

--- a/crawl-ref/source/wizard.cc
+++ b/crawl-ref/source/wizard.cc
@@ -289,7 +289,6 @@ void handle_wizard_command()
         tiles.layout_statcol();
 #endif
         redraw_screen();
-        update_screen();
         if (crawl_state.cmd_repeat_start)
         {
             crawl_state.cancel_cmd_repeat("Can't repeat re-activating wizard "
@@ -325,7 +324,6 @@ void handle_wizard_command()
         tiles.layout_statcol();
 #endif
         redraw_screen();
-        update_screen();
 
         if (crawl_state.cmd_repeat_start)
         {
@@ -410,7 +408,6 @@ void enter_explore_mode()
         you.explore = true;
         save_game(false);
         redraw_screen();
-        update_screen();
 
         if (crawl_state.cmd_repeat_start)
         {
@@ -544,10 +541,7 @@ int list_wizard_commands(bool do_redraw_screen)
 
     int key = show_keyhelp_menu(cols.formatted_lines());
     if (do_redraw_screen)
-    {
         redraw_screen();
-        update_screen();
-    }
     return key;
 }
 #endif // defined(WIZARD)

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -3735,7 +3735,6 @@ bool move_stair(coord_def stair_pos, bool away, bool allow_under)
 
     // Clear out "missile trails"
     viewwindow();
-    update_screen();
 
     if (!swap_features(stair_pos, ray.pos(), false, false))
     {


### PR DESCRIPTION
We render multiple frames for every player turn, e.g. after the player takes an action, after a monster takes an action, start of the player's turn, when going through menus etc. However, most of these frames are replaced with a new frame before the next monitor vblank and are thus discarded. If we discard these short lived frames ourself, it should look better than having one occasionally pop up briefly while simplifying the code as tiles already discards these frames.