### PR TITLE
Fix pathfinding through doors

### DIFF
--- a/crawl-ref/source/mon-pathfind.cc
+++ b/crawl-ref/source/mon-pathfind.cc
@@ -444,9 +444,6 @@ bool monster_pathfind::traversable(const coord_def& p)
     if (traverse_no_actors && actor_at(p))
         return false;
 
-    if (feat_is_solid(feat) && (!mons || !mons->can_pass_through_feat(feat)))
-        return false;
-
     if (monster* mon_at = monster_at(p))
     {
         // Try to path around immobile monsters.
@@ -467,8 +464,12 @@ bool monster_pathfind::traversable(const coord_def& p)
     if (mons)
         return mons_traversable(p);
 
+    // No monster specified, default to a normal walking monster.
     if (traverse_doors && feat_is_closed_door(feat) && !cell_is_runed(p))
         return true;
+
+    if (feat_is_solid(feat))
+        return false;
 
     return feat_has_solid_floor(feat);
 }


### PR DESCRIPTION
Monsters that can open doors should pathfind through them.

This was causing a bug whereby a monster on the other side of a closed translucent door did not stop the player feeling safe (and perhaps other problems).

We move a "feature is solid" check only to be triggered when we don't have an explicit monster; in the case of an actual monster this is triggered anyway by mons_traversable (specifically, in the habitability check).

We also move it to after the door check, to fix this in the case where we are pathfinding for a default monster.