### PR TITLE
feat: Add options to limit longwalking aka shift running

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1144,6 +1144,23 @@ travel_open_doors = (avoid | approach | open)
             open = Autoexplore/travel will open doors. (default)
         This does not affect runed doors, which are always avoided.
 
+longwalk_range = (los | visible | unlimited | constant)
+        Set the maximum distance for longwalking (shift+direction by default).
+          los = Your current line of sight range. This is 7 for most species and
+                is affected by items such as scarf of shadows.
+          visible = Only visit visible tiles. This is limited by line of sight
+                range but also by clouds such as steam or fog that could limit
+                which tiles are visible.
+          unlimited = No distance limitation. You'll keep moving until something
+                else stops you.
+          constant = A constant maximum distance that you provide in
+                longwalk_range_constant.
+
+longwalk_range_constant = 7
+        If longwalk_range is set to constant, this will set the maximum distance
+        for longwalking (shift+direction by default). Otherwise, it will do
+        nothing.
+
 3-g     Command Enhancements.
 -----------------------------
 

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1155,9 +1155,9 @@ longwalk_range = (los | visible | unlimited | constant)
           unlimited = No distance limitation. You'll keep moving until something
                 else stops you.
           constant = A constant maximum distance that you provide in
-                longwalk_range_constant.
+                longwalk_range_constant. (default)
 
-longwalk_range_constant = 7
+longwalk_range_constant = 15
         If longwalk_range is set to constant, this will set the maximum distance
         for longwalking (shift+direction by default). Otherwise, it will do
         nothing.

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -52,7 +52,8 @@ The contents of this text are:
                 interrupt_<delay>, delay_safe_poison, runrest_ignore_monster,
                 rest_wait_both, rest_wait_ancestor, rest_wait_percent,
                 explore_auto_rest, explore_auto_rest_status,
-                auto_exclude, travel_open_doors
+                auto_exclude, travel_open_doors, longwalk_range,
+                longwalk_range_constant
 3-g     Command Enhancements.
                 auto_switch, easy_unequip, equip_unequip, jewellery_prompt,
                 easy_confirm, simple_targeting, force_spell_targeter,

--- a/crawl-ref/source/externs.h
+++ b/crawl-ref/source/externs.h
@@ -174,6 +174,8 @@ public:
     int direction;
     int turns_passed;
     bool skip_autorest;
+    coord_def starting_pos; // For long-walking
+    int max_longwalk_distance;
 
     FixedVector<run_check_dir,3> run_check; // array of grids to check
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -49,6 +49,7 @@
 #include "jobs.h"
 #include "kills.h"
 #include "libutil.h"
+#include "longwalk-range-mode.h"
 #include "macro.h"
 #include "mapdef.h"
 #include "maps.h"
@@ -768,6 +769,14 @@ const vector<GameOption*> game_options::build_options_list()
              {"open", travel_open_doors_type::open},
              {"false", travel_open_doors_type::_false},
              {"true", travel_open_doors_type::_true}}),
+        new MultipleChoiceGameOption<longwalk_range_mode>(
+            SIMPLE_NAME(longwalk_range),
+            longwalk_range_mode::LWR_LOS,
+            {{"los", longwalk_range_mode::LWR_LOS},
+            {"visible", LWR_VISIBLE},
+            {"unlimited", LWR_UNLIMITED},
+            {"constant", LWR_CONSTANT}}),
+        new IntGameOption(SIMPLE_NAME(longwalk_range_constant), 7, 1, 100),
 
         new MultipleChoiceGameOption<level_gen_type>(
             SIMPLE_NAME(pregen_dungeon),

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -771,12 +771,12 @@ const vector<GameOption*> game_options::build_options_list()
              {"true", travel_open_doors_type::_true}}),
         new MultipleChoiceGameOption<longwalk_range_mode>(
             SIMPLE_NAME(longwalk_range),
-            longwalk_range_mode::LWR_LOS,
+            longwalk_range_mode::LWR_CONSTANT,
             {{"los", longwalk_range_mode::LWR_LOS},
             {"visible", LWR_VISIBLE},
             {"unlimited", LWR_UNLIMITED},
             {"constant", LWR_CONSTANT}}),
-        new IntGameOption(SIMPLE_NAME(longwalk_range_constant), 7, 1, 100),
+        new IntGameOption(SIMPLE_NAME(longwalk_range_constant), 15, 1, 100),
 
         new MultipleChoiceGameOption<level_gen_type>(
             SIMPLE_NAME(pregen_dungeon),

--- a/crawl-ref/source/longwalk-range-mode.h
+++ b/crawl-ref/source/longwalk-range-mode.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// For the longwalk_range option.
+enum longwalk_range_mode
+{
+    LWR_LOS,
+    LWR_VISIBLE,
+    LWR_UNLIMITED,
+    LWR_CONSTANT
+};

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -21,6 +21,7 @@
 #include "kill-dump-options-type.h"
 #include "lang-t.h"
 #include "level-gen-type.h"
+#include "longwalk-range-mode.h"
 #include "maybe-bool.h"
 #include "mon-dam-level-type.h"
 #include "mon-util.h"
@@ -512,6 +513,8 @@ public:
     FixedBitVector<NUM_OBJECT_CLASSES> autopickups; // items to autopickup
     bool        auto_switch;     // switch melee&ranged weapons according to enemy range
     travel_open_doors_type travel_open_doors; // open doors while exploring
+    longwalk_range_mode longwalk_range; // Maximum distance type for longwalking.
+    int         longwalk_range_constant;
     bool        easy_unequip;    // allow auto-removing of armour / jewellery
     bool        equip_unequip;   // Make 'W' = 'T', and 'P' = 'R'.
     bool        jewellery_prompt; // Always prompt for slot when changing jewellery.


### PR DESCRIPTION
I often use shift+direction instead of autoexplore because it lets me explore manually with significantly fewer key presses and lets me act fast with the assurance that it will stop if a monster comes on screen. However, sometimes longwalking can unexpectedly put you dozens of tiles from where you started in unexplored territory leaving a lot of opportunity for monsters to flank you. Avoiding such situations is usually why I opted for longwalking over autoexplore in the first place!

There's a new option, longwalk_range, that gives you some control over the maximum distance shift+direction can take you. It is documented in options_guide.txt but I will summarize the possibilities here:
* los       - travel as far as your character's current line of sight range.
* visible   - travel only to tiles you can see when you start.
* unlimited - no distance limitation. Just as it was before.
* constant  - a set distance the user can provide using the new longwalk_range_constant option.

-- end commit message

I've wanted this feature for years but got lost trying to make sense of the travel code every time I tired haha.

Some bike shedding potential:
* is longwalk a good name for it? That's the name given in the in-game control menu `??` and I preferred using that name at least in the codebase because I felt "run" might be ambiguous. The player-facing option doesn't need to keep that name, I think.
* What's the best default mode? The current default is `los` which is a character's los radius, which changes with species, equipment and god abilities. A `constant` 7 or 10 might confuse players less. My favorite is `visible` which only travels to tiles you could currently see (so up to 2 tiles with heavenly storm active) but I am not sure if others would appreciate that.
