### PR TITLE
Clarified tile_layout_priority

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -2602,14 +2602,12 @@ tile_layout_priority = command, spell, monster
         This option allows you to move the tabs from the inventory window into
         their own lines.  These lines will always be placed below the minimap
         and above the inventory, in the reverse order of the config.  
-        On small resolution, there won't be enough room for everything, so only
-        the first items will be placed. The inventory tab will always be placed 
-        below these fields but is initialised at a minimum size (4 lines).
-        Placed tabs may override the inventory tab on smaller resolutions, and will
-        have priority over it such that inventory may not be able to expand to 
-        its maximum size (6 lines). The possible options are: 
-        abilities, commands, memorisation, monsters, navigation, skills, spells,
-        system commands
+        The inventory tab will always be placed below these fields, initialised
+        at a minimum size (4 lines). Placed tabs may override the inventory tab
+        on smaller resolutions, and will have priority over it such that 
+        inventory may not be able to expand to its maximum size (6 lines). 
+        The possible options are: abilities, commands, memorisation, monsters,
+        navigation, skills, spells, system commands
 
 tile_display_mode = (tiles | glyphs | hybrid)
         Controls how the dungeon is rendered. You can use normal tiles (default)


### PR DESCRIPTION
The current description in the options_text of tile_layout_priority is highly misleading.  

It implies that you are able to modify the entire side bar, but because of how the interface is cobbled together, that is not at all what it does. Instead the minimap/inventory fields don't actually DO anything, they are static containers, and the only thing this actually does it pull the tabs OUT of the inventory pane and place them above.  Also its in reverse order from bottom to top for some reason.  

I re-wrote the description to more accurately affect the extant reality.  

Here is the original for reference 

    tile_layout_priority = minimap, inventory, command, spell, monster
        (Ordered list option)
        This option allows you to control the order in which elements are
        placed on the right of the screen, below the stat area. On small
        resolution, there won't be enough room for everything, so only the
        first items will be placed. You can also remove items you don't want
        to be permanently displayed. The inventory tab will always be placed at
        the bottom but is initialised at a minimum size (4 lines). If you put a
        tab before it on the option line, the tab will still be placed above it,
        but it will have priority over it so the inventory might not be able to
        expand to its maximum size (6 lines). The minimap is always placed
        between the stat area and the tabs. The memorisation and skill tabs can
        be added to the list too, but are not by default. The possible options
        are: abilities, commands, inventory, memorisation, minimap, monsters,
        navigation, skills, spells, system commands


<img width="747" height="563" alt="screenshot_2025-12-22-155328" src="https://github.com/user-attachments/assets/cbfc28d0-8922-4ae2-b2d4-91238ee21426" />

And this is a representation of the RC line:
```tile_layout_priority = memorisation, monster, navigation, skills, system commands, commands, abilities, spells```  

This exhibits the behavior that is present, and makes it clear what is going on, I think?  


I update it to  
```
    tile_layout_priority = command, spell, monster
        (Ordered list option)
        This option allows you to move the tabs from the inventory window into
        their own lines.  These lines will always be placed below the minimap
        and above the inventory, in the reverse order of the config.  
        The inventory tab will always be placed below these fields, initialised
        at a minimum size (4 lines). Placed tabs may override the inventory tab
        on smaller resolutions, and will have priority over it such that 
        inventory may not be able to expand to its maximum size (6 lines). 
        The possible options are: abilities, commands, memorisation, monsters,
        navigation, skills, spells, system commands
```