### PR TITLE
Rework specifying tile weights

### DIFF
--- a/crawl-ref/source/rltiles/dc-feat.txt
+++ b/crawl-ref/source/rltiles/dc-feat.txt
@@ -2,7 +2,6 @@
 %prefix TILE
 %startvalue TILE_WALL_MAX wall
 
-%weight 10
 %sdir dngn/trees
 tree1 DNGN_TREE
 tree2
@@ -334,7 +333,6 @@ statue_zot_oldest_guardian
 %syn DNGN_STATUE_ZOT_OLDEST_GUARDIAN
 
 # damaged statues
-%weight 1
 crumbled_column_1 DNGN_CRUMBLED_COLUMN
 crumbled_column_2
 crumbled_column_3
@@ -412,7 +410,6 @@ mystic_cage_2
 ## magical conduits for themed magic branches, portals, vaults
 ## conj, hex, summ / tloc, necro, alch, fire, ice, air, earth
 
-%weight 1
 arcane_conduit_0 ARCANE_CONDUIT
 arcane_conduit_1
 arcane_conduit_2
@@ -847,6 +844,7 @@ cache_of_fruit_0 DNGN_CACHE_OF_FRUIT
 cache_of_fruit_1
 %weight 10
 cache_of_fruit_2
+%weight 10
 cache_of_meat_0 DNGN_CACHE_OF_MEAT
 %weight 3
 %syn DNGN_CACHE_OF_PIZZA

--- a/crawl-ref/source/rltiles/dc-floor.txt
+++ b/crawl-ref/source/rltiles/dc-floor.txt
@@ -289,6 +289,7 @@ swamp1
 swamp2
 swamp3
 
+%weight 3
 salt0 FLOOR_SALT
 %weight 2
 salt1
@@ -298,7 +299,6 @@ salt3
 salt4
 %weight 5
 salt5
-%weight 10
 
 %weight 20
 spider00 FLOOR_SPIDER
@@ -317,7 +317,6 @@ spider09
 %weight 1
 spider10
 spider11
-%weight 3
 
 tomb0 FLOOR_TOMB
 tomb1
@@ -973,6 +972,7 @@ zot_diamonds5
 zot_diamonds6
 zot_diamonds7
 
+%weight 10
 iron0 FLOOR_IRON
 %weight 1
 iron1
@@ -1152,6 +1152,7 @@ studio7
 studio8
 studio9
 
+%weight 3
 cage0 FLOOR_CAGE
 cage1
 cage2

--- a/crawl-ref/source/rltiles/dc-wall.txt
+++ b/crawl-ref/source/rltiles/dc-wall.txt
@@ -35,7 +35,6 @@ brick_dark_2_5
 brick_dark_2_6
 brick_dark_2_7
 
-%weight 5
 brick_dark_2_8 WALL_BRICK_DARK_2_TORCH
 brick_dark_2_9
 brick_dark_2_10
@@ -77,7 +76,6 @@ brick_dark_4_13
 brick_dark_4_14
 brick_dark_4_15
 
-%weight 10
 brick_dark_4_8 WALL_BRICK_DARK_4_TORCH
 brick_dark_4_9
 brick_dark_4_10
@@ -127,7 +125,6 @@ brick_dark_6_17
 brick_dark_6_18
 brick_dark_6_19
 
-%weight 15
 brick_dark_6_12 WALL_BRICK_DARK_6_TORCH
 brick_dark_6_13
 brick_dark_6_14
@@ -654,7 +651,6 @@ stone_mossy1
 %weight 3
 stone_mossy2
 stone_mossy3
-%weight 10
 
 # sss (snakeishly)
 %weight 10
@@ -672,6 +668,7 @@ snake8
 %weight 10
 snake9
 
+%weight 10
 wall_stone_snake0 STONE_WALL_SNAKE
 %weight 3
 wall_stone_snake1
@@ -721,7 +718,6 @@ wall_stone_spider1
 wall_stone_spider2
 wall_stone_spider3
 
-%weight 10
 slime0 WALL_SLIME
 slime1
 slime2
@@ -872,6 +868,7 @@ vault1
 vault2
 vault3
 
+%weight 1
 vault_stone00 STONE_WALL_VAULT
 vault_stone01
 vault_stone02
@@ -911,6 +908,7 @@ vaults-crystal1
 vaults-crystal2
 vaults-crystal3
 
