### PR TITLE
Fix console resize in webtiles

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -610,7 +610,7 @@ wint_t TilesFramework::_handle_control_message(sockaddr_un addr, string data)
     return c;
 }
 
-bool TilesFramework::await_input(wint_t& c, bool block)
+bool TilesFramework::await_input(wint_t& c, int timeout_millisecond)
 {
     int result;
     fd_set fds;
@@ -625,16 +625,13 @@ bool TilesFramework::await_input(wint_t& c, bool block)
             if (!m_sock_name.empty())
                 FD_SET(m_sock, &fds);
 
-            if (block)
-            {
-                tiles.flush_messages();
+            if (timeout_millisecond < 0)
                 result = select(maxfd + 1, &fds, nullptr, nullptr, nullptr);
-            }
             else
             {
                 timeval timeout;
                 timeout.tv_sec = 0;
-                timeout.tv_usec = 0;
+                timeout.tv_usec = timeout_millisecond * 1000;
 
                 result = select(maxfd + 1, &fds, nullptr, nullptr, &timeout);
             }

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -179,12 +179,12 @@ public:
        a control message, it will be written into c; otherwise,
        it still has to be read from stdin.
 
-       If block is false, await_input will immediately return,
+       If timeout_millisecond is zero, await_input will immediately return,
        even if no input is available. The return value indicates
        whether input can be read from stdin; c will be non-zero
        if input came via a control message.
      */
-    bool await_input(wint_t& c, bool block);
+    bool await_input(wint_t& c, int timeout_millisecond);
 
     void check_for_control_messages();
 


### PR DESCRIPTION
When playing webtiles on a console, the game needs to check for any of the player's inputs on the console as well as any spectator joining messages from a socket. To do this, we use the `select` function to wait from input from both stdin and the socket. However, this misses any input from the console that isn't sent on stdin which seems to just be console resize messages.

I can't think of a perfect solution to this, but checking for console input every 100ms allows us to handle the resize events with only a small delay without using too much CPU time constantly checking.