### PR TITLE
Display Status Icons on Monster Tile in Title of Describe View

### DIFF
--- a/crawl-ref/source/tiledgnbuf.cc
+++ b/crawl-ref/source/tiledgnbuf.cc
@@ -106,6 +106,7 @@ void DungeonCellBuffer::add_monster(const monster_info &mon, int x, int y)
 {
     tile_with_flags_t t = tileidx_monster(mon);
     tileidx_t t0   = t.tile();
+    tile_flag_t flag = t.flags();
 
     // Copied from _tile_place_monster()
     if (!mons_class_is_stationary(mon.type) || mon.type == MONS_TRAINING_DUMMY)
@@ -133,6 +134,13 @@ void DungeonCellBuffer::add_monster(const monster_info &mon, int x, int y)
             m_buf_main.add(base_idx, x, y);
         m_buf_main.add(t0, x, y);
     }
+
+    // pack_foreground() is needed to draw status icons and foreground flags
+    // on the monster tile in the title of the describe view in Local Tiles
+    packed_cell fake_cell;
+    fake_cell.fg = flag;
+    fake_cell.icons = status_icons_for(mon);
+    pack_foreground(x, y, fake_cell);
 }
 
 void DungeonCellBuffer::add_dngn_tile(int tileidx, int x, int y,


### PR DESCRIPTION
The function DungeonCellBuffer::add_monster() is used once in describe.cc to display the monster tile when viewing a monster description, and is used nowhere else. Local Tiles has not displayed status icons nor foreground flags on the monster tile in the title of the describe view since commit 322ac23. A call to function pack_foreground() was removed from add_monster() in that commit, and that led to issue #5132.

Add a function call to pack_foreground() in DungeonCellBuffer::add_monster() so that status icons and foreground flags display on the monster tile in the title of the describe view. This effectively reverts 322ac23, while incorporating the tile_with_flags_t refactoring done in 9a5c35d, and fixes #5132.