### PR TITLE
Fix crash (null pointer dereference) in _ench_animation (issue #4926)

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -224,7 +224,8 @@ static void _ench_animation(int flavour, const monster* mon, bool force)
         break;
     }
 
-    _zap_animation(element_colour(elem, mon->pos()), mon, force);
+    coord_def loc = mon ? mon->pos() : you.pos();
+    _zap_animation(element_colour(elem, loc), mon, force);
 }
 
 // If needs_tracer is true, we need to check the beam path for friendly


### PR DESCRIPTION
Fix for crash reported in issue #4926 
Check mon is not null before calling mon->pos()