### PR TITLE
Unify status icon sizes between web and local tiles

### DIFF
--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -921,6 +921,7 @@ python.exe util/gen-all.py</Command>
     <ClInclude Include="..\recite-type.h" />
     <ClInclude Include="..\religion-enum.h" />
     <ClInclude Include="..\religion.h" />
+    <ClInclude Include="..\rltiles\status-icon-sizes.h" />
     <ClInclude Include="..\rltiles\tiledef-dngn.h" />
     <ClInclude Include="..\rltiles\tiledef-feat.h" />
     <ClInclude Include="..\rltiles\tiledef-floor.h" />

--- a/crawl-ref/source/MSVC/crawl.vcxproj.filters
+++ b/crawl-ref/source/MSVC/crawl.vcxproj.filters
@@ -2298,6 +2298,9 @@
     <ClInclude Include="..\mon-aura.h">
       <Filter>h</Filter>
     </ClInclude>
+    <ClInclude Include="..\rltiles\status-icon-sizes.h">
+      <Filter>rtiles_generated</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="cc">

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1265,7 +1265,8 @@ DOC_BASE        := ../docs
 DOC_TEMPLATES   := $(DOC_BASE)/template
 GENERATED_DOCS  := $(DOC_BASE)/aptitudes.txt $(DOC_BASE)/aptitudes-wide.txt $(DOC_BASE)/FAQ.html $(DOC_BASE)/crawl_manual.txt $(DOC_BASE)/quickstart.txt
 # Headers that need to exist before attempting to compile cc files
-GENERATED_HEADERS := art-enum.h config.h mon-mst.h species-type.h job-type.h form-data.h
+GENERATED_HEADERS := art-enum.h config.h mon-mst.h species-type.h job-type.h \
+                     form-data.h $(RLTILES)status-icon-sizes.h
 # All other generated files will be created later
 GENERATED_FILES := $(GENERATED_HEADERS) art-data.h mi-enum.h \
                    $(RLTILES)/dc-unrand.txt build.h compflag.h dat/dlua/tags.lua \
@@ -1330,7 +1331,8 @@ STATICFILES = $(TILEIMAGEFILES:%=webserver/game_data/static/%.png) \
               webserver/static/stone_soup_icon-32x32.png \
               $(TITLEIMGS:%=webserver/static/title_%.png) \
               $(TILEINFOJS:%=webserver/game_data/static/tileinfo-%.js) \
-              webserver/webtiles/version.txt
+              webserver/webtiles/version.txt \
+              webserver/game_data/static/status-icon-sizes.js
 
 $(TILEINFOJS:%=$(RLTILES)/tileinfo-%.js): build-rltiles
 
@@ -1879,6 +1881,12 @@ job-groups.h: job-data.h
 
 # no-op
 job-type.h: job-groups.h
+	$(QUIET_GEN)
+	
+$(RLTILES)status-icon-sizes.h : util/status-icon-sizes-gen.py $(RLTILES)/icon-sizes.txt
+	$(QUIET_PYTHON)$(PYTHON) util/status-icon-sizes-gen.py $(RLTILES)/icon-sizes.txt
+	
+$(RLTILES)status-icon-sizes.js : $(RLTILES)status-icon-sizes.h
 	$(QUIET_GEN)
 
 $(RLTILES)/dc-unrand.txt: art-data.h

--- a/crawl-ref/source/rltiles/.gitignore
+++ b/crawl-ref/source/rltiles/.gitignore
@@ -4,3 +4,5 @@ tiledef*.h
 tool/tilegen.elf
 tile*.html
 tileinfo*.js
+status-icon-sizes.h
+status-icon-sizes.js

