### PR TITLE
Check skill training targets when cursing items

### DIFF
--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -451,6 +451,9 @@ void ash_check_bondage()
 
     calc_hp(true);
     calc_mp(true);
+
+    // We may have reached training targets for some skills.
+    check_training_targets();
 }
 
 void ash_id_inventory()


### PR DESCRIPTION
This isn't terribly important - without this we still check the target next time we gain experience, and disable the skill then - but is a bit clearer and is consistent with other strange skill gainings, like draconian apts changes.