### PR TITLE
In Lua 5.4, coroutines need to be explicitly loaded.

### DIFF
--- a/crawl-ref/source/clua.cc
+++ b/crawl-ref/source/clua.cc
@@ -798,6 +798,7 @@ void CLua::init_lua()
         {LUA_TABLIBNAME, luaopen_table},
         {LUA_STRLIBNAME, luaopen_string},
         {LUA_MATHLIBNAME, luaopen_math},
+        {LUA_COLIBNAME, luaopen_coroutine},  // Required for macro system
     };
 
     for (auto l : lua_core_libs)


### PR DESCRIPTION
It is necessary to explicitly load the coroutine library here; otherwise, due to the isolation between the _dlua_ and _clua_ environments, macros with user-bound custom functions will fail.
@gammafunk 