### PR TITLE
Make revelation reveal most squares exactly.

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -2974,7 +2974,7 @@ bool bolt::can_affect_wall(const coord_def& p, bool map_knowledge) const
 
     // digging might affect unseen squares, as far as the player knows
     if (map_knowledge && flavour == BEAM_DIGGING &&
-                                        !env.map_knowledge(pos()).seen())
+                                        !env.map_knowledge(p).known())
     {
         return true;
     }

--- a/crawl-ref/source/feature.cc
+++ b/crawl-ref/source/feature.cc
@@ -236,43 +236,14 @@ const feature_def &get_feature_def(dungeon_feature_type feat)
  */
 dungeon_feature_type magic_map_base_feat(dungeon_feature_type feat)
 {
-    switch (feat)
-    {
-        case DNGN_ENDLESS_SALT:
-            return DNGN_FLOOR;
-        case DNGN_OPEN_SEA:
-        case DNGN_LAVA_SEA:
-            return DNGN_SHALLOW_WATER;
-        case DNGN_DECORATIVE_FLOOR:
-            return DNGN_DECORATIVE_FLOOR;
-        default:
-            break;
-    }
-
     const feature_def& fdef = get_feature_def(feat);
     switch (fdef.dchar)
     {
-    case DCHAR_STATUE:
-        return DNGN_GRANITE_STATUE;
-    case DCHAR_FLOOR:
-        return DNGN_FLOOR;
-    case DCHAR_WAVY:
-        return DNGN_SHALLOW_WATER;
     case DCHAR_ARCH:
         return DNGN_UNKNOWN_PORTAL;
-    case DCHAR_FOUNTAIN:
-        return DNGN_FOUNTAIN_BLUE;
-    case DCHAR_WALL:
-        // special-case vaults walls because the vast majority of vaults walls
-        // are stone, and the rock walls look totally different
-        if (you.where_are_you == BRANCH_VAULTS)
-            return DNGN_STONE_WALL;
-        else
-            return DNGN_ROCK_WALL;
     case DCHAR_ALTAR:
         return DNGN_UNKNOWN_ALTAR;
     default:
-        // We could do more, e.g. map the different upstairs together.
         return feat;
     }
 }

--- a/crawl-ref/source/losparam.cc
+++ b/crawl-ref/source/losparam.cc
@@ -122,7 +122,7 @@ opacity_type opacity_no_actor::operator()(const coord_def& p) const
 opacity_type opacity_excl::operator()(const coord_def& p) const
 {
     map_cell& cell = env.map_knowledge(p);
-    if (!cell.seen())
+    if (!cell.known())
         return OPC_CLEAR;
     else if (!cell.changed())
         return feat_is_opaque(env.grid(p)) ? OPC_OPAQUE : OPC_CLEAR;

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -618,7 +618,7 @@ bool targeter_dig::valid_aim(coord_def a)
         {
             possible_squares_affected = 0;
             for (auto p : path_taken)
-                if (beam.can_affect_wall(p) ||
+                if (beam.can_affect_wall(p, true) ||
                         in_bounds(p) && env.map_knowledge(p).feat() == DNGN_UNSEEN)
                 {
                     possible_squares_affected++;
@@ -665,7 +665,7 @@ aff_type targeter_dig::is_affected(coord_def loc)
         {
             if (!cell_is_solid(pc))
                 current = AFF_TRACER;
-            else if (!beam.can_affect_wall(pc))
+            else if (!beam.can_affect_wall(pc, true))
             {
                 current = AFF_TRACER; // show tracer at the barrier cell
                 hit_barrier = true;
@@ -2439,7 +2439,7 @@ aff_type targeter_mortar::is_affected(coord_def loc)
         // mmapped walls.
         if (in_bounds(pc) && env.map_knowledge(pc).feat() != DNGN_UNSEEN)
         {
-            if (cell_is_solid(pc) && !beam.can_affect_wall(pc)
+            if (cell_is_solid(pc) && !beam.can_affect_wall(pc, true)
                 || (monster_at(pc) && you.can_see(*monster_at(pc))
                     && !beam.ignores_monster(monster_at(pc))))
             {

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1309,11 +1309,8 @@ void tileidx_out_of_los(tileidx_t *fg, tileidx_t *bg, tileidx_t *cloud, const co
 
     const map_cell &cell = env.map_knowledge(gc);
 
-    // Override terrain for magic mapping.
-    if (!cell.seen() && env.map_knowledge(gc).mapped())
-        *bg = tileidx_feature_base(cell.feat());
-    else
-        *bg = mem_bg;
+    // Set unseen flag.
+    *bg = mem_bg;
     *bg |= tileidx_unseen_flag(gc);
 
     // Override foreground for monsters/items

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -1101,11 +1101,6 @@ void tile_draw_map_cell(const coord_def& gc, bool foreground_only)
         tile_env.bk_cloud(gc) = 0;
 }
 
-void tile_wizmap_terrain(const coord_def &gc)
-{
-    tile_env.bk_bg(gc) = _get_floor_bg(gc);
-}
-
 static bool _is_torch(tileidx_t basetile)
 {
     return basetile == TILE_WALL_BRICK_DARK_2_TORCH

--- a/crawl-ref/source/tileview.h
+++ b/crawl-ref/source/tileview.h
@@ -48,7 +48,6 @@ void tile_draw_map_cells();
 void tile_draw_floor();
 void tile_reset_fg(const coord_def &gc);
 void tile_draw_map_cell(const coord_def &gc, bool foreground_only = false);
-void tile_wizmap_terrain(const coord_def &gc);
 
 void tile_apply_animations(tileidx_t bg, tile_flavour *flv);
 void tile_apply_properties(const coord_def &gc, packed_cell &cell);


### PR DESCRIPTION
Make revelation reveal most squares exactly.

This removes aliasing from features such as floors, walls, water, statues, and fountains, which previously showed as base types when mapped.

The aliasing wasn't really doing much - vaults are already often quite identifiable from shapes. Magic mapped levels now look prettier, and we don't tell small lies to players.

Altars and portals are still mapped to UNKNOWN_ALTAR and UNKNOWN_PORTAL, because running after unknown altars and portals is fun.

Small consequences:
- Exclusions placed in unseen terrain now respect the opacity of that terrain, since we know it from mapping.
- Digging targeters now know whether mapped squares are diggable, fixing #4509.
- We note any notable features when we map them, if the aliased feature is notable. This includes orb statues revealing the orb enemy.