### PR TITLE
Prevent mirroring minmay_shattered_shrine

### DIFF
--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -8259,7 +8259,7 @@ ENDMAP
 
 NAME:   minmay_shattered_shrine
 DEPTH:  D:7-, Depths, Lair
-TAGS:   transparent
+TAGS:   transparent no_hmirror no_vmirror
 KMONS:  p = plant
 SUBST:  9 = 9., " = .:190 0:5 %:5, ' = .:30 0:5 %:5
 MAP


### PR DESCRIPTION
<img width="969" height="674" alt="image" src="https://github.com/user-attachments/assets/86a451dd-8de4-4fc8-9ad4-21e6f6c41ad4" />
<img width="850" height="531" alt="image" src="https://github.com/user-attachments/assets/b40e9b44-f5ac-4049-be54-e3bf42e23eeb" />

https://www.reddit.com/r/dcss/comments/mvrc1w/did_anyone_of_you_notice_that_lair5_contains_a_qr/
https://gall.dcinside.com/board/view/?id=rlike&no=313557

The minmay_shattered_shrine vault contains a QR-code-style layout. QR codes remain readable when rotated, but horizontal or vertical mirroring breaks the encoded pattern.

Add no_hmirror and no_vmirror to preserve the intended layout while still allowing normal rotation.