+%weight 1
 rock_wall_crypt0 ROCK_WALL_CRYPT
 %weight 2
 rock_wall_crypt1
@@ -932,8 +930,8 @@ crypt6
 crypt7
 crypt8
 crypt9
-%weight 10
 
+%weight 10
 crypt-metal0 WALL_CRYPT_METAL
 %weight 2
 crypt-metal1
@@ -941,7 +939,6 @@ crypt-metal2
 crypt-metal3
 crypt-metal4
 
-%weight 10
 tomb0 WALL_TOMB
 tomb1
 tomb2
@@ -977,7 +974,6 @@ wall_metal_depths_leafy1
 wall_metal_depths_leafy2
 wall_metal_depths_leafy3
 
-%weight 10
 crystal_wall_depths_0 WALL_DEPTHS_CRYSTAL
 crystal_wall_depths_1
 crystal_wall_depths_2
@@ -1519,6 +1515,7 @@ wall_stone_pyre3
 wall_stone_pyre4
 
 # Cocytus tiles.
+%weight 9
 ice_wall0 WALL_ICE
 ice_wall1
 ice_wall2
@@ -1585,7 +1582,6 @@ wall_oozing1
 %weight 4
 wall_oozing2
 wall_oozing3
-%weight 10
 
 # Ossuaries.
 wall_stone_ossuary0 STONE_WALL_OSSUARY
@@ -1635,6 +1631,7 @@ lab-stone3
 lab-stone4
 lab-stone5
 
+%weight 1
 lab-metal0 WALL_LAB_METAL
 %weight 2
 lab-metal1
@@ -1684,7 +1681,6 @@ stone_black_marked4
 stone_black_marked5
 stone_black_marked6
 stone_black_marked7
-%weight 1
 stone_black_marked8
 
 # Zonguldrok's Shrine.
@@ -1713,7 +1709,6 @@ workshop3
 workshop2b
 workshop3b
 
-%weight 10
 bmaus_stone_wall0 WALL_BORG_STONE
 bmaus_stone_wall1
 bmaus_stone_wall2
@@ -2016,7 +2011,6 @@ catacombs12
 catacombs13
 catacombs14
 catacombs15
-%weight 10
 
 beehives0 WALL_WAX
 beehives1

--- a/crawl-ref/source/rltiles/tool/tile_list_processor.h
+++ b/crawl-ref/source/rltiles/tool/tile_list_processor.h
@@ -61,6 +61,7 @@ protected:
     tile* m_texture;
     vector<variation> m_variations;
     int m_weight;
+    bool m_weight_has_been_used;
     double m_alpha;
     int m_domino;
 

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -938,15 +938,8 @@ void apply_variations(const tile_flavour &flv, tileidx_t *bg,
         return;
     }
 
-    if (tile == TILE_DNGN_PORTAL_WIZARD_LAB
-             || tile == TILE_DNGN_EXIT_NECROPOLIS
-             || tile == TILE_DNGN_TRAP_HARLEQUIN)
-    {
-        tile = tile + flv.special % tile_dngn_count(tile);
-    }
-    else if ((tile == TILE_SHOALS_SHALLOW_WATER
-              || tile == TILE_SHOALS_DEEP_WATER)
-             && element_colour(ETC_WAVES, gc, false) == LIGHTCYAN)
+    if ((tile == TILE_SHOALS_SHALLOW_WATER || tile == TILE_SHOALS_DEEP_WATER)
+         && element_colour(ETC_WAVES, gc, false) == LIGHTCYAN)
     {
         tile = tile + 6 + flv.special % 6;
     }


### PR DESCRIPTION
When defining a group of tiles, you can use %weight commends to set the weight of tiles defined after it so that when picking a tile from the group different tiles have different chances of being picked. However, when we want all the tiles in a group to have the same weight we don't use any %weight command and the weight is left at whatever it was last set to. This leads to two problems, first, our handling of weights isn't perfect so we don't have an equal chance of picking tiles of a group that all have equal weights and higher weights make this worse. Second, cycling animations require the weights to all be one for tiles in the group and we were often special cases the tile picking for these tile groups as a result.

To fix these problems, reset the weight back to one every time we define a new tile group and add a %weight command to the start of the few tile groups that were relying on a weight set in a previous group.