### PR TITLE
Interrupt for monsters on their turn

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -986,13 +986,6 @@ static bool _should_stop_activity(Delay* delay,
     if (user_stop.is_bool())
         return user_stop.to_bool();
 
-    // Don't interrupt player on monster's turn, they might wander off.
-    if (you.turn_is_over
-        && (at.context == SC_ALREADY_SEEN || at.context == SC_UNCHARM))
-    {
-        return false;
-    }
-
     // No monster will attack you inside a sanctuary,
     // so presence of monsters won't matter.
     if (ai == activity_interrupt::see_monster && is_sanctuary(you.pos()))


### PR DESCRIPTION
This fixes a bug whereby seen_monster interrupts were sometimes not triggering, because:
- On the first turn an already seen monster comes into view, if it is the monster's turn when we check for the interrupt, we don't interrupt in case it wanders off.
- On subsequent turns, the player has already seen it so the interrupt doesn't trigger.

We simply remove the first check. It's probably better to give the player a chance to interrupt for monsters who wander onto the screen even if they might wander off again.