### PR TITLE
Wake Blorkula when changing from bat to orc (projectNoob)

### DIFF
--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -946,6 +946,7 @@ static bool _blorkula_bat_split(monster& blorkula, killer_type ktype)
     {
         // Suppress messages about status effects wearing off
         msg::suppress msg;
+        blorkula.behaviour = BEH_SEEK;
         blorkula.heal(blorkula.max_hit_points);
         blorkula.del_ench(ENCH_CONFUSION, true);    // Don't blink at random
         blorkula.stop_being_constricted(true);


### PR DESCRIPTION
Sets Blorkula behavior to SEEK when returning to orc form after splitting into bats. This resolves #5082 by always waking Blorkula in the case that they turn into bats while sleeping.

From the player's perspective, this change will result in Blorkula having the "unaware" and "hasn't noticed you" status on the turn they change back into an orc, rather than remaining asleep, in the case that Blorkula turned into bats while sleeping.