### PR TITLE
Fix Coglin quiver switching weapons on equipment change

### DIFF
--- a/crawl-ref/source/player-equip.cc
+++ b/crawl-ref/source/player-equip.cc
@@ -1013,8 +1013,7 @@ void player_equip_set::remove(const item_def& item)
     {
         if (items[i].item == item.link)
         {
-            items[i] = items[items.size() - 1];
-            items.pop_back();
+            items.erase(items.begin() + i);
         }
     }
 


### PR DESCRIPTION
Unequipping any gear (eg: leather armour) as a Coglin with two slings could cause the quiver to flip to the offhand weapon.

`player_equip_set::remove()` used swap and pop, which doesn't preserve the ordering of the `items` vector. Since `get_first_slot_item()` returns the first match, this caused `you.weapon()` to return the wrong weapon after unrelated equipment changes.

Use `erase()` to preserve ordering instead. The `items` vector is at most ~20 entries, so the performance difference "should be" negligible.

**Repo Steps:** Start a new Coglin Hunter and unequip the leather armour. The quiver flips from the +2 sling to the +0 sling.