### PR TITLE
Update map correctly when Ashenzari reveals portals

### DIFF
--- a/crawl-ref/source/map-knowledge.cc
+++ b/crawl-ref/source/map-knowledge.cc
@@ -30,6 +30,7 @@ void set_terrain_mapped(const coord_def gc)
     cell->flags &= (~MAP_CHANGED_FLAG);
     cell->flags |= MAP_MAGIC_MAPPED_FLAG;
 #ifdef USE_TILE
+    tile_draw_map_cell(gc);
     // This may have changed the explore horizon, so update adjacent minimap
     // squares as well.
     for (adjacent_iterator ai(gc, false); ai; ++ai)
@@ -543,6 +544,9 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
                 set_terrain_seen(pos);
                 StashTrack.add_stash(pos);
                 show_update_at(pos);
+#ifdef USE_TILE
+                tile_draw_map_cell(pos);
+#endif
             }
             else
             {
@@ -552,9 +556,6 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
                 else if (get_feature_dchar(feat) == DCHAR_ARCH)
                     num_shops_portals++;
             }
-#ifdef USE_TILE
-            tile_draw_map_cell(pos);
-#endif
 
             did_map = true;
         }


### PR DESCRIPTION
19414c7 changed how we handle revelation, drawing mapped cells immediately when revealed. However, it neglected to do this for other methods of mapping, such as when Ashenzari reveals a portal.

We fix this so that whenever we set the magic mapping flag, we also draw the mapped tile.