### PR TITLE
Implement a bias for exploring near stairs

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -672,6 +672,7 @@ const vector<GameOption*> game_options::build_options_list()
         new IntGameOption(SIMPLE_NAME(explore_delay), -1, -1, 2000),
         new IntGameOption(SIMPLE_NAME(explore_item_greed), 10, -1000, 1000),
         new IntGameOption(SIMPLE_NAME(explore_wall_bias), 0, -1000, 1000),
+        new IntGameOption(SIMPLE_NAME(explore_stair_bias), 0, -1000, 1000),
         new IntGameOption(SIMPLE_NAME(scroll_margin_x), 2, 0),
         new IntGameOption(SIMPLE_NAME(scroll_margin_y), 2, 0),
         new IntGameOption(SIMPLE_NAME(item_stack_summary_minimum), 4),

--- a/crawl-ref/source/mon-place.cc
+++ b/crawl-ref/source/mon-place.cc
@@ -2978,13 +2978,13 @@ public:
         :  habitat_wanted(ht_wanted), maxdistance(maxdist),
            best_distance(0), nfound(0), levelgen(_levelgen)
     {
-        start = pos;
+        starts = {pos};
     }
 
     // This is an overload, not an override!
     coord_def pathfind()
     {
-        set_floodseed(start);
+        set_floodseeds(starts);
         return travel_pathfind::pathfind(RMODE_CONNECTIVITY);
     }
 

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -731,6 +731,9 @@ public:
     // How much autoexplore favours visiting squares next to walls.
     int         explore_wall_bias;
 
+    // How much autoexplore favours visiting squares near stairs.
+    int         explore_stair_bias;
+
     // Wait for rest wait percent HP and MP before exploring.
     bool        explore_auto_rest;
 

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1302,7 +1302,7 @@ FixedVector<coord_def, GXM * GYM> travel_pathfind::circumference[2];
 // const int travel_pathfind::INFINITE_DIST;
 
 travel_pathfind::travel_pathfind()
-    : runmode(RMODE_NOT_RUNNING), start(), dest(), next_travel_move(),
+    : runmode(RMODE_NOT_RUNNING), starts(), dest(), next_travel_move(),
       floodout(false), double_flood(false), ignore_hostile(false),
       ignore_danger(false), annotate_map(false), ls(nullptr),
       need_for_greed(false), autopickup(false),
@@ -1332,19 +1332,24 @@ void travel_pathfind::set_src_dst(const coord_def &src, const coord_def &dst)
 {
     // Yes, this is backwards - for travel, we always start from the destination
     // and search outwards for the starting position.
-    start = dst;
+    starts = {dst};
     dest  = src;
 
     floodout = double_flood = false;
 }
 
-void travel_pathfind::set_floodseed(const coord_def &seed, bool dblflood)
+void travel_pathfind::set_floodseeds(const vector<coord_def> &seeds, bool dblflood)
 {
-    start = seed;
+    starts = seeds;
     dest.reset();
 
     floodout = true;
     double_flood = dblflood;
+}
+
+void travel_pathfind::set_floodseed(const coord_def &seed, bool dblflood)
+{
+    set_floodseeds({seed}, dblflood);
 }
 
 void travel_pathfind::set_feature_vector(vector<coord_def> *feats)
@@ -1373,6 +1378,30 @@ const coord_def travel_pathfind::explore_target() const
     return coord_def(0, 0);
 }
 
+void travel_pathfind::populate_stair_distances()
+{
+    LevelInfo &li = travel_cache.get_level_info(level_id::current());
+    vector<coord_def> stair_positions = {};
+    for (auto s : li.get_stairs())
+    {
+        if (feat_stair_direction(s.grid) == CMD_GO_UPSTAIRS)
+            stair_positions.push_back(s.position);
+    }
+    if (stair_positions.empty())
+    {
+        for (int x = 0; x < GXM; ++x)
+            for (int y = 0; y < GYM; ++y)
+                stair_distances[x][y] = INFINITE_DIST;
+    }
+    else
+    {
+        fill_travel_point_distance_multiple(stair_positions);
+        for (int x = 0; x < GXM; ++x)
+            for (int y = 0; y < GYM; ++y)
+                stair_distances[x][y] = travel_point_distance[x][y];
+    }
+}
+
 // The travel algorithm is based on the NetHack travel code written by Warwick
 // Allison - used with his permission.
 coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
@@ -1397,6 +1426,12 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
         {
             autopickup = can_autopickup();
             need_for_greed = autopickup;
+        }
+        if (Options.explore_stair_bias
+            && (runmode == RMODE_EXPLORE || runmode == RMODE_EXPLORE_GREEDY))
+        {
+            // Need distances from stairs to implement stair bias.
+            populate_stair_distances();
         }
     }
 
