### PR TITLE
Make revivification inflict doom

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -230,8 +230,10 @@ caster staggering backwards.
 %%%%
 Borgnjor's Revivification spell
 
-Instantly heals any and all wounds suffered by the caster, but also permanently
-damages their health, to a degree dependent on (and inversely related to) power.
+Instantly heals any and all wounds suffered by the caster. Meddling with fate in
+such a way comes at a cost; casting this spell also inflicts heavy doom on the
+caster, usually enough to inflict a bane outright. Spellpower reduces the amount
+of doom inflicted.
 
 It is powerful enough to cancel the effects of Death's Door, although doing so
 will briefly paralyse the caster. It has no effect on the undead.

--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -232,8 +232,8 @@ Borgnjor's Revivification spell
 
 Instantly heals any and all wounds suffered by the caster. Meddling with fate in
 such a way comes at a cost; casting this spell also inflicts heavy doom on the
-caster, usually enough to inflict a bane outright. Spellpower reduces the amount
-of doom inflicted.
+caster and temporarily drains their maximum health. Spellpower decreases the
+amount of doom and draining applied.
 
 It is powerful enough to cancel the effects of Death's Door, although doing so
 will briefly paralyse the caster. It has no effect on the undead.

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -19,7 +19,6 @@
 #include "items.h" // stack_iterator
 #include "libutil.h"
 #include "message.h"
-#include "mutation.h" // add_bane
 #include "output.h"
 #include "player.h"
 #include "prompt.h"
@@ -95,20 +94,8 @@ spret cast_revivification(int pow, bool fail)
     fail_check();
     mpr("Your body is completely healed.");
 
-    // we can't actually call player::doom directly because 1) that downscales
-    // based on current banes, and 2) we want a residual amount of doom after
-    // the (very likely) first bane is applied, so spellpower does something.
-    int doom = 135 - div_rand_round(pow, 4);
-    doom = random_range(doom, doom + 25) + you.attribute[ATTR_DOOM];
-
-    while (doom > 100)
-    {
-        mprf(MSGCH_WARN, "Doom befalls you....");
-        add_bane();
-        doom = doom - 100;
-    }
-
-    you.attribute[ATTR_DOOM] = doom;
+    you.doom(random_range(89 - div_rand_round(pow,10), 99 - div_rand_round(pow,20)));
+    drain_player(125 - random2(1 + div_rand_round(pow, 4)), false, true);
     set_hp(you.hp_max);
 
     if (you.duration[DUR_DEATHS_DOOR])

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -19,6 +19,7 @@
 #include "items.h" // stack_iterator
 #include "libutil.h"
 #include "message.h"
+#include "mutation.h" // add_bane
 #include "output.h"
 #include "player.h"
 #include "prompt.h"
@@ -92,10 +93,22 @@ void fiery_armour()
 spret cast_revivification(int pow, bool fail)
 {
     fail_check();
-    mpr("Your body is healed in an amazingly painful way.");
+    mpr("Your body is completely healed.");
 
-    const int loss = 6 + binomial(9, 8, pow);
-    dec_max_hp(loss * you.hp_max / 100);
+    // we can't actually call player::doom directly because 1) that downscales
+    // based on current banes, and 2) we want a residual amount of doom after
+    // the (very likely) first bane is applied, so spellpower does something.
+    int doom = 135 - div_rand_round(pow, 4);
+    doom = random_range(doom, doom + 25) + you.attribute[ATTR_DOOM];
+
+    while (doom > 100)
+    {
+        mprf(MSGCH_WARN, "Doom befalls you....");
+        add_bane();
+        doom = doom - 100;
+    }
+
+    you.attribute[ATTR_DOOM] = doom;
     set_hp(you.hp_max);
 
     if (you.duration[DUR_DEATHS_DOOR])


### PR DESCRIPTION
Rather than permanently lowering max hp, inflict a very large amount of doom. This doom is not stepped down like normal doom applications and is guaranteed to apply a bane outright until power is very high, plus residual doom on top in most cases. There was some discussion about doing this a while back because players dislike the feeling of permanent max hp reduction.