### PR TITLE
Time out poison when poison immune

### DIFF
--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4613,12 +4613,7 @@ void handle_player_poison(int delay)
 
     const int decrease = you.duration[DUR_POISONING] - (int) new_dur;
 
-    // Transforming into a form with no metabolism merely suspends the poison
-    // but doesn't let your body get rid of it.
-    if (you.is_nonliving() || you.is_lifeless_undead())
-        return;
-
-    // Other sources of immunity (Zin, staff of Olgreb) let poison dissipate.
+    // Poison immunity means poison does no damage but dissipates.
     bool do_dmg = (player_res_poison() >= 3 ? false : true);
 
     int dmg = (you.duration[DUR_POISONING] / 1000)


### PR DESCRIPTION
While intentional and reasonable flavourwise, poison going inert when in an unliving form is consistently surprising to players, and doesn't seem important from a gameplay perspective when all unliving forms are slow to swap into.

Fixes #5176, #5218