### PR TITLE
Improve ranged combat tabbing

### DIFF
--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -394,6 +394,7 @@ python.exe util/gen-all.py</Command>
     <ClCompile Include="..\l-wiz.cc" />
     <ClCompile Include="..\lang-fake.cc" />
     <ClCompile Include="..\losglobal.cc" />
+    <ClCompile Include="..\l-autofight.cc" />
     <ClCompile Include="..\l-colour.cc" />
     <ClCompile Include="..\l-crawl.cc" />
     <ClCompile Include="..\l-debug.cc" />

--- a/crawl-ref/source/MSVC/crawl.vcxproj.filters
+++ b/crawl-ref/source/MSVC/crawl.vcxproj.filters
@@ -721,6 +721,9 @@
     <ClCompile Include="..\l-dgn.cc">
       <Filter>cc</Filter>
     </ClCompile>
+    <ClCompile Include="..\l-autofight.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
     <ClCompile Include="..\l-crawl.cc">
       <Filter>cc</Filter>
     </ClCompile>

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -95,6 +95,7 @@ jobs.o \
 json.o \
 kills.o \
 known-items.o \
+l-autofight.o \
 l-colour.o \
 l-crawl.o \
 l-debug.o \

--- a/crawl-ref/source/android-project/jni/src/Android.mk
+++ b/crawl-ref/source/android-project/jni/src/Android.mk
@@ -114,6 +114,7 @@ LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
     $(CRAWL_PATH)/json.cc \
     $(CRAWL_PATH)/kills.cc \
     $(CRAWL_PATH)/known-items.cc \
+    $(CRAWL_PATH)/l-autofight.cc \
     $(CRAWL_PATH)/l-colour.cc \
     $(CRAWL_PATH)/l-crawl.cc \
     $(CRAWL_PATH)/l-debug.cc \

--- a/crawl-ref/source/clua.cc
+++ b/crawl-ref/source/clua.cc
@@ -815,6 +815,7 @@ void CLua::init_libraries()
     cluaopen_travel(_state);
     cluaopen_view(_state);
     cluaopen_spells(_state);
+    cluaopen_autofight(_state);
 
     cluaopen_globals(_state);
 

--- a/crawl-ref/source/dat/clua/autofight.lua
+++ b/crawl-ref/source/dat/clua/autofight.lua
@@ -292,33 +292,6 @@ local function compare_monster_info(m1, m2)
   return false
 end
 
-local function is_candidate_for_attack(x,y, no_move)
-  m = monster.get_monster_at(x, y)
-  --if m then crawl.mpr("Checking: (" .. x .. "," .. y .. ") " .. m:name()) end
-  if not m then
-    return false
-  end
-  if m:name() == "butterfly"
-      or m:name() == "orb of destruction" then
-    return false
-  end
-  if m:is_firewood() then
-  --crawl.mpr("... is firewood.")
-    if string.find(m:name(), "ballistomycete") then
-      return true
-    end
-    return false
-  end
-  if m:is_damage_immune() and (no_move or not m:is("warding")) then
-    return false
-  end
-  if m:attitude() == ATT_HOSTILE
-      or m:attitude() == ATT_NEUTRAL and m:is("frenzied") then
-    return true
-  end
-  return false
-end
-
 local function get_target(no_move)
   local los_radius = you.los()
   local x, y, bestx, besty, best_info, new_info
@@ -327,7 +300,7 @@ local function get_target(no_move)
   best_info = nil
   for x = -los_radius,los_radius do
     for y = -los_radius,los_radius do
-      if is_candidate_for_attack(x, y, no_move) then
+      if autofight.is_candidate_for_attack(x, y, no_move) then
         new_info = get_monster_info(x, y, no_move)
         if (not best_info) or compare_monster_info(new_info, best_info) then
           bestx = x
@@ -341,6 +314,8 @@ local function get_target(no_move)
 end
 
 local function attack_fire(x,y)
+  -- Try to find a better place to shoot that goes through (x, y).
+  x, y = autofight.best_aim(x, y)
   if AUTOFIGHT_FORCE_FIRE or not have_ranged() then
     -- fire from quiver
     crawl.do_targeted_command("CMD_FIRE", x, y, AUTOFIGHT_FIRE_STOP)

