### PR TITLE
Exorcise some untimely dead

### DIFF
--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -382,9 +382,10 @@ public:
 
     make_derived_undead_fineff(coord_def pos, mgen_data _mg, int _xl,
         const string& _agent, const string& _msg,
-        bool _act_immediately)
+        function<bool ()> _should_trigger, bool _act_immediately)
         : final_effect(0, 0, pos), mg(_mg), experience_level(_xl),
-        agent(_agent), message(_msg), act_immediately(_act_immediately)
+        agent(_agent), message(_msg), should_trigger(_should_trigger),
+        act_immediately(_act_immediately)
     {
     }
 protected:
@@ -392,6 +393,7 @@ protected:
     int experience_level;
     string agent;
     string message;
+    function<bool ()> should_trigger;
     bool act_immediately;
 };
 
@@ -705,10 +707,12 @@ void schedule_infestation_death_fineff(coord_def pos, const string& name)
 void schedule_make_derived_undead_fineff(coord_def pos, mgen_data mg, int xl,
                                          const string& agent,
                                          const string& msg,
+                                         function<bool ()> should_trigger,
                                          bool act_immediately)
 {
     _schedule_final_effect(new make_derived_undead_fineff(pos, mg, xl, agent,
                                                           msg,
+                                                          should_trigger,
                                                           act_immediately));
 }
 
@@ -1441,6 +1445,9 @@ void infestation_death_fineff::fire()
 
 void make_derived_undead_fineff::fire()
 {
+    if (!should_trigger())
+        return;
+
     monster *undead = create_monster(mg);
     if (!undead)
         return;

--- a/crawl-ref/source/fineff.h
+++ b/crawl-ref/source/fineff.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 
 #include "beh-type.h"
@@ -66,6 +67,7 @@ void schedule_infestation_death_fineff(coord_def pos, const string& name);
 void schedule_make_derived_undead_fineff(coord_def pos, mgen_data mg, int xl,
                                          const string& agent,
                                          const string& msg,
+                                         function<bool ()> should_trigger = []() { return true; },
                                          bool act_immediately = false);
 void schedule_mummy_death_curse_fineff(const actor* attack,
                                        const monster* dead_mummy,

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -3,6 +3,8 @@
  * @brief Contains monster death functionality, including unique code.
 **/
 
+#include <functional>
+
 #include "AppHdr.h"
 
 #include "mon-death.h"
@@ -1466,17 +1468,20 @@ static string _derived_undead_message(const monster &mons, monster_type which_z,
 /**
  * Make derived undead out of a dying/dead monster.
  *
- * @param mons       the monster that died
- * @param quiet      whether to print flavour messages
- * @param which_z    the kind of zombie
- * @param beh        the zombie's behavior
- * @param spell      the spell or summon type used (if any)
- * @param god        the god involved (if any)
+ * @param mons           the monster that died
+ * @param quiet          whether to print flavour messages
+ * @param which_z        the kind of zombie
+ * @param beh            the zombie's behavior
+ * @param spell          the spell or summon type used (if any)
+ * @param god            the god involved (if any)
+ * @param should_trigger condition to check just before triggering the effect
  */
 static void _make_derived_undead(monster* mons, bool quiet,
                                  monster_type which_z, beh_type beh,
                                  int spell, god_type god,
-                                 string msg = "", string fail_msg = "")
+                                 string msg = "", string fail_msg = "",
+                                 function<bool ()> should_trigger = []() { return true; }
+                                )
 {
     bool requires_corpse = which_z == MONS_ZOMBIE || which_z == MONS_DRAUGR;
     // This function is used by several different sorts of things, each with
@@ -1565,7 +1570,7 @@ static void _make_derived_undead(monster* mons, bool quiet,
                            god == GOD_KIKUBAAQUDGHA ? "Kikubaaqudgha cackles." :
                            _derived_undead_message(*mons, which_z, msg);
     schedule_make_derived_undead_fineff(mons->pos(), mg,
-            mons->get_experience_level(), agent_name, message);
+            mons->get_experience_level(), agent_name, message, should_trigger);
 }
 
 static void _druid_final_boon(const monster* mons)
@@ -2677,7 +2682,7 @@ item_def* monster_die(monster& mons, killer_type killer,
         schedule_make_derived_undead_fineff(simu.pos, simu,
                                             get_monster_data(simu.base_type)->HD,
                                             "the player",
-                                            msg.c_str(), true);
+                                            msg.c_str(), []() { return true; }, true);
 
         silent = true;
     }
@@ -3455,10 +3460,15 @@ item_def* monster_die(monster& mons, killer_type killer,
             && you.duration[DUR_DEATH_CHANNEL]
             && !have_passive(passive_t::reaping))
         {
+            // Need to recheck death channel is still up, as it may expire between
+            // scheduling and execution.
+            function<bool ()> should_trigger = []() { return you.duration[DUR_DEATH_CHANNEL] > 0; };
             _make_derived_undead(&mons, !death_message, MONS_SPECTRAL_THING,
                                  BEH_FRIENDLY,
                                  SPELL_DEATH_CHANNEL,
-                                 static_cast<god_type>(you.attribute[ATTR_DIVINE_DEATH_CHANNEL]));
+                                 static_cast<god_type>(you.attribute[ATTR_DIVINE_DEATH_CHANNEL]),
+                                 "", "",
+                                 should_trigger);
         }
         else if (!you_worship(GOD_YREDELEMNUL))
             (_reaping_brand(mons));


### PR DESCRIPTION
Fix death channel creating ghosts after the effect expires.

This could happen when killing monsters with various end-of-turn effect such as yak form walls and fusillade.

The sequence of events is:
- Player turn happens; monsters killed are marked for ghosting.
- Monsters killed on turn produce ghosts.
- End of turn sequence; monsters killed are marked for ghosting.
- Death channel expires, all existing ghosts disappear.
- Monsters killed by end of turn sequence produce ghosts.
- \<These ghosts persist until death channel expires again\>

We fix this by checking death channel is still up when producing ghosts.

Closes #3040