### PR TITLE
Fix buggy descriptor with easy_floor_use.

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -196,6 +196,7 @@ static string _oper_name(operation_types oper)
     case OPER_TAKEOFF: return "take off";
     case OPER_REMOVE:  return "remove";
     case OPER_UNEQUIP: return "unequip";
+    case OPER_ANY: return "select";
     default:
         return "buggy";
     }


### PR DESCRIPTION
When using identify, brand or enchant scrolls with easy_floor_use, the descriptor for the item selection prompt was "buggy".