### PR TITLE
Do not power up Wyrmbane twice when killing dragons with convulsion

### DIFF
--- a/crawl-ref/source/art-func.h
+++ b/crawl-ref/source/art-func.h
@@ -623,9 +623,12 @@ static void _WYRMBANE_melee_effects(item_def* weapon, actor* /*attacker*/,
             attack_strength_punctuation(bonus_dam).c_str());
 
         atk->inflict_damage(bonus_dam);
+        // The defender may be dead, but even if so we dont want to power up
+        // the lance, as this will happen on another call in the kill phase.
+        return;
     }
 
-    if (defender->alive() || !hd)
+    if (!hd)
         return;
 
     // The cap can be reached by:


### PR DESCRIPTION
Since 2bee245, when we killed a dragon with convulsion wyrmbane powered up twice - once in the on-hit melee effects call, and once in the on-kill one.

The reason this worked _before_ that commit is that when wyrmbane killed a monster via the hurt() method, the monster was cleaned up and therefore did not register as a dragon in handle_phase_killed() call. Now that we use inflict_damage, this has changed. So we make sure we never power up wyrmbane in the on-hit melee effects, and leave it to handle_phase_killed in all cases.