### PR TITLE
fix(spells): Make binding sigil speed up players

### DIFF
--- a/crawl-ref/source/spl-other.cc
+++ b/crawl-ref/source/spl-other.cc
@@ -598,7 +598,10 @@ void trigger_binding_sigil(actor& actor)
     if (actor.is_player())
     {
         mprf(MSGCH_WARN, "You move over the binding sigil and are bound in place!");
-        you.increase_duration(DUR_NO_MOMENTUM, random_range(3, 6));
+        int dur = random_range(3, 6);
+        you.increase_duration(DUR_NO_MOMENTUM, dur);
+        you.set_duration(DUR_SWIFTNESS, dur * 2);
+        you.attribute[ATTR_SWIFTNESS] = you.duration[DUR_SWIFTNESS];
         revert_terrain_change(you.pos(), TERRAIN_CHANGE_BINDING_SIGIL);
         return;
     }


### PR DESCRIPTION

The sigil's description says "Anyone who passes over them"
would receive swiftness once it wears off.
However, this is not the current behavior.

This change mirrors the swiftness spell after the player is bound.
The amount is the same as monsters, 2x the duration of immobilization.

Resolves issue #5138