### PR TITLE
Simplify piety and remove decay

### DIFF
--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -466,19 +466,10 @@ struct like_response
     const char* desc;
     /// Whether the god should be described as "especially" liking it.
     bool really_like;
-    /** Gain in piety for triggering this conduct; added to calculated denom.
-     *
-     * This number is usually negative. In that case, the maximum piety gain
-     * is one point, and the chance of *not* getting that point is:
-     *    -piety_bonus/(piety_denom_bonus + level - you.xl/xl_denom)
-     * (omitting the you.xl term if xl_denom is zero)
-     */
-    int piety_bonus;
-    /// Divider for piety gained by this conduct; added to 'level'.
-    int piety_denom_bonus;
-    /// Degree to which your XL modifies piety gained. If zero, do not
-    /// modify piety by XL; otherwise divide player XL by this value.
-    int xl_denom;
+    /// Numerator for gain in piety (before level-based scaling).
+    int piety_numerator;
+    /// Denominator for gain in piety.
+    int piety_denominator;
     /// Something your god says when you trigger this conduct. May be nullptr.
     const char *message;
     /// Special-case code for weird likes. May modify piety bonus/denom, or
@@ -490,7 +481,7 @@ struct like_response
     void operator()(conduct_type thing_done, int level, bool /*known*/,
                     const monster *victim)
     {
-        // if the conduct filters on affected monsters, & the relevant monster
+        // If the conduct filters on affected monsters, & the relevant monster
         // isn't valid, don't trigger the conduct's consequences.
         if (victim && !_god_likes_killing(*victim))
             return;
@@ -500,13 +491,18 @@ struct like_response
         if (message)
             simple_god_message(message);
 
-        // this is all very strange, but replicates legacy behaviour.
-        // See the comment on piety_bonus above.
-        int denom = piety_denom_bonus + level;
-        if (xl_denom)
-            denom -= you.get_experience_level() / xl_denom;
+        int denom = piety_denominator;
+        int gain = piety_numerator;
 
-        int gain = denom + piety_bonus;
+        if (level > 0)
+        {
+            // If the level isn't high enough, don't give piety.
+            //
+            // The probablity of giving piety is 1 - 12 / (36 + 2*monster_level - our_level).
+            int extra_denom = (36 + 2*level - you.experience_level);
+            denom *= extra_denom;
+            gain *= (extra_denom - 12);
+        }
 
         // handle weird special cases
         // may modify gain/denom
@@ -519,70 +515,51 @@ struct like_response
 };
 
 /**
- * The piety bonus that is given for killing monsters of the appropriate
- * holiness.
- *
- * Gets slotted into a very strange equation. It's weird.
- */
-static int _piety_bonus_for_holiness(mon_holy_type holiness)
-{
-    if (holiness & (MH_NATURAL | MH_PLANT | MH_NONLIVING))
-        return -6;
-    else if (holiness & MH_UNDEAD)
-        return -5;
-    else if (holiness & MH_DEMONIC)
-        return -4;
-    else if (holiness & MH_HOLY)
-        return -3;
-    else
-        die("unknown holiness type; can't give a bonus");
-}
-
-/**
  * Generate an appropriate kill response (piety gain scaling, message, &c),
  * for gods that like killing this sort of thing.
- *
- * @param holiness      The holiness of the relevant type of monsters.
- * @param god_is_good   Whether this is a good god.
- *                      (They don't scale piety with XL in the same way...?)
- * @param special       A special-case function.
- * @return              An appropriate like_response.
  */
-static like_response _on_kill(const char* desc, mon_holy_type holiness,
-                              bool god_is_good = false,
-                              special_piety_t special = nullptr,
-                              bool really_like = false)
+static like_response _on_kill(const char* desc,
+                              int scaled_piety = 100)
 {
     return {
         desc,
-        really_like,
-        _piety_bonus_for_holiness(holiness),
-        18,
-        god_is_good ? 0 : 2,
+        false,
+        scaled_piety,
+        100,
         " accepts your kill.",
-        special
+        nullptr
     };
 }
 
 /// Response for gods that like killing the living.
-static const like_response KILL_LIVING_RESPONSE =
-    _on_kill("you kill living beings", MH_NATURAL);
+static const like_response kill_living_response(int scaled_piety = 100)
+{
+    return _on_kill("you kill living beings", scaled_piety);
+}
 
 /// Response for non-good gods that like killing (?) undead.
