### PR TITLE
Prevent hiding from your past

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -661,9 +661,9 @@ static void _handle_recitation(int step)
  */
 static void _try_to_respawn_ancestor()
 {
-     monster *ancestor = create_monster(hepliaklqana_ancestor_gen_data());
-     if (!ancestor)
-         return;
+    monster *ancestor = create_monster(hepliaklqana_ancestor_gen_data());
+    if (!ancestor)
+        return;
 
     mprf("%s emerges from the mists of memory!",
          ancestor->name(DESC_YOUR).c_str());


### PR DESCRIPTION
(Edited this description to match the changes)

Fix friendly monsters not to target our pet_target if it is invalid.

This changes the behaviour in this case from:
- Set the foe to pet_target, then later clear it to MHITNOT, to
- Set the foe to the nearest monster, or the player if none exists

The motivating bug is one with Hep, where if we run from a fight and then our ancestor respawns, they can end up wandering. However, the main noticeable change to monster behaviour is in the case where we have allies and a monster on the screen, but have not begun hostilities or have only used certain AoE effects (and hence not set our pet target). Previously, the behaviour in this case depends on whether we have a previous pet_target - our allies would take the initiative and begin the fight if and only if our pet_target is empty.

This could also be quite bad if there is any case in which we fail to set pet_target. In that case, we could have an entire fight in which our allies just don't really do anything.