### PR TITLE
fix: Faulty feedback when paralyzing sleeping enemies  (qwarkbark)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -1962,11 +1962,9 @@ void bolt::apply_bolt_paralysis(monster* mons)
 {
     if (mons->paralysed() || mons->stasis())
         return;
-    // asleep monsters can still be paralysed (and will be always woken by
-    // trying to resist); the message might seem wrong but paralysis is
-    // always visible.
+
     if (!mons->is_firewood()
-        && simple_monster_message(*mons, " suddenly stops moving!"))
+        && simple_monster_message(*mons, " cannot move!"))
     {
         obvious_effect = true;
     }


### PR DESCRIPTION
You would get "Nothing appears to happen" which sounds like a failure message. Code comments indicate that "monster stops moving!" was the intended paralysis message even for sleeping targets. That intention was broken years later when mons_is_immotile checked if the monster was sleeping or petrified.

https://tavern.dcss.io/t/paralysis-wand-and-status-check-minor-bug/1468