### PR TITLE
Fix: prompt handling of mouse clicks on yes/no popups issue #4968

### DIFF
--- a/crawl-ref/source/prompt.cc
+++ b/crawl-ref/source/prompt.cc
@@ -238,7 +238,7 @@ int yesno(const char *str, bool allow_lowercase, int default_answer, bool clear_
                 if (actual_key != EOF && actual_key > UCHAR_MAX)
                     actual_key = tmp;
 
-                if (isalpha(actual_key) && actual_key != tmp)
+                if (isaalpha(actual_key) && actual_key != tmp)
                     tmp = actual_key;
                 // otherwise, leave as ESCAPE
             }


### PR DESCRIPTION
A bug was causing mouse clicks on yes/no popups to be ignored on Windows. Root cause: negative mouse keycodes (for example CK_MOUSE_B1 == -9997) were sometimes passed to C library character functions (such as isalpha/toupper). Those functions are defined only for EOF or values representable as unsigned char; passing negative non-EOF values invokes undefined behaviour and corrupted the prompt logic. The fix replaces use of the C library character test with the project’s ASCII-only helper [isaalpha] when checking popup input. Using [isaalpha] avoids invoking undefined behaviour on negative keycodes and ensures mouse clicks are correctly accepted. This change only replaces the character test; no other logic was changed. Verified locally on Windows 10.