### PR TITLE
Don't update colour animations more than once per turn

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -170,7 +170,7 @@ static void _zap_animation(int colour, const monster* mon = nullptr,
     if (in_los_bounds_v(drawp))
     {
 #ifdef USE_TILE
-        view_add_tile_overlay(p, tileidx_zap(colour));
+        view_add_tile_overlay(p, tileidx_zap(colour, p));
 #endif
         view_add_glyph_overlay(p, {dchar_glyph(DCHAR_FIRED_ZAP),
                                    static_cast<unsigned short>(colour)});
@@ -224,7 +224,7 @@ static void _ench_animation(int flavour, const monster* mon, bool force)
         break;
     }
 
-    _zap_animation(element_colour(elem), mon, force);
+    _zap_animation(element_colour(elem, mon->pos()), mon, force);
 }
 
 // If needs_tracer is true, we need to check the beam path for friendly
@@ -813,11 +813,11 @@ void bolt::draw(const coord_def& p, bool force_refresh)
 #ifdef USE_TILE
     // Set default value if none specified.
     if (tile_beam == 0)
-        tile_beam = tileidx_zap(colour);
+        tile_beam = tileidx_zap(colour, p);
     view_add_tile_overlay(p, vary_bolt_tile(tile_beam, source, target, p));
 #endif
-    const unsigned short c = colour == BLACK ? random_colour(true)
-                                             : element_colour(colour);
+    colour_t adjusted_colour = colour == BLACK ? ETC_RANDOM : colour;
+    const unsigned short c = element_colour(adjusted_colour, p);
     view_add_glyph_overlay(p, {glyph, c});
 
     // If reduce_animations is set, the redraw is unnecessary and
@@ -7202,12 +7202,12 @@ bool bolt::explosion_draw_cell(const coord_def& p)
                 if (tile_beam != 0)
                     tile_explode = tile_beam;
                 else
-                    tile_explode = tileidx_zap(colour);
+                    tile_explode = tileidx_zap(colour, p);
             }
             view_add_tile_overlay(p, vary_bolt_tile(tile_explode, source, target, p));
 #endif
-            const unsigned short c = colour == BLACK ?
-                    random_colour(true) : element_colour(colour, false, p);
+            colour_t adjusted_colour = colour == BLACK ? ETC_RANDOM : colour;
+            const unsigned short c = element_colour(adjusted_colour, p, false);
             view_add_glyph_overlay(p, {dchar_glyph(DCHAR_EXPLOSION), c});
 
             return true;

--- a/crawl-ref/source/colour.h
+++ b/crawl-ref/source/colour.h
@@ -91,7 +91,7 @@ struct base_colour_calc
 protected:
     int rand_max {120}; // 0-119 is the range of randomness promised to
                         // Lua colour functions.
-    int rand(bool non_random) const;
+    int rand(bool non_random, coord_def pos) const;
 };
 
 
@@ -116,20 +116,19 @@ const string colour_to_str(colour_t colour, bool human_readable=false);
 
 void init_element_colours();
 void add_element_colour(base_colour_calc *colour);
-colour_t random_colour(bool ui_rand = false);
+colour_t random_colour();
 colour_t random_uncommon_colour();
 bool is_low_colour(colour_t colour) IMMUTABLE;
 bool is_high_colour(colour_t colour) IMMUTABLE;
 colour_t make_low_colour(colour_t colour) IMMUTABLE;
 colour_t make_high_colour(colour_t colour) IMMUTABLE;
-int  element_colour(int element, bool no_random = false,
-                    const coord_def& loc = coord_def());
+int element_colour(int element, coord_def loc, bool no_random = false);
 int get_disjunct_phase(const coord_def& loc);
 bool get_orb_phase(const coord_def& loc);
 int dam_colour(const monster_info&);
 colour_t rune_colour(int type);
 
 // Applies ETC_ colour substitutions
-unsigned real_colour(unsigned raw_colour, const coord_def& loc = coord_def());
+unsigned real_colour(unsigned raw_colour, const coord_def& loc);
 
 string colourize_str(string base, colour_t col);

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -360,7 +360,7 @@ static cglyph_t _get_ray_glyph(const coord_def& pos, int colour, int glych,
         colour = mcol;
     }
     return {static_cast<char32_t>(glych),
-            static_cast<unsigned short>(real_colour(colour))};
+            static_cast<unsigned short>(real_colour(colour, pos))};
 }
 
 // Unseen monsters in shallow water show a "strange disturbance".

--- a/crawl-ref/source/l-colour.cc
+++ b/crawl-ref/source/l-colour.cc
@@ -32,7 +32,7 @@ int lua_element_colour_calc::get(const coord_def& loc, bool non_random) const
     lua_State *ls = dlua.state();
 
     function.push();
