### PR TITLE
Don't allow knockback to take monsters out of bounds

### DIFF
--- a/crawl-ref/source/melee-attack.cc
+++ b/crawl-ref/source/melee-attack.cc
@@ -4855,6 +4855,7 @@ bool melee_attack::do_knockback(bool slippery)
     if (!slippery && !x_chance_in_y(size_diff + 3, 6)
         // need a valid tile
         || !defender->is_habitable(new_pos)
+        || !in_bounds(new_pos)
         // don't trample anywhere the attacker can't follow
         || !attacker->is_habitable(old_pos)
         // don't trample into a monster - or do we want to cause a chain


### PR DESCRIPTION
This could cause rare crashes with wall walkers being trampled