### PR TITLE
Fix IMB uselessness check

### DIFF
--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1747,6 +1747,9 @@ bool spell_no_hostile_in_range(spell_type spell)
     case SPELL_SCORCH:
         return find_near_hostiles(range, false, you).empty();
 
+    case SPELL_ISKENDERUNS_MYSTIC_BLAST:
+        return find_near_hostiles(range, false, you).empty();
+
     case SPELL_ANGUISH:
         for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
         {


### PR DESCRIPTION
Fixes the case where we want to cast IMB with a friendly monster between ourself and a hostile one; this should be a warning not a useless cast.