-static const like_response KILL_UNDEAD_RESPONSE =
-    _on_kill("you destroy the undead", MH_UNDEAD);
+static const like_response kill_undead_response(int scaled_piety = 100)
+{
+    return _on_kill("you destroy the undead", scaled_piety);
+}
 
 /// Response for non-good gods that like killing (?) demons.
-static const like_response KILL_DEMON_RESPONSE =
-    _on_kill("you kill demons", MH_DEMONIC);
+static const like_response kill_demon_response(int scaled_piety = 100)
+{
+    return _on_kill("you kill demons", scaled_piety);
+}
 
-/// Response for non-good gods that like killing (?) holies.
-static const like_response KILL_HOLY_RESPONSE =
-    _on_kill("you kill holy beings", MH_HOLY);
+/// Response for gods that like killing (?) holies.
+static const like_response kill_holy_response(int scaled_piety = 100)
+{
+    return _on_kill("you kill holy beings", scaled_piety);
+}
 
 /// Response for non-good gods that like killing (?) nonliving enemies.
-static const like_response KILL_NONLIVING_RESPONSE =
-    _on_kill("you destroy nonliving beings", MH_NONLIVING);
+static const like_response kill_nonliving_response(int scaled_piety = 100)
+{
+    return _on_kill("you destroy nonliving beings", scaled_piety);
+}
 
 // Note that holy deaths are special - they're always noticed...
 // If you or any friendly kills one, you'll get the credit/blame.
@@ -592,7 +569,7 @@ static like_response okawaru_kill(const char* desc)
     return
     {
         desc, false,
-        0, 0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
+        0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
         {
             piety = get_fuzzied_monster_difficulty(*victim);
             dprf("fuzzied monster difficulty: %4.2f", piety * 0.01);
@@ -615,7 +592,7 @@ static const like_response _fedhas_kill_living_response()
     return
     {
         "you kill living beings", false,
-        _piety_bonus_for_holiness(MH_NATURAL), 18, 0,
+        100, 100,
         nullptr, [] (int &, int &, const monster* victim)
         {
             if (victim && mons_class_can_leave_corpse(mons_species(victim->type)))
@@ -631,7 +608,7 @@ static const like_response _yred_kill_response()
     return
     {
         nullptr, false,
-        _piety_bonus_for_holiness(MH_NATURAL), 18, 0,
+        100, 100,
         nullptr, [] (int &piety, int &, const monster* victim)
         {
             if (victim)
@@ -664,18 +641,35 @@ static const like_response _yred_kill_response()
     };
 }
 
-static const like_response EXPLORE_RESPONSE = {
-    "you explore the world", false,
-    0, 0, 0, nullptr,
-    [] (int &piety, int &/*denom*/, const monster* /*victim*/)
-    {
-        // piety = denom = level at the start of the function
-        piety = 14;
-    }
-};
+static like_response explore_response(int chance, const char* desc = "you explore the world")
+{
+    return {
+        desc,
+        false,
+        chance,
+        10000,
+        nullptr
+    };
+}
 
 
 typedef map<conduct_type, like_response> like_map;
+
+// A default set of kill responses for gods that like killing in general.
+static const like_map DEFAULT_KILL_CONDUCT = {
+        { DID_KILL_LIVING, kill_living_response() },
+        { DID_KILL_UNDEAD, kill_undead_response() },
+        { DID_KILL_DEMON, kill_demon_response() },
+        { DID_KILL_HOLY, kill_holy_response() },
+        { DID_KILL_NONLIVING, kill_nonliving_response() },
+};
+
+static const like_map default_kill_conduct_with_extra(like_map extra)
+{
+    like_map lm = DEFAULT_KILL_CONDUCT;
+    lm.insert(extra.begin(), extra.end());
+    return lm;
+}
 
 /// a per-god map of conducts to piety rewards given by that god.
 static like_map divine_likes[] =
@@ -684,17 +678,17 @@ static like_map divine_likes[] =
     like_map(),
     // GOD_ZIN,
     {
-        { DID_KILL_UNCLEAN, _on_kill("you kill unclean or chaotic beings", MH_DEMONIC, true) },
-        { DID_KILL_CHAOTIC, _on_kill(nullptr, MH_DEMONIC, true) },
+        { DID_KILL_UNCLEAN, _on_kill("you kill unclean or chaotic beings") },
+        { DID_KILL_CHAOTIC, _on_kill(nullptr) },
     },
     // GOD_SHINING_ONE,
     {
-        { DID_KILL_UNDEAD, _on_kill("you kill the undead", MH_UNDEAD, true) },
-        { DID_KILL_DEMON, _on_kill("you kill demons", MH_DEMONIC, true) },
-        { DID_KILL_NATURAL_EVIL, _on_kill("you kill evil beings", MH_DEMONIC, true) },
+        { DID_KILL_UNDEAD, _on_kill("you kill the undead") },
+        { DID_KILL_DEMON, _on_kill("you kill demons") },
+        { DID_KILL_NATURAL_EVIL, _on_kill("you kill evil beings") },
         { DID_SEE_MONSTER, {
             "you encounter other hostile creatures", false,
-            0, 0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
+            0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
             {
                 // don't give piety for seeing things we get piety for killing.
                 if (victim && victim->evil())
@@ -707,13 +701,7 @@ static like_map divine_likes[] =
         } },
     },
     // GOD_KIKUBAAQUDGHA,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_YREDELEMNUL,
     {
         { DID_KILL_LIVING, _yred_kill_response() },
@@ -723,13 +711,7 @@ static like_map divine_likes[] =
     // GOD_XOM,
     like_map(),
     // GOD_VEHUMET,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_OKAWARU,
     {
         { DID_KILL_LIVING, okawaru_kill("you kill living beings") },
@@ -739,107 +721,68 @@ static like_map divine_likes[] =
         { DID_KILL_NONLIVING, okawaru_kill("you destroy nonliving beings") },
     },
     // GOD_MAKHLEB,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_SIF_MUNA,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_TROG,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-        { DID_KILL_WIZARD, {
-            "you kill wizards and other users of magic", true,
-            -6, 10, 0, " appreciates your killing of a magic user."
-        } },
-    },
+    default_kill_conduct_with_extra(
+        {
+            { DID_KILL_WIZARD, {
+                "you kill wizards and other users of magic", true,
+                100, 100, " appreciates your killing of a magic user."
+            } },
+        }
+    ),
     // GOD_NEMELEX_XOBEH,
     {
-        { DID_EXPLORATION, EXPLORE_RESPONSE },
+        { DID_EXPLORATION, explore_response(56) },
     },
     // GOD_ELYVILON,
     {
-        { DID_EXPLORATION, {
-            "you explore the world", false,
-            0, 0, 0, nullptr,
-            [] (int &piety, int &/*denom*/, const monster* /*victim*/)
-            {
-                // piety = denom = level at the start of the function
-                piety = 20;
-            }
-        } },
+        { DID_EXPLORATION, explore_response(80) },
     },
     // GOD_LUGONU,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-        { DID_BANISH, {
-            "you banish creatures to the Abyss", false,
-            -6, 18, 2, " claims a new guest."
-        } },
-    },
+    default_kill_conduct_with_extra(
+        {
+            { DID_BANISH, {
+                "you banish creatures to the Abyss", false,
+                100, 100, " claims a new guest."
+            } },
+        }
+    ),
     // GOD_BEOGH,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-        { DID_KILL_PRIEST, {
