### PR TITLE
Make Brom's Barrelling Boulder autotarget

### DIFF
--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -3770,7 +3770,7 @@ static const struct spell_desc spelldata[] =
     spflag::target | spflag::not_self,
     4,
     100,
-    1, 1,
+    LOS_RADIUS, LOS_RADIUS,
     0,
     TILEG_BOULDER,
 },


### PR DESCRIPTION
By changing its range. This should have no other effect except changing the displayed range.

The true range of BBB is a matter for philosophers; displaying  LoS-radius is consistent with OOD, which is another sphere-summoning spell with projectiles that can go to LoS and beyond.