### PR TITLE
Don't chaos lace or fire champion derived undead.

### DIFF
--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -1618,6 +1618,7 @@ static monster* _ignis_champion_target()
             || !mons_can_use_stairs(*mon, DNGN_STONE_STAIRS_DOWN_I)
             || mon->is_stationary()
             || mon->wont_attack()
+            || mons_is_zombified(*mon)
             // no stealing another god's pals :P
             || mon->is_priest()
             || mon->god != GOD_NO_GOD)

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -185,6 +185,7 @@ bool trap_def::is_safe(actor* act) const
 // or draining attacks. They also need attacks that aren't already chaos brand.
 bool chaos_lace_criteria (monster* mon) {
     return mons_has_attacks(*mon) && !(mon->is_peripheral())
+            && !(mons_is_zombified(*mon))
             && !(mon->is_holy()) && !(is_good_god(mon->god))
             && (mons_attack_spec(*mon, 0, true).flavour != AF_CHAOTIC);
 }


### PR DESCRIPTION
These statuses were not functional, so don't bother trying. 
Fixes #4279.