### PR TITLE
Bugfix range description for two monster spells

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -371,7 +371,7 @@ static string _range_string(const spell_type &spell, const monster_info *mon_own
 
     int minrange = 0;
     if (spell == SPELL_CALL_DOWN_LIGHTNING || spell == SPELL_FLASHING_BALESTRA)
-        minrange = 2;
+        minrange = 3;
 
     const bool in_range = has_range
                     && crawl_state.need_save

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4654,7 +4654,7 @@ static void _get_spell_description(const spell_type spell,
         const int hd = mon_owner->spell_hd();
         const int range = mons_spell_range_for_hd(spell, hd, mon_owner->is(MB_PLAYER_SERVITOR));
         const int minrange = (spell == SPELL_CALL_DOWN_LIGHTNING
-                                || spell == SPELL_FLASHING_BALESTRA) ? 2 : 0;
+                                || spell == SPELL_FLASHING_BALESTRA) ? 3 : 0;
 
         description += "\nRange : ";
         description += range_string(range, -1, minrange);


### PR DESCRIPTION
These two spells both use _foe_not_nearby
https://github.com/crawl/crawl/blob/511dc2e70d5548748bd4992796731a204faa7df3/crawl-ref/source/mon-cast.cc#L473

https://github.com/crawl/crawl/blob/511dc2e70d5548748bd4992796731a204faa7df3/crawl-ref/source/mon-cast.cc#L537

which enforces a minimum range of 3, not 2
https://github.com/crawl/crawl/blob/511dc2e70d5548748bd4992796731a204faa7df3/crawl-ref/source/mon-cast.cc#L3590

I notice that beckoning gale also uses _foe_not_nearby, maybe it should also receive special treatment at these two locations?