### PR TITLE
Fix phantom tentacles

### DIFF
--- a/crawl-ref/source/mon-clone.cc
+++ b/crawl-ref/source/mon-clone.cc
@@ -351,6 +351,10 @@ monster* clone_mons(const monster* orig, bool quiet, bool* obvious,
         mons->props.erase(OKAWARU_DUEL_ABANDONED_KEY);
     }
 
+    // Clear the base for tentacles, if any.
+    if (mons->props.exists(BASE_POSITION_KEY))
+        mons->props.erase(BASE_POSITION_KEY);
+
     // Don't display non-functional bullseye targets
     if (mons->has_ench(ENCH_BULLSEYE_TARGET))
         mons->del_ench(ENCH_BULLSEYE_TARGET);


### PR DESCRIPTION
These were broken in the case of cloning an eldritch tentacle which had moved, because the base position was being cloned.