### PR TITLE
Fix Ru drink and words thresholds slightly

### DIFF
--- a/crawl-ref/source/player-reacts.cc
+++ b/crawl-ref/source/player-reacts.cc
@@ -475,7 +475,7 @@ static void _handle_hoarding()
 {
     if (you.has_mutation(MUT_RENOUNCE_POTIONS))
     {
-        if (you.hp < you.hp_max / 2)
+        if (2 * you.hp < you.hp_max)
             you.props.erase(RENOUNCE_POTIONS_TIMER_KEY);
         else if (there_are_monsters_nearby(true, true, false))
             you.props[RENOUNCE_POTIONS_TIMER_KEY].get_int() = you.elapsed_time + 60;
@@ -485,7 +485,7 @@ static void _handle_hoarding()
 
     if (you.has_mutation(MUT_RENOUNCE_SCROLLS))
     {
-        if (you.hp <= you.hp_max / 2)
+        if (2 * you.hp < you.hp_max)
             you.props.erase(RENOUNCE_SCROLLS_TIMER_KEY);
         else if (there_are_monsters_nearby(true, true, false))
             you.props[RENOUNCE_SCROLLS_TIMER_KEY].get_int() = you.elapsed_time + 60;


### PR DESCRIPTION
This makes them both obey their wording "below 50% of its maximum".

Previously, words allowed scrolls at exactly 50% HP, while drink banned potions just below 50% if you had odd max HP.