### PR TITLE
Fix digging targetters leaking diggability

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2974,7 +2974,7 @@ bool bolt::can_affect_wall(const coord_def& p, bool map_knowledge) const
 
     // digging might affect unseen squares, as far as the player knows
     if (map_knowledge && flavour == BEAM_DIGGING &&
-                                        !env.map_knowledge(pos()).seen())
+                                        !env.map_knowledge(p).seen())
     {
         return true;
     }

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -618,7 +618,7 @@ bool targeter_dig::valid_aim(coord_def a)
         {
             possible_squares_affected = 0;
             for (auto p : path_taken)
-                if (beam.can_affect_wall(p) ||
+                if (beam.can_affect_wall(p, true) ||
                         in_bounds(p) && env.map_knowledge(p).feat() == DNGN_UNSEEN)
                 {
                     possible_squares_affected++;
@@ -665,7 +665,7 @@ aff_type targeter_dig::is_affected(coord_def loc)
         {
             if (!cell_is_solid(pc))
                 current = AFF_TRACER;
-            else if (!beam.can_affect_wall(pc))
+            else if (!beam.can_affect_wall(pc, true))
             {
                 current = AFF_TRACER; // show tracer at the barrier cell
                 hit_barrier = true;
@@ -2439,7 +2439,7 @@ aff_type targeter_mortar::is_affected(coord_def loc)
         // mmapped walls.
         if (in_bounds(pc) && env.map_knowledge(pc).feat() != DNGN_UNSEEN)
         {
-            if (cell_is_solid(pc) && !beam.can_affect_wall(pc)
+            if (cell_is_solid(pc) && !beam.can_affect_wall(pc, true)
                 || (monster_at(pc) && you.can_see(*monster_at(pc))
                     && !beam.ignores_monster(monster_at(pc))))
             {


### PR DESCRIPTION
This affected walls which had been revealed by revelation.

The change to can_affect_wall is a no-op for other callers, who all have p = pos() if they use map_knowledge.

Fixes #4509, although that issue claims it doesn't affect digging.