### PR TITLE
Prevent concussion player movement when in tree form

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -692,6 +692,8 @@ void melee_attack::handle_concussion_brand()
     if (did_move && !is_projected && !cleaving && !never_cleave
         && wu_jian_attack != WU_JIAN_ATTACK_WHIRLWIND
         && wu_jian_attack != WU_JIAN_ATTACK_WALL_JUMP
+        && (attacker->is_player()
+            && you.form != transformation::tree)
         && adjacent(attacker->pos(), old_pos))
     {
         schedule_trample_follow_fineff(attacker, old_pos);


### PR DESCRIPTION
I noticed during gameplay that I could move around in tree form while having a concussion weapon. I don't think that's intended, is it? This is my first PR to dcss, let me know if there's anything I should address.