### PR TITLE
Don't leak info about polar vortex casters

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -2189,3 +2189,18 @@ bool chaos_affects_actor(actor* victim, actor* source)
 
     return obvious_effect;
 }
+
+bool get_vortex_phase(const coord_def& loc)
+{
+    coord_def center = get_cloud_originator(loc);
+    if (center.origin())
+        return ui_random(2); // source died/went away
+    else
+    {
+        int x = loc.x - center.x;
+        int y = loc.y - center.y;
+        double dir = atan2(x, y) / PI;
+        double dist = sqrt(x * x + y * y);
+        return ((int)floor(dir * 2 + dist * 0.33 - (you.frame_no % 54) / 2.7)) & 1;
+    }
+}

--- a/crawl-ref/source/cloud.h
+++ b/crawl-ref/source/cloud.h
@@ -105,3 +105,5 @@ void end_still_winds();
 void surround_actor_with_cloud(const actor* a, cloud_type cloud);
 
 bool chaos_affects_actor(actor* victim, actor* source);
+
+bool get_vortex_phase(const coord_def& loc);

--- a/crawl-ref/source/colour.cc
+++ b/crawl-ref/source/colour.cc
@@ -277,25 +277,11 @@ static int _etc_mangrove(int, const coord_def& loc)
     return col == LIGHTGREEN ? BROWN : col;
 }
 
