### PR TITLE
Display Acid Splash in monster description

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -6469,6 +6469,13 @@ static string _monster_stat_description(const monster_info& mi, bool mark_spells
     if (mons_class_flag(mi.type, M_BURROWS))
         result << uppercase_first(pronoun) << " can burrow through diggable terrain.\n";
 
+    if (mons_class_flag(mi.type, M_ACID_SPLASH))
+    {
+        result << uppercase_first(pronoun) << " "
+               << conjugate_verb("splash", plural)
+               << " acid when struck in melee.\n";
+    }
+
     // Insubstantialness should take priority.
     if (mons_class_flag(mi.type, M_INSUBSTANTIAL))
     {


### PR DESCRIPTION
This ability of jellies isn't shown in game despite being a big part of of their threat.

Resolves #3376