### PR TITLE
Preview attack delay in equip (SentientSupper)

### DIFF
--- a/crawl-ref/source/actor.h
+++ b/crawl-ref/source/actor.h
@@ -101,7 +101,8 @@ public:
     }
     virtual item_def *offhand_weapon() const { return nullptr; }
     virtual random_var attack_delay(const item_def *projectile = nullptr,
-                                    bool rescale = true) const = 0;
+                                    bool rescale = true,
+                                    bool ignore_temporary = false) const = 0;
     virtual int has_claws(bool allow_tran = true) const = 0;
     virtual item_def *shield() const = 0;
     virtual item_def *body_armour() const = 0;

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1841,21 +1841,22 @@ static string _equipment_switchto_string(const item_def &item)
 static string _equipment_property_change_description(const item_def &item,
                                                      bool remove = false)
 {
-    // First, test if there is any AC/EV/SH change at all.
+    // First, test if there is any status change at all.
     const int cur_ac = you.base_ac(100);
     const int cur_ev = you.evasion_scaled(100, true);
     const int cur_sh = player_displayed_shield_class(100, true);
-    int new_ac, new_ev, new_sh;
+    const int cur_ad = player_displayed_attack_delay(true);
+    int new_ac, new_ev, new_sh, new_ad;
     FixedVector<int, MAX_KNOWN_SPELLS> cur_fail, new_fail;
     for (int i = 0; i < MAX_KNOWN_SPELLS; ++i)
         cur_fail[i] = raw_spell_fail(you.spells[i]);
 
     if (remove)
-        you.preview_stats_without_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_fail);
+        you.preview_stats_without_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_fail, &new_ad);
     else if (item.base_type == OBJ_TALISMANS)
-        you.preview_stats_in_specific_form(100, item, &new_ac, &new_ev, &new_sh, &new_fail);
+        you.preview_stats_in_specific_form(100, item, &new_ac, &new_ev, &new_sh, &new_fail, &new_ad);
     else
-        you.preview_stats_with_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_fail);
+        you.preview_stats_with_specific_item(100, item, &new_ac, &new_ev, &new_sh, &new_fail, &new_ad);
 
     // Check if any spell failures changed, and save the greatest magnitude that
     // any of them changed.
@@ -1943,23 +1944,30 @@ static string _equipment_property_change_description(const item_def &item,
         }
     }
 
