### PR TITLE
Fix wildshape skill estimation for talismans

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -1656,6 +1656,15 @@ skill_diff skill_level_to_diffs(skill_type skill, double amount,
         if (ash_has_skill_boost(skill))
             you_skill += ash_skill_point_boost(skill, you.skills[skill] * 10);
 
+        // Factor in wildshape amulet bonus (+5 shapeshifting levels)
+        if (skill == SK_SHAPESHIFTING && you.wearing_jewellery(AMU_WILDSHAPE))
+        {
+            const int wildshape_level = min(you.skills[skill] + 5,
+                                            (int)MAX_SKILL_LEVEL);
+            you_skill += skill_exp_needed(wildshape_level, skill)
+                         - skill_exp_needed(you.skills[skill], skill);
+        }
+
         if (you.skill_manual_points[skill])
             target = you_skill + (target - you_skill) / 2;
     }


### PR DESCRIPTION
Resolves: https://github.com/crawl/crawl/issues/4873

The calculation for estimated XLs to train up to talisman min Shapeshifting requirements took into account other sources of XP boosting but not the new wildshape amulet. This resolves that.