### PR TITLE
Allow igniting poisoned allies

### DIFF
--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -9604,8 +9604,7 @@ ai_action::goodness monster_spell_goodness(monster* mon, spell_type spell)
         }
 
     case SPELL_IGNITE_POISON:
-        return ai_action::good_or_bad(
-            cast_ignite_poison(mon, 0, false, true) == spret::success);
+        return ai_action::good_or_bad(ignite_poison_net_work(mon) > 0);
 
     case SPELL_GLACIATE:
         ASSERT(foe);

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -58,6 +58,7 @@ int terrain_shatter_chance(coord_def where, const actor &agent);
 spret cast_irradiate(int powc, actor &caster, bool fail);
 dice_def irradiate_damage(int powc, bool random = true);
 bool ignite_poison_affects_cell(const coord_def where, actor* agent);
+int ignite_poison_net_work(actor* agent);
 spret cast_ignite_poison(actor *agent, int pow, bool fail,
                               bool tracer = false);
 spret cast_unravelling(coord_def target, int pow, bool fail);


### PR DESCRIPTION
The tracer codepath in cast_ignite_poison was being used in two different ways - to decide if the spell was useless, and to check if monsters should cast it. These wanted different criteria, and so the uselessness check was wrong. We split the check by adding a separate function to do the check for monsters.

Fixes #4858