### PR TITLE
fix: overflow vault cloud typo (srcrip)

### DIFF
--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -2357,7 +2357,7 @@ KFEAT:   f = lava
 KFEAT:   w = deep_water
 KFEAT:   CDEF = c
 KPROP:   e = no_tele_into
-: single_cloud(_G, "a", "thin_mist", false)
+: single_cloud(_G, "a", "thin mist", false)
 : single_cloud(_G, "e", "sparse dust", false)
 : standard_overflow_setup(_G, { { "qazlal", "_" } }, true)
 TILE:   C = wall_stone_scorched


### PR DESCRIPTION
Fixes the placement of decorative thin mist clouds.