### PR TITLE
buff archery ego

### DIFF
--- a/crawl-ref/source/dat/descript/egos.txt
+++ b/crawl-ref/source/dat/descript/egos.txt
@@ -148,7 +148,7 @@ It enhances your Air magic.
 %%%%
 archery (Archery) armour ego
 
-It has half the normal encumbrance for the purpose of ranged combat.
+It has one-third the normal encumbrance for the purpose of ranged combat.
 %%%%
 attunement (Attunement) armour ego
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -6144,7 +6144,7 @@ int player::unadjusted_body_armour_penalty(bool archery) const
     if (!body_armour)
         return 0;
 
-    int rfactor = archery && you.wearing_ego(OBJ_ARMOUR, SPARM_ARCHERY) ? 2 : 1;
+    int rfactor = archery && you.wearing_ego(OBJ_ARMOUR, SPARM_ARCHERY) ? 3 : 1;
 
     // PARM_EVASION is always less than or equal to 0
     return max(0, -property(*body_armour, PARM_EVASION) / 10 / rfactor


### PR DESCRIPTION
To make it more attractive, reduce enc to 1/3rd for ranged using it instead of 
half. This makes plate equivalent to acid scales for the purpose of ranged.
Since there are already tradeoffs wrt strength requirement and evasion, this
may help expand the archery ego's niche slightly.