@@ -1433,21 +1468,24 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
     // point, i.e. the distance travelled to get there.
     memset(point_distance, 0, sizeof(travel_distance_grid_t));
 
-    if (!in_bounds(start))
-        return coord_def();
-
-    // Abort run if we're trying to go someplace evil. Travel to traps is
-    // specifically allowed here if the player insists on it.
-    if (!floodout
-        && !is_travelsafe_square(start, false, ignore_danger, true)
-        && !is_trap(start))          // player likes pain
+    bool any_valid = false;
+    for (auto start : starts)
     {
-        return coord_def();
+        if (!in_bounds(start))
+            continue;
+
+        // Nothing to do?
+        if (!floodout && start == dest)
+            return start;
+
+        if (floodout
+            || is_travelsafe_square(start, false, ignore_danger, true)
+            || is_trap(start))          // player likes pain
+            any_valid = true;
     }
 
-    // Nothing to do?
-    if (!floodout && start == dest)
-        return start;
+    if (!any_valid)
+        return coord_def();
 
     unwind_bool slime_wall_check(g_Slime_Wall_Check,
                                  !ignore_player_traversability
@@ -1478,7 +1516,8 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
     // the "next round" becomes the current one, and the old points can be
     // overwritten with newer ones. Since we count the number of points for
     // next round in next_iter_points, we don't even need to reset the array.
-    circumference[circ_index][0] = start;
+    for (unsigned int i = 0; i < starts.size(); ++i)
+        circumference[circ_index][i] = starts[i];
 
     bool found_target = false;
 
@@ -1496,7 +1535,8 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
                 if (runmode == RMODE_TRAVEL)
                     return next_travel_move;
                 else if (runmode == RMODE_CONNECTIVITY
-                         || !Options.explore_wall_bias)
+                         || (!Options.explore_wall_bias
+                             && !Options.explore_stair_bias))
                 {
                     return explore_target();
                 }
@@ -1505,7 +1545,7 @@ coord_def travel_pathfind::pathfind(run_mode_type rmode, bool fallback_explore)
             }
         }
 
-        // Handle exploration with wall bias
+        // Handle exploration with wall/stair bias
         if (next_iter_points == 0 && found_target)
             return explore_target();
 
@@ -1646,6 +1686,10 @@ void travel_pathfind::check_square_greed(const coord_def &c)
         if (Options.explore_wall_bias > 0)
             dist += Options.explore_wall_bias * 3;
 
+        // Penalize distance to favour exploring near stairs
+        if (Options.explore_stair_bias)
+            dist += Options.explore_stair_bias * stair_distances[c.x][c.y] / 10;
+
         greedy_dist = dist;
         greedy_place = c;
     }
@@ -1733,6 +1777,10 @@ bool travel_pathfind::path_flood(const coord_def &c, const coord_def &dc)
                     }
                 }
 
+                // Penalize distance to favour exploring near stairs
+                if (Options.explore_stair_bias)
+                    dist += Options.explore_stair_bias * stair_distances[c.x][c.y] / 10;
+
                 // Replace old target if nearer (or less penalized)
                 // don't let dist get < 0
                 if (dist < unexplored_dist || unexplored_dist < 0)
@@ -1778,6 +1826,7 @@ bool travel_pathfind::path_flood(const coord_def &c, const coord_def &dc)
     if (!in_bounds(dc))
         return false;
 
+    bool dc_is_start = find(starts.begin(), starts.end(), dc) != starts.end();
     // We don't want to follow the transporter at c if it's excluded. We also
     // don't want to update point_distance for the destination based on
     // taking this transporter.
