### PR TITLE
Add check for targets in plasma beam

### DIFF
--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1783,6 +1783,9 @@ bool spell_no_hostile_in_range(spell_type spell)
     case SPELL_PERMAFROST_ERUPTION:
         return permafrost_targets(you, false).empty();
 
+    case SPELL_PLASMA_BEAM:
+        return plasma_beam_targets(you, pow, false).empty();
+
     default:
         break;
     }


### PR DESCRIPTION
Fixes a bad behaviour where casting plasma beam with some monsters but no targettable monsters could waste a turn and MP.

Fixes #3337