### PR TITLE
Remove a no longer needed tile cache

### DIFF
--- a/crawl-ref/source/tile-env.h
+++ b/crawl-ref/source/tile-env.h
@@ -15,15 +15,9 @@ struct crawl_tile_environment
     FixedArray<tile_fg_store, GXM, GYM> bk_fg;
     FixedArray<tileidx_t, GXM, GYM> bk_bg;
     FixedArray<tileidx_t, GXM, GYM> bk_cloud;
-#endif
-    FixedArray<tile_flavour, GXM, GYM> flv;
-    // indexed by (show-1) coords
-#ifdef USE_TILE // TODO: separate out this stuff from crawl_environment
-    FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> fg;
-    FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> bg;
-    FixedArray<tileidx_t, ENV_SHOW_DIAMETER, ENV_SHOW_DIAMETER> cloud;
     map<coord_def, set<tileidx_t>> icons;
 #endif
+    FixedArray<tile_flavour, GXM, GYM> flv;
     tile_flavour default_flavour;
     std::vector<std::string> names;
 };

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1789,8 +1789,7 @@ static void _add_tentacle_overlay(const coord_def pos,
     if (!in_bounds(next))
         return;
 
-    const coord_def next_showpos(grid2show(next));
-    if (!show_bounds(next_showpos))
+    if (!show_bounds(grid2show(next)))
         return;
 
     tile_flags flag;
@@ -1802,7 +1801,7 @@ static void _add_tentacle_overlay(const coord_def pos,
         case main_dir::west: flag = TILE_FLAG_TENTACLE_SE; break;
         default: die("invalid direction");
     }
-    tile_env.bg(next_showpos) |= flag;
+    tile_env.bk_bg(next) |= flag;
 
     switch (type)
     {
@@ -1814,7 +1813,7 @@ static void _add_tentacle_overlay(const coord_def pos,
         case tentacle_type::spectral_kraken: flag = TILE_FLAG_TENTACLE_SPECTRAL_KRAKEN; break;
         default: flag = TILE_FLAG_TENTACLE_KRAKEN;
     }
-    tile_env.bg(next_showpos) |= flag;
+    tile_env.bk_bg(next) |= flag;
 }
 
 static void _handle_tentacle_overlay(const coord_def pos,

--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -760,7 +760,8 @@ bool DungeonRegion::update_tip_text(string &tip)
                 tip += make_stringf("HEIGHT(%d)\n", dgn_height_at(gc));
 
             tip += "\n";
-            tip += tile_debug_string(tile_env.fg(ep), tile_env.bg(ep), ' ');
+            tip += tile_debug_string(tile_env.bk_fg(gc), tile_env.bk_bg(gc),
+                                     ' ');
             tip += "\n";
         }
         else

--- a/crawl-ref/source/tilereg-mon.cc
+++ b/crawl-ref/source/tilereg-mon.cc
@@ -171,15 +171,14 @@ void MonsterRegion::pack_buffers()
             if (mon)
             {
                 const coord_def gc = mon->pos;
-                const coord_def ep = grid2show(gc);
 
                 if (crawl_view.in_los_bounds_g(gc))
                 {
                     packed_cell cell;
-                    cell.fg = tile_env.fg(ep);
-                    cell.bg = tile_env.bg(ep);
+                    cell.fg = tile_env.bk_fg(gc);
+                    cell.bg = tile_env.bk_bg(gc);
                     cell.flv = tile_env.flv(gc);
-                    if (set<tileidx_t>* icons = map_find(tile_env.icons, ep))
+                    if (set<tileidx_t>* icons = map_find(tile_env.icons, gc))
                         cell.icons = *icons;
                     tile_apply_properties(gc, cell);
 

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -1136,16 +1136,6 @@ static update_flags player_view_update_at(const coord_def &gc)
         env.pgrid(gc) |= FPROP_SEEN_OR_NOEXP;
     }
 
-#ifdef USE_TILE
-    const coord_def ep = grid2show(gc);
-
-    // We remove any references to mcache when
-    // writing to the background.
-    tile_env.bk_fg(gc) = tile_env.fg(ep);
-    tile_env.bk_bg(gc) = tile_env.bg(ep);
-    tile_env.bk_cloud(gc) = tile_env.cloud(ep);
-#endif
-
     return ret;
 }
 
@@ -1187,8 +1177,7 @@ static void _draw_out_of_bounds(screen_cell_t *cell)
 #endif
 }
 