@@ -1803,7 +1852,7 @@ bool travel_pathfind::path_flood(const coord_def &c, const coord_def &dc)
         // trap, we'll want to put it on the feature vector anyway.
         if (_is_reseedable(dc, ignore_danger)
             && !point_distance[dc.x][dc.y]
-            && dc != start)
+            && !dc_is_start)
         {
             if (features && (is_trap(dc) || is_exclude_root(dc))
                 && find(features->begin(), features->end(), dc)
@@ -1848,7 +1897,7 @@ bool travel_pathfind::path_flood(const coord_def &c, const coord_def &dc)
         {
             dungeon_feature_type feature = env.map_knowledge(dc).feat();
 
-            if (dc != start
+            if (!dc_is_start
                 && (feature != DNGN_FLOOR
                        && !feat_is_water(feature)
                        && feature != DNGN_LAVA
@@ -1861,7 +1910,7 @@ bool travel_pathfind::path_flood(const coord_def &c, const coord_def &dc)
             }
         }
 
-        if (features && dc != start && is_exclude_root(dc)
+        if (features && !dc_is_start && is_exclude_root(dc)
             && find(features->begin(), features->end(), dc)
                == features->end())
         {
@@ -1982,19 +2031,20 @@ int travel_pathfind::explore_status()
     return status;
 }
 
-
 /**
- * Run the travel_pathfind algorithm, from the given position in floodout mode
- * to populate travel_point_distance relative to that starting point.
+ * Run the travel_pathfind algorithm, from the given positions in floodout mode
+ * to populate travel_point_distance relative to those positions. The distance
+ * is the minimum distance from any of the positions.
  *
  * @param      youpos The starting position.
  * @param[in]  features A vector of features to give to travel_pathfind.
  */
-void fill_travel_point_distance(const coord_def& youpos,
-                                vector<coord_def>* features)
+void fill_travel_point_distance_multiple(
+    const vector<coord_def>& positions,
+    vector<coord_def>* features)
 {
     travel_pathfind tp;
-    tp.set_floodseed(youpos);
+    tp.set_floodseeds(positions);
     tp.set_feature_vector(features);
 
     // Calling pathfind() twice like this changes the order of *features, but
@@ -2002,6 +2052,20 @@ void fill_travel_point_distance(const coord_def& youpos,
     if (features)
         tp.pathfind(RMODE_NOT_RUNNING, false);
     tp.pathfind(RMODE_NOT_RUNNING, true);
+}
+
+
+/**
+ * Run the travel_pathfind algorithm, from the given position in floodout mode
+ * to populate travel_point_distance relative to the point.
+ *
+ * @param      youpos The starting position.
+ * @param[in]  features A vector of features to give to travel_pathfind.
+ */
+void fill_travel_point_distance(const coord_def& youpos,
+                                vector<coord_def>* features)
+{
+    fill_travel_point_distance_multiple({youpos}, features);
 }
 
 extern map<branch_type, set<level_id> > stair_level;

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -78,6 +78,9 @@ bool is_unknown_transporter(const coord_def &p);
 
 void fill_travel_point_distance(const coord_def& youpos,
                      vector<coord_def>* coords = nullptr);
+void fill_travel_point_distance_multiple(
+    const vector<coord_def>& positions,
+    vector<coord_def>* coords = nullptr);
 
 bool is_stair_exclusion(const coord_def &p);
 
@@ -458,7 +461,9 @@ public:
     // sealed doors as traversable
     coord_def pathfind(run_mode_type rt, bool fallback_explore = false);
 
-    // For flood-fills (explore), sets starting (seed) square.
+    // For flood-fills (explore), sets starting (seed) square(s).
+    void set_floodseeds(const vector<coord_def> &seeds,
+                        bool double_flood = false);
     void set_floodseed(const coord_def &seed, bool double_flood = false);
 
     // For regular travel, set starting point (usually the character's current
@@ -496,6 +501,7 @@ protected:
     bool square_slows_movement(const coord_def &c);
     void check_square_greed(const coord_def &c);
     void good_square(const coord_def &c);
+    void populate_stair_distances();
 
 protected:
     static const int UNFOUND_DIST  = -30000;
@@ -506,7 +512,8 @@ protected:
 
     // Where pathfinding starts, and the destination. Note that dest is not
     // relevant for explore!
-    coord_def start, dest;
+    vector<coord_def> starts;
+    coord_def dest;
 
     // This is the square adjacent to the starting position to move
     // along the shortest path to the destination. Does *not* apply
@@ -566,6 +573,9 @@ protected:
 
     // Which index of the circumference array are we currently looking at?
     int circ_index;
+
+    // The distances of points on the level from the nearest upstair.
+    int stair_distances[GXM][GYM];
 
     // Used by all instances of travel_pathfind. Happily, we do not need to be
     // re-entrant or thread-safe.


### PR DESCRIPTION
This penalises squares in autoexplore by their distance to the nearest known upstair.

The formula is
adjusted_distance(x) = distance(x) + bias*stair_distance(x)/10

From some testing, a bias of x adds approximately x% to explore time for x=0,5,10,20,100. The exploration clearly hugs stairs, sensible so at biases from 0 to 20 and tediously so at 100.

Performance-wise, this adds one extra floodfill to autoexplore, which very roughly doubles how long it takes; on my laptop from 1.1ms to 1.8ms in a typical case on a fully-explored floor.