### PR TITLE
fix: Elven twins didn't get haste/berserk if they can't see the player

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -4178,7 +4178,7 @@ void seen_monsters_react()
         if (!mi->visible_to(&you))
             continue;
 
-        if (!mi->has_ench(ENCH_FRENZIED) && mi->can_see(you))
+        if (!mi->has_ench(ENCH_FRENZIED) && you.see_cell(mi->pos()))
         {
             // Trigger Duvessa & Dowan upgrades
             if (mi->props.exists(ELVEN_ENERGIZE_KEY))

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -4235,7 +4235,7 @@ void elven_twin_died(monster* twin, bool in_transit, killer_type killer, int kil
     }
 
     // Finally give them new energy
-    if (mons->can_see(you) && !mons->has_ench(ENCH_FRENZIED))
+    if (you.see_cell(mons->pos()) && !mons->has_ench(ENCH_FRENZIED))
         elven_twin_energize(mons);
     else
         mons->props[ELVEN_ENERGIZE_KEY] = true;


### PR DESCRIPTION
The twins get a buff if the other twin is dead when they first see you. If they were blind or you were invisible, they wouldn't get their buffs until the moment they could see you. It's unclear if this was once intended behavior but it's spoilery tech if so.

Now they get buffed when they are your line of sight, regardless of who can see whom. This should ensure that the player gets a message when the buff is applied. (unless the twins are invisible somehow)