--- a/crawl-ref/source/rltiles/icon-sizes.txt
+++ b/crawl-ref/source/rltiles/icon-sizes.txt
@@ -1,0 +1,87 @@
+# Width of zero actually means these icons have a fixed position
+berserk: 0
+idealised: 0
+touch_of_beogh: 0
+shadowless: 0
+summoned: 0
+minion: 0
+unrewarding: 0
+animated_weapon: 0
+vengeance_target: 0
+vampire_thrall: 0
+enkindled_1: 0
+enkindled_2: 0
+nobody_memory_1: 0
+nobody_memory_2: 0
+nobody_memory_3: 0
+pyrrhic: 0
+frenzied: 0
+
+drain: 6
+might: 6
+swift: 6
+dazed: 6
+hasted: 6
+slowed: 6
+corroded: 6
+infested: 6
+weakened: 6
+petrified: 6
+petrifying: 6
+bound_soul: 6
+possessable: 6
+partially_charged: 6
+fully_charged: 6
+vitrified: 6
+confused: 6
+sentinel_mark: 6
+dimmed: 6
+
+laced_with_chaos: 7
+conc_venom: 7
+fire_champ: 7
+inner_flame: 7
+pain_mirror: 7
+sticky_flame: 7
+
+anguish: 8
+fire_vuln: 8
+resistance: 8
+ghostly: 8
+malmutated: 8
+
+recall: 9
+teleporting: 9
+figment: 9
+
+blind: 10
+brilliance: 10
+slowly_dying: 10
+waterlogged: 10
+still_winds: 10
+antimagic: 10
+repel_missiles: 10
+injury_bond: 10
+glow_light: 10
+glow_heavy: 10
+bullseye: 10
+curse_of_agony: 10
+regeneration: 10
+retreat: 10
+rimeblight: 10
+undying_arms: 10
+bind: 10
+sign_of_ruin: 10
+weak_willed: 10
+doubled_vigour: 10
+kinetic_grapnel: 10
+tempered: 10
+heart: 10
+unstable: 10
+vexed: 10
+paradox: 10
+warding: 10
+
+constricted: 11
+vile_clutch: 11
+pain_bond: 11

--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -8,6 +8,7 @@
 #include "rltiles/tiledef-icons.h"
 #include "rltiles/tiledef-main.h"
 #include "rltiles/tiledef-player.h"
+#include "rltiles/status-icon-sizes.h"
 #include "tag-version.h"
 #include "tiledoll.h"
 #include "tilefont.h"
@@ -458,80 +459,6 @@ void DungeonCellBuffer::pack_background(int x, int y, const packed_cell &cell)
     }
 }
 