-static void _draw_outside_los(screen_cell_t *cell, const coord_def &gc,
-                                    const coord_def &ep)
+static void _draw_outside_los(screen_cell_t *cell, const coord_def &gc)
 {
     // Outside the env.show area.
     cglyph_t g = get_cell_glyph(gc);
@@ -1198,16 +1187,14 @@ static void _draw_outside_los(screen_cell_t *cell, const coord_def &gc,
 #ifdef USE_TILE
     // this is just for out-of-los rays, but I don't see a more efficient way..
     if (in_bounds(gc))
-        cell->tile.bg = tile_env.bg(ep);
+        cell->tile.bg = tile_env.bk_bg(gc);
 
     tileidx_out_of_los(&cell->tile.fg, &cell->tile.bg, &cell->tile.cloud, gc);
-#else
-    UNUSED(ep);
 #endif
 }
 
 static void _draw_player(screen_cell_t *cell,
-                         const coord_def &gc, const coord_def &ep,
+                         const coord_def &gc,
                          bool anim_updates)
 {
     // Player overrides everything in cell.
@@ -1228,19 +1215,19 @@ static void _draw_player(screen_cell_t *cell,
     cell->colour = real_colour(cell->colour);
 
 #ifdef USE_TILE
-    cell->tile.fg = tile_env.fg(ep) = tileidx_player();
-    cell->tile.bg = tile_env.bg(ep);
-    cell->tile.cloud = tile_env.cloud(ep);
+    cell->tile.fg = tileidx_player();
+    cell->tile.bg = tile_env.bk_bg(gc);
+    cell->tile.cloud = tile_env.bk_cloud(gc);
     cell->tile.icons = status_icons_for_player();
     if (anim_updates)
         tile_apply_animations(cell->tile.bg, &tile_env.flv(gc));
 #else
-    UNUSED(ep, anim_updates);
+    UNUSED(anim_updates);
 #endif
 }
 
 static void _draw_los(screen_cell_t *cell,
-                      const coord_def &gc, const coord_def &ep,
+                      const coord_def &gc,
                       bool anim_updates)
 {
     cglyph_t g = get_cell_glyph(gc);
@@ -1248,15 +1235,15 @@ static void _draw_los(screen_cell_t *cell,
     cell->colour = g.col;
 
 #ifdef USE_TILE
-    cell->tile.fg = tile_env.fg(ep);
-    cell->tile.bg = tile_env.bg(ep);
-    cell->tile.cloud = tile_env.cloud(ep);
-    if (set<tileidx_t>* icons = map_find(tile_env.icons, ep))
+    cell->tile.fg = tile_env.bk_fg(gc);
+    cell->tile.bg = tile_env.bk_bg(gc);
+    cell->tile.cloud = tile_env.bk_cloud(gc);
+    if (set<tileidx_t>* icons = map_find(tile_env.icons, gc))
         cell->tile.icons = *icons;
     if (anim_updates)
         tile_apply_animations(cell->tile.bg, &tile_env.flv(gc));
 #else
-    UNUSED(ep, anim_updates);
+    UNUSED(anim_updates);
 #endif
 }
 
@@ -1728,23 +1715,22 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
 #ifdef USE_TILE
     cell->tile.clear();
 #endif
-    const coord_def ep = grid2show(gc);
 
     if (!map_bounds(gc))
         _draw_out_of_bounds(cell);
     else if (!crawl_view.in_los_bounds_g(gc))
-        _draw_outside_los(cell, gc, coord_def());
+        _draw_outside_los(cell, gc);
     else if (gc == you.pos() && you.on_current_level
              && _layers & Layer::PLAYER
              && !crawl_state.game_is_arena()
              && !crawl_state.arena_suspended)
     {
-        _draw_player(cell, gc, ep, anim_updates);
+        _draw_player(cell, gc, anim_updates);
     }
     else if (you.see_cell(gc))
-        _draw_los(cell, gc, ep, anim_updates);
+        _draw_los(cell, gc, anim_updates);
     else
-        _draw_outside_los(cell, gc, ep); // in los bounds but not visible
+        _draw_outside_los(cell, gc); // in los bounds but not visible
 
 #ifdef USE_TILE
     cell->tile.map_knowledge = map_bounds(gc) ? env.map_knowledge(gc) : map_cell();


### PR DESCRIPTION
We had a cache for tiles of squares in view and another one for all other tiles. This allowed us to easily set tiles to unseen as they exited view in the Labyrinth branch by never writing them to the out of view tile cache (Labyrinth no longer exists), replace mcache reference tiles for monsters out of view with generic ones (but the bug that caused us to do this is gone and we no longer do this), and support the clean_map option (which no longer exists). As none of these reasons for keeping the two separate caches exist anymore it should be fine to just use one cache for all tiles.

The cache for tiles in view stored tiles within a radius of 8 from the player and was indexed with coordinates that were relative to the player. This meant it would become invalid after the player moved if it wasn't updated and was sometimes leading to a crash in webtiles when drawing parchments. Using a single cache indexed by grid coordinates should fix this.