### PR TITLE
fix: Amulet of Dissipation now removes -Swift faster (aeshnacyanea)

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -114,7 +114,8 @@ bool duration_dispellable(duration_type dur)
 
 bool duration_negative(duration_type dur)
 {
-    return _lookup_duration(dur)->duration_has_flag(D_NEGATIVE);
+    return _lookup_duration(dur)->duration_has_flag(D_NEGATIVE)
+        || (dur == DUR_SWIFTNESS && you.attribute[ATTR_SWIFTNESS] < 0);
 }
 
 bool duration_extended_by_attacks(duration_type dur)


### PR DESCRIPTION
-Swift is dispellable and apparently negative. However, it uses DUR_SWIFTNESS which is also used by the positive Swift status and so it is not flagged D_NEGATIVE.

We now check for -swift when checking if the effect is negative so dissipation will speed up the slow down effect.

---

(I know the parenthesis isn't necessary but thought it would be good for clarity)