### PR TITLE
fix: missing newline in spell descriptions

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4194,6 +4194,7 @@ static string _player_spell_stats(const spell_type spell)
     if (!crawl_state.need_save
         || (get_spell_flags(spell) & spflag::monster))
     {
+        description += "\n";
         return description; // all other info is player-dependent
     }
 


### PR DESCRIPTION
When viewing spell descriptions from the main menu, there was a missing newline when the description ended early. If the spell had a quote, a string of underscores would be appended to the spell school instead of on a new line.

<img width="731" height="250" alt="image" src="https://github.com/user-attachments/assets/75b9c206-1c05-4e6e-8eba-1a39a3d5798d" />
