### PR TITLE
Don't re-enter shops after they reappear (Flugkiller)

### DIFF
--- a/crawl-ref/source/dgn-overview.h
+++ b/crawl-ref/source/dgn-overview.h
@@ -16,7 +16,7 @@ bool move_notable_thing(const coord_def& orig, const coord_def& dest);
 bool overview_knows_portal(branch_type portal);
 int  overview_knows_num_portals(dungeon_feature_type portal);
 void display_overview();
-bool unnotice_feature(const level_pos &pos);
+void unnotice_feature(const level_pos &pos);
 string overview_description_string(bool display);
 void enter_branch(branch_type branch, level_id from);
 void mark_corrupted_level(level_id li);

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -1582,9 +1582,9 @@ void destroy_shop_at(coord_def p)
 {
     if (shop_at(p))
     {
+        unnotice_feature(level_pos(level_id::current(), p));
         env.shop.erase(p);
         env.grid(p) = DNGN_ABANDONED_SHOP;
-        unnotice_feature(level_pos(level_id::current(), p));
     }
 }
 


### PR DESCRIPTION
When a shop was covered by a temporary terrain change, it was marked as unnoticed when it came back, and therefore reentered.

This was happening because even though temporary changes don't call unnotice_feature, their reversions do.

We fix this by making unnotice_feature only work on features which are present (which was already the case for stairs), and fixing the one caller of this who changed features before unnoticing them.

Also make a function with an unused return type void.