-bool get_vortex_phase(const coord_def& loc)
-{
-    coord_def center = get_cloud_originator(loc);
-    if (center.origin())
-        return _ui_coinflip(); // source died/went away
-    else
-    {
-        int x = loc.x - center.x;
-        int y = loc.y - center.y;
-        double dir = atan2(x, y)/PI;
-        double dist = sqrt(x*x + y*y);
-        return ((int)floor(dir*2 + dist*0.33 - (you.frame_no % 54)/2.7))&1;
-    }
-}
-
 static int _etc_vortex(int, const coord_def& loc)
 {
-    const bool phase = get_vortex_phase(loc);
-    switch (env.grid(loc))
+    const cloud_info* cloud = env.map_knowledge(loc).cloudinfo();
+    const bool phase = cloud ? (bool)cloud->variety : true;
+    switch (env.map_knowledge(loc).feat())
     {
     case DNGN_LAVA:
         return phase ? LIGHTRED : _ui_one_chance_in(3) ? MAGENTA : RED;

--- a/crawl-ref/source/colour.h
+++ b/crawl-ref/source/colour.h
@@ -125,7 +125,6 @@ colour_t make_high_colour(colour_t colour) IMMUTABLE;
 int  element_colour(int element, bool no_random = false,
                     const coord_def& loc = coord_def());
 int get_disjunct_phase(const coord_def& loc);
-bool get_vortex_phase(const coord_def& loc);
 bool get_orb_phase(const coord_def& loc);
 int dam_colour(const monster_info&);
 colour_t rune_colour(int type);

--- a/crawl-ref/source/map-cell.h
+++ b/crawl-ref/source/map-cell.h
@@ -44,20 +44,20 @@
 
 struct cloud_info
 {
-    cloud_info() : type(CLOUD_NONE), colour(0), duration(3), tile(0), pos(0, 0),
+    cloud_info() : type(CLOUD_NONE), colour(0), variety(3), tile(0), pos(0, 0),
                    killer(KILL_NONE)
     { }
 
     cloud_info(cloud_type t, colour_t c,
                uint8_t dur, unsigned short til, coord_def gc,
                killer_type kill)
-        : type(t), colour(c), duration(dur), tile(til), pos(gc), killer(kill)
+        : type(t), colour(c), variety(dur), tile(til), pos(gc), killer(kill)
     { }
 
     friend bool operator==(const cloud_info &lhs, const cloud_info &rhs) {
         return lhs.type == rhs.type
                && lhs.colour == rhs.colour
-               && lhs.duration == rhs.duration
+               && lhs.variety == rhs.variety
                && lhs.tile == rhs.tile
                && lhs.pos == rhs.pos
                && lhs.killer == rhs.killer;
@@ -70,7 +70,9 @@ struct cloud_info
 
     cloud_type type:8;
     colour_t colour;
-    uint8_t duration; // decay/20, clamped to 0-3
+    // for clouds with duration: decay/20, clamped to 0-3
+    // for vortex clouds: the vortex phase
+    uint8_t variety;
     // TODO: should this be tileidx_t?
     unsigned short tile;
     coord_def pos;

--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -288,17 +288,33 @@ void update_item_at(const coord_def &gp, bool wizard)
     env.map_knowledge(gp).set_item(eitem, more_items);
 }
 
+static int _get_cloud_variety(cloud_struct& cloud)
+{
+    const cloud_tile_info& tile_info = cloud_type_tile_info(cloud.type);
+    switch (tile_info.variation)
+    {
+    case CTVARY_VORTEX:
+        return get_vortex_phase(cloud.pos);
+
+    case CTVARY_DUR:
+    case CTVARY_MUTAGENIC:
+    default:
+        int dur = cloud.decay / 20;
+        if (dur < 0)
+            dur = 0;
+        else if (dur > 3)
+            dur = 3;
+        return dur;
+    }
+    return 0;
+}
+
 static void _update_cloud(cloud_struct& cloud)
 {
     const coord_def gp = cloud.pos;
+    const int variety = _get_cloud_variety(cloud);
 
-    int dur = cloud.decay/20;
-    if (dur < 0)
-        dur = 0;
-    else if (dur > 3)
-        dur = 3;
-
-    cloud_info ci(cloud.type, get_cloud_colour(cloud), dur, 0, gp,
+    cloud_info ci(cloud.type, get_cloud_colour(cloud), variety, 0, gp,
                   cloud.killer);
     env.map_knowledge(gp).set_cloud(ci);
 }

--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -481,7 +481,7 @@ static cglyph_t _get_cell_glyph_with_class(const map_cell& cell,
             == CTVARY_DUR)
         {
             // duration is already clamped to 0-3
-            int dur = cell.cloudinfo()->duration;
+            int dur = cell.cloudinfo()->variety;
             switch (dur)
             {
             case 0:

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -338,6 +338,7 @@ enum tag_minor_version
     TAG_MINOR_FIX_BLOOD_KNOWLEDGE, // Add blood rotation to map knowledge so out of sight changes aren't leaked
     TAG_MINOR_BRANCH_UNIQ_MAPS,    // buniq_* tags for "only once per branch" vault groups
     TAG_MINOR_TRACK_ORIGIN_LEVEL,  // Track the original level on which a monster was generated
+    TAG_MINOR_FIX_POLAR_VORTEX_INFO_LEAK, // Don't leak whether the polar vortex caster has moved or gone
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6291,7 +6291,7 @@ void marshallMapCell(writer &th, const map_cell &cell)
         cloud_info* ci = cell.cloudinfo();
         marshallUnsigned(th, ci->type);
         marshallUnsigned(th, ci->colour);
-        marshallUnsigned(th, ci->duration);
+        marshallUnsigned(th, ci->variety);
         marshallShort(th, ci->tile);
         marshallUByte(th, ci->killer);
     }
@@ -6359,7 +6359,7 @@ void unmarshallMapCell(reader &th, map_cell& cell)
         cloud_info ci;
         ci.type = (cloud_type)unmarshallUnsigned(th);
         unmarshallUnsigned(th, ci.colour);
-        unmarshallUnsigned(th, ci.duration);
+        unmarshallUnsigned(th, ci.variety);
         ci.tile = unmarshallShort(th);
 #if TAG_MAJOR_VERSION == 34
         if (th.getMinorVersion() >= TAG_MINOR_CLOUD_OWNER)
@@ -7014,6 +7014,16 @@ static void _fixup_blood_knowledge(MapKnowledge& map_knowledge)
         }
     }
 }
+
+static void _fixup_cloud_varieties(MapKnowledge& map_knowledge)
+{
+    for (rectangle_iterator ri(0); ri; ++ri)
+    {
+        cloud_info* ci = map_knowledge(*ri).cloudinfo();
+        if (ci && ci->type == CLOUD_VORTEX)
+            ci->variety = get_vortex_phase(*ri);
+    }
+}
 #endif
 
 static void _tag_read_level(reader &th)
@@ -7076,6 +7086,8 @@ static void _tag_read_level(reader &th)
 #if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() < TAG_MINOR_FIX_BLOOD_KNOWLEDGE)
         _fixup_blood_knowledge(env.map_knowledge);
+    if (th.getMinorVersion() <= TAG_MINOR_FIX_POLAR_VORTEX_INFO_LEAK)
+        _fixup_cloud_varieties(env.map_knowledge);
 #endif
 
 #if TAG_MAJOR_VERSION == 34
@@ -7093,6 +7105,8 @@ static void _tag_read_level(reader &th)
 #if TAG_MAJOR_VERSION == 34
         if (th.getMinorVersion() < TAG_MINOR_FIX_BLOOD_KNOWLEDGE)
             _fixup_blood_knowledge(*f);
+        if (th.getMinorVersion() <= TAG_MINOR_FIX_POLAR_VORTEX_INFO_LEAK)
+            _fixup_cloud_varieties(*f);
 #endif
         env.map_forgotten.reset(f);
     }

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -3537,7 +3537,7 @@ tileidx_t tileidx_cloud(const cloud_info &cl)
 {
     const cloud_type type  = cl.type;
     const int colour = cl.colour;
-    const unsigned int dur = cl.duration;
+    const unsigned int variety = cl.variety;
 
     tileidx_t ch = cl.tile;
 
@@ -3551,7 +3551,7 @@ tileidx_t tileidx_cloud(const cloud_info &cl)
                 ch = tile_info.base;
                 break;
             case CTVARY_DUR:
-                ch = tile_info.base + min(dur,
+                ch = tile_info.base + min(variety,
                                           tile_main_count(tile_info.base) - 1);
                 break;
             case CTVARY_RANDOM:
@@ -3560,14 +3560,14 @@ tileidx_t tileidx_cloud(const cloud_info &cl)
                         cl.pos.y * GXM + cl.pos.x, you.frame_no);
                 break;
             case CTVARY_MUTAGENIC:
-                ch = (dur == 0 ? TILE_CLOUD_MUTAGENIC_0 :
-                      dur == 1 ? TILE_CLOUD_MUTAGENIC_1
-                               : TILE_CLOUD_MUTAGENIC_2);
+                ch = (variety == 0 ? TILE_CLOUD_MUTAGENIC_0 :
+                      variety == 1 ? TILE_CLOUD_MUTAGENIC_1
+                                   : TILE_CLOUD_MUTAGENIC_2);
                 ch += ui_random(tile_main_count(ch));
                 break;
             case CTVARY_VORTEX:
-                ch = get_vortex_phase(cl.pos) ? TILE_CLOUD_FREEZING_WINDS_0
-                                              : TILE_CLOUD_FREEZING_WINDS_1;
+                ch = variety ? TILE_CLOUD_FREEZING_WINDS_0
+                             : TILE_CLOUD_FREEZING_WINDS_1;
                 break;
         }
 


### PR DESCRIPTION
Polar vortex clouds have a phase that is based on the caster's location or random if the spell has ended. This could help locate the caster after teleporting away or otherwise moving out of sight (although if playing tiles you had to reload the game to get out of view clouds to update their phase due to a bug). Instead, only update the phase of polar vortex clouds you can see, so you only gain information from in view clouds.