### PR TITLE
Don't use randart tiles for enchanted hammers

### DIFF
--- a/crawl-ref/source/rltiles/dc-item.txt
+++ b/crawl-ref/source/rltiles/dc-item.txt
@@ -71,7 +71,7 @@ eveningstar3 WPN_EVENINGSTAR_RANDART
 hammer1 WPN_HAMMER
 %enchant_variation WPN_HAMMER shiny runed glowing
 hammer2 WPN_HAMMER_MAGIC
-%enchant_variation WPN_HAMMER shiny runed glowing randart
+%enchant_variation WPN_HAMMER randart
 hammer3 WPN_HAMMER_RANDART
 bullwhip WPN_WHIP
 %enchant_variation WPN_WHIP shiny runed glowing


### PR DESCRIPTION
Fixes #5165

I couldn't reproduce this (though I have seen it on webtiles), but this seems very likely to be the cause.