### PR TITLE
Change solo tentacles only to attack targets in our LoS

### DIFF
--- a/crawl-ref/source/mon-tentacle.cc
+++ b/crawl-ref/source/mon-tentacle.cc
@@ -623,6 +623,9 @@ static void _collect_foe_positions(monster *mons,
 {
     coord_def foe_pos(-1, -1);
     actor * foe = mons->get_foe();
+    // We put the foe in the vector first, though note that the
+    // pathfinding algorithm that uses this don't actually care about
+    // the order, so in fact tentacles ignore their foe.
     if (foe && sight_check(foe))
     {
         foe_positions.push_back(mons->get_foe()->pos());
@@ -708,6 +711,12 @@ void move_solo_tentacle(monster* tentacle)
         _collect_foe_positions(tentacle, foe_positions,
                 [tentacle, base_position](const actor *test) -> bool
                 {
+                    if (tentacle->friendly()
+                        && !you.see_cell_no_trans(test->pos()))
+                    {
+                        // Friendly tentacles should only attack in our LoS.
+                        return false;
+                    }
                     return test->visible_to(tentacle)
                         && cell_see_cell(base_position, test->pos(),
                                          LOS_SOLID_SEE);


### PR DESCRIPTION
This fixes a rather annoying behaviour where malign gateway will attack monsters out of our LoS, if they are closer than monsters in our LoS.

This happens because tentacles ignore their foe, instead targetting the nearest enemy to their current head.

This has multiple consequences for eldritch tentacles. At least:
- Tentacles ignore commands and other normal source of ally targets.
- As above, tentacles can go out of LoS.

It is unclear how much of this is intended. _collect_foe_positions *seems* to want to prioritise the foe by adding it first in the array, but it then pathfinding doesn't actually use the order.

This commit is a minimal fix to the LoS issue, that does not change the "ignores commands" behaviour. One could instead change tentacles to actually care about their foes, and then special case foe selection for malign gateways if we want to keep "ignore commands".