### PR TITLE
Handle feature mimics and terrain change better

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1010,6 +1010,10 @@ void discover_mimic(const coord_def& pos)
 
     const dungeon_feature_type feat = env.grid(pos);
 
+    // If the feature mimic is covered by something else, don't reveal it.
+    if (feature_mimic && orig_terrain(pos) != feat)
+        return;
+
     // If the feature has been destroyed, don't create a floor mimic.
     if (feature_mimic && !feat_is_mimicable(feat, false))
     {

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -1363,8 +1363,6 @@ static void _terrain_changed(coord_def pos,
     _dgn_check_terrain_monsters(pos);
     if (!wizmode)
         _dgn_check_terrain_player(pos);
-    if (!temporary && feature_mimic_at(pos))
-        env.level_map_mask(pos) &= ~MMT_MIMIC;
 
     set_terrain_changed(pos);
 


### PR DESCRIPTION
We ignore feature mimics which are currently covered by a terrain change, and don't discard feature mimics on terrain reversion.

This fixes a few silly issues:
- If you covered a mimic and didn't step next to it, it became a real feature. This awesome tech can be used to get 1% more shops using hellfire mortar or similar.
- If you cover a mimic with temporary terrain other than water (e.g. a bog or hellfire mortar), and then stepped next to it, it was revealed as a lava mimic or similar.

This means that if temporary mimics previously worked (which the author would bet against), they definitely don't now.