-            "you kill the priests of other religions", true,
-            -6, 18, 0, " appreciates your killing of a heretic priest."
-        } },
-    },
+    default_kill_conduct_with_extra(
+        {
+            { DID_KILL_PRIEST, {
+                "you kill the priests of other religions", true,
+                100, 100, " appreciates your killing of a heretic priest."
+            } },
+        }
+    ),
     // GOD_JIYVA,
     {
-        { DID_EXPLORATION, {
-            "you explore the world outside of the Slime Pits", false,
-            0, 0, 0, nullptr,
-            [] (int &piety, int &/*denom*/, const monster* /*victim*/)
-            {
-                // piety = denom = level at the start of the function
-                piety = 26;
-            }
-        } },
+        { DID_EXPLORATION, explore_response(
+            104, "you explore the world outside of the Slime Pits") },
     },
     // GOD_FEDHAS,
     {
         { DID_KILL_LIVING, _fedhas_kill_living_response() },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
+        { DID_KILL_UNDEAD, kill_undead_response() },
+        { DID_KILL_DEMON, kill_demon_response() },
+        { DID_KILL_HOLY, kill_holy_response() },
+        { DID_KILL_NONLIVING, kill_nonliving_response() },
     },
     // GOD_CHEIBRIADOS,
     {
         { DID_KILL_FAST, {
             "you kill non-sluggish things", false,
-            -6, 18, 2, nullptr,
+            4, 3, nullptr,
             [] (int &piety, int &/*denom*/, const monster* victim)
             {
                 const int mons_speed = mons_base_speed(*victim);
                 dprf("Chei DID_KILL_FAST: %s base speed: %d",
                      victim->name(DESC_PLAIN, true).c_str(),
                      mons_speed);
-
-                // Scale piety up a bit in general.
-                piety = div_rand_round(4 * piety, 3);
 
                 // Double piety for speedy monsters sometimes
                 if (mons_speed > 10 && x_chance_in_y(mons_speed - 10, 10))
@@ -855,7 +798,7 @@ static like_map divine_likes[] =
     // GOD_ASHENZARI,
     {
         { DID_EXPLORATION, {
-            nullptr, false, 0, 0, 0, nullptr,
+            nullptr, false, 0, 0, nullptr,
             [] (int &piety, int &denom, const monster* /*victim*/)
             {
                 piety = 0;
@@ -870,30 +813,16 @@ static like_map divine_likes[] =
     },
     // GOD_DITHMENOS,
     {
-        { DID_EXPLORATION, {
-            "you explore the world", false,
-            0, 0, 0, nullptr,
-            [] (int &piety, int &/*denom*/, const monster* /*victim*/)
-            {
-                // piety = denom = level at the start of the function
-                piety = 18;
-            }
-        } },
+        { DID_EXPLORATION, explore_response(72) },
     },
     // GOD_GOZAG,
     like_map(),
     // GOD_QAZLAL,
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_RU,
     {
         { DID_EXPLORATION, {
-            nullptr, false, 0, 0, 0, nullptr,
+            nullptr, false, 0, 0, nullptr,
             [] (int &piety, int &denom, const monster* /*victim*/)
             {
                 piety = 0;
@@ -909,43 +838,27 @@ static like_map divine_likes[] =
 #if TAG_MAJOR_VERSION == 34
     // GOD_PAKELLAS,
     {
-        { DID_KILL_LIVING, _on_kill("you kill living beings", MH_NATURAL, false,
-                                  [](int &piety, int &denom,
-                                     const monster* /*victim*/)
-            {
-                piety *= 4;
-                denom *= 3;
-            }
-        ) },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
+        { DID_KILL_LIVING, _on_kill("you kill living beings", 100) },
+        { DID_KILL_UNDEAD, kill_undead_response() },
+        { DID_KILL_DEMON, kill_demon_response() },
+        { DID_KILL_HOLY, kill_holy_response() },
+        { DID_KILL_NONLIVING, kill_nonliving_response() },
     },
 #endif
     // GOD_USKAYAW
     {
+        // Not actually used to give piety, only for the description.
         { DID_HURT_FOE, {
             "you hurt your foes; however, effects that cause damage over "
-            "time do not interest Uskayaw", true, 1, 1, 0, nullptr,
-            [] (int &/*piety*/, int &denom, const monster* /*victim*/)
-            {
-                denom = 1;
-            }
+            "time do not interest Uskayaw", true, 0, 0, nullptr
         } },
     },
     // GOD_HEPLIAKLQANA
     {
-        { DID_EXPLORATION, EXPLORE_RESPONSE },
+        { DID_EXPLORATION, explore_response(56) },
     },
     // GOD_WU_JIAN
-    {
-        { DID_KILL_LIVING, KILL_LIVING_RESPONSE },
-        { DID_KILL_UNDEAD, KILL_UNDEAD_RESPONSE },
-        { DID_KILL_DEMON, KILL_DEMON_RESPONSE },
-        { DID_KILL_HOLY, KILL_HOLY_RESPONSE },
-        { DID_KILL_NONLIVING, KILL_NONLIVING_RESPONSE },
-    },
+    DEFAULT_KILL_CONDUCT,
     // GOD_IGNIS,
     like_map(),
 };

--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -683,20 +683,18 @@ static like_map divine_likes[] =
     },
     // GOD_SHINING_ONE,
     {
-        { DID_KILL_UNDEAD, _on_kill("you kill the undead") },
-        { DID_KILL_DEMON, _on_kill("you kill demons") },
-        { DID_KILL_NATURAL_EVIL, _on_kill("you kill evil beings") },
+        // TSO gets substantially boosted piety for killing evil beings,
+        // and reduced piety for seeings (but not killing) other monsters.
+        { DID_KILL_UNDEAD, _on_kill("you kill the undead", 147) },
+        { DID_KILL_DEMON, _on_kill("you kill demons", 147) },
+        { DID_KILL_NATURAL_EVIL, _on_kill("you kill evil beings", 147) },
         { DID_SEE_MONSTER, {
             "you encounter other hostile creatures", false,
-            0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
+            43, 100, nullptr, [] (int &piety, int &, const monster* victim)
             {
                 // don't give piety for seeing things we get piety for killing.
                 if (victim && victim->evil())
-                    return;
-
-                const int level = denom; // also = piety
-                denom = level / 2 + 6 - you.experience_level / 4;
-                piety = denom - 4;
+                    piety = 0;
             }
         } },
     },

--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -519,7 +519,7 @@ struct like_response
  * for gods that like killing this sort of thing.
  */
 static like_response _on_kill(const char* desc,
-                              int scaled_piety = 100)
+                              int scaled_piety = 90)
 {
     return {
         desc,
@@ -532,31 +532,31 @@ static like_response _on_kill(const char* desc,
 }
 
 /// Response for gods that like killing the living.
-static const like_response kill_living_response(int scaled_piety = 100)
+static const like_response kill_living_response(int scaled_piety = 90)
 {
     return _on_kill("you kill living beings", scaled_piety);
 }
 
 /// Response for non-good gods that like killing (?) undead.
-static const like_response kill_undead_response(int scaled_piety = 100)
+static const like_response kill_undead_response(int scaled_piety = 90)
 {
     return _on_kill("you destroy the undead", scaled_piety);
 }
 
 /// Response for non-good gods that like killing (?) demons.
-static const like_response kill_demon_response(int scaled_piety = 100)
+static const like_response kill_demon_response(int scaled_piety = 90)
 {
     return _on_kill("you kill demons", scaled_piety);
 }
 
 /// Response for gods that like killing (?) holies.
-static const like_response kill_holy_response(int scaled_piety = 100)
+static const like_response kill_holy_response(int scaled_piety = 90)
 {
     return _on_kill("you kill holy beings", scaled_piety);
 }
 
 /// Response for non-good gods that like killing (?) nonliving enemies.
-static const like_response kill_nonliving_response(int scaled_piety = 100)
+static const like_response kill_nonliving_response(int scaled_piety = 90)
 {
     return _on_kill("you destroy nonliving beings", scaled_piety);
 }
@@ -573,7 +573,7 @@ static like_response okawaru_kill(const char* desc)
         {
             piety = get_fuzzied_monster_difficulty(*victim);
             dprf("fuzzied monster difficulty: %4.2f", piety * 0.01);
-            denom = 550;
+            denom = 600;
 
             if (piety > 3200)
             {
@@ -592,7 +592,7 @@ static const like_response _fedhas_kill_living_response()
     return
     {
         "you kill living beings", false,
-        100, 100,
+        95, 100,
         nullptr, [] (int &, int &, const monster* victim)
         {
             if (victim && mons_class_can_leave_corpse(mons_species(victim->type)))
@@ -608,7 +608,7 @@ static const like_response _yred_kill_response()
     return
     {
         nullptr, false,
-        100, 100,
+        90, 100,
         nullptr, [] (int &piety, int &, const monster* victim)
         {
             if (victim)
@@ -678,8 +678,8 @@ static like_map divine_likes[] =
     like_map(),
     // GOD_ZIN,
     {
-        { DID_KILL_UNCLEAN, _on_kill("you kill unclean or chaotic beings") },
-        { DID_KILL_CHAOTIC, _on_kill(nullptr) },
+        { DID_KILL_UNCLEAN, _on_kill("you kill unclean or chaotic beings", 100) },
+        { DID_KILL_CHAOTIC, _on_kill(nullptr, 100) },
     },
     // GOD_SHINING_ONE,
     {
@@ -729,24 +729,24 @@ static like_map divine_likes[] =
         {
             { DID_KILL_WIZARD, {
                 "you kill wizards and other users of magic", true,
-                100, 100, " appreciates your killing of a magic user."
+                90, 100, " appreciates your killing of a magic user."
             } },
         }
     ),
     // GOD_NEMELEX_XOBEH,
     {
-        { DID_EXPLORATION, explore_response(56) },
+        { DID_EXPLORATION, explore_response(47) },
     },
     // GOD_ELYVILON,
     {
-        { DID_EXPLORATION, explore_response(80) },
+        { DID_EXPLORATION, explore_response(71) },
     },
     // GOD_LUGONU,
     default_kill_conduct_with_extra(
         {
             { DID_BANISH, {
                 "you banish creatures to the Abyss", false,
-                100, 100, " claims a new guest."
+                90, 100, " claims a new guest."
             } },
         }
     ),
@@ -762,21 +762,25 @@ static like_map divine_likes[] =
     // GOD_JIYVA,
     {
         { DID_EXPLORATION, explore_response(
-            104, "you explore the world outside of the Slime Pits") },
+            93, "you explore the world outside of the Slime Pits") },
     },
     // GOD_FEDHAS,
     {
+        // Fedhas gets slightly more piety for killing than other gods.
+        // This may well be a historical accident, and possibly should
+        // be adjusted by reducing his base piety rate to 0.9 like all
+        // the other normal killy gods.
         { DID_KILL_LIVING, _fedhas_kill_living_response() },
-        { DID_KILL_UNDEAD, kill_undead_response() },
-        { DID_KILL_DEMON, kill_demon_response() },
-        { DID_KILL_HOLY, kill_holy_response() },
-        { DID_KILL_NONLIVING, kill_nonliving_response() },
+        { DID_KILL_UNDEAD, kill_undead_response(95) },
+        { DID_KILL_DEMON, kill_demon_response(95) },
+        { DID_KILL_HOLY, kill_holy_response(95) },
+        { DID_KILL_NONLIVING, kill_nonliving_response(95) },
     },
     // GOD_CHEIBRIADOS,
     {
         { DID_KILL_FAST, {
             "you kill non-sluggish things", false,
-            4, 3, nullptr,
+            123, 100, nullptr,
             [] (int &piety, int &/*denom*/, const monster* victim)
             {
                 const int mons_speed = mons_base_speed(*victim);
@@ -813,7 +817,7 @@ static like_map divine_likes[] =
     },
     // GOD_DITHMENOS,
     {
-        { DID_EXPLORATION, explore_response(72) },
+        { DID_EXPLORATION, explore_response(55) },
     },
     // GOD_GOZAG,
     like_map(),
@@ -855,7 +859,7 @@ static like_map divine_likes[] =
     },
     // GOD_HEPLIAKLQANA
     {
-        { DID_EXPLORATION, explore_response(56) },
+        { DID_EXPLORATION, explore_response(47) },
     },
     // GOD_WU_JIAN
     DEFAULT_KILL_CONDUCT,

--- a/crawl-ref/source/god-conduct.cc
+++ b/crawl-ref/source/god-conduct.cc
@@ -571,8 +571,8 @@ static like_response okawaru_kill(const char* desc)
         desc, false,
         0, 0, nullptr, [] (int &piety, int &denom, const monster* victim)
         {
-            piety = get_fuzzied_monster_difficulty(*victim);
-            dprf("fuzzied monster difficulty: %4.2f", piety * 0.01);
+            piety = okawaru_monster_difficulty(*victim);
+            dprf("monster difficulty: %4.2f", piety * 0.01);
             denom = 600;
 
             if (piety > 3200)

--- a/crawl-ref/source/god-prayer.cc
+++ b/crawl-ref/source/god-prayer.cc
@@ -233,7 +233,7 @@ int zin_tithe(const item_def& item, int quant, bool converting)
             tithe *= 47;
             denom *= 20 + env.absdepth0;
         }
-        gain_piety(tithe * 3, denom);
+        gain_piety(tithe * 5, denom * 2);
     }
     you.attribute[ATTR_TITHE_BASE] = due;
     return taken;

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5524,7 +5524,6 @@ player::player()
     religion         = GOD_NO_GOD;
     jiyva_second_name.clear();
     raw_piety        = 0;
-    piety_hysteresis = 0;
     gift_timeout     = 0;
     saved_good_god_piety = 0;
     previous_good_god = GOD_NO_GOD;

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2281,6 +2281,7 @@ void dock_piety(int piety_loss, int penance, bool no_lecture)
 {
     static int last_piety_lecture   = -1;
     static int last_penance_lecture = -1;
+    god_type current_god = you.religion;
 
     if (piety_loss <= 0 && penance <= 0)
         return;
@@ -2304,9 +2305,7 @@ void dock_piety(int piety_loss, int penance, bool no_lecture)
         lose_piety(piety_loss);
     }
 
-    if (you.raw_piety < 1)
-        excommunication();
-    else if (penance)       // only if still in religion
+    if (you.religion == current_god && penance)       // only if still in religion
     {
         if (last_penance_lecture != you.num_turns && !no_lecture)
         {
@@ -2726,6 +2725,9 @@ void lose_piety(int pgn)
         you.props[MIN_IGNIS_PIETY_KEY] = you.raw_piety;
 
     _handle_piety_loss(old_piety);
+
+    if (you.raw_piety < 1)
+        excommunication();
 }
 
 /// Whether Fedhas would set `target` to a neutral attitude

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -2545,8 +2545,8 @@ static void _gain_piety_point()
     if (!you_worship(GOD_RU))
     {
         if (you.raw_piety >= MAX_PIETY
-            || you.raw_piety >= piety_breakpoint(5) && one_chance_in(3)
-            || you.raw_piety >= piety_breakpoint(3) && one_chance_in(3))
+            || you.raw_piety >= piety_breakpoint(5) && x_chance_in_y(2, 5)
+            || you.raw_piety >= piety_breakpoint(3) && x_chance_in_y(2, 5))
         {
             you.piety_info.register_piety_gain(PG_EVENT_STEPDOWN);
             do_god_gift();
@@ -4217,12 +4217,6 @@ bool god_protects_from_harm()
     return false;
 }
 
-void decay_piety()
-{
-    lose_piety(1);
-    you.piety_info.register_piety_decay();
-}
-
 void handle_god_time(int /*time_delta*/)
 {
     if (you.attribute[ATTR_GOD_WRATH_COUNT] > 0)
@@ -4251,39 +4245,7 @@ void handle_god_time(int /*time_delta*/)
         int sacrifice_count;
         switch (you.religion)
         {
-        case GOD_TROG:
-        case GOD_OKAWARU:
-        case GOD_MAKHLEB:
-        case GOD_LUGONU:
-        case GOD_DITHMENOS:
-        case GOD_QAZLAL:
-        case GOD_KIKUBAAQUDGHA:
-        case GOD_VEHUMET:
-        case GOD_ZIN:
-#if TAG_MAJOR_VERSION == 34
-        case GOD_PAKELLAS:
-#endif
-        case GOD_JIYVA:
-        case GOD_WU_JIAN:
-        case GOD_SIF_MUNA:
-        case GOD_YREDELEMNUL:
-            if (one_chance_in(17))
-                decay_piety();
-            break;
-
-        case GOD_ELYVILON:
-        case GOD_HEPLIAKLQANA:
-        case GOD_FEDHAS:
-        case GOD_CHEIBRIADOS:
-        case GOD_SHINING_ONE:
-        case GOD_NEMELEX_XOBEH:
-            if (one_chance_in(35))
-                decay_piety();
-            break;
-
         case GOD_BEOGH:
-            if (one_chance_in(17))
-                decay_piety();
             maybe_generate_apostle_challenge();
             break;
 
@@ -4315,16 +4277,6 @@ void handle_god_time(int /*time_delta*/)
 
             break;
 
-        case GOD_IGNIS:
-            // Losing piety over time would be extremely annoying for people
-            // trying to get polytheist with Ignis. Almost impossible.
-        case GOD_USKAYAW:
-            // We handle Uskayaw elsewhere because this func gets called rarely
-        case GOD_GOZAG:
-        case GOD_XOM:
-            // Gods without normal piety do nothing each tick.
-            return;
-
         case GOD_NO_GOD:
         case GOD_RANDOM:
         case GOD_ECUMENICAL:
@@ -4332,11 +4284,9 @@ void handle_god_time(int /*time_delta*/)
         case NUM_GODS:
             die("Bad god, no bishop!");
             return;
-
+        default:
+            return;
         }
-
-        if (you.raw_piety < 1)
-            excommunication();
     }
 
     if (player_in_branch(BRANCH_CRUCIBLE))

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4678,11 +4678,10 @@ int get_tension(god_type god)
     return max(tension_min, tension);
 }
 
-int get_fuzzied_monster_difficulty(const monster& mons)
+int okawaru_monster_difficulty(const monster& mons)
 {
     double factor = sqrt(exp_needed(you.experience_level) / 30.0);
     int exp = exp_value(mons) * 100;
-    exp = random2(exp) + random2(exp);
     return exp / (1 + factor);
 }
 

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -155,7 +155,7 @@ void religion_turn_end();
 
 int get_tension(god_type god = you.religion);
 int get_monster_tension(const monster& mons, god_type god = you.religion);
-int get_fuzzied_monster_difficulty(const monster& mons);
+int okawaru_monster_difficulty(const monster& mons);
 
 typedef void (*delayed_callback)(const mgen_data &mg, monster *&mon, int placed);
 

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -343,6 +343,7 @@ enum tag_minor_version
     TAG_MINOR_LUA_5_4,             // Upgrade from Lua 5.1 to Lua 5.4.
     TAG_MINOR_PIETY_LOGGING,       // Log piety events
     TAG_MINOR_MONINFO_CLEANUP,     // Stop marshalling some unused info and start marshalling some overlooked info
+    TAG_MINOR_REMOVE_PIETY_DECAY,  // Remove piety decay and hysteresis mechanics
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1927,8 +1927,6 @@ static void _tag_construct_you(writer &th)
     for (mid_t monger : you.fearmongers)
         _marshall_as_int(th, monger);
 
-    marshallByte(th, you.piety_hysteresis);
-
     you.quiver_action.save(QUIVER_MAIN_SAVE_KEY);
 
     CANARY;
@@ -4406,7 +4404,10 @@ static void _tag_read_you(reader &th)
         you.fearmongers.push_back(unmarshall_int_as<mid_t>(th));
     }
 
-    you.piety_hysteresis = unmarshallByte(th);
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() < TAG_MINOR_REMOVE_PIETY_DECAY)
+        unmarshallByte(th);
+#endif
 
 #if TAG_MAJOR_VERSION == 34
     you.m_quiver_history.load(th);

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -293,7 +293,8 @@ static update_flags player_view_update_at(const coord_def &gc)
             && !(branches[you.where_are_you].branch_flags & brflag::fully_map)
             && !(player_in_branch(BRANCH_SLIME) && you_worship(GOD_JIYVA)))
         {
-            did_god_conduct(DID_EXPLORATION, 2500);
+            // Level is not used.
+            did_god_conduct(DID_EXPLORATION, 0);
             const int density = env.density ? env.density : 2000;
             you.exploration += div_rand_round(1<<16, density);
             roll_trap_effects();


### PR DESCRIPTION
This PR makes multiple related changes to piety. We do them all at once to minimise the testing and monitoring needed.

1. Simplification of monster-related piety formulae

Previously, how piety scaled with level and how much you got were interrelated. This made it surprisingly hard to do operations like "increase piety by x%", and different conducts scaled piety differently by monster and player level (with good gods in particular ignoring player level for no clear reason, and monster holiness mattering slightly).

We simplify this, so that monster-related conducts have a fixed scaling component `f(monster_level, player_level)`, matching the most common one before. Different conducts can now have different magnitudes of piety by providing an explicit scaling factor, so the overall piety is `g(conduct) * f(monster_level, player_level)`.

2. Remove piety decay and hysteresis

Piety decay acts as a soft clock, which applies to most gods. While the effect is relatively minor, this leads to some bad incentives - it's generally not that fun to try to minimise turns. The upside is limited; these days there aren't many mechanics that necessitate a soft clock, and at any rate there are several gods who don't have piety decay.

Piety hysteresis existed to stop thrashing around level boundaries due to piety decay, so we remove that too.

3. Fix a bug with TSO

TSO was previously giving piety for seeing undead monsters, but given code comments this was a clear bug. It also seems undesirable to have a god who is _so_ skewed towards piety gain in extended. We fix this. TSO remains the fastest piety gainer in evil-dominated settings.

4. Balance the above

None of the above changes are piety-neutral. Using logs from real games, we balance these changes as best we can. This ends up meaning:
- Decrease piety gain rates by between 5 and 25% to account for piety decay
- Raise good gods' kill piety 20%, and other gods' minutely, to account for level scaling changes
- Increase stepdown probabilities from 33% to 40%, to account for the fact that piety decay affected stepped-down piety more.

The balance is not perfect; in particular different gods and levels want different stepdown probabilities (even assuming we've done everything else perfectly, which we obviously haven't). But everything should be _fairly_ balanced - within perhaps 10% in the worst case.

For details of how we got to these numbers, see https://docs.google.com/document/d/1G7-EvOMX8yOKw2EuyDPSm6fUAaNl8dUXhWRwGc5Pp3c/edit?tab=t.0#heading=h.48gpjrrr7g5v.

Testing: we tested this by playing games with a bunch of gods of representative piety styles (Oka, Zin, Hep, Fed, TSO) to around championing, making sure they felt OK and roughly matched the typical times for piety milestones. This isn't a way to check fine balance - the natural variance in this from piety RNG and spawn RNG is much higher than 10% - but it would have flagged up very large errors.