### PR TITLE
Fix display of HP penalty in flux preview

### DIFF
--- a/crawl-ref/source/dat/forms/flux.yaml
+++ b/crawl-ref/source/dat/forms/flux.yaml
@@ -2,6 +2,7 @@ enum: flux
 equivalent_mons: shapeshifter
 description: something dangerously unstable.
 skill: {min: 5, max: 14}
+hp_skill_penalty_mult: 2
 special_damage: 2d5+(30/15)
 special_damage_name: Contam Dmg
 melds: [held, body, gloves]

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -164,6 +164,7 @@ static const form_entry &_find_form_entry(transformation form)
 Form::Form(const form_entry &fe)
     : short_name(fe.short_name), wiz_name(fe.wiz_name),
       min_skill(fe.min_skill), max_skill(fe.max_skill),
+      hp_skill_penalty_mult(fe.hp_skill_penalty_mult),
       str_mod(fe.str_mod), dex_mod(fe.dex_mod), base_move_speed(fe.move_speed),
       blocked_slots(fe.blocked_slots), size(fe.size),
       can_cast(fe.can_cast),
@@ -340,9 +341,7 @@ int Form::mult_hp(int base_hp, bool force_talisman, int skill) const
     const int scale = 100;
     const int lvl = skill == -1 ? get_level(scale) : skill * scale;
     // Only penalize if you're in a talisman/bauble form with insufficient skill.
-    // (Flux form gets double the HP penalty per level, since its min skill is so low.)
-    const int shortfall = (min_skill * scale - lvl)
-                          * (you.form == transformation::flux ? 2 : 1);
+    const int shortfall = (min_skill * scale - lvl) * hp_skill_penalty_mult;
     const bool should_downscale = force_talisman
                                   || you.default_form == you.form
                                   || you.form == transformation::flux;

--- a/crawl-ref/source/transform.h
+++ b/crawl-ref/source/transform.h
@@ -183,6 +183,8 @@ public:
     const int min_skill;
     /// The skill level beyond which further skill provides no benefit.
     const int max_skill;
+    /// Multiplier to HP penalties for insufficient skill in talisman forms.
+    const int hp_skill_penalty_mult;
 
     /// flat str bonus
     const int str_mod;

--- a/crawl-ref/source/util/form-gen.py
+++ b/crawl-ref/source/util/form-gen.py
@@ -321,6 +321,7 @@ keyfns = {
     'description': Field(parse_str),
 
     'skill': Field(parse_skill),
+    'hp_skill_penalty_mult': Field(lambda s: parse_num(s, 1, 10)),
     'talisman': Field(lambda s: "TALISMAN_" + s.upper()),
 
     'melds': Field(parse_slots),
@@ -382,6 +383,7 @@ defaults = {
     'description': "",
 
     'skill': Skill(0, 0),
+    'hp_skill_penalty_mult': 1,
     'talisman': 'NUM_TALISMANS',
 
     'melds': 0,

--- a/crawl-ref/source/util/form-gen/body.txt
+++ b/crawl-ref/source/util/form-gen/body.txt
@@ -2,7 +2,7 @@
 {{
     {full_enum}, {equivalent_mons}, "{short_name}", "{long_name}", "{wiz_name}",
     "{description}",
-    {skill.min}, {skill.max}, {talisman},
+    {skill.min}, {skill.max}, {hp_skill_penalty_mult}, {talisman},
     {melds}, {joined_resists},
     {str}, {dex}, {size}, {hp_mod}, {move_speed},
     {ac_scaling}, {ev_scaling}, {body_ac_mult_scaling}, {can_cast}, {unarmed_scaling},

--- a/crawl-ref/source/util/form-gen/header.txt
+++ b/crawl-ref/source/util/form-gen/header.txt
@@ -21,6 +21,7 @@ struct form_entry
     // Row 3:
     int min_skill;
     int max_skill;
+    int hp_skill_penalty_mult;
     talisman_type talisman;
 
     // Row 4:


### PR DESCRIPTION
Fix incorrect HP display in flux preview

We do this by moving the special casing for flux HP to a form field, which is probably a cleaner place to have it anyway.

Closes #4817.