### PR TITLE
Fix a bug with exclusions for new enemies on descent

### DIFF
--- a/crawl-ref/source/exclude.cc
+++ b/crawl-ref/source/exclude.cc
@@ -553,19 +553,32 @@ void set_exclude(const coord_def &p, int radius, bool autoexcl, bool vaultexcl,
         string desc = "";
         if (!defer_updates)
         {
-            // Don't list a monster in the exclusion annotation if the
-            // exclusion was triggered by e.g. the flamethrowers' lua check.
-            const map_cell& cell = env.map_knowledge(p);
-            if (cell.monster() != MONS_NO_MONSTER)
+            monster* m = monster_at(p);
+            if (autoexcl && m)
             {
-                desc = mons_type_name(cell.monster(), DESC_PLAIN);
-                if (cell.detected_monster())
-                    desc += " (detected)";
+                // Autoexcludes use the ground truth monster, not the map
+                // knowledge, since sometimes this isn't set when placing
+                // autoexclusions for a newly visible monster, and the caller
+                // has already check that there's an autoexclude-worthy monster
+                // here.
+                desc = mons_type_name(m->type, DESC_PLAIN);
             }
             else
             {
-                const dungeon_feature_type feat = cell.feat();
-                desc = feat_type_name(feat);
+                // Don't list a monster in the exclusion annotation if the
+                // exclusion was triggered by e.g. the flamethrowers' lua check.
+                const map_cell& cell = env.map_knowledge(p);
+                if (cell.monster() != MONS_NO_MONSTER)
+                {
+                    desc = mons_type_name(cell.monster(), DESC_PLAIN);
+                    if (cell.detected_monster())
+                        desc += " (detected)";
+                }
+                else
+                {
+                    const dungeon_feature_type feat = cell.feat();
+                    desc = feat_type_name(feat);
+                }
             }
         }
         else if (cloud_struct* cloud = cloud_at(p))


### PR DESCRIPTION
Flagging that there may be better ways to fix this - particularly we could make map_knowledge in date so that auto exclusions don't need to look at ground truth monster data.

---

When we traverse stairs and see a new monster which should be autoexcluded, we were previously placing an exclusion without the monster name in its description, and then immediately removed it before the player could even see it.

This is happening because the autoexclusions happen before our map_knowledge is updated. An alternative fix would be to update map_knowledge before add_auto_excludes, or on changing level.