### PR TITLE
Fix a bolt of flesh redirection crash

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -1302,7 +1302,7 @@ void bolt::do_fire()
         // If requested to stop before hitting allies, do so now.
         const actor* act_at = actor_at(pos());
         if (act_at && stop_at_allies && mons_atts_aligned(attitude, act_at->temp_attitude())
-            && can_affect_actor(act_at)
+            && can_affect_actor(act_at) && !aimed_at_feet
             && !(act_at->is_player() && ignores_player() || ignores_monster(act_at->as_monster())))
         {
             ray.regress();


### PR DESCRIPTION
When firing a Zykzyl bolt of flesh with Ru redirection or Dith's Marionette, we would sometimes crash. This is because the tracer beam for the attack is aimed at the Zykzyl itself, and the beam sets stop_at_allies. This causes us to attempt to regress a ray with no position or direction, which does not work.

We fix this by not regressing self-aimed rays when stop_at_allies is set.