### PR TITLE
Fix info leaks from feature tile overrides (CrawlOdds)

### DIFF
--- a/crawl-ref/source/abyss.cc
+++ b/crawl-ref/source/abyss.cc
@@ -777,6 +777,7 @@ static void _abyss_wipe_square_at(coord_def p, bool saveMonsters=false)
     env.map_knowledge(p).clear();
     if (env.map_forgotten)
         (*env.map_forgotten)(p).clear();
+    tile_env.remembered_flavour.clear_at(p);
     env.map_seen.set(p, false);
 #ifdef USE_TILE
     tile_forget_map(p);

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1558,6 +1558,7 @@ void dgn_reset_level(bool enable_random_maps)
     env.grid_colours.init(BLACK);
     env.map_knowledge.init(map_cell());
     env.map_forgotten.reset();
+    tile_env.remembered_flavour.reset();
     env.map_seen.reset();
 
     // Initialise all items.

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1193,6 +1193,7 @@ static void _clear_env_map()
 {
     env.map_knowledge.init(map_cell());
     env.map_forgotten.reset();
+    tile_env.remembered_flavour.reset();
 }
 
 static void _grab_follower(monster* fol)

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -54,6 +54,7 @@
 #include "libutil.h"
 #include "losglobal.h"
 #include "macro.h"
+#include "map-knowledge.h"
 #include "mapmark.h"
 #include "maps.h"
 #include "message.h"
@@ -7366,7 +7367,7 @@ void makhleb_crucible_kill(monster& victim)
         simple_god_message(" acknowledges your contrition and permits you to"
                            " depart the Crucible.", false, GOD_MAKHLEB);
 