-static const int FIXED_LOC_ICON = -1;
-
-static map<tileidx_t, int> status_icon_sizes = {
-    { TILEI_STICKY_FLAME,   7 },
-    { TILEI_INNER_FLAME,    7 },
-    { TILEI_CONSTRICTED,    11 },
-    { TILEI_HASTED,         6 },
-    { TILEI_SLOWED,         6 },
-    { TILEI_MIGHT,          6 },
-    { TILEI_DRAIN,          6 },
-    { TILEI_PAIN_MIRROR,    7 },
-    { TILEI_PETRIFYING,     6 },
-    { TILEI_PETRIFIED,      6 },
-    { TILEI_BLIND,          10 },
-    { TILEI_BOUND_SOUL,     6 },
-    { TILEI_POSSESSABLE,    6 },
-    { TILEI_INFESTED,       6 },
-    { TILEI_CORRODED,       6 },
-    { TILEI_SWIFT,          6 },
-    { TILEI_RECALL,         6 },
-    { TILEI_VILE_CLUTCH,    11 },
-    { TILEI_SLOWLY_DYING,   10 },
-    { TILEI_FIRE_CHAMP,     7 },
-    { TILEI_ANGUISH,        8 },
-    { TILEI_WEAKENED,       6 },
-    { TILEI_WATERLOGGED,    10 },
-    { TILEI_STILL_WINDS,    10 },
-    { TILEI_GHOSTLY,        8 },
-    { TILEI_ANTIMAGIC,      10 },
-    { TILEI_DAZED,          6 },
-    { TILEI_PARTIALLY_CHARGED, 6 },
-    { TILEI_FULLY_CHARGED,  6 },
-    { TILEI_FIRE_VULN,      8 },
-    { TILEI_CONC_VENOM,     7 },
-    { TILEI_REPEL_MISSILES, 10 },
-    { TILEI_INJURY_BOND,    10 },
-    { TILEI_TELEPORTING,    9 },
-    { TILEI_RESISTANCE,     8 },
-    { TILEI_BRILLIANCE,     10 },
-    { TILEI_MALMUTATED,     8 },
-    { TILEI_GLOW_LIGHT,     10 },
-    { TILEI_GLOW_HEAVY,     10 },
-    { TILEI_PAIN_BOND,      11 },
-    { TILEI_BULLSEYE,       10 },
-    { TILEI_VITRIFIED,      6 },
-    { TILEI_CURSE_OF_AGONY, 10 },
-    { TILEI_REGENERATION,   8 },
-
-    // These are in the bottom right, so don't need to shift.
-    { TILEI_BERSERK,        FIXED_LOC_ICON },
-    { TILEI_FRENZIED,       FIXED_LOC_ICON },
-    { TILEI_VAMPIRE_THRALL, FIXED_LOC_ICON },
-    { TILEI_IDEALISED,      FIXED_LOC_ICON },
-    { TILEI_TOUCH_OF_BEOGH, FIXED_LOC_ICON },
-    { TILEI_ENKINDLED_1,    FIXED_LOC_ICON },
-    { TILEI_ENKINDLED_2,    FIXED_LOC_ICON },
-
-    // These are always in the top left. They may overlap.
-    // (E.g. for summoned dancing weapons.)
-    { TILEI_ANIMATED_WEAPON, FIXED_LOC_ICON },
-    { TILEI_SUMMONED,        FIXED_LOC_ICON },
-    { TILEI_MINION,          FIXED_LOC_ICON },
-    { TILEI_UNREWARDING,     FIXED_LOC_ICON },
-    { TILEI_VENGEANCE_TARGET,FIXED_LOC_ICON },
-
-    // Along the bottom of the monster.
-    { TILEI_SHADOWLESS,      FIXED_LOC_ICON },
-
-    { TILEI_NOBODY_MEMORY_1, FIXED_LOC_ICON },
-    { TILEI_NOBODY_MEMORY_2, FIXED_LOC_ICON },
-    { TILEI_NOBODY_MEMORY_3, FIXED_LOC_ICON },
-    { TILEI_PYRRHIC, FIXED_LOC_ICON },
-};
-
 void DungeonCellBuffer::pack_foreground(int x, int y, const packed_cell &cell)
 {
     const tileidx_t fg = cell.fg;
@@ -658,17 +585,19 @@ void DungeonCellBuffer::pack_foreground(int x, int y, const packed_cell &cell)
     // Currently, they default to iteration order.
     for (auto icon : cell.icons)
     {
-        int size = status_icon_sizes[icon];
-        if (size == FIXED_LOC_ICON)
+        int size = status_icon_size(icon);
+
+        // Size of zero actually means the icon has a fixed position
+        if (size == 0)
         {
             m_buf_icons.add(icon, x, y);
             continue;
         }
 
         m_buf_icons.add(icon, x, y, -status_shift, 0);
-        if (!size)
+        if (size < 0)
         {
-            dprf("unknown icon %" PRIu64, icon);
+            mprf(MSGCH_ERROR, "unknown size for icon %" PRIu64, icon);
             size = 7; // could maybe crash here?
         }
         status_shift += size;

--- a/crawl-ref/source/util/gen-all.py
+++ b/crawl-ref/source/util/gen-all.py
@@ -193,6 +193,14 @@ def build_rtiles():
         copy_if_needed('rltiles/' + tile_type + '.png',
                        'dat/tiles/' + tile_type + '.png')
 
+    python = sys.executable
+
+    generated_files = ['rltiles/status-icon-sizes.h',
+                       'rltiles/status-icon-sizes.js']
+    input_files = ['util/status-icon-sizes-gen.py', 'rltiles/icon-sizes.txt']
+    command = [python] + input_files
+    run_if_needed(generated_files, input_files, command)
+
 def main():
     perl = shutil.which('perl')
     if not perl:

--- a/crawl-ref/source/util/status-icon-sizes-gen.py
+++ b/crawl-ref/source/util/status-icon-sizes-gen.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+"""
+Generate status-icon-sizes.h, and status-icon-sizes.js
+
+Works with both Python 2 & 3. If that changes, update how the Makefile calls
+this.
+"""
+
+from __future__ import print_function
+
+import sys
+
+def parse_icon_sizes(file_name, icon_sizes):
+    with open(file_name) as input_file:
+        line_num = 0
+        for line in input_file:
+            line_num += 1
+            trimmed_line = line.strip()
+            if trimmed_line == '' or trimmed_line.startswith('#'):
+                continue
+            values = trimmed_line.split(':', 1)
+            if len(values) < 2:
+                print('Error: failed to parse line ', line_num, ' of ',
+                      file_name, file=sys.stderr)
+                return False
+
+            icon_name = values[0].strip()
+            icon_width = values[1].strip()
+            if icon_width in icon_sizes:
+                icon_sizes[icon_width].append(icon_name)
+            else:
+                icon_sizes[icon_width] = [icon_name]
+
+    return True
+
+def output_icon_sizes(icon_sizes, input_file_name):
+    with open('rltiles/status-icon-sizes.h', 'w') as file:
+        file.write('#pragma once\n')
+        file.write('\n')
+        file.write('// This file is auto generated, edit ' + input_file_name
+                   + ' instead.\n')
+        file.write('\n')
+        file.write('#include "tiledef-icons.h"\n')
+        file.write('\n')
+        file.write('inline int status_icon_size(tileidx_t icon)\n')
+        file.write('{\n')
+        file.write('    switch (icon)\n')
+        file.write('    {\n')
+        for size, names in icon_sizes.items():
+            for name in names:
+                file.write('    case TILEI_' + name.upper() + ':\n')
+            file.write('        return ' + size + ';\n')
+        file.write('    default:\n')
+        file.write('        return -1;\n')
+        file.write('    }\n')
+        file.write('}\n')
+
+    with open('rltiles/status-icon-sizes.js', 'w') as file:
+        file.write('define(["./tileinfo-icons"], function (icons) {\n')
+        file.write('// This file is auto generated, edit ' + input_file_name
+                   + ' instead.\n')
+        file.write('\n')
+        file.write('var exports = {};\n')
+        file.write('\n')
+        file.write('exports.status_icon_size = function (icon)\n')
+        file.write('{\n')
+        file.write('    switch (icon)\n')
+        file.write('    {\n')
+        for size, names in icon_sizes.items():
+            for name in names:
+                file.write('    case icons.' + name.upper() + ':\n')
+            file.write('        return ' + size + ';\n')
+        file.write('    default:\n')
+        file.write('        return -1;\n')
+        file.write('    }\n')
+        file.write('}\n')
+        file.write('\n')
+        file.write('return exports;\n')
+        file.write('});\n')
+
+def main():
+    if len(sys.argv) < 2:
+        print('Error: Missing input file', file=sys.stderr)
+        sys.exit(1)
+
+    # List of icons by size
+    icon_sizes = {}
+    succeeded = parse_icon_sizes(sys.argv[1], icon_sizes)
+    if not succeeded:
+        sys.exit(1)
+
+    output_icon_sizes(icon_sizes, sys.argv[1])
+
+if __name__ == '__main__':
+    main()

--- a/crawl-ref/source/webserver/game_data/static/cell_renderer.js
+++ b/crawl-ref/source/webserver/game_data/static/cell_renderer.js
@@ -1,9 +1,9 @@
 define(["jquery", "./view_data", "./tileinfo-gui", "./tileinfo-main",
         "./tileinfo-player", "./tileinfo-icons", "./tileinfo-dngn", "./enums",
         "./map_knowledge", "./tileinfos", "./player", "./options",
-        "contrib/jquery.json"],
+        "./status-icon-sizes", "contrib/jquery.json"],
 function ($, view_data, gui, main, tileinfo_player, icons, dngn, enums,
-          map_knowledge, tileinfos, player, options) {
+          map_knowledge, tileinfos, player, options, icon_sizes) {
     "use strict";
 
     function DungeonCellRenderer()
@@ -1091,105 +1091,14 @@ function ($, view_data, gui, main, tileinfo_player, icons, dngn, enums,
 
         draw_icon_type: function(idx, x, y, ofsx, ofsy, img_scale)
         {
-            switch (idx)
-            {
-                //These icons are in the lower right, so status_shift doesn't need changing.
-                case icons.BERSERK:
-                case icons.IDEALISED:
-                case icons.TOUCH_OF_BEOGH:
-                case icons.SHADOWLESS:
-                // Anim. weap. and summoned might overlap, but that's okay
-                case icons.SUMMONED:
-                case icons.MINION:
-                case icons.UNREWARDING:
-                case icons.ANIMATED_WEAPON:
-                case icons.VENGEANCE_TARGET:
-                case icons.VAMPIRE_THRALL:
-                case icons.ENKINDLED_1:
-                case icons.ENKINDLED_2:
-                case icons.NOBODY_MEMORY_1:
-                case icons.NOBODY_MEMORY_2:
-                case icons.NOBODY_MEMORY_3:
-                case icons.PYRRHIC:
-                case icons.FRENZIED:
-                    this.draw_icon(idx, x, y, undefined, undefined, img_scale);
-                    return 0;
-                case icons.DRAIN:
-                case icons.MIGHT:
-                case icons.SWIFT:
-                case icons.DAZED:
-                case icons.HASTED:
-                case icons.SLOWED:
-                case icons.CORRODED:
-                case icons.INFESTED:
-                case icons.WEAKENED:
-                case icons.PETRIFIED:
-                case icons.PETRIFYING:
-                case icons.BOUND_SOUL:
-                case icons.POSSESSABLE:
-                case icons.PARTIALLY_CHARGED:
-                case icons.FULLY_CHARGED:
-                case icons.VITRIFIED:
-                case icons.CONFUSED:
-                case icons.LACED_WITH_CHAOS:
-                case icons.SENTINEL_MARK:
-                case icons.DIMMED:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 6;
-                case icons.CONC_VENOM:
-                case icons.FIRE_CHAMP:
-                case icons.INNER_FLAME:
-                case icons.PAIN_MIRROR:
-                case icons.STICKY_FLAME:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 7;
-                case icons.ANGUISH:
-                case icons.FIRE_VULN:
-                case icons.RESISTANCE:
-                case icons.GHOSTLY:
-                case icons.MALMUTATED:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 8;
-                case icons.RECALL:
-                case icons.TELEPORTING:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 9;
-                case icons.BLIND:
-                case icons.BRILLIANCE:
-                case icons.SLOWLY_DYING:
-                case icons.WATERLOGGED:
-                case icons.STILL_WINDS:
-                case icons.ANTIMAGIC:
-                case icons.REPEL_MISSILES:
-                case icons.INJURY_BOND:
-                case icons.GLOW_LIGHT:
-                case icons.GLOW_HEAVY:
-                case icons.BULLSEYE:
-                case icons.CURSE_OF_AGONY:
-                case icons.REGENERATION:
-                case icons.RETREAT:
-                case icons.RIMEBLIGHT:
-                case icons.UNDYING_ARMS:
-                case icons.BIND:
-                case icons.SIGN_OF_RUIN:
-                case icons.WEAK_WILLED:
-                case icons.DOUBLED_VIGOUR:
-                case icons.KINETIC_GRAPNEL:
-                case icons.TEMPERED:
-                case icons.HEART:
-                case icons.UNSTABLE:
-                case icons.VEXED:
-                case icons.PARADOX:
-                case icons.WARDING:
-                case icons.FIGMENT:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 10;
-                case icons.CONSTRICTED:
-                case icons.VILE_CLUTCH:
-                case icons.PAIN_BOND:
-                    this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
-                    return 11;
-            }
+            var size = icon_sizes.status_icon_size(idx);
+            if (size < 0)
+                return 0;
+            if (size == 0)
+                this.draw_icon(idx, x, y, undefined, undefined, img_scale);
+            else
+                this.draw_icon(idx, x, y, ofsx, ofsy, img_scale);
+            return size;
         },
 
         // Helper functions for drawing from specific textures


### PR DESCRIPTION
Webtiles had a list of widths of status icons in a javascript file and
localtiles had a similar list in a c++ file. However, the localtiles
list was missing a lot of entries and there were some minor differences
where one of the lists had an incorrect value.

The reason for the missing values in the localtiles list is that it had
a default value and you couldn't tell if this value resulted in bad
spacing between the icons without having multiple icons on a monster so
it was often missed when adding a status icon. Webtiles on the other
hand just doesn't show a status icon if it doesn't have a width for it
which resulted in widths being added to its list when it was noticed
that the status icon wasn't showing up in webtiles.

To fix these problems, move the list of status icon widths to a text
file and generate the javascript and c++ lists from this. Also, give an
error message in the message log when trying to draw a status icon
without a width in localtiles. This should allow testing a new status
icon in either web or local tiles and have it just work in the other.