### PR TITLE
fix: Usk grand finale on wall creatures crash

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -5876,6 +5876,11 @@ spret uskayaw_grand_finale(bool fail)
         {
             // try again (messages handled by check_moveto)
         }
+        else if (cell_is_solid(beam.target))
+        {
+            clear_messages();
+            canned_msg(MSG_UNTHINKING_ACT);
+        }
         else if (you.see_cell_no_trans(beam.target))
         {
             // Grid in los, no problem.


### PR DESCRIPTION
Don't let the player target creatures inside of walls!

I still really like hellmonk's idea I implemented in #5002 but if that's not desired this PR just forbids the edge(heh)-case.