### PR TITLE
EXPERIMENTAL: Fix local tiles segfault with placement.lua -dump.

### DIFF
--- a/crawl-ref/source/libgui.cc
+++ b/crawl-ref/source/libgui.cc
@@ -225,6 +225,9 @@ void delay(unsigned int ms)
 
 void update_screen(unsigned int min_delay_ms)
 {
+    if (crawl_state.tiles_disabled)
+        return;
+
     if (tiles.need_redraw(min_delay_ms))
         tiles.redraw();
 }


### PR DESCRIPTION
By putting back a bit of code removed in 43d75eb.

Closes #4851.

[NOTE: I don't understand this code very well; it should be looked over first by someone who does understand it.]