### PR TITLE
Fix Eringya's Surprising Crocodile movement effects

### DIFF
--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -4016,6 +4016,8 @@ spret cast_surprising_crocodile(actor& agent, const coord_def& targ, int pow, bo
              agent.pronoun(PRONOUN_POSSESSIVE).c_str());
     }
 
+    agent.finalise_movement();
+
     // Make the temporary water (after the movement, so we don't get slash
     // messages before the main part appears to happen).)
     for (int i = 0; i < 3; ++i)
@@ -4027,8 +4029,6 @@ spret cast_surprising_crocodile(actor& agent, const coord_def& targ, int pow, bo
                                 TERRAIN_CHANGE_FLOOD);
         }
     }
-
-    agent.finalise_movement();
 
     return spret::success;
 }


### PR DESCRIPTION
When the spell moved the player 1 tile and created shallow water there, movement effects like barbs and icy armour breaking weren't triggering.

This happened because the terrain change was calling trigger_movement_effects, clearing the deferred move.

This does mean that if there were any movement effects that should be suppressed by the terrain change, we'd trigger them anyway. But since we only change terrain if it is plain floor, this shouldn't be a problem in practice.