### PR TITLE
Stop stationary monsters pathfinding

### DIFF
--- a/crawl-ref/source/mon-pathfind.cc
+++ b/crawl-ref/source/mon-pathfind.cc
@@ -109,6 +109,9 @@ bool monster_pathfind::init_pathfind(const monster* mon, coord_def dest,
         return true;
     }
 
+    if (mon->is_stationary())
+        return false;
+
     return start_pathfind(msg);
 }
 


### PR DESCRIPTION
This is causing a bug where you can't rest behind a translucent wall from a stationary monster.