### PR TITLE
Fix crocodile targeter

### DIFF
--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -2554,6 +2554,9 @@ bool targeter_surprising_crocodile::set_aim(coord_def a)
 
 aff_type targeter_surprising_crocodile::is_affected(coord_def loc)
 {
+    if (loc == aim)
+        return AFF_YES;
+
     for (coord_def spot : landing_spots)
         if (spot == loc)
             return AFF_YES;


### PR DESCRIPTION
Crocodile's targeter was not marking the location aimed at as affected, which since e713047 meant that it would not autotarget when cast or quivered.