### PR TITLE
Don't delete tentacles on terrain change

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5589,7 +5589,8 @@ void monster::finalise_movement(const actor* to_blame)
         }
     }
     // If tentacle monsters get moved by any means other than themselves, kill and cleanup.
-    else if (!(last_move_flags & MV_DELIBERATE) || (last_move_flags & MV_TRANSLOCATION))
+    else if (last_move_pos != pos()
+             && (!(last_move_flags & MV_DELIBERATE) || (last_move_flags & MV_TRANSLOCATION)))
     {
         if (mons_is_tentacle_head(mons_base_type(*this)))
             destroy_tentacles(this); // If the main body teleports get rid of the tentacles


### PR DESCRIPTION
Friendly and unfriendly tentacles were completely destroyed by any change to the terrain underneath them. For example, eldritch tentacles could be deleted by casting hellfire mortar at any segment, or Summon Forest when the generated pool touched the tentacle.

We fix this by only deleting tentacles when finalizing movement in the case that the monster has actually moved.