-        env.map_knowledge(pos).set_feature(DNGN_EXIT_CRUCIBLE);
+        update_terrain_knowledge(pos);
 #ifdef USE_TILE
         tile_env.bk_bg(pos) = TILE_DNGN_PORTAL;
         tiles.update_minimap(pos);

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -536,7 +536,7 @@ static bool _check_portal(coord_def where)
     const dungeon_feature_type feat = env.grid(where);
     if (feat != env.map_knowledge(where).feat() && is_ash_portal(feat))
     {
-        env.map_knowledge(where).set_feature(feat);
+        update_terrain_knowledge(where);
         set_terrain_mapped(where);
 
         if (!testbits(env.pgrid(where), FPROP_SEEN_OR_NOEXP))

--- a/crawl-ref/source/god-wrath.cc
+++ b/crawl-ref/source/god-wrath.cc
@@ -32,6 +32,7 @@
 #include "items.h"
 #include "losglobal.h"
 #include "makeitem.h"
+#include "map-knowledge.h"
 #include "message.h"
 #include "misc.h"
 #include "mon-behv.h"
@@ -1921,8 +1922,7 @@ void gozag_abandon_shops_on_level()
             dungeon_change_base_terrain(pos, DNGN_ABANDONED_SHOP);
             if (env.map_knowledge(pos).feat() == DNGN_ENTER_SHOP)
             {
-                const colour_t col = env.map_knowledge(pos).feat_colour();
-                env.map_knowledge(pos).set_feature(DNGN_ABANDONED_SHOP, col);
+                update_terrain_knowledge(pos, !env.map_knowledge(pos).seen());
                 redraw_view_at(pos);
             }
             env.markers.remove(feat);

--- a/crawl-ref/source/l-debug.cc
+++ b/crawl-ref/source/l-debug.cc
@@ -26,6 +26,7 @@
 #include "stairs.h"
 #include "state.h"
 #include "stringutil.h"
+#include "tile-env.h"
 #include "tileview.h"
 #include "unique-creature-list-type.h"
 #include "unwind.h"
@@ -103,6 +104,8 @@ LUAFN(debug_generate_level)
 {
     msg::suppress mx;
     env.map_knowledge.init(map_cell());
+    env.map_forgotten.reset();
+    tile_env.remembered_flavour.reset();
     los_changed();
     tile_init_default_flavour();
     tile_clear_flavour();

--- a/crawl-ref/source/map-cell.h
+++ b/crawl-ref/source/map-cell.h
@@ -169,9 +169,13 @@ struct map_cell
         return _feat_colour;
     }
 
-    void set_feature(dungeon_feature_type nfeat, unsigned colour = 0)
+    void set_feature(dungeon_feature_type nfeat)
     {
         _feat = nfeat;
+    }
+
+    void set_feat_colour(colour_t colour = 0)
+    {
         _feat_colour = colour;
     }
 
@@ -307,6 +311,11 @@ struct map_cell
     bool mapped() const
     {
         return !!(flags & MAP_MAGIC_MAPPED_FLAG);
+    }
+
+    bool feat_known() const
+    {
+        return !!(flags & (MAP_MAGIC_MAPPED_FLAG | MAP_SEEN_FLAG));
     }
 
 #ifdef USE_TILE

--- a/crawl-ref/source/map-knowledge.cc
+++ b/crawl-ref/source/map-knowledge.cc
@@ -13,6 +13,7 @@
 #include "religion.h"
 #include "stringutil.h"
 #include "terrain.h"
+#include "tile-env.h"
 #ifdef USE_TILE
  #include "tilepick.h"
  #include "tileview.h"
@@ -486,7 +487,8 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
             if (knowledge.seen()
                 || env.map_forgotten && (*env.map_forgotten)(pos).seen())
             {
-                knowledge.set_feature(env.grid(pos), env.grid_colours(pos));
+                update_terrain_knowledge(pos);
+                update_grid_colour_knowledge(pos);
                 redraw_view_at(pos);
             }
             else
@@ -503,13 +505,10 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
         if (!full_info && (knowledge.seen() || already_mapped))
             continue;
 
-        dungeon_feature_type feat = env.grid(pos);
-        if (!full_info)
-            feat = magic_map_base_feat(feat);
-
         bool open = true;
 
-        if (feat_is_solid(feat) && !feat_is_closed_door(feat))
+        if (feat_is_solid(env.grid(pos))
+            && !feat_is_closed_door(env.grid(pos)))
         {
             open = false;
             for (adjacent_iterator ai(pos); ai; ++ai)
@@ -525,9 +524,10 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
 
         if (open)
         {
-            knowledge.set_feature(feat, _feat_default_map_colour(feat));
-            if (is_notable_terrain(feat))
-                seen_notable_thing(feat, pos);
+            update_terrain_knowledge(pos, !full_info);
+            update_grid_colour_knowledge(pos, !full_info);
+            if (is_notable_terrain(knowledge.feat()))
+                seen_notable_thing(knowledge.feat(), pos);
 
             if (emphasise(pos))
                 knowledge.flags |= MAP_EMPHASIZE;
@@ -544,9 +544,9 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
             else
             {
                 set_terrain_mapped(pos);
-                if (get_feature_dchar(feat) == DCHAR_ALTAR)
+                if (get_feature_dchar(knowledge.feat()) == DCHAR_ALTAR)
                     num_altars++;
-                else if (get_feature_dchar(feat) == DCHAR_ARCH)
+                else if (get_feature_dchar(knowledge.feat()) == DCHAR_ARCH)
                     num_shops_portals++;
             }
 
@@ -581,4 +581,33 @@ bool magic_mapping(int map_radius, int proportion, bool suppress_msg,
     }
 
     return did_map;
+}
+
+void update_terrain_knowledge(coord_def pos,
+                              bool partial_knowledge_only)
+{
+    dungeon_feature_type feat = env.grid(pos);
+    tileidx_t feat_tile = tile_env.flv(pos).feat;
+    unsigned short feat_tile_idx = tile_env.flv(pos).feat_idx;
+    if (partial_knowledge_only)
+    {
+        feat = magic_map_base_feat(feat);
+        if (feat == DNGN_UNKNOWN_PORTAL || feat == DNGN_UNKNOWN_ALTAR)
+        {
+            feat_tile = 0;
+            feat_tile_idx = 0;
+        }
+    }
+    env.map_knowledge(pos).set_feature(feat);
+    tile_env.remembered_flavour.set_feat_flavour(pos, feat_tile,
+                                                 feat_tile_idx);
+}
+
+void update_grid_colour_knowledge(coord_def pos,
+                             bool partial_knowledge_only)
+{
+    colour_t colour = env.grid_colours(pos);
+    if (partial_knowledge_only)
+        colour = _feat_default_map_colour(env.map_knowledge(pos).feat());
+    env.map_knowledge(pos).set_feat_colour(colour);
 }

--- a/crawl-ref/source/map-knowledge.h
+++ b/crawl-ref/source/map-knowledge.h
@@ -56,3 +56,8 @@ void reautomap_level();
  */
 std::pair<coord_def, coord_def> known_map_bounds();
 bool in_known_map_bounds(const coord_def& p);
+
+void update_terrain_knowledge(coord_def pos,
+                              bool partial_knowledge_only = false);
+void update_grid_colour_knowledge(coord_def pos,
+                             bool partial_knowledge_only = false);

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -42,6 +42,7 @@
 #include "libutil.h"
 #include "losglobal.h"
 #include "makeitem.h"
+#include "map-knowledge.h"
 #include "mapmark.h"
 #include "message.h"
 #include "misc.h"
@@ -3529,7 +3530,7 @@ static bool _seal_doors_and_stairs(const monster* warden,
                 {
                     if (env.map_knowledge(dc).seen())
                     {
-                        env.map_knowledge(dc).set_feature(DNGN_CLOSED_DOOR);
+                        update_terrain_knowledge(dc);
 #ifdef USE_TILE
                         tile_env.bk_bg(dc) = TILE_DNGN_CLOSED_DOOR;
 #endif

--- a/crawl-ref/source/mon-death.cc
+++ b/crawl-ref/source/mon-death.cc
@@ -72,6 +72,7 @@
 #include "tag-version.h"
 #include "target.h"
 #include "terrain.h"
+#include "tile-env.h"
 #ifdef USE_TILE
 #include "rltiles/tiledef-player.h"
 #endif
@@ -1247,6 +1248,17 @@ void fire_monster_death_event(monster* mons,
             {
                 tile_clear_flavour(*ri);
                 tile_init_flavour(*ri);
+            }
+            if (!env.map_knowledge(*ri).feat_known()
+                && env.map_forgotten
+                && feat_is_stone_stair((*env.map_forgotten)(*ri).feat()))
+            {
+                tile_env.remembered_flavour.set_feat_flavour(*ri, 0, 0);
+            }
+            else if (feat_is_stone_stair(env.map_knowledge(*ri).feat()))
+            {
+                tile_env.remembered_flavour.set_feat_flavour(*ri, 0, 0);
+                redraw_view_at(*ri);
             }
         }
     }

--- a/crawl-ref/source/movement.cc
+++ b/crawl-ref/source/movement.cc
@@ -654,8 +654,8 @@ static void _handle_trying_to_move_into_unpassable_terrain(coord_def targ)
         map_cell& knowledge = env.map_knowledge(targ);
         if (!knowledge.mapped() || knowledge.changed())
         {
-            dungeon_feature_type newfeat = env.grid(targ);
-            knowledge.set_feature(newfeat, env.grid_colours(targ));
+            update_terrain_knowledge(targ);
+            update_grid_colour_knowledge(targ);
             set_terrain_mapped(targ);
         }
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -53,6 +53,7 @@
 #include "level-state-type.h"
 #include "libutil.h"
 #include "macro.h"
+#include "map-knowledge.h"
 #include "melee-attack.h"
 #include "message.h"
 #include "mon-behv.h"
@@ -2398,6 +2399,7 @@ void forget_map(bool rot)
         env.map_knowledge(p).clear();
         if (env.map_forgotten)
             (*env.map_forgotten)(p).clear();
+        tile_env.remembered_flavour.clear_at(p);
         StashTrack.update_stash(p);
 #ifdef USE_TILE
         tile_forget_map(p);
@@ -8943,7 +8945,7 @@ void player_open_door(coord_def doorpos)
         // door!
         if (env.map_knowledge(dc).seen())
         {
-            env.map_knowledge(dc).set_feature(env.grid(dc));
+            update_terrain_knowledge(dc);
 #ifdef USE_TILE
             tile_env.bk_bg(dc) = tileidx_feature_base(env.grid(dc));
 #endif
@@ -9114,7 +9116,7 @@ void player_close_door(coord_def doorpos)
         // want the entire door to be updated.
         if (env.map_knowledge(dc).seen())
         {
-            env.map_knowledge(dc).set_feature(env.grid(dc));
+            update_terrain_knowledge(dc);
 #ifdef USE_TILE
             tile_env.bk_bg(dc) = tileidx_feature_base(env.grid(dc));
 #endif

--- a/crawl-ref/source/show.cc
+++ b/crawl-ref/source/show.cc
@@ -111,9 +111,9 @@ bool show_type::is_cleanable_monster() const
 static void _update_feat_at(const coord_def &gp)
 {
     dungeon_feature_type feat = env.grid(gp);
-    unsigned colour = env.grid_colours(gp);
 
-    env.map_knowledge(gp).set_feature(feat, colour);
+    update_terrain_knowledge(gp);
+    update_grid_colour_knowledge(gp);
 
     if (haloed(gp))
         env.map_knowledge(gp).flags |= MAP_HALOED;

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -871,7 +871,8 @@ spret cast_tomb(int pow, actor* victim, int source, bool fail)
                 tile_env.flv(*ai).feat = TILE_DNGN_SILVER_WALL;
                 if (env.map_knowledge(*ai).seen())
                 {
-                    env.map_knowledge(*ai).set_feature(DNGN_METAL_WALL);
+                    update_terrain_knowledge(*ai);
+                    update_grid_colour_knowledge(*ai);
                     env.map_knowledge(*ai).clear_item();
 #ifdef USE_TILE
                     tile_env.bk_bg(*ai) = TILE_DNGN_SILVER_WALL;
@@ -891,7 +892,8 @@ spret cast_tomb(int pow, actor* victim, int source, bool fail)
                 tile_env.flv(*ai).feat = TILE_WALL_SANDSTONE;
                 if (env.map_knowledge(*ai).seen())
                 {
-                    env.map_knowledge(*ai).set_feature(DNGN_ROCK_WALL);
+                    update_terrain_knowledge(*ai);
+                    update_grid_colour_knowledge(*ai);
                     env.map_knowledge(*ai).clear_item();
 #ifdef USE_TILE
                     tile_env.bk_bg(*ai) = TILE_WALL_SANDSTONE;

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -350,6 +350,7 @@ enum tag_minor_version
     TAG_MINOR_REFACTOR_MALIGN_MARKER,   // Refactor handling of map_malign_gateway_marker
     TAG_MINOR_REMOVE_MORTAR_MARKERS, // Remove map_hellfire_mortar_lava_marker and refactor again
     TAG_MINOR_FIX_VENGEANCE_CLEANUP, // Fix a crash when changing levels due to old vengeance targets
+    TAG_MINOR_FLAVOUR_KNOWLEDGE,   // Save player knowledge of feature flavour
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -6520,7 +6520,8 @@ void unmarshallMapCell(reader &th, map_cell& cell)
 #endif
     }
 
-    cell.set_feature(feature, feat_colour);
+    cell.set_feature(feature);
+    cell.set_feat_colour(feat_colour);
 
     if (flags & MAP_SERIALIZE_CLOUD)
     {
@@ -7165,6 +7166,15 @@ void _tag_construct_level_tiles(writer &th)
             marshallShort(th, tile_env.flv[count_x][count_y].floor);
             marshallShort(th, tile_env.flv[count_x][count_y].feat);
             marshallShort(th, tile_env.flv[count_x][count_y].special);
+        }
+
+    const flavour_knowledge& remembered = tile_env.remembered_flavour;
+    for (int count_x = 0; count_x < GXM; count_x++)
+        for (int count_y = 0; count_y < GYM; count_y++)
+        {
+            coord_def pos(count_x, count_y);
+            unsigned short tile_idx = remembered.feat_flavour_idx(pos);
+            marshallShort(th, tile_idx);
         }
 
     marshallInt(th, TILE_WALL_MAX);
@@ -8290,6 +8300,33 @@ static void _debug_count_tiles()
 #endif
 }
 
+#if TAG_MAJOR_VERSION == 34
+static void _fixup_flavour_knowledge()
+{
+    flavour_knowledge& knowledge = tile_env.remembered_flavour;
+    const MapKnowledge& map = env.map_knowledge;
+
+    for (rectangle_iterator ri(0); ri; ++ri)
+    {
+        const dungeon_feature_type feat = map(*ri).feat();
+        // We used to ignore tile overrides on these features
+        if (feat != DNGN_FLOOR
+            && feat != DNGN_UNSEEN
+            && feat != DNGN_PASSAGE_OF_GOLUBRIA
+            && feat != DNGN_MALIGN_GATEWAY
+            && feat != DNGN_BINDING_SIGIL
+            && feat != DNGN_UNKNOWN_PORTAL
+            && feat != DNGN_TREE)
+        {
+            unsigned short tile_idx = tile_env.flv(*ri).feat_idx;
+            knowledge.set_feat_flavour(*ri, 0, tile_idx);
+        }
+        else
+            knowledge.set_feat_flavour(*ri, 0, 0);
+    }
+}
+#endif
+
 void _tag_read_level_tiles(reader &th)
 {
     // Map grids.
@@ -8331,6 +8368,22 @@ void _tag_read_level_tiles(reader &th)
             tile_env.flv[x][y].feat    = unmarshallShort(th);
             tile_env.flv[x][y].special = unmarshallShort(th);
         }
+
+#if TAG_MAJOR_VERSION == 34
+    if (th.getMinorVersion() < TAG_MINOR_FLAVOUR_KNOWLEDGE)
+        _fixup_flavour_knowledge();
+    else
+#endif
+    {
+        flavour_knowledge& remembered = tile_env.remembered_flavour;
+        for (int x = 0; x < gx; x++)
+            for (int y = 0; y < gy; y++)
+            {
+                coord_def pos(x, y);
+                unsigned short feat_idx = unmarshallShort(th);
+                remembered.set_feat_flavour(pos, 0, feat_idx);
+            }
+    }
 
     _debug_count_tiles();
 
@@ -8428,9 +8481,23 @@ static void _regenerate_tile_flavour()
             else
                 flv.feat = new_feat;
         }
+
+        unsigned short remembered_feat_idx =
+            tile_env.remembered_flavour.feat_flavour_idx(*ri);
+        if (remembered_feat_idx)
+        {
+            tileidx_t new_feat = _get_tile_from_vector(remembered_feat_idx);
+            if (!new_feat)
+                remembered_feat_idx = 0;
+            tile_env.remembered_flavour.set_feat_flavour(*ri, new_feat,
+                                                         remembered_feat_idx);
+        }
     }
 
     tile_new_level(true, false);
+
+    for (rectangle_iterator ri(0); ri; ++ri)
+        tile_init_remembered_flavour(*ri);
 }
 
 static void _draw_tiles()

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -2255,11 +2255,16 @@ bool revert_terrain_change(coord_def pos, terrain_change_type ctype)
         noisy(spell_effect_noise(SPELL_GOLUBRIAS_PASSAGE), pos);
     }
 
-    if (ctype == TERRAIN_CHANGE_BOG)
-        env.map_knowledge(pos).set_feature(newfeat, colour);
     _current_terrain_changed(pos, newfeat, false, true, false, newfeat_flv,
                              newfeat_flv_idx);
     env.grid_colours(pos) = colour;
+
+    if (ctype == TERRAIN_CHANGE_BOG)
+    {
+        update_terrain_knowledge(pos);
+        update_grid_colour_knowledge(pos);
+    }
+
     return true;
 }
 
@@ -2657,7 +2662,7 @@ void descent_crumble_stairs()
             mpr("The exit collapses.");
         if (env.map_knowledge(*ri).feat() == original_feat)
         {
-            env.map_knowledge(*ri).set_feature(DNGN_FLOOR);
+            update_terrain_knowledge(*ri, !env.map_knowledge(*ri).seen());
             set_terrain_mapped(*ri);
             redraw_view_at(*ri);
         }

--- a/crawl-ref/source/tile-env.h
+++ b/crawl-ref/source/tile-env.h
@@ -8,6 +8,52 @@
 #include "fixedarray.h"
 #include "rltiles/tiledef_defines.h"
 
+struct flavour_knowledge
+{
+    flavour_knowledge()
+    {
+        reset();
+    }
+
+    void reset()
+    {
+        _feat_flavour.init(0);
+        _feat_flavour_idx.init(0);
+    }
+
+    tileidx_t feat_flavour(coord_def pos) const
+    {
+        return _feat_flavour(pos);
+    }
+
+    unsigned short feat_flavour_idx(coord_def pos) const
+    {
+        return _feat_flavour_idx(pos);
+    }
+
+    void set_feat_flavour(coord_def pos, tileidx_t tile,
+                          unsigned short tile_idx)
+    {
+        _feat_flavour(pos) = tile;
+        _feat_flavour_idx(pos) = tile_idx;
+    }
+
+    void copy_at(coord_def pos, const flavour_knowledge& source)
+    {
+        _feat_flavour(pos) = source._feat_flavour(pos);
+        _feat_flavour_idx(pos) = source._feat_flavour_idx(pos);
+    }
+
+    void clear_at(coord_def pos)
+    {
+        set_feat_flavour(pos, 0, 0);
+    }
+
+private:
+    FixedArray<tileidx_t, GXM, GYM> _feat_flavour;
+    FixedArray<unsigned short, GXM, GYM> _feat_flavour_idx;
+};
+
 struct crawl_tile_environment
 {
     // indexed by grid coords
@@ -19,6 +65,7 @@ struct crawl_tile_environment
 #endif
     FixedArray<tile_flavour, GXM, GYM> flv;
     tile_flavour default_flavour;
+    flavour_knowledge remembered_flavour;
     std::vector<std::string> names;
 };
 

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -944,17 +944,13 @@ static tileidx_t _tileidx_feature_no_overrides(const coord_def &gc)
 {
     dungeon_feature_type feat = env.map_knowledge(gc).feat();
 
-    tileidx_t override = tile_env.flv(gc).feat;
-    bool can_override = !feat_is_door(feat)
-                        && feat != DNGN_FLOOR
-                        && feat != DNGN_UNSEEN
-                        && feat != DNGN_PASSAGE_OF_GOLUBRIA
-                        && feat != DNGN_MALIGN_GATEWAY
-                        && feat != DNGN_BINDING_SIGIL
-                        && feat != DNGN_UNKNOWN_PORTAL
-                        && feat != DNGN_TREE; // summon forest spell
-    if (override && can_override)
+    tileidx_t override = tile_env.remembered_flavour.feat_flavour(gc);
+    // Door tile overrides get special handling in apply_variations
+    if (override && !feat_is_door(feat)
+        && env.map_knowledge(gc).feat_known())
+    {
         return override;
+    }
 
     // Any grid-specific tiles.
     switch (feat)

--- a/crawl-ref/source/tileview.cc
+++ b/crawl-ref/source/tileview.cc
@@ -506,6 +506,46 @@ static bool _same_door_at(dungeon_feature_type feat, const coord_def &gc)
            && (feat_is_sealed(feat) || feat_is_sealed(door));
 }
 
+static void _init_feat_flavour(tileidx_t& flavour, dungeon_feature_type feat)
+{
+    if (feat_is_stone_stair(feat))
+    {
+        const bool up = feat_stair_direction(feat) == CMD_GO_UPSTAIRS;
+        if (player_in_branch(BRANCH_SHOALS))
+        {
+            flavour = up ? TILE_DNGN_SHOALS_STAIRS_UP
+                         : TILE_DNGN_SHOALS_STAIRS_DOWN;
+        }
+        else if (player_in_branch(BRANCH_VAULTS))
+        {
+            if (you.depth == branches[BRANCH_VAULTS].numlevels - 1 && !up)
+                flavour = TILE_DNGN_METAL_STAIRS_DOWN;
+            else if (you.depth == branches[BRANCH_VAULTS].numlevels && up)
+                flavour = TILE_DNGN_METAL_STAIRS_UP;
+        }
+        else if (player_in_branch(BRANCH_ZOT))
+        {
+            if (you.depth == branches[BRANCH_VAULTS].numlevels - 1 && !up)
+                flavour = TILE_DNGN_ZOT_STAIRS_DOWN;
+            else if (you.depth == branches[BRANCH_VAULTS].numlevels && up)
+                flavour = TILE_DNGN_ZOT_STAIRS_UP;
+        }
+        else if (player_in_branch(BRANCH_SLIME) && !you.royal_jelly_dead)
+        {
+            if (up)
+                flavour = TILE_DNGN_SLIMY_STAIRS_UP;
+            else
+                flavour = TILE_DNGN_SLIMY_STAIRS_DOWN;
+        }
+    }
+    else if (feat_is_escape_hatch(feat) && player_in_branch(BRANCH_TOMB))
+    {
+        const bool up = feat_stair_direction(feat) == CMD_GO_UPSTAIRS;
+        flavour = up ? TILE_DNGN_ONE_WAY_STAIRS_UP
+                     : TILE_DNGN_ONE_WAY_STAIRS_DOWN;
+    }
+}
+
 void tile_init_flavour(const coord_def &gc, const int domino)
 {
     if (!map_bounds(gc))
@@ -557,43 +597,7 @@ void tile_init_flavour(const coord_def &gc, const int domino)
     else
         tile_env.flv(gc).wall = pick_dngn_tile(tile_env.flv(gc).wall, rand2);
 
-    if (feat_is_stone_stair(env.grid(gc)))
-    {
-        const bool up = feat_stair_direction(env.grid(gc)) == CMD_GO_UPSTAIRS;
-        if (player_in_branch(BRANCH_SHOALS))
-        {
-            tile_env.flv(gc).feat = up ? TILE_DNGN_SHOALS_STAIRS_UP
-                                       : TILE_DNGN_SHOALS_STAIRS_DOWN;
-        }
-        else if (player_in_branch(BRANCH_VAULTS))
-        {
-            if (you.depth == branches[BRANCH_VAULTS].numlevels - 1 && !up)
-                tile_env.flv(gc).feat = TILE_DNGN_METAL_STAIRS_DOWN;
-            else if (you.depth == branches[BRANCH_VAULTS].numlevels && up)
-                tile_env.flv(gc).feat = TILE_DNGN_METAL_STAIRS_UP;
-        }
-        else if (player_in_branch(BRANCH_ZOT))
-        {
-            if (you.depth == branches[BRANCH_VAULTS].numlevels - 1 && !up)
-                tile_env.flv(gc).feat = TILE_DNGN_ZOT_STAIRS_DOWN;
-            else if (you.depth == branches[BRANCH_VAULTS].numlevels && up)
-                tile_env.flv(gc).feat = TILE_DNGN_ZOT_STAIRS_UP;
-        }
-        else if (player_in_branch(BRANCH_SLIME) && !you.royal_jelly_dead)
-        {
-            if (up)
-                tile_env.flv(gc).feat = TILE_DNGN_SLIMY_STAIRS_UP;
-            else
-                tile_env.flv(gc).feat = TILE_DNGN_SLIMY_STAIRS_DOWN;
-        }
-    }
-
-    if (feat_is_escape_hatch(env.grid(gc)) && player_in_branch(BRANCH_TOMB))
-    {
-        const bool up = feat_stair_direction(env.grid(gc)) == CMD_GO_UPSTAIRS;
-        tile_env.flv(gc).feat = up ? TILE_DNGN_ONE_WAY_STAIRS_UP
-                                   : TILE_DNGN_ONE_WAY_STAIRS_DOWN;
-    }
+    _init_feat_flavour(tile_env.flv(gc).feat, env.grid(gc));
 
     if (feat_is_door(env.grid(gc)))
     {
@@ -629,6 +633,17 @@ void tile_init_flavour(const coord_def &gc, const int domino)
     }
     else if (!tile_env.flv(gc).special)
         tile_env.flv(gc).special = hash_with_seed(256, seed, 10);
+}
+
+void tile_init_remembered_flavour(coord_def pos)
+{
+    dungeon_feature_type feat = env.map_knowledge(pos).feat();
+    if (!env.map_knowledge(pos).feat_known() && env.map_forgotten)
+        feat = (*env.map_forgotten)(pos).feat();
+    tileidx_t tile = tile_env.remembered_flavour.feat_flavour(pos);
+    _init_feat_flavour(tile, feat);
+    unsigned short idx = tile_env.remembered_flavour.feat_flavour_idx(pos);
+    tile_env.remembered_flavour.set_feat_flavour(pos, tile, idx);
 }
 
 enum SpecialIdx

--- a/crawl-ref/source/tileview.h
+++ b/crawl-ref/source/tileview.h
@@ -39,6 +39,7 @@ void tile_clear_flavour();
 void tile_init_flavour();
 // Init the flavour of a single cell.
 void tile_init_flavour(const coord_def &gc, const int domino = -1);
+void tile_init_remembered_flavour(coord_def pos);
 // Draw a halo using 'tile' (which has 9 variations) around any features
 // that match target.
 void tile_floor_halo(dungeon_feature_type target, tileidx_t tile);

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -28,6 +28,7 @@
 #include "god-passive.h"
 #include "items.h"
 #include "libutil.h"
+#include "map-knowledge.h"
 #include "mapmark.h"
 #include "message.h"
 #include "mgen-data.h"
@@ -990,7 +991,8 @@ void timeout_terrain_changes(int duration, bool force)
         // so forcibly redraw anything the player could see at the start of them.
         if (m_pos.was_in_los)
         {
-            env.map_knowledge(m_pos.pos).set_feature(env.grid(m_pos.pos));
+            update_terrain_knowledge(m_pos.pos);
+            update_grid_colour_knowledge(m_pos.pos);
 #ifdef USE_TILE
             tile_env.bk_bg(m_pos.pos) = tileidx_feature_base(env.grid(m_pos.pos));
 #endif

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -28,6 +28,7 @@
 #include "item-prop.h"
 #include "items.h"
 #include "libutil.h"
+#include "map-knowledge.h"
 #include "mapmark.h"
 #include "mon-cast.h" // recall for zot traps
 #include "mon-enum.h"
@@ -679,7 +680,7 @@ void destroy_trap(const coord_def& pos)
     dungeon_terrain_changed(pos, DNGN_FLOOR);
     if (you.see_cell(pos))
     {
-        env.map_knowledge(pos).set_feature(DNGN_FLOOR);
+        update_terrain_knowledge(pos);
         StashTrack.update_stash(pos);
     }
 }

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -30,6 +30,7 @@
 #include "state.h"
 #include "stringutil.h"
 #include "terrain.h"
+#include "tile-env.h"
 #include "tileview.h"
 #include "tiles-build-specific.h"
 #include "travel.h"

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -1552,8 +1552,8 @@ static void _xom_lights_up_webs(int /*sever*/)
         place_cloud(CLOUD_FIRE, pos, blaze_time, nullptr, 0);
 
         webs_count++;
-        env.map_knowledge(pos).set_feature(DNGN_FLOOR);
         dungeon_terrain_changed(pos, DNGN_FLOOR);
+        update_terrain_knowledge(pos);
 
         if (actor* act = actor_at(pos))
             if (act->caught_by() == CAUGHT_WEB)


### PR DESCRIPTION
When creating temporary terrain, we either clear or replace any existing tile override and then restore it when the temporary terrain ends. This is helpful as for example if you use summon forest to create a tree on a square that contained a wall with a tile override you wouldn't want the tree to use the tile override for the wall.

However, we were drawing the feature that the player remembered being at a square with the current tile override for the square. This could leak whether the feature in the square had changed since the player had last seen it, so we were using a number of hacks to try and prevent this. One of these hacks was that we wouldn't use the tile override when drawing types of terrain that are used by temporary terrain. This would prevent a problem in cases such as when the player had seen a tree from summon forest on a square that used to have a wall with a tile override then moved out of view of it then waited for summon forest to end as this would result in there being a remembered tree with the tile override from the wall that currently exists in the square. However, this doesn't work for all terrain types that can be created by temporary terrain as we want to use tile overrides for some of these terrain types. Also, the list of terrain types to not use tile overrides on was not being updated when adding new types of temporary terrain. Another hack that we were using is that we would always draw some terrain using the tile override that the square would have if it didn't have temporary terrain (which can be extracted from the temporary terrain marker if needed). We did this for terrain types that aren't created by temporary terrain but can have temporary terrain created on them. This would prevent an information leak where creating temporary terrain out of view (such as some of the trees from summon forest) would cause the remembered terrain to be drawn with the tile override for the temporary terrain revealing where the out of view temporary terrain had been created. However, our list of terrain types to use for this was outdated and also could never be perfect as many terrain types can both have temporary terrain created on them and be temporary terrain. This hack also seems to have been lost in a recent refactoring.

Instead of using these hacks, store the remembered tile override for squares the player has seen and magic mapped and use this for drawing. A side effect of this change is that dead trees in Crypt now use the dead tree tile when magic mapped rather than the living tree tile as they have a tile override that used to be unused (non-magic mapped dead trees in Crypt were able to got there dead tree tile through their grid colour).

Fixes #5168