-    lua_pushinteger(ls, rand(non_random));
+    lua_pushinteger(ls, rand(non_random, loc));
     lua_pushinteger(ls, loc.x);
     lua_pushinteger(ls, loc.y);
     if (!dlua.callfn(nullptr, 3, 1))

--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -815,7 +815,7 @@ static MenuEntry* _cloud_menu_gen(char letter, const string &str, string &key)
     cloud_struct fake_cloud;
     fake_cloud.type = cloud;
     fake_cloud.decay = 1000;
-    me->colour = element_colour(get_cloud_colour(fake_cloud));
+    me->colour = element_colour(get_cloud_colour(fake_cloud), fake_cloud.pos);
 
     cloud_info fake_cloud_info;
     fake_cloud_info.type = cloud;

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -738,7 +738,8 @@ static void _print_stats_equip(int x, int y)
                 {
                     const item_def& item = entries[i].get_item();
                     cglyph_t g = get_item_glyph(item);
-                    g.col = element_colour(g.col, !Options.animate_equip_bar);
+                    g.col = element_colour(g.col, you.pos(),
+                                           !Options.animate_equip_bar);
                     formatted_string::parse_string(glyph_to_tagstr(g)).display();
                 }
             }
@@ -1873,9 +1874,9 @@ static void _print_next_monster_desc(const vector<monster_info>& mons,
 
             monster_info mi = mons[start];
 #ifdef TARGET_OS_WINDOWS
-            textcolour(real_colour(dam_colour(mi) | COLFLAG_ITEM_HEAP));
+            textcolour(real_colour(dam_colour(mi) | COLFLAG_ITEM_HEAP, mi.pos));
 #else
-            textcolour(real_colour(dam_colour(mi) | COLFLAG_REVERSE));
+            textcolour(real_colour(dam_colour(mi) | COLFLAG_REVERSE, mi.pos));
 #endif
             CPRINTF(" ");
             textbackground(BLACK);

--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -613,7 +613,7 @@ cglyph_t get_mons_glyph(const monster_info& mi)
 
     g.ch = mons_char(stype);
     g.col = _get_mons_colour(mi);
-    g.col = real_colour(g.col);
+    g.col = real_colour(g.col, mi.pos);
     return g;
 }
 

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -1404,7 +1404,7 @@ static bool _init_frag_grid(frag_effect &effect,
    else
    {
        effect.colour = element_colour(get_feature_def(grid).colour(),
-                                     false, target);
+                                     target, false);
    }
     return true;
 }

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -433,7 +433,8 @@ static void _rune_effect(dungeon_feature_type ftype)
 
         mprf("You insert the %s rune into the lock.", rune_type_name(runes[2]));
 #ifdef USE_TILE_LOCAL
-        view_add_tile_overlay(you.pos(), tileidx_zap(rune_colour(runes[2])));
+        view_add_tile_overlay(you.pos(), tileidx_zap(rune_colour(runes[2]),
+                                                     you.pos()));
         viewwindow(false);
         update_screen();
 #else

--- a/crawl-ref/source/tilemcache.cc
+++ b/crawl-ref/source/tilemcache.cc
@@ -1715,16 +1715,19 @@ mcache_demon::mcache_demon(const monster_info& minf)
     const uint32_t seed = hash32(&minf.mname[0], minf.mname.size());
 
     m_demon.head = tile_player_coloured(TILEP_DEMON_HEAD,
-                                        element_colour(minf.colour()))
+                                        element_colour(minf.colour(),
+                                                       minf.pos))
         + hash_with_seed(tile_player_count(TILEP_DEMON_HEAD), seed, 1);
     m_demon.body = tile_player_coloured(TILEP_DEMON_BODY,
-                                        element_colour(minf.colour()))
+                                        element_colour(minf.colour(),
+                                                       minf.pos))
         + hash_with_seed(tile_player_count(TILEP_DEMON_BODY), seed, 2);
 
     if (minf.is(MB_AIRBORNE))
     {
         m_demon.wings = tile_player_coloured(TILEP_DEMON_WINGS,
-                                             element_colour(minf.colour()))
+                                             element_colour(minf.colour(),
+                                                            minf.pos))
             + hash_with_seed(tile_player_count(TILEP_DEMON_WINGS), seed, 3);
     }
     else

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -944,7 +944,7 @@ void apply_variations(const tile_flavour &flv, tileidx_t *bg,
     }
     else if ((tile == TILE_SHOALS_SHALLOW_WATER
               || tile == TILE_SHOALS_DEEP_WATER)
-             && element_colour(ETC_WAVES, 0, gc) == LIGHTCYAN)
+             && element_colour(ETC_WAVES, gc, false) == LIGHTCYAN)
     {
         tile = tile + 6 + flv.special % 6;
     }
