### PR TITLE
Display non-integer values for EV and AC in forms

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -2055,7 +2055,8 @@ static int _player_aux_evasion_penalty(const int scale)
     return piece_armour_evasion_penalty * scale / 10;
 }
 
-// Long-term player flat EV bonuses/penalties (eg: evasion rings, EV mutations, forms)
+// Long-term player flat integer EV bonuses/penalties (eg: evasion rings, EV
+// mutations). This does not include forms as they provide fractional EV.
 static int _player_base_evasion_modifiers()
 {
     int evbonus = 0;
@@ -2079,12 +2080,6 @@ static int _player_base_evasion_modifiers()
     // transformation penalties/bonuses not covered by size alone:
     if (you.get_mutation_level(MUT_SLOW_REFLEXES))
         evbonus -= you.get_mutation_level(MUT_SLOW_REFLEXES) * 5;
-
-    // Consider this a 'permanent' bonus, since players in forms will often
-    // remain in that form for a long time. This is slightly untrue for
-    // hostile polymorph, however I don't think any of them affect the player's
-    // EV in this manner (tree form simply caps it in the same way as paralysis)
-    evbonus += get_form()->ev_bonus();
 
     return evbonus;
 }
@@ -2193,6 +2188,7 @@ static int _player_evasion(int final_scale, bool ignore_temporary)
         - you.adjusted_body_armour_penalty(scale)
         - you.adjusted_shield_penalty(scale)
         - _player_aux_evasion_penalty(scale)
+        + get_form()->ev_bonus() // Comes pre-scaled by a factor of 100.
         + _player_base_evasion_modifiers() * scale;
 
     if (you.form == transformation::statue)

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -294,9 +294,20 @@ int Form::get_ac_bonus(int skill) const
     return max(0, scaling_value(ac, skill, false, 1));
 }
 
+
+/**
+ * What EV bonus does the player get while in this form?
+ *
+ * @param level The shapeshifting skill level to calculate this bonus for.
+ *              (Default is -1, meaning 'Use the player's current skill')
+ *
+ * @return  The EV bonus currently granted by the form, multiplied by 100 to
+ *          allow for pseudo-decimal flexibility and to match the scale used
+ *          in the player evasion calculation.
+ */
 int Form::ev_bonus(int skill) const
 {
-    return max(0, scaling_value(ev, skill));
+    return max(0, scaling_value(ev, skill, false, 1));
 }
 
 /**


### PR DESCRIPTION
Display fractional EV and AC gains from forms; these already provide randomly rounded bonuses, but we were displaying them rounded down.

This tweaks how EV scaling in forms works so that it is randomly rounded in the main EV calculation rather than in the form itself.

Also, allow variable numbers of decimal places in such displays - most want 1, but regeneration wants 2.