+    // Only display attack delay line with non-weapons
+    if (item.base_type != OBJ_WEAPONS && cur_ad != new_ad)
+    {
+        description += "\nYour attack delay would "
+                       + _describe_point_diff(cur_ad * 10, new_ad * 10) + ".";
+    }
+
     return description;
 }
 
 static string _spell_fail_change_description(const item_def &item,
                                              bool remove = false)
 {
-    int dummy1, dummy2, dummy3;
+    int dummy1, dummy2, dummy3, dummy4;
     FixedVector<int, MAX_KNOWN_SPELLS> cur_fail, new_fail;
     for (int i = 0; i < MAX_KNOWN_SPELLS; ++i)
         cur_fail[i] = raw_spell_fail(you.spells[i]);
 
     if (remove)
-        you.preview_stats_without_specific_item(100, item, &dummy1, &dummy2, &dummy3, &new_fail);
+        you.preview_stats_without_specific_item(100, item, &dummy1, &dummy2, &dummy3, &new_fail, &dummy4);
     else if (item.base_type == OBJ_TALISMANS)
-        you.preview_stats_in_specific_form(100, item, &dummy1, &dummy2, &dummy3, &new_fail);
+        you.preview_stats_in_specific_form(100, item, &dummy1, &dummy2, &dummy3, &new_fail, &dummy4);
     else
-        you.preview_stats_with_specific_item(100, item, &dummy1, &dummy2, &dummy3, &new_fail);
+        you.preview_stats_with_specific_item(100, item, &dummy1, &dummy2, &dummy3, &new_fail, &dummy4);
 
     // Check if any spell failures changed.
     int fail_change = 0;

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -437,7 +437,8 @@ vorpal_damage_type monster::damage_type(int which_attack)
  *                    and the given projectile, in aut.
  */
 random_var monster::attack_delay(const item_def *projectile,
-                                 bool /*rescale*/) const
+                                 bool /*rescale*/,
+                                 bool /*ignore_temporary*/) const
 {
     const item_def* weap = weapon();
     if (!weap || (projectile && is_throwable(this, *projectile)))

--- a/crawl-ref/source/monster.h
+++ b/crawl-ref/source/monster.h
@@ -283,7 +283,8 @@ public:
     brand_type  damage_brand(int which_attack = -1) override;
     vorpal_damage_type damage_type(int which_attack = -1) override;
     random_var  attack_delay(const item_def *projectile = nullptr,
-                             bool rescale = true) const override;
+                             bool rescale = true,
+                             bool ignore_temporary = false) const override;
     int         has_claws(bool allow_tran = true) const override;
 
     int wearing(object_class_type obj_type, int sub_type,

--- a/crawl-ref/source/player-act.cc
+++ b/crawl-ref/source/player-act.cc
@@ -226,10 +226,12 @@ brand_type player::damage_brand(int)
  *                   attack delay. It can be casted to an int, in which case
  *                   its value is determined by the appropriate rolls.
  */
-random_var player::attack_delay(const item_def *projectile, bool rescale) const
+random_var player::attack_delay(const item_def *projectile, bool rescale,
+                                bool ignore_temporary) const
 {
     const item_def *primary = weapon();
-    const random_var primary_delay = attack_delay_with(projectile, rescale, primary);
+    const random_var primary_delay = attack_delay_with(projectile, rescale, primary,
+                                        ignore_temporary);
     if (projectile && !is_launcher_ammo(*projectile))
         return primary_delay; // throwing doesn't use the offhand
 
@@ -242,12 +244,13 @@ random_var player::attack_delay(const item_def *projectile, bool rescale) const
     }
 
     // re-use of projectile is very dubious here
-    const random_var offhand_delay = attack_delay_with(projectile, rescale, offhand);
+    const random_var offhand_delay = attack_delay_with(projectile, rescale, offhand,
+                                        ignore_temporary);
     return div_rand_round(primary_delay + offhand_delay, 2);
 }
 
 random_var player::attack_delay_with(const item_def *projectile, bool rescale,
-                                     const item_def *weap) const
+                                     const item_def *weap, bool ignore_temporary) const
 {
     // The delay for swinging non-weapons and tossing non-missiles.
     random_var attk_delay(15);
@@ -268,7 +271,7 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         const skill_type wpn_skill = SK_THROWING;
         const int projectile_delay = 10 + property(*projectile, PWPN_DAMAGE) / 2;
         attk_delay = random_var(projectile_delay);
-        attk_delay -= div_rand_round(random_var(you.skill(wpn_skill, 10)),
+        attk_delay -= div_rand_round(random_var(you.skill(wpn_skill, 10, false, !ignore_temporary)),
                                      DELAY_SCALE);
 
         // apply minimum to weapon skill modification
@@ -278,7 +281,7 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
     else if (unarmed_attack)
     {
         int sk = form_uses_xl() ? experience_level * 10 :
-                                  skill(SK_UNARMED_COMBAT, 10);
+                                  skill(SK_UNARMED_COMBAT, 10, false, !ignore_temporary);
         attk_delay = random_var(10) - div_rand_round(random_var(sk), 27*2);
     }
     else if (melee_weapon_attack || ranged_weapon_attack)
@@ -286,7 +289,7 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         const skill_type wpn_skill = item_attack_skill(*weap);
         // Cap skill contribution to mindelay skill, so that rounding
         // doesn't make speed brand benefit from higher skill.
-        const int wpn_sklev = min(you.skill(wpn_skill, 10),
+        const int wpn_sklev = min(you.skill(wpn_skill, 10, false, !ignore_temporary),
                                   10 * weapon_min_delay_skill(*weap));
 
         attk_delay = random_var(property(*weap, PWPN_SPEED));
@@ -319,7 +322,7 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         attk_delay += div_rand_round(random_var(aevp), DELAY_SCALE);
     }
 
-    if (you.duration[DUR_FINESSE])
+    if (you.duration[DUR_FINESSE] && !ignore_temporary)
     {
         ASSERT(!you.duration[DUR_BERSERK]);
         // Finesse shouldn't stack with Haste, so we make this attack take
@@ -329,7 +332,10 @@ random_var player::attack_delay_with(const item_def *projectile, bool rescale,
         attk_delay = div_rand_round(attk_delay, 2);
     }
 
-    return rv::max(div_rand_round(attk_delay * player_speed(), BASELINE_DELAY),
+    if (ignore_temporary)
+        return rv::max(attk_delay,random_var(1));
+    else
+        return rv::max(div_rand_round(attk_delay * player_speed(), BASELINE_DELAY),
                    random_var(1));
 }
 

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -650,9 +650,11 @@ public:
     brand_type  damage_brand(int which_attack = -1) override;
     vorpal_damage_type damage_type(int which_attack = -1) override;
     random_var  attack_delay(const item_def *projectile = nullptr,
-                             bool rescale = true) const override;
+                             bool rescale = true,
+                             bool ignore_temporary = false) const override;
     random_var  attack_delay_with(const item_def *projectile, bool rescale,
-                                  const item_def *weapon) const;
+                                  const item_def *weapon,
+                                  bool ignore_temporary = false) const;
     int         constriction_damage(constrict_type typ) const override;
 
     int       has_claws(bool allow_tran = true) const override;
@@ -913,13 +915,16 @@ public:
     // given item, along with the fail rate on all their known spells.
     void preview_stats_with_specific_item(int scale, const item_def& new_item,
                                           int *ac, int *ev, int *sh,
-                                          FixedVector<int, MAX_KNOWN_SPELLS> *fail);
+                                          FixedVector<int, MAX_KNOWN_SPELLS> *fail,
+                                          int *ad);
     void preview_stats_without_specific_item(int scale, const item_def& item_to_remove,
                                              int *ac, int *ev, int *sh,
-                                             FixedVector<int, MAX_KNOWN_SPELLS> *fail);
+                                             FixedVector<int, MAX_KNOWN_SPELLS> *fail,
+                                             int *ad);
     void preview_stats_in_specific_form(int scale, const item_def& talisman,
                                         int *ac, int *ev, int *sh,
-                                        FixedVector<int, MAX_KNOWN_SPELLS> *fail);
+                                        FixedVector<int, MAX_KNOWN_SPELLS> *fail,
+                                        int *ad);
 
     bool wearing_light_armour(bool with_skill = false) const;
     int  skill(skill_type skill, int scale = 1, bool real = false,
@@ -1057,6 +1062,8 @@ int player_armour_shield_spell_penalty();
 int player_armour_stealth_penalty();
 
 int player_movement_speed(bool check_terrain = true, bool temp = true);
+
+int player_displayed_attack_delay(bool ignore_temporary);
 
 int player_icemail_armour_class();
 int player_condensation_shield_class();


### PR DESCRIPTION
Updated for the past ~2 years of changes and fixed some bugs. It may be better to expand the existing armour skill delay message to unworn equipment instead.

Closes #3715.