### PR TITLE
Separate hidden spells for divine exegesis

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5813,6 +5813,11 @@ bool player::cannot_speak() const
     return false;
 }
 
+FixedBitVector<NUM_SPELLS> *player::current_hidden_spells()
+{
+    return you.divine_exegesis ? &you.hidden_exegesis_spells : &you.hidden_spells;
+}
+
 /**
  * What verb should be used to describe the player's shouting?
  *

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -206,6 +206,7 @@ public:
 
     FixedBitVector<NUM_SPELLS> spell_library;
     FixedBitVector<NUM_SPELLS> hidden_spells;
+    FixedBitVector<NUM_SPELLS> hidden_exegesis_spells;
     FixedVector<spell_type, MAX_KNOWN_SPELLS> spells;
     set<spell_type> old_vehumet_gifts, vehumet_gifts;
 
@@ -593,6 +594,8 @@ public:
 
     bool has_spell(spell_type spell) const override;
     bool has_any_spells() const;
+    // Currently relevant hidden spell set - for exegesis if that is active, otherwise memorisation.
+    FixedBitVector<NUM_SPELLS> *current_hidden_spells();
 
     string shout_verb(bool directed = false) const;
     int shout_volume() const;

--- a/crawl-ref/source/spl-book.cc
+++ b/crawl-ref/source/spl-book.cc
@@ -773,7 +773,7 @@ private:
                 continue;
             }
 
-            const bool spell_hidden = you.hidden_spells.get(spell.spell);
+            const bool spell_hidden = you.current_hidden_spells()->get(spell.spell);
 
             if (spell_hidden)
                 hidden_count++;
@@ -922,7 +922,7 @@ public:
                     return examine_by_key(item.hotkeys[0]);
             case action::hide:
             case action::unhide:
-                you.hidden_spells.set(spell, !you.hidden_spells.get(spell));
+                you.current_hidden_spells()->set(spell, !you.current_hidden_spells()->get(spell));
                 update_entries();
                 update_menu(true);
                 update_more();

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -337,6 +337,7 @@ enum tag_minor_version
     TAG_MINOR_ACCURATE_INVIS_INDICATORS, // Invis indicators now always show at the monsters position
     TAG_MINOR_FIX_BLOOD_KNOWLEDGE, // Add blood rotation to map knowledge so out of sight changes aren't leaked
     TAG_MINOR_BRANCH_UNIQ_MAPS,    // buniq_* tags for "only once per branch" vault groups
+    TAG_MINOR_EXEGESIS_HIDDEN,     // Divine exegesis gets a separate list of hidden spells
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1697,6 +1697,7 @@ static void _tag_construct_you(writer &th)
 
     _marshallFixedBitVector<NUM_SPELLS>(th, you.spell_library);
     _marshallFixedBitVector<NUM_SPELLS>(th, you.hidden_spells);
+    _marshallFixedBitVector<NUM_SPELLS>(th, you.hidden_exegesis_spells);
 
     // how many spells?
     marshallUByte(th, MAX_KNOWN_SPELLS);
@@ -3113,8 +3114,19 @@ static void _tag_read_you(reader &th)
     }
 #endif
 
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() >= TAG_MINOR_EXEGESIS_HIDDEN)
+    {
+#endif
+        _unmarshallFixedBitVector<NUM_SPELLS>(th, you.hidden_exegesis_spells);
+#if TAG_MAJOR_VERSION == 34
+        _fixup_library_spells(you.hidden_exegesis_spells);
+    }
+#endif
+
     remove_removed_library_spells(you.spell_library);
     remove_removed_library_spells(you.hidden_spells);
+    remove_removed_library_spells(you.hidden_exegesis_spells);
 
     you.spells = unmarshall_player_spells(th);
     you.spell_letter_table = unmarshall_player_spell_letter_table(th);


### PR DESCRIPTION
Change the divine exegesis menu so that it maintains a separate list of hidden spells from memorisation.

The player often wants these lists to be very different, as exegesis uses spells the player will never be able to cast.