### PR TITLE
Added talismans to autopickup documentation in options_guide.txt

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -578,7 +578,7 @@ one_SDL_sound_channel = false
 3-a     Picking up and Dropping.
 --------------------------------
 
-autopickup = $?!+"/♦
+autopickup = $?!+%"/♦
         The above is the default list. The valid symbols are
         )       Weapons
         (       Missiles


### PR DESCRIPTION
I'm finally sitting down to write my own RC file, and I had to verify and validate this, and it is in fact %, and it works.  

I'm going through the entire options_guide, so there may be more PRs but I figured it was easiest to just send the simple one liner first to establish the process.