### PR TITLE
fix: Blade-form status text (Undo)

### DIFF
--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -626,14 +626,6 @@ public:
     static const FormBlade &instance() { static FormBlade inst; return inst; }
 
     /**
-     * % screen description
-     */
-    string get_long_name() const override
-    {
-        return you.base_hand_name(true, true);
-    }
-
-    /**
      * @ description
      */
     string get_description(bool past_tense) const override


### PR DESCRIPTION
It was simply "hands" (or whatever similar limbs you possessed). Now it defaults to "blade-form" since eels are the hands-replacer now.