### PR TITLE
text: consider corrosion in some descriptions (#4885 and more)

### DIFF
--- a/crawl-ref/source/item-def.h
+++ b/crawl-ref/source/item-def.h
@@ -93,7 +93,8 @@ public:
 
     string name(description_level_type descrip, bool terse = false,
                 bool ident = false, bool with_inscription = true,
-                bool quantity_in_words = false) const;
+                bool quantity_in_words = false,
+                bool consider_corrosion = false) const;
     bool has_spells() const;
     bool cursed() const;
     colour_t get_colour() const;
@@ -155,7 +156,7 @@ public:
 
 private:
     string name_aux(description_level_type desc, bool terse, bool ident,
-                    bool with_inscription) const;
+                    bool with_inscription, bool consider_corrosion) const;
 
     colour_t randart_colour() const;
 

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -134,14 +134,16 @@ static string _item_inscription(const item_def &item)
 }
 
 string item_def::name(description_level_type descrip, bool terse, bool ident,
-                      bool with_inscription, bool quantity_in_words) const
+                      bool with_inscription, bool quantity_in_words,
+                      bool consider_corrosion) const
 {
     if (descrip == DESC_NONE)
         return "";
 
     ostringstream buff;
 
-    const string auxname = name_aux(descrip, terse, ident, with_inscription);
+    const string auxname = name_aux(descrip, terse, ident, with_inscription,
+                                    consider_corrosion);
 
     const bool startvowel     = is_vowel(auxname[0]);
     const bool qualname       = (descrip == DESC_QUALNAME);
@@ -1381,11 +1383,12 @@ static bool _use_basename(const item_def &item, description_level_type desc,
 /**
  * The plus-describing prefix to a weapon's name, including trailing space.
  */
-static string _plus_prefix(const item_def &weap)
+static string _plus_prefix(const item_def &weap, bool consider_corrosion = false)
 {
     if (is_unrandom_artefact(weap, UNRAND_WOE))
         return Options.char_set == CSET_ASCII ? "+inf " : "+\u221e "; // ∞
-    return make_stringf("%+d ", weap.plus);
+    return make_stringf("%+d ", weap.plus - (consider_corrosion ?
+                                             you.corrosion_amount() : 0));
 }
 
 /**
@@ -1450,11 +1453,12 @@ string weapon_brand_desc(const char *body, const item_def &weap,
  * @param ident         Whether the weapon should be named as if it were
  *                      identified.
  * @param inscr         Whether an inscription will be added later.
+ * @param corr          Whether to consider corrosion.
  * @return              A name for the weapon.
  *                      TODO: example
  */
 static string _name_weapon(const item_def &weap, description_level_type desc,
-                           bool terse, bool ident, bool inscr)
+                           bool terse, bool ident, bool inscr, bool corr)
 {
     const bool dbname   = (desc == DESC_DBNAME);
     const bool basename = _use_basename(weap, desc, ident);
@@ -1462,10 +1466,14 @@ static string _name_weapon(const item_def &weap, description_level_type desc,
 
     const bool identified = weap.is_identified();
 
-    const string curse_prefix = !dbname && !terse && weap.cursed() ? "cursed " : "";
-    const string plus_text = identified && !dbname && !qualname ? _plus_prefix(weap) : "";
-    const string chaotic = testbits(weap.flags, ISFLAG_CHAOTIC) ? "chaotic " : "";
-    const string replica = testbits(weap.flags, ISFLAG_REPLICA) ? "replica " : "";
+    const string curse_prefix = !dbname && !terse && weap.cursed() ?
+                                "cursed " : "";
+    const string plus_text = identified && !dbname && !qualname ?
+                             _plus_prefix(weap, corr) : "";
+    const string chaotic = testbits(weap.flags, ISFLAG_CHAOTIC) ?
+                           "chaotic " : "";
+    const string replica = testbits(weap.flags, ISFLAG_REPLICA) ?
+                           "replica " : "";
 
     if (is_artefact(weap) && !dbname)
     {
@@ -1530,7 +1538,7 @@ static string _name_weapon(const item_def &weap, description_level_type desc,
 // Note that "terse" is only currently used for the "in hand" listing on
 // the game screen.
 string item_def::name_aux(description_level_type desc, bool terse, bool ident,
-                          bool with_inscription) const
+                          bool with_inscription, bool consider_corrosion) const
 {
     // Shortcuts
     const int item_typ   = sub_type;
@@ -1556,7 +1564,8 @@ string item_def::name_aux(description_level_type desc, bool terse, bool ident,
     switch (base_type)
     {
     case OBJ_WEAPONS:
-        buff << _name_weapon(*this, desc, terse, ident, with_inscription);
+        buff << _name_weapon(*this, desc, terse, ident, with_inscription,
+                             consider_corrosion);
         break;
 
     case OBJ_MISSILES:

--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -3345,7 +3345,7 @@ string melee_attack::weapon_desc()
 {
     if (!weapon || !you.offhand_weapon())
         return "";
-    return " with " + weapon->name(DESC_YOUR, false, false, false);
+    return " with " + weapon->name(DESC_YOUR, false, false, false, false, true);
 }
 
 string melee_attack::charge_desc()

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1140,16 +1140,6 @@ static int _wpn_name_colour(const item_def &wpn)
     return LIGHTGREY;
 }
 
-static string _wpn_name_corroded(const item_def &weapon)
-{
-    if (!you.corrosion_amount() || weapon.base_type != OBJ_WEAPONS)
-        return weapon.name(DESC_PLAIN, true);
-
-    item_def wpn_copy = weapon;
-    wpn_copy.plus -= you.corrosion_amount();
-    return wpn_copy.name(DESC_PLAIN, true);
-}
-
 static void _print_unarmed_name()
 {
     textcolour(HUD_CAPTION_COLOUR);
@@ -1170,7 +1160,7 @@ static void _print_weapon_name(const item_def &weapon, int width)
     CPRINTF("%s", slot_name.c_str());
     textcolour(_wpn_name_colour(weapon));
     const int max_name_width = width - slot_name.size();
-    const string name = _wpn_name_corroded(weapon);
+    const string name = weapon.name(DESC_PLAIN, true, false, true, false, true);
     CPRINTF("%s", chop_string(name, max_name_width).c_str());
     textcolour(LIGHTGREY);
 }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -3457,7 +3457,7 @@ static void _display_damage_rating(const item_def *weapon)
 {
     string weapon_name;
     if (weapon)
-        weapon_name = weapon->name(DESC_YOUR);
+        weapon_name = weapon->name(DESC_YOUR, false, false, true, false, true);
     else
         weapon_name = "unarmed combat";
 

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -396,12 +396,14 @@ namespace quiver
                 menu_colour(weapon.name(DESC_PLAIN), prefix, "stats", false);
             if (!is_enabled())
                 qdesc.textcolour(DARKGREY);
+            else if (you.corrosion_amount())
+                qdesc.textcolour(RED);
             else if (prefcol != -1)
                 qdesc.textcolour(prefcol);
             else
                 qdesc.textcolour(LIGHTGREY);
 
-            qdesc += weapon.name(DESC_PLAIN, true);
+            qdesc += weapon.name(DESC_PLAIN, true, false, true, false, true);
             return qdesc;
         }
 

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1978,15 +1978,15 @@ static void _tag_construct_you_items(writer &th)
     // how many unique items?
     marshallUByte(th, MAX_UNRANDARTS);
     for (int j = 0; j < MAX_UNRANDARTS; ++j)
-        marshallByte(th,you.unique_items[j]);
+        marshallByte(th, you.unique_items[j]);
 
     marshallShort(th, NUM_WEAPONS);
     for (int j = 0; j < NUM_WEAPONS; ++j)
-        marshallInt(th,you.seen_weapon[j]);
+        marshallInt(th, you.seen_weapon[j]);
 
     marshallShort(th, NUM_ARMOURS);
     for (int j = 0; j < NUM_ARMOURS; ++j)
-        marshallInt(th,you.seen_armour[j]);
+        marshallInt(th, you.seen_armour[j]);
 
     _marshallFixedBitVector<NUM_MISCELLANY>(th, you.seen_misc);
     _marshallFixedBitVector<NUM_TALISMANS>(th, you.seen_talisman);
@@ -2040,7 +2040,7 @@ static void _tag_construct_you_dungeon(writer &th)
     // how many unique creatures?
     marshallShort(th, NUM_MONSTERS);
     for (int j = 0; j < NUM_MONSTERS; ++j)
-        marshallByte(th,you.unique_creatures[j]); // unique beasties
+        marshallByte(th, you.unique_creatures[j]); // unique beasties
 
     // how many branches?
     marshallByte(th, NUM_BRANCHES);

--- a/crawl-ref/source/wiz-fsim.cc
+++ b/crawl-ref/source/wiz-fsim.cc
@@ -109,19 +109,15 @@ static string _equipped_weapon_name(bool show_prefix)
 
     if (iweap)
     {
-        if (show_prefix)
-            return "Wielding: " + iweap->name(DESC_PLAIN);
-        else
-            return iweap->name(DESC_PLAIN);
+        return show_prefix ? "Wielding: " : "" +
+               iweap->name(DESC_PLAIN, false, false, true, false, true);
     }
 
     if (missile != -1 && you.inv[missile].defined()
                 && you.inv[missile].base_type == OBJ_MISSILES)
     {
-        if (show_prefix)
-            return "Quivering: " + you.inv[missile].name(DESC_PLAIN);
-        else
-            return you.inv[missile].name(DESC_PLAIN);
+        return show_prefix ? "Quivering: " : "" +
+               you.inv[missile].name(DESC_PLAIN);
     }
 
     return "Unarmed";


### PR DESCRIPTION
The idea is: if the description cares about the weapon you are wielding *now* and your current status, take corrosion into account (e.g. damage rating, hit chance); if the description only cares about your *possession* of the weapon, don't (e.g. inventory, wielding/unwielding message). Sorry for my unfamiliarity to the crawl codebase if I happen to miss out some occurrences.

A brief summary:
* describe.cc: consider corrosion in damage rating (rating may be less than 0 if heavily corroded, but since damage can never be negative, we want a non-negative value here) and when describing hit chance (although it doesn't affect the number)

* item-def.h: adjust declaration accordingly

* item-name.cc: add parameters regarding corrosion

* melee-attack.cc: consider corrosion when notifying which weapon did what on Coglins

* output.cc: remove unused function

* player.cc: consider corrosion in damage rating

* quiver.cc: make corroded quiver red; consider corrosion in quivered weapon (#4885)

* tags.cc: irrelevant; noticed these when randomly browsing the code

* wiz-fsim.cc: consider corrosion when describing the weapon used in fsim; use ternary operators

Closes #4885 and #5181.