### PR TITLE
fix: ^Fragile equipment being destroyed before unequip effects

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1666,15 +1666,16 @@ void unequip_effect(int item_slot, bool meld, bool msg)
 
     const interrupt_block block_meld_interrupts(meld);
 
-   if (is_artefact(item))
-        unequip_artefact_effect(item, &msg, meld);
-
     if (is_weapon(item))
         _unequip_weapon_effect(item, msg, meld);
     else if (item.base_type == OBJ_ARMOUR)
         _unequip_armour_effect(item, meld);
     else if (item.base_type == OBJ_JEWELLERY)
         _unequip_jewellery_effect(item, meld);
+
+    // Artprops includes ^Fragile so the item may be destroyed after this.
+    if (is_artefact(item))
+        unequip_artefact_effect(item, &msg, meld);
 
     // Cursed items should always be destroyed on unequip.
     if (item.cursed() && !meld)


### PR DESCRIPTION
I got to use the bug for my benefit and now I am pulling up the ladder behind me!
---
The player could dodge negative unequip effects on a ^Fragile item. This means Amulets of Faith wouldn't have a piety penalty for removal and weapons of Distortion wouldn't do their distortion unwield effects. This is apparently unintended and it turns a negative property into a positive one which will surprise players and vault makers.

This commit breaks ^Fragile gear only after other unequip effects have happened.