### PR TITLE
Paged inventory: Include Tab in the in-game help

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -8,7 +8,7 @@ Use the usual navigation keys (<w>arrow</w> keys, <w>pgdn</w>/<w>pgup</w>, <w>ho
 items, and <w>Space</w>/<w>.</w> to toggle whether the selected item will be picked up or
 dropped. Pressing an item's letter key will also toggle its pickup/drop state.
 Gear, potions, scrolls, and evocable items are on separate pages which can be
-switched between by <w>left arrow</w> and <w>right arrow</w>.
+switched between by <w>left arrow</w> and <w>right arrow</w> or <w>Tab</w> and <w>Shift-Tab</w>.
 Press <w>Return</w> to accept the current set of items.
 
 Entering a number before selecting by letter will toggle just that quantity of

--- a/crawl-ref/source/invent.cc
+++ b/crawl-ref/source/invent.cc
@@ -340,7 +340,7 @@ void InvMenu::set_title(const string &s)
             case 2: str = "Scrolls: "; break;
             case 3: str = "Evocable Items: "; break;
         }
-        str += "    (Left/Right to switch category)";
+        str += "    (Left/Right/Tab to switch category)";
         set_title(new InvTitle(this, str, title_annotate));
         return;
     }
@@ -1489,7 +1489,7 @@ void display_inventory()
 
 static string _drop_menu_titlefn(const Menu*, const string &)
 {
-    return "Drop what? (Left/Right to switch category) " + slot_description() + " (_ for help)";
+    return "Drop what? (Left/Right/Tab to switch category) " + slot_description() + " (_ for help)";
 }
 
 /**


### PR DESCRIPTION
Some Android users are confused with the new inventory interface. Arrow keys are not available with the default virtual keyboard settings and the in-game help does not mention the Tab key.

These are the menus affected by the patch. Please warn me if you notice anything missing.

<img width="602" height="243" alt="Captura de pantalla -2026-02-13 10-03-39" src="https://github.com/user-attachments/assets/2cdcbdfe-6dec-46c2-80ad-162a4e8abb53" />

<img width="770" height="290" alt="Captura de pantalla -2026-02-13 10-08-15" src="https://github.com/user-attachments/assets/7a4fe855-81b1-4e9a-b6f5-a47f34e57177" />

<img width="770" height="247" alt="Captura de pantalla -2026-02-13 10-09-19" src="https://github.com/user-attachments/assets/ba48405c-4269-4c29-b0c4-b4a368fbb67f" />
