### PR TITLE
feat: alert monsters affected by clouds to the clouder

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -1378,7 +1378,7 @@ static void _actor_apply_cloud(actor *act, cloud_struct &cloud)
         actor *oppressor = cloud.agent();
         if (oppressor && oppressor->alive())
         {
-            // Alert the monster to the oppressor but don't give away their 
+            // Alert the monster to the oppressor but don't give away their
             // position.
             behaviour_event(mons, ME_ALERT, oppressor, act->pos());
         }


### PR DESCRIPTION
Since f96b50d monsters are no longer alerted automatically to cast spells. That made apparent that clouds weren't alerting monsters to the cloud creator; monsters would wander through player-created freezing clouds without taking notice of the player. Silly! So change that.