### PR TITLE
Bind right click to Describe when in Display Map to match Look Around

### DIFF
--- a/crawl-ref/source/tilereg-dgn.cc
+++ b/crawl-ref/source/tilereg-dgn.cc
@@ -474,8 +474,7 @@ int DungeonRegion::handle_mouse(wm_mouse_event &event)
         return 0;
 
     if (mouse_control::current_mode() == MOUSE_MODE_NORMAL
-        && event.event == wm_mouse_event::PRESS
-        && event.button == wm_mouse_event::LEFT)
+        && event.event == wm_mouse_event::PRESS)
     {
         m_last_clicked_grid = m_cursor[CURSOR_MOUSE];
 
@@ -484,7 +483,10 @@ int DungeonRegion::handle_mouse(wm_mouse_event &event)
         const coord_def gc(cx + m_cx_to_gx, cy + m_cy_to_gy);
         tiles.place_cursor(CURSOR_MOUSE, gc);
 
-        return CK_MOUSE_CLICK;
+        if (event.button == wm_mouse_event::LEFT)
+            return CK_MOUSE_CLICK;
+        else if (event.button == wm_mouse_event::RIGHT)
+            return CK_MOUSE_CMD;
     }
 
     if (mouse_control::current_mode() == MOUSE_MODE_MACRO


### PR DESCRIPTION
I kept getting thrown off when trying to right click examine things in Display Map mode ('X') because it currently does nothing, requiring a 'v' press instead, so I matched the typical behavior of right click in standard gameplay. Right clicks in map mode/`MOUSE_MODE_NORMAL` were just being thrown away, so it's just using a button that was previously unused.

I also moved describing into a seperate function with a position argument instead of calling `process_command(CMD_MAP_DESCRIBE)` because `CMD_MAP_DESCRIBE` requires you move the cursor first, which jarringly moves the view as well, unlike the typical right click examine. 

I agree with the comments about "this really seems like it shouldn't be here" for the click handling code, but it's above my expertise so I didn't do any further refactors; hopefully my change is small enough that it's not growing the existing slightly-messy code too badly.