--- a/crawl-ref/source/l-autofight.cc
+++ b/crawl-ref/source/l-autofight.cc
@@ -1,0 +1,159 @@
+/*
+--- Autofight function bindings
+
+module "autofight"
+*/
+
+#include "AppHdr.h"
+
+#include "l-libs.h"
+
+#include "beam.h"
+#include "cluautil.h"
+#include "coord.h"
+#include "coordit.h"
+#include "env.h"
+#include "los.h"
+#include "losglobal.h"
+#include "map-knowledge.h"
+#include "monster.h"
+#include "mon-info.h"
+
+
+static bool is_candidate_for_attack(coord_def c, bool no_move)
+{
+    map_cell& cell = env.map_knowledge(c);
+    monster_info *mi = cell.monsterinfo();
+    if (!mi)
+        return false;
+
+    if (mi->type == MONS_ORB_OF_DESTRUCTION || mi->type == MONS_BUTTERFLY)
+        return false;
+
+    if (mi->is(MB_FIREWOOD))
+        return false;
+
+    if (mi->is(MB_PLAYER_DAMAGE_IMMUNE) && (no_move || !mi->is(MB_WARDING)))
+        return false;
+
+    if (mi->attitude == ATT_HOSTILE
+        || (mi->attitude == ATT_NEUTRAL && mi->is(MB_FRENZIED)))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+
+static int score(coord_def target, coord_def aim)
+{
+    bolt beam;
+    beam.source = you.pos();
+    beam.set_is_tracer(true);
+    beam.range = LOS_RADIUS;
+    beam.target = aim;
+    beam.aimed_at_spot = true;
+    beam.pierce = true;
+    beam.fire();
+
+    int num_hostiles = 0;
+    int num_blockers = 0;
+    bool found_main_target = false;
+    bool found_main_target_first = false;
+    for (auto g : beam.path_taken)
+    {
+        if (g == target)
+        {
+            found_main_target = true;
+            if (num_hostiles == 0 && num_blockers == 0)
+                found_main_target_first = true;
+        }
+        if (is_candidate_for_attack(g, true))
+            num_hostiles++;
+        else
+        {
+            map_cell& cell = env.map_knowledge(g);
+            monster_info *mi = cell.monsterinfo();
+            if (mi && !mi->can_shoot_through_monster)
+                num_blockers++;
+        }
+    }
+    if (!found_main_target)
+        return -1000;
+    else
+    {
+        int main_target_score = found_main_target_first ? 1000 : 0;
+        return main_target_score + num_hostiles - 10 * num_blockers;
+    }
+}
+
+
+/*** What is the best square to aim at to hit (x, y) with a ranged weapon?
+ * @tparam int x coordinate of target, in player coordinates
+ * @tparam int y coordinate of target, in player coordinates
+ * @treturn (x, y) coordinates to aim at.
+ * the best square to aim at.
+ * @function best_aim
+ */
+LUAFN(autofight_best_aim)
+{
+    coord_def a;
+    a.x = luaL_safe_checkint(ls, 1);
+    a.y = luaL_safe_checkint(ls, 2);
+    coord_def target = player2grid(a);
+
+    coord_def best_coord = target;
+    int best_score = score(target, target);
+    for (radius_iterator ri(you.pos(), LOS_SOLID_SEE); ri; ++ri)
+    {
+        int sc = score(target, *ri);
+        if (sc > best_score)
+        {
+            best_score = sc;
+            best_coord = *ri;
+        }
+    }
+
+    coord_def c = grid2player(best_coord);
+    lua_pushnumber(ls, c.x);
+    lua_pushnumber(ls, c.y);
+
+    return 2;
+}
+
+
+
+/*** Is there a monster worth attacking in this square?
+ * @tparam int x coordinate of target, in player coordinates
+ * @tparam int y coordinate of target, in player coordinates
+ * @tparam boolean whether we are allowed to move
+ * @treturn whether there is a monster worth attacking here
+ * @function is_candidate_for_attack
+ */
+LUAFN(autofight_is_candidate_for_attack)
+{
+    coord_def a;
+    a.x = luaL_safe_checkint(ls, 1);
+    a.y = luaL_safe_checkint(ls, 2);
+    const bool no_move = lua_toboolean(ls, 3);
+
+    coord_def target = player2grid(a);
+    bool is_candidate = is_candidate_for_attack(target, no_move);
+
+    lua_pushboolean(ls, is_candidate);
+    return 1;
+}
+
+
+static const struct luaL_reg autofight_lib[] =
+{
+    { "best_aim", autofight_best_aim },
+    { "is_candidate_for_attack", autofight_is_candidate_for_attack},
+    { nullptr, nullptr }
+};
+
+void cluaopen_autofight(lua_State *ls)
+{
+    luaL_openlib(ls, "autofight", autofight_lib, 0);
+}

--- a/crawl-ref/source/l-libs.h
+++ b/crawl-ref/source/l-libs.h
@@ -21,6 +21,7 @@ void cluaopen_travel(lua_State *ls);
 void cluaopen_view(lua_State *ls);
 void cluaopen_you(lua_State *ls);
 void cluaopen_spells(lua_State *ls);
+void cluaopen_autofight(lua_State *ls);
 
 void cluaopen_globals(lua_State *ls);
 

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -596,6 +596,7 @@ monster_info::monster_info(const monster* m, int milev)
     menergy = mons_energy(*m);
     can_go_frenzy = m->can_go_frenzy();
     can_feel_fear = m->can_feel_fear(false);
+    can_shoot_through_monster = shoot_through_monster(&you, m);
     sleepwalking = m->sleepwalking();
     backlit = m->backlit(false);
     umbraed = m->umbra();

--- a/crawl-ref/source/mon-info.h
+++ b/crawl-ref/source/mon-info.h
@@ -306,6 +306,7 @@ struct monster_info_base
     mon_attack_def attack[MAX_NUM_ATTACKS];
     bool can_go_frenzy;
     bool can_feel_fear;
+    bool can_shoot_through_monster;
     bool sleepwalking;
     bool backlit;
     bool umbraed;


### PR DESCRIPTION
Update automatic shooting of ranged weapon - via tab or p - so that we pick shots with more chance of hitting monsters other than the primary target and less of hitting allies.

Specifically, we calculate the same primary target as before, but instead of shooting straight at it we search for the beam which (in order of priority):
- Hits the primary target
- Hits as few friendly monsters as possible (if there are any, tabbing isn't actually going to work)
- Hits as many enemies as possible
- Is the primary target (to retain predictability in the simple case)

The main effect is that when we miss the main target, or are firing a penetrating weapon, we are more likely to hit other targets.