### PR TITLE
Fix Vaults:4 down stairs description (acrobat3)

### DIFF
--- a/crawl-ref/source/dat/dlua/layout/hyper_place.lua
+++ b/crawl-ref/source/dat/dlua/layout/hyper_place.lua
@@ -427,11 +427,5 @@ function hyper.place.restore_stairs(results, usage_grid, options)
     table.remove(stairs,i)
   end
 
-  if you.depth() == 4 then
-    e.set_feature_name("stone_stairs_down_i", "metal staircase leading down")
-    e.set_feature_name("stone_stairs_down_ii", "metal staircase leading down")
-    e.set_feature_name("stone_stairs_down_iii", "metal staircase leading down")
-  end
-
   return true
 end

--- a/crawl-ref/source/dat/dlua/v_rooms.lua
+++ b/crawl-ref/source/dat/dlua/v_rooms.lua
@@ -433,12 +433,6 @@ function place_vaults_rooms(e, data, room_count, options)
   -- Useful to see what's going on when things are getting veto'd:
   if _VAULTS_DEBUG then dump_usage_grid(data) end
 
-  if you.depth() == 4 then
-    e.set_feature_name("stone_stairs_down_i", "metal staircase leading down")
-    e.set_feature_name("stone_stairs_down_ii", "metal staircase leading down")
-    e.set_feature_name("stone_stairs_down_iii", "metal staircase leading down")
-  end
-
   return true
 end
 

--- a/crawl-ref/source/directn.h
+++ b/crawl-ref/source/directn.h
@@ -367,7 +367,7 @@ string feature_description(dungeon_feature_type grid,
                            trap_type trap = NUM_TRAPS,
                            const string & cover_desc = "",
                            description_level_type dtype = DESC_A,
-                           branch_type branch = you.where_are_you);
+                           level_id place = level_id::current());
 
 vector<dungeon_feature_type> features_by_desc(const base_pattern &pattern);
 


### PR DESCRIPTION
We were trying to override the description for stone down stairs in Vaults:4 to be metal stairs in the layout code for Vaults. However, the vaults placed by the layout have their own set of overrides which are used instead. Instead of trying to use vault description overrides, special case stone down stairs in `_base_feature_desc` similar to what we do for rock walls in Pandemonium.

Fixes #4896