@@ -3955,7 +3955,7 @@ tileidx_t vary_bolt_tile(tileidx_t tile, int dir, int dist)
     }
 }
 
-tileidx_t tileidx_zap(int colour)
+tileidx_t tileidx_zap(int colour, coord_def pos)
 {
     switch (colour)
     {
@@ -3963,7 +3963,7 @@ tileidx_t tileidx_zap(int colour)
         colour = YELLOW;
         break;
     default:
-        colour = element_colour(colour);
+        colour = element_colour(colour, pos);
         break;
     }
 

--- a/crawl-ref/source/tilepick.h
+++ b/crawl-ref/source/tilepick.h
@@ -56,7 +56,7 @@ tileidx_t tileidx_bolt(const bolt &bolt);
 tileidx_t vary_bolt_tile(tileidx_t tile, const coord_def& origin,
                          const coord_def& target, const coord_def& pos);
 tileidx_t vary_bolt_tile(tileidx_t tile, int dir = 0, int dist = 0);
-tileidx_t tileidx_zap(int colour);
+tileidx_t tileidx_zap(int colour, coord_def pos);
 tileidx_t tileidx_spell(const spell_type spell);
 tileidx_t tileidx_skill(const skill_type skill, int train);
 tileidx_t tileidx_command(const command_type cmd);

--- a/crawl-ref/source/util/monster/monster-main.cc
+++ b/crawl-ref/source/util/monster/monster-main.cc
@@ -53,7 +53,7 @@ static int bgr[8] = {0, 4, 2, 6, 1, 5, 3, 7};
 static string colour(int colour, string text, bool bg = false)
 {
     if (_is_element_colour(colour))
-        colour = element_colour(colour, true);
+        colour = element_colour(colour, coord_def(), true);
 
     if (isatty(1))
     {

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -981,7 +981,7 @@ void view_update_at(const coord_def &pos)
     int cell_colour =
         flash_colour &&
         (mons == MONS_NO_MONSTER || mons_class_is_firewood(mons))
-            ? real_colour(flash_colour)
+            ? real_colour(flash_colour, pos)
             : g.col;
 
     const coord_def vp = grid2view(pos);
@@ -1212,7 +1212,7 @@ static void _draw_player(screen_cell_t *cell,
 #endif
         cell->colour |= COLFLAG_REVERSE;
 
-    cell->colour = real_colour(cell->colour);
+    cell->colour = real_colour(cell->colour, gc);
 
 #ifdef USE_TILE
     cell->tile.fg = tileidx_player();
@@ -1564,7 +1564,7 @@ void flash_tile(coord_def p, colour_t colour, int delay, tileidx_t tile)
         if (tile > 0)
             view_add_tile_overlay(p, vary_bolt_tile(tile));
         else
-            view_add_tile_overlay(p, tileidx_zap(colour));
+            view_add_tile_overlay(p, tileidx_zap(colour, p));
 #else
         UNUSED(tile);
 #endif
@@ -1754,7 +1754,7 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
 #ifdef USE_TILE
     if (you.duration[DUR_BLIND] && you.see_cell(gc))
     {
-        cell->flash_colour = real_colour(you.props[BLIND_COLOUR_KEY].get_int());
+        cell->flash_colour = real_colour(you.props[BLIND_COLOUR_KEY].get_int(), gc);
         // Using a square curve for the alpha is nicer on the eyes than a straight multiple.
         // The effect of alpha is already disproportionate depending on the flash colour
         // and may need to be revised: for a white flash the effect is already extreme by
@@ -1770,10 +1770,10 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
         if (!you.see_cell(gc))
             cell->colour = DARKGREY;
         else if (gc != you.pos() && allow_mon_recolour)
-            cell->colour = real_colour(flash_colour);
+            cell->colour = real_colour(flash_colour, gc);
 #ifdef USE_TILE
         if (you.see_cell(gc)) {
-            cell->flash_colour = real_colour(flash_colour);
+            cell->flash_colour = real_colour(flash_colour, gc);
             cell->flash_alpha = 0;
         }
 #endif

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -1431,7 +1431,7 @@ static cglyph_t _get_feat_glyph(const coord_def& gc)
     }
     else
         col = fdef.seen_colour();
-    g.col = real_colour(col);
+    g.col = real_colour(col, gc);
     return g;
 }
 #endif


### PR DESCRIPTION
We were updating some colour animations whenever we redrew the screen. This was okay for console were this mainly only happens when you press a key. However, this doesn't work well in tiles as moving the mouse while in a menu or targeting causes a whole bunch of redraws. Due to the way we cache tiles and only sometimes invalidate to cache, this wasn't always noticeable, however, animated blindness colours and after commit 6dfb6d6 animated floor tiles would appear to rapidly animate.