### PR TITLE
Upload an artifact on Linux test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,27 @@ jobs:
         working-directory: crawl-ref/source
       # Only run `make test` with TAG_MAJOR_VERSION 34 (it fails with 35).
       - if: matrix.debug == 'FULLDEBUG=1' && (matrix.build_opts == '' || matrix.build_opts == 'WEBTILES=1') && matrix.tag_upgrade == false
-        run: make -j$(nproc) ${{ matrix.build_opts }} ${{ matrix.debug }} ${{ matrix.build_all }} test
+        id: tests
+        run: |
+          ulimit -c unlimited
+          sudo sh -c 'echo core > /proc/sys/kernel/core_pattern'
+          make -j$(nproc) ${{ matrix.build_opts }} ${{ matrix.debug }} ${{ matrix.build_all }} test
         working-directory: crawl-ref/source
         env:
           TERM: dumb
+      # Upload an artifact containing the executable, core if any, and morgue if the tests failed
+      # `failure()` ensures this step runs even if a failure (such as the one we want to catch) happens
+      # see https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#failure
+      # `conclusion` will be 'skipped' if it didn't run, so the condition doesn't need to be repeated
+      - if: failure() && steps.tests.conclusion == 'failure'
+        uses: actions/upload-artifact@v6
+        with:
+          name: morgue-${{ matrix.compiler }}-${{ matrix.build_opts }}
+          path: |
+            crawl-ref/source/morgue
+            crawl-ref/source/saves
+            crawl-ref/source/crawl
+            crawl-ref/source/core
 
   build_appimage:
     permissions:


### PR DESCRIPTION
The artifact contains the executable, the morgue, the save directory, and a core file if available (with the executable matching the core file for debugging). The artifact can be accessed by opening the `actions/upload-artifact` step log, as a URL to a `zip` file.