### PR TITLE
Make the Cost column show the full cost of reaching skill targets

### DIFF
--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -54,7 +54,7 @@ typedef set<skill_type> skill_set;
 string skill_names(const skill_set &skills);
 
 int skill_cost_baseline();
-int one_level_cost(skill_type sk);
+int target_cost(skill_type sk);
 float scaled_skill_cost(skill_type sk);
 
 unsigned int skill_cost_needed(int level);
@@ -125,6 +125,10 @@ float species_apt_factor(skill_type sk, species_type sp = you.species);
 float apt_to_factor(int apt);
 unsigned int skill_exp_needed(int lev, skill_type sk,
                               species_type sp = you.species);
+unsigned int deciskill_exp_needed(int decilev, skill_type sk,
+                                  species_type sp = you.species);
+unsigned int deciskill_exp_needed(double decilev, skill_type sk,
+                                  species_type sp = you.species);
 skill_diff skill_level_to_diffs(skill_type skill, double amount,
     int scaled_training=100, bool base_only=true);
 


### PR DESCRIPTION
- What it does
  - When a target is set, the Cost column shows the total cost of
    reaching the target skill level

  - When no target is set, the Cost column shows the cost of adding 1.0
    to the skill level.

    - For integral skill levels, there is no change in the current
      behavior.


- Why is it useful
  - Suppose a player wishes to compare the cost of:

    - Training Shields from 1.1 to 10
    - versus training Dodging from 1.5 to ??

  - Currently, it is difficult (without a wizmode test) to determine how
    many levels of Dodging could be trained for the same amount of XP as
    the first option. This PR makes this easier to do in-game.
![cost](https://github.com/user-attachments/assets/58a22ab5-6fbb-426c-ac17-24eda9802fb2)
![target](https://github.com/user-attachments/assets/ad552ae9-0448-421a-b9d9-dec3813ff1c3)

  - As a side effect of computing total cost to reach decimal targets,
    this PR makes the Cost column change more granularly, as
    skill levels (or targets) change by tenths.

    - For example, currently the Cost column does not change
      as long as the floor of the skill level stays the same. With this
      PR, the cost changes as either the skill level or the target
      changes by tenths:
```
      | skill level | target | master cost | PR cost |
      |-------------+--------+-------------+---------|
      |         1.0 |    2.0 |         3.4 |     3.4 |
      |         1.0 |    1.1 |         3.4 |     0.3 |
      |         1.5 |    2.0 |         3.4 |     1.7 |
      |         1.5 |    2.5 |         3.4 |     4.2 |
```
- Handling modified skill levels (like Wildshape or Ash skill boosts)
  - Normally, a player sets a target based on (possibly) modified skill
    levels. But the cost of improving that skill should be based on the
    unmodified skill level. So (for the purpose of computing the cost)
    the target is adjusted (generally downwards) by the amount the skill
    is currently boosted. Note that this adjustment may be roughly
    correct but not exactly accurate for Ash skill boosts, since the
    size of the skill boost is itself affected by the skill level.

  - Here is an example of the PR's behavior when using Wildshape. For
    each pair of lines below, the first line shows what cost is reported
    when using wildshape. The second line confirms the computed costs
    using unmodified skill and target levels.

```
    | wildshape | raw skill | target | master cost | PR cost |
    |-----------+-----------+--------+-------------+---------|
    | yes       |         0 |      6 |         1.4 |     1.4 |
    | no        |         0 |      1 |         1.4 |     1.4 |
    |-----------+-----------+--------+-------------+---------|
    | yes       |         0 |      8 |         1.4 |     8.5 |
    | no        |         0 |      3 |         1.4 |     8.5 |
    |-----------+-----------+--------+-------------+---------|
    | yes       |         5 |     12 |         8.5 |    18.4 |
    | no        |         5 |      7 |         8.5 |    18.4 |
```  
