### PR TITLE
Add rest_wait_ignore_mp option

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1092,6 +1092,12 @@ rest_wait_both = false
         when both HP and MP are fully restored, not when either one of
         them is restored.
 
+rest_wait_ignore_mp = false
+        Never continue to rest because MP are depleted. This option
+	overrules rest_wait_both. It is provided for characters who
+	are intermittently wielding antimagic weapons and have no use
+	for MP.
+
 rest_wait_ancestor = false
         If rest_wait_ancestor is set to true then resting will only stop when
         the ancestor's health is fully restored in addition to player HP or MP

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -580,6 +580,7 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(dump_on_save), true),
         new BoolGameOption(SIMPLE_NAME(rest_wait_both), false),
         new BoolGameOption(SIMPLE_NAME(rest_wait_ancestor), false),
+        new BoolGameOption(SIMPLE_NAME(rest_wait_ignore_mp), false),
         new BoolGameOption(SIMPLE_NAME(cloud_status), !is_tiles()),
         new BoolGameOption(SIMPLE_NAME(always_show_zot), false),
         new BoolGameOption(SIMPLE_NAME(always_show_gems), false),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -824,6 +824,9 @@ public:
     bool        rest_wait_ancestor;// Stop resting only if the ancestor's HP
                                    // is fully restored.
 
+    bool        rest_wait_ignore_mp; // Completely disregard depleted MP when
+                                     // resting
+
     int         rest_wait_percent; // Stop resting after restoring this
                                    // fraction of HP or MP
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4044,8 +4044,11 @@ void inc_mp(int mp_gain, bool silent)
 
     if (!silent)
     {
-        if (_should_stop_resting(you.magic_points, you.max_magic_points))
+        if (_should_stop_resting(you.magic_points, you.max_magic_points)
+            && !Options.rest_wait_ignore_mp)
+        {
             interrupt_activity(activity_interrupt::full_mp);
+        }
         you.redraw_magic_points = true;
     }
 }
@@ -5827,7 +5830,7 @@ bool player::is_sufficiently_rested(bool starting) const
     return (!player_regenerates_hp()
                 || _should_stop_resting(hp, hp_max, !starting)
                 || !hp_interrupts)
-        && (!player_regenerates_mp()
+        && (!player_regenerates_mp() || Options.rest_wait_ignore_mp
                 || _should_stop_resting(magic_points, max_magic_points, !starting)
                 || !mp_interrupts)
         && (can_freely_move || !hp_interrupts);


### PR DESCRIPTION
For Troggies who swap to and from antimagic weapons and don't care if MP are full, etc.

(cherry picked from commit a44d6c2e30122ae8655c229552f346ea1b736606) (cherry picked from commit 44df99e921829b4ea6125d69da57ee80e0a4b00b)

I mentioned this on IRC in, er, 2024 and the reaction was positive, so here it is.