### PR TITLE
Add messages for firing without anything quivered

### DIFF
--- a/crawl-ref/source/l-you.cc
+++ b/crawl-ref/source/l-you.cc
@@ -1381,8 +1381,7 @@ LUAFN(you_status)
  */
 LUAFN(you_quiver_valid)
 {
-    PLUARET(boolean, !you.quiver_action.is_empty()
-                   && you.quiver_action.get()->is_valid());
+    PLUARET(boolean, !quiver::is_empty());
 }
 
 /*** Is your quivered action enabled?
@@ -1391,8 +1390,7 @@ LUAFN(you_quiver_valid)
  */
 LUAFN(you_quiver_enabled)
 {
-    PLUARET(boolean, !you.quiver_action.is_empty()
-                   && you.quiver_action.get()->is_enabled());
+    PLUARET(boolean, quiver::get_secondary_action()->is_enabled());
 }
 
 /*** Does your quivered action use MP?

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1934,13 +1934,13 @@ static void _handle_autofight(command_type cmd, command_type prev_cmd)
 
     if (cmd == CMD_AUTOFIRE)
     {
-        auto a = quiver::get_secondary_action();
-        if (!a || !a->is_valid())
+        if (quiver::is_empty())
         {
-            mpr("Nothing quivered!"); // Can this happen?
+            mpr("Nothing quivered!");
             return;
         }
 
+        auto a = quiver::get_secondary_action();
         const bool secondary_enabled = a->is_enabled();
 
         // Some quiver actions need to be triggered directly. Disabled quiver

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -66,6 +66,13 @@ static vector<string> _desc_hit_chance(const monster_info &mi)
 
 namespace quiver
 {
+    formatted_string _empty_quiver_string(bool short_desc)
+    {
+        return formatted_string::parse_string(
+            short_desc ? "<darkgrey>Empty</darkgrey>"
+                       : "<darkgrey>Nothing quivered</darkgrey>");
+    }
+
     static bool _quiver_inscription_ok(int slot)
     {
         if (slot < 0 || slot >= ENDOFPACK || !you.inv[slot].defined())
@@ -138,11 +145,9 @@ namespace quiver
         return af_hp_check || af_mp_check;
     }
 
-    formatted_string action::quiver_description(bool short_desc) const
+    formatted_string action::valid_quiver_description(bool short_desc) const
     {
-        return formatted_string::parse_string(
-                        short_desc ? "<darkgrey>Empty</darkgrey>"
-                                   : "<darkgrey>Nothing quivered</darkgrey>");
+        return _empty_quiver_string(short_desc);
     }
 
     vector<tile_def> action::get_tiles() const
@@ -372,11 +377,8 @@ namespace quiver
             return "fire";
         }
 
-        formatted_string quiver_description(bool short_desc=false) const override
+        formatted_string valid_quiver_description(bool short_desc=false) const override
         {
-            if (!is_valid())
-                return action::quiver_description(short_desc);
-
             formatted_string qdesc;
             const item_def &weapon = *get_launcher();
 
@@ -475,11 +477,8 @@ namespace quiver
                 return "hit"; // could use more subtype flavor Vs?
         }
 
-        formatted_string quiver_description(bool short_desc=false) const override
+        formatted_string valid_quiver_description(bool short_desc=false) const override
         {
-            if (!is_valid())
-                return action::quiver_description(short_desc);
-
             formatted_string qdesc;
             const item_def *weapon = you.weapon();
 
@@ -801,12 +800,8 @@ namespace quiver
                                         && you.inv[item_slot].defined();
         }
 
-        formatted_string quiver_description(bool short_desc) const override
+        formatted_string valid_quiver_description(bool ) const override
         {
-            // TODO: generalize this code
-            if (!is_valid())
-                return action::quiver_description(short_desc);
-
             formatted_string qdesc;
 
             const item_def& quiver = you.inv[item_slot];
@@ -911,12 +906,9 @@ namespace quiver
             you.m_quiver_history.on_item_fired(you.inv[item_slot]);
         }
 
-        virtual formatted_string quiver_description(bool short_desc) const override
+        virtual formatted_string valid_quiver_description(bool short_desc) const override
         {
             ASSERT_RANGE(item_slot, -1, ENDOFPACK);
-            // or error?
-            if (!is_valid())
-                return action::quiver_description(short_desc);
 
             formatted_string qdesc;
 
@@ -1185,11 +1177,8 @@ namespace quiver
             return { tile_def(get_spell_tile(spell)) };
         }
 
-        formatted_string quiver_description(bool short_desc) const override
+        formatted_string valid_quiver_description(bool ) const override
         {
-            if (!is_valid())
-                return action::quiver_description(short_desc);
-
             formatted_string qdesc;
 
             qdesc.textcolour(Options.status_caption_colour);
@@ -1480,11 +1469,8 @@ namespace quiver
             t = target; // copy back, in case they are different
         }
 
-        formatted_string quiver_description(bool short_desc) const override
+        formatted_string valid_quiver_description(bool ) const override
         {
-            if (!is_valid())
-                return action::quiver_description(short_desc);
-
             formatted_string qdesc;
 
             qdesc.textcolour(Options.status_caption_colour);
@@ -2368,6 +2354,16 @@ namespace quiver
     }
 
     /**
+     * Return whether the quiver is empty.
+     *
+     * @return whether if the quiver is empty.
+     */
+    bool is_empty()
+    {
+        return you.quiver_action.is_empty();
+    }
+
+    /**
      * Return an action corresponding to a spell.
      *
      * @param spell the spell to use
@@ -2894,7 +2890,13 @@ namespace quiver
         // involved to support that, but for now that project is too
         // impractical, because each code path (except throwing) is called from
         // many places.
+        if (is_empty())
+        {
+            mpr("Nothing quivered!");
+            return;
+        }
         shared_ptr<action> initial = get();
+
         clear_messages(); // this kind of looks better as a force clear, but
                           // for consistency with direct targeting commands,
                           // I will leave it as non-force

--- a/crawl-ref/source/quiver.h
+++ b/crawl-ref/source/quiver.h
@@ -24,6 +24,8 @@ namespace quiver
 {
     void reset_state();
 
+    formatted_string _empty_quiver_string(bool short_desc);
+
     struct action : public enable_shared_from_this<action>
     {
         action()
@@ -53,6 +55,9 @@ namespace quiver
 
         virtual void invalidate() { }
         virtual bool is_enabled() const { return false; }
+        // Whether this can be quivered. If false, this being the quivered
+        // action is equivalent to nothing being quivered at all (which can
+        // happen e.g. if the action runs out of ammo).
         virtual bool is_valid() const { return true; }
         virtual bool is_targeted() const { return false; }
         bool do_inscription_check() const;
@@ -75,7 +80,13 @@ namespace quiver
 
         virtual vector<tile_def> get_tiles() const;
 
-        virtual formatted_string quiver_description(bool short_desc=false) const;
+        virtual formatted_string valid_quiver_description(bool short_desc=false) const;
+        virtual formatted_string quiver_description(bool short_desc=false) const
+        {
+            return is_valid() ? valid_quiver_description(short_desc)
+                              : _empty_quiver_string(short_desc);
+
+        };
         virtual string quiver_verb() const { return ""; } // currently only for items
 
         // basically noops for this class, but keep `target` clean
@@ -115,6 +126,7 @@ namespace quiver
     shared_ptr<action> ability_to_action(ability_type abil);
     shared_ptr<action> get_primary_action();
     shared_ptr<action> get_secondary_action();
+    bool is_empty();
     void set_needs_redraw();
 
     bool anything_to_quiver();
@@ -128,7 +140,10 @@ namespace quiver
         void load(const string key);
 
         shared_ptr<action> get() const;
-        virtual bool is_empty() const { return *current == action(); }
+        virtual bool is_empty() const
+        {
+            return *current == action() || !current->is_valid();
+        }
         bool spell_is_quivered(spell_type s) const;
         bool item_is_quivered(const item_def &item);
         bool item_is_quivered(int item_slot) const;


### PR DESCRIPTION
Fixes some code which intended to give a message when autofiring without a quivered action, and adds the same message for CMD_FIRE.

Also tidy up quiver_description code to commonise a validity check, and improve the consistency of how l-you.cc quiver functions work.