### PR TITLE
Create a missing async event loop in terminal.py

### DIFF
--- a/crawl-ref/source/webserver/webtiles/terminal.py
+++ b/crawl-ref/source/webserver/webtiles/terminal.py
@@ -86,6 +86,15 @@ class TerminalRecorder(object):
             # so, sometimes, a race condition here leads to the main process
             # reloading its config...currently some key cases are handled
             # elsewhere by a brute force delay.
+
+            # Create a async event loop if it is not already running.
+            # It appears to not be copied over on a fork, so the child has its
+            # own event loop
+            try:
+                asyncio.get_event_loop()
+            except RuntimeError:
+                asyncio.set_event_loop(asyncio.new_event_loop())
+
             asyncio.get_event_loop().remove_signal_handler(signal.SIGHUP)
 
             # Set window size


### PR DESCRIPTION
When starting up a terminal to capture crawl for webtiles, the server tries to turn off the SIGHUP handler in the child thread to prevent race conditions. This causes crashes on newer versions of python, as in the behaviour of `asyncio.get_event_loop()` has been reworked. In previous python versions this call would silently succeed and create a new async loop. Now, this call will no longer create an async loop and thus the loop needs to be manually created.

Though this maintains the same behaviour as before, I suspect it is masking a bug, though I don't understand the comment about a SIGHUP race condition. Removing the SIGHUP handler, on line 98, likely does nothing, as it is referencing a freshly created asyncio loop with no handlers attached. It seems like maybe this depends on python version, and the behaviour of fork, but in Python 3.14.2 it definitely is a fresh loop as fork does not copy the async loop from parent to child. I'm not sure what the expected result is here.

Fixes #5027