### PR TITLE
Correctly set tile flavours with multiple terrain changes

### DIFF
--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -2230,11 +2230,11 @@ bool revert_terrain_change(coord_def pos, terrain_change_type ctype)
                 if (tmarker->colour != BLACK)
                     colour = tmarker->colour;
                 if (!newfeat)
+                {
                     newfeat = tmarker->old_feature;
-                if (!newfeat_flv)
                     newfeat_flv = tmarker->flv_old_feature;
-                if (!newfeat_flv_idx)
                     newfeat_flv_idx = tmarker->flv_old_feature_idx;
+                }
                 env.markers.remove(tmarker);
             }
             else
@@ -2244,6 +2244,8 @@ bool revert_terrain_change(coord_def pos, terrain_change_type ctype)
                     tmarker->colour = colour;
                 colour = BLACK;
                 newfeat = tmarker->new_feature;
+                newfeat_flv = 0;
+                newfeat_flv_idx = 0;
             }
         }
     }


### PR DESCRIPTION
This fixes a bug whereby reverting one of a stack of terrain changes would show the flavour of the base tile. For example:
- Cast bog in shoals, covering an upstair (which has a flavour tile).
- Have a water nymph cover the upstair tile.
- Kill the nymph

This would display a stairs tile (but not allow the player to go up it)