### PR TITLE
Tweak putting on orb text

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -172,6 +172,8 @@ const char* EquipOnDelay::get_verb()
         return "haunting";
     else if (equip.base_type == OBJ_ARMOUR && you.form == transformation::fortress_crab)
         return "fusing with";
+    else if (equip.base_type == OBJ_ARMOUR && equip.sub_type == ARM_ORB)
+        return "holding";
     else
         return "putting on";
 }


### PR DESCRIPTION
Hi there,

This is my first crawl PR so let me know if theres anything special I'm supposed to do.
this changes the text when you equip an orb from `"you begin putting on your orb"` to `"you begin holding your orb"`.

I would like to change the removing text too but I'm not sure what the best verbiage is. 'you begin removing your orb' also sounds weird but not as bad as 'you begin putting on your orb'.