### PR TITLE
Remove fuzz_invis_tracer

### DIFF
--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -413,7 +413,6 @@ private:
     // methods to change the path
     void bounce();
     void reflect();
-    bool fuzz_invis_tracer();
 public:
     void choose_ray();
 


### PR DESCRIPTION
This updated the tracer target. This did almost nothing; the target is not persisted because undo_tracer reverts the update, and the ray being traced was not changed. There's a possibility it was having more subtle effects, like changing when the ray stopped or whether it thinks it passed its target, but if so these were almost certainly unintended and unreliable, so it's hard to see how they could matter.

We keep the other thing this function did, which was check whether the monster is targetting somewhere near the player.