### PR TITLE
Update Vehumet's gift weighting to consider averages

### DIFF
--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1301,7 +1301,7 @@ static set<spell_type> _vehumet_eligible_gift_spells(set<spell_type> excluded_sp
 
 static int _vehumet_weighting(spell_type spell)
 {
-    int bias = 100 + destructive_elemental_preference(spell, 10);
+    int bias = 70 + destructive_preference(spell, 10);
     return bias;
 }
 

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -2591,43 +2591,37 @@ int get_crosstrain_points(skill_type sk)
 }
 
 /**
- * Is the provided skill one of the elemental spellschools?
+ * Is the provided skill one of the destructive spellschools?
  *
  * @param sk    The skill in question.
- * @param ext   If we want to also include alchemy or conjurations.
- *              (The kinda-poison and kinda-pure elements?)
- * @return      Whether it is fire, ice, earth, air, or possibly the above two.
+ * @return      Whether it is fire, ice, earth, air, alchemy or conjurations.
  */
-static bool _skill_is_elemental(skill_type sk, bool ext)
+static bool _skill_is_destructive(skill_type sk)
 {
-    if (ext)
-    {
-        return sk == SK_FIRE_MAGIC || sk == SK_EARTH_MAGIC || sk == SK_AIR_MAGIC
-               || sk == SK_ICE_MAGIC || sk == SK_ALCHEMY || sk == SK_CONJURATIONS;
-    }
-    else
-    {
-        return sk == SK_FIRE_MAGIC || sk == SK_EARTH_MAGIC
-               || sk == SK_AIR_MAGIC || sk == SK_ICE_MAGIC;
-    }
+    return sk == SK_FIRE_MAGIC || sk == SK_EARTH_MAGIC || sk == SK_AIR_MAGIC
+            || sk == SK_ICE_MAGIC || sk == SK_ALCHEMY || sk == SK_CONJURATIONS;
 }
 
 /**
- * How skilled is the player at the elemental components of a spell?
+ * How skilled is the player at the destructive components of a spell?
  *
  * @param spell     The type of spell in question.
  * @param scale     Scaling factor for skill.
- * @return          The player's skill at the elemental parts of a given spell.
+ * @return          The player's skill at the destructive parts of a given spell.
  */
-int destructive_elemental_preference(spell_type spell, int scale)
+int destructive_preference(spell_type spell, int scale)
 {
     skill_set skill_list;
     spell_skills(spell, skill_list);
     int preference = 0;
+    int num_destructive = 0;
     for (skill_type sk : skill_list)
-        if (_skill_is_elemental(sk, true))
+        if (_skill_is_destructive(sk))
+        {
             preference += you.skill(sk, scale);
-    return preference;
+            num_destructive++;
+        }
+    return preference / num_destructive;
 }
 
 void dump_skills(string &text)

--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -129,7 +129,7 @@ skill_diff skill_level_to_diffs(skill_type skill, double amount,
 vector<skill_type> get_crosstrain_skills(skill_type sk);
 int get_crosstrain_points(skill_type sk);
 
-int destructive_elemental_preference(spell_type spell, int scale = 1);
+int destructive_preference(spell_type spell, int scale = 1);
 
 void skill_menu(int flag = 0, int exp = 0);
 void dump_skills(string &text);


### PR DESCRIPTION
It seems wrong that we are more likely to offer multischool spells; e.g. offering Chain Lightning more than MCC to a mage with 20 air magic and 5 conjurations feels off. So we update the weighting to consider the average skill of (revelant) schools, rather than the sum.

Since Veh's spells average around 1.6 schools, we then increase the weight of the preference by a similar amount so that on average we should get about as many relevant gifts.

Also do a light cleanup and rename of destructive_elemental_preference, since we probably won't want the elemental-only version of this function again.