### PR TITLE
Make spell name lookup prefer spells that exist

### DIFF
--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -151,6 +151,7 @@ bool spell_can_be_enkindled(spell_type spell);
 bool is_monster_net_escape_spell(spell_type spell);
 
 bool spell_removed(spell_type spell);
+bool spell_is_monster_only(spell_type spell);
 #if TAG_MAJOR_VERSION == 34
 bool spell_was_form(spell_type spell);
 #endif

--- a/crawl-ref/source/wiz-you.cc
+++ b/crawl-ref/source/wiz-you.cc
@@ -191,7 +191,7 @@ void wizard_memorise_spec_spell()
         }
     }
 
-    if (get_spell_flags(static_cast<spell_type>(spell)) & spflag::monster)
+    if (spell_is_monster_only(static_cast<spell_type>(spell)))
         mpr("Spell is monster-only - unpredictable behaviour may result.");
     if (!learn_spell(static_cast<spell_type>(spell), true))
         crawl_state.cancel_cmd_repeat();


### PR DESCRIPTION
This makes it easier to memorise Freezing Cloud in wizmode, for example.