### PR TITLE
Fix felids receiving attacks while dead

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -42,6 +42,7 @@ public:
     virtual god_type  deity() const = 0;
 
     virtual bool      alive() const = 0;
+    virtual bool      alive_or_reviving() const = 0;
 
     // Should return false for perma-summoned things.
     virtual bool is_summoned() const = 0;

--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -649,9 +649,7 @@ static void _WYRMBANE_melee_effects(item_def* weapon, actor* attacker,
 
         defender->hurt(attacker, bonus_dam);
 
-        // Allow the lance to charge when killing dragonform felid players.
-        mondied = defender->is_player() ? defender->as_player()->pending_revival
-                                        : !defender->alive();
+        mondied = !defender->alive();
     }
 
     if (!mondied || !hd)

--- a/crawl-ref/source/attack.cc
+++ b/crawl-ref/source/attack.cc
@@ -713,7 +713,7 @@ int attack::inflict_damage(int dam, beam_type flavour, bool clean)
     const int final = defender->hurt(responsible, dam, flavour, kill_type,
                                      "", aux_source.c_str(), clean);
 
-    if (!defender->alive())
+    if (defender->is_monster() && !defender->alive())
         defender->props[ATTACK_KILL_KEY] = true;
 
     return final;
@@ -1588,8 +1588,8 @@ actor &attack::stat_source() const
     if (summoner_mid == MID_NOBODY)
         return *attacker;
 
-    actor* summoner = actor_by_mid(attacker->as_monster()->summoner);
-    if (!summoner || !summoner->alive())
+    actor* summoner = actor_by_mid(summoner_mid);
+    if (!summoner || !summoner->alive_or_reviving())
         return *attacker;
     return *summoner;
 }

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3146,7 +3146,7 @@ void bolt::affect_place_explosion_clouds()
             mg.set_summoned(summ, SPELL_FIRE_STORM, summ_dur(1), false, false);
 
             // Spell-summoned monsters need to have a live summoner.
