### PR TITLE
Lore: Adjust description of the book of Transmutation.

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -430,9 +430,11 @@ being described.
 book of transmutation
 
 A meticulous compendium of research notes, filled with formulae for decomposing
-and reconstituting all manner of substances. The author appears to have had a
-strange obsession with becoming a spider, but even if their ultimate aim eluded
-them, many of the spells detailed therein are nonetheless quite practical.
+and reconstituting all manner of substances. It was written by one of the
+legendary alchemists among the sludge elves, before that species mysteriously
+vanished from the world. The author appears to have had a strange obsession with
+becoming a butterfly, but even if their ultimate aim eluded them, many of the
+spells detailed therein are nonetheless quite practical.
 %%%%
 book of the tundra
 


### PR DESCRIPTION
Make it reference now-gone sludge elves, since they were known as transmuters when both the species and the job existed in-game, and the book has Fulsome Fusillade in it, which is thematically similar to the now-gone Fulsome Distillation spell.

Also, at mumra's suggestion, replace the author's spider obsession with a butterfly obsession, since spider form is currently accessible via talisman, and butterfly form is not a thing at all.

[Another spellbook mentions the hill dwarves' civilisation being destroyed, so there's precedent for this.]