-            if (summ == nullptr || !summ->alive())
+            if (summ == nullptr || !summ->alive_or_reviving())
             {
                 if (!source_name.empty())
                     mg.non_actor_summoner = source_name;

--- a/crawl-ref/source/death-curse.cc
+++ b/crawl-ref/source/death-curse.cc
@@ -218,7 +218,9 @@ static const vector<curse_effect> curse_effects = {
             // XXX: Passing a cached copy of a dead mummy will crash here if
             //      another monster is the victim, via behavior_event() since
             //      monster::mindex() is unsafe for copies.
-            torment_cell(target.pos(), source->alive() ? source : nullptr, TORMENT_MISCAST);
+            torment_cell(target.pos(),
+                         source->alive_or_reviving() ? source : nullptr,
+                         TORMENT_MISCAST);
         },
         0, 15,
     },

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -436,11 +436,8 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
     // monster mid-revival (since they're still actually supposed to be there).
     if (!defender->alive())
     {
-        if (defender->is_monster()
-            && (defender->as_monster()->flags & MF_PENDING_REVIVAL))
-        {
+        if (defender->alive_or_reviving())
             return true;
-        }
         else
         {
             die("%s trying to attack a dead %s", attacker->name(DESC_THE).c_str(),
@@ -571,7 +568,8 @@ bool fight_melee(actor *attacker, actor *defender, bool *did_hit, bool simu)
             for (adjacent_iterator i(attacker->pos()); i; ++i)
             {
                 if (*i == you.pos()
-                    && !mons_aligned(attacker, &you))
+                    && !mons_aligned(attacker, &you)
+                    && you.alive())
                 {
                     attacker->as_monster()->foe = MHITYOU;
                     attacker->as_monster()->target = you.pos();

--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -1277,7 +1277,7 @@ void shock_discharge_fineff::fire()
 
     bolt beam;
     beam.flavour = BEAM_ELECTRICITY;
-    const string name = serpent && serpent->alive() ?
+    const string name = serpent && serpent->alive_or_reviving() ?
                         serpent->name(DESC_A, true) :
                         "a shock serpent"; // dubious
     oppressor.hurt(serpent, final_dmg, beam.flavour, KILLED_BY_BEAM,

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -870,12 +870,12 @@ bool melee_attack::handle_phase_hit()
 
     // Fireworks when using Serpent's Lash to kill.
     if (!defender->alive()
-        && defender->as_monster()->has_blood()
+        && defender->has_blood()
         && wu_jian_has_momentum(wu_jian_attack))
     {
-        blood_spray(defender->pos(), defender->as_monster()->type,
-                    damage_done / 5);
-        defender->as_monster()->flags |= MF_EXPLODE_KILL;
+        blood_spray(defender->pos(), defender->type, damage_done / 5);
+        if (defender->is_monster())
+            defender->as_monster()->flags |= MF_EXPLODE_KILL;
     }
 
     // Trigger Curse of Agony after most normal damage is already applied
@@ -1208,8 +1208,11 @@ bool melee_attack::handle_phase_killed()
     if (execute)
         makhleb_execution_activate();
 
-    if (attacker->is_player() && you.form == transformation::werewolf)
+    if (attacker->is_player() && you.form == transformation::werewolf
+        && defender->is_monster())
+    {
         _handle_werewolf_kill_bonus(*defender->as_monster(), is_bestial_takedown);
+    }
 
     return killed;
 }

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1998,7 +1998,7 @@ static bool _leash_range_exceeded(const monster* mons)
         return false;
 
     actor* creator = actor_by_mid(mons->summoner);
-    return creator && creator->alive()
+    return creator && creator->alive_or_reviving()
            && grid_distance(creator->pos(), mons->pos()) > max_dist;
 }
 
@@ -3386,7 +3386,7 @@ bool mon_can_move_to_pos(const monster* mons, const coord_def& delta,
     if (leash_range > 0)
     {
         actor* creator = actor_by_mid(mons->summoner);
-        if (creator && creator->alive())
+        if (creator && creator->alive_or_reviving())
         {
             if (grid_distance(creator->pos(), mons->pos()) <= leash_range
                 && grid_distance(creator->pos(), targ) > leash_range)
@@ -3413,7 +3413,7 @@ bool mon_can_move_to_pos(const monster* mons, const coord_def& delta,
     if (mons->type == MONS_BATTLESPHERE || mons->type == MONS_RENDING_BLADE)
     {
         actor* creator = actor_by_mid(mons->summoner);
-        if (creator && creator->alive())
+        if (creator && creator->alive_or_reviving())
         {
             if (creator->see_cell_no_trans(mons->pos())
                 && !creator->see_cell_no_trans(targ))

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -1486,7 +1486,11 @@ static void _cast_beckoning_gale(monster &caster, mon_spell_slot, bolt&)
               BEAM_MISSILE, KILLED_BY_BEAM, "", "by a beckoning gale");
     _whack(caster, *foe);
 
-    if (foe->alive())
+    // XXX: It's a bit late now to call `apply_location_effects` for monster's
+    // that are pending revival as `hurt` likely already moved them and even
+    // if it didn't `apply_location_effects` would need fixing to handle them.
+    // Even the messaging for player's that are pending revival isn't good.
+    if (foe->alive() || (foe->is_player() && foe->alive_or_reviving()))
         foe->apply_location_effects(old_pos);
 }
 

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -1379,7 +1379,7 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
     {
         blame_prefix = "summoned by ";
 
-        if (mg.summoner != nullptr && mg.summoner->alive()
+        if (mg.summoner != nullptr && mg.summoner->alive_or_reviving()
             && mg.summoner->type == MONS_MARA)
         {
             blame_prefix = "woven by ";
@@ -1410,10 +1410,9 @@ static monster* _place_monster_aux(const mgen_data &mg, const monster *leader,
     // by the Fire Storm spell); a deceased summoner's mindex might also
     // be reused to create its summon, so make sure the summon doesn't
     // think it has summoned itself.
-    else if (mg.summoner != nullptr && mg.summoner->alive()
+    else if (mg.summoner != nullptr && mg.summoner->alive_or_reviving()
              && mg.summoner != mon)
     {
-        ASSERT(mg.summoner->alive());
         mon->summoner = mg.summoner->mid;
         if (mg.summoner->is_player())
             mons_add_blame(mon, blame_prefix + "the player character");

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4203,6 +4203,11 @@ bool monster::alive() const
     return hit_points > 0 && type != MONS_NO_MONSTER;
 }
 
+bool monster::alive_or_reviving() const
+{
+    return monster::alive() || testbits(flags, MF_PENDING_REVIVAL);
+}
+
 god_type monster::deity() const
 {
     return god;
@@ -5940,11 +5945,11 @@ void monster::react_to_damage(const actor *oppressor, int damage,
         if (owner && owner != oppressor && oppressor->mid != summoner)
         {
             int shared_damage = div_rand_round(damage*7,10);
-            if (shared_damage > 0)
+            if (shared_damage > 0 && owner->alive())
             {
                 if (owner->is_player())
                     mpr("Your spectral weapon shares its damage with you!");
-                else if (owner->alive() && you.can_see(*owner))
+                else if (you.can_see(*owner))
                 {
                     string buf = " shares ";
                     buf += owner->pronoun(PRONOUN_POSSESSIVE);

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -264,6 +264,7 @@ public:
     int      get_experience_level() const override;
     god_type deity() const override;
     bool     alive() const override;
+    bool     alive_or_reviving() const override;
     bool     defined() const { return alive(); }
     bool     swimming() const override;
     bool     swimming(bool energy_cost) const;

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -59,6 +59,11 @@ bool player::alive() const
 {
     // Simplistic, but if the player dies the game is over anyway, so
     // nobody can ask further questions.
+    return !crawl_state.game_is_arena() && !pending_revival;
+}
+
+bool player::alive_or_reviving() const
+{
     return !crawl_state.game_is_arena();
 }
 

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -623,6 +623,7 @@ public:
 
     god_type  deity() const override;
     bool      alive() const override;
+    bool      alive_or_reviving() const override;
     bool      is_summoned() const override { return false; };
     bool      was_created_by(int) const override { return false; };
     bool      was_created_by(const actor&, int = SPELL_NO_SPELL) const override

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -1203,7 +1203,7 @@ int torment_cell(coord_def where, actor *attacker, torment_source_type taux)
 {
     int damage = 0;
 
-    if (where == you.pos()
+    if (where == you.pos() && you.alive()
         // The Sceptre of Torment and pain card do not affect the user.
         && !(attacker && attacker->is_player()
             && (taux == TORMENT_SCEPTRE || taux == TORMENT_CARD_PAIN)))

--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1560,11 +1560,8 @@ spret cast_manifold_assault(actor& agent, int pow, bool fail, bool real,
 
         // Stop further attacks if we somehow died in the process.
         // (e.g. from riposte, spiny or injury mirror)
-        if (agent.is_player() && (you.hp <= 0 || you.pending_revival)
-            || agent.is_monster() && !agent.alive())
-        {
+        if (!agent.alive())
             break;
-        }
     }
 
     // Refund duration for catalyst, but only if we cast the spell.


### PR DESCRIPTION
Unlike monster's that count as dead while pending revival, the player counted as alive. This caused them to to receive attacks while dead, which usually didn't matter as most of the effects from the attacks were cleaned up when reviving. However, not all effects are cleared on reviving and you do end up with messages in the message log that don't make a log of sense for a dead character. Instead, count felids that are pending revival as dead and fix up any of the checks that should still affect them (or a monster) when pending revival.

Fixes #4845