### PR TITLE
Extend and improve "unusual_monster_items" option functionality and clarify its guide

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1838,16 +1838,21 @@ use_animations += branch_entry
           branch_entry     - Animations that run when you enter a new branch.
                              Currently only the Abyss and Zot have animations.
 
+unusual_monster_items = wand, disto, chaos, curare, atropa, datura, dispersal, disjunction,
+                        throwing net, vulnerable:holy_wrath, vulnerable:entangling, reflect,
+                        Reflect
 unusual_monster_items += <regex>, <regex>, ...
         (List option)
         Monsters whose inventory items match a regex in this comma-separated
-        list will display with unusual threat level. E.g.
-            unusual_monster_items =  wand
-            unusual_monster_items += disto,chaos
-            unusual_monster_items += curare,atropa,datura,dispersal
-            unusual_monster_items += throwing net
+        list will display with unusual threat level.
         The item descriptions matched against are the short item names that
         ordinarily display when a monster is examined with 'xv'.
+        Adding a "vulnerable:" prefix to a weapon brand will match dangerous weapon brands
+        that your character is affected by. These include holy wrath, entangling, venom, draining,
+        pain and electrocution, the latter being the only one that checks resistance and not complete immunity.
+        This behaviour can be further adjusted by adding a numerical suffix to the entry, which makes the vulnerability
+        check only apply if you are not above the specified XL (for example, "vulnerable:venom:13" would only match
+        venom weapons if you are both not poison immune and at XL 13 or below).
 
         This option determines which monsters will be regarded as "unusual" for
         the options tile_show_threat_levels (tiles only), monster_list_colour,

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1846,17 +1846,30 @@ unusual_monster_items += <regex>, <regex>, ...
         Monsters whose inventory items match a regex in this comma-separated
         list will display with unusual threat level.
         The item descriptions matched against are the short item names that
-        ordinarily display when a monster is examined with 'xv'.
+        ordinarily display when a monster is examined with 'xv'. Menu prefixes are
+        supported, but regex matching and vulnerability checks are mutually exclusive.
+
         Adding a "vulnerable:" prefix to a weapon brand will match dangerous weapon brands
-        that your character is affected by. These include holy wrath, entangling, venom, draining,
-        pain and electrocution, the latter being the only one that checks resistance and not complete immunity.
-        This behaviour can be further adjusted by adding a numerical suffix to the entry, which makes the vulnerability
-        check only apply if you are not above the specified XL (for example, "vulnerable:venom:13" would only match
-        venom weapons if you are both not poison immune and at XL 13 or below).
+        that your character is affected by. Supported brands are holy_wrath, entangling, venom,
+        draining, pain, vampirism, flaming, freezing and electrocution. The last three require one
+        rank of resistance for you to not be considered vulnerable, all others require complete
+        immunity. Note that vulnerability is only checked for these specific brand values and other
+        items will be matched even if you're immune to their effects. More sophisticated checks
+        (e.g. curare darts for undead species or throwing nets for Poltergeists) require custom
+        Lua scripting.
+
+        All entries can be made XL-conditional by adding the corresponding XL value as a suffix
+        following a colon. Such an entry will only be checked against if your XL is equal to or
+        lower than that value.
 
         This option determines which monsters will be regarded as "unusual" for
         the options tile_show_threat_levels (tiles only), monster_list_colour,
         and unusual_highlight (console only).
+
+        Examples:
+          "wand of flame:7" will mark all monsters with a wand of flame as unusual, but only at XL<=7;
+          "artefact" will mark all monsters with artifact equipment, including unrands;
+          "vulnerable:venom:15" will mark all monsters with venom weapons at XL<=15;
 
 darken_beyond_range = true
         If set to true, everything beyond range when targeting will be

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3164,34 +3164,44 @@ void game_options::update_consumable_shortcuts()
     }
 }
 
-// Extract 'vulnerable brand' options from unusual_monster_items
+// Extract 'vulnerable brand' and XL-conditional options from unusual_monster_items
 void game_options::process_unusual_items()
 {
-    vulnerable_brand_warning.clear();
+    unusual_item_patterns.clear();
     for (int i = (int)unusual_monster_items.size() - 1; i >= 0; --i)
     {
         text_pattern& pattern = unusual_monster_items[i];
         string str = pattern.tostring();
-
-        if (!starts_with(str, "vulnerable:"))
-            continue;
-
         vector<string> splits = split_string(":", str, true, true, -1, true);
+
+        text_pattern stripped_pattern;
+        brand_type vuln_brand = SPWPN_FORBID_BRAND;
+        int xl_threshold = -1;
 
         if (splits.size() >= 2)
         {
-            int brand = str_to_ego(OBJ_WEAPONS, splits[1]);
-            if (brand <= 0)
-                continue;
+            if (splits[0] == "vulnerable")
+            {
+              int brand = str_to_ego(OBJ_WEAPONS, splits[1]);
+              if (brand >= 0)
+                vuln_brand = static_cast<brand_type>(brand);
 
-            int xl = 27;
-            if (splits.size() >= 3)
-                parse_int(splits[2].c_str(), xl);
-
-            vulnerable_brand_warning.push_back({static_cast<brand_type>(brand), xl});
+              if (splits.size() >= 3)
+              {
+                  stripped_pattern = text_pattern(splits[1]);
+                  parse_int(splits[2].c_str(), xl_threshold);
+              }
+            }
+            else
+            {
+              stripped_pattern = text_pattern(splits[0]);
+              parse_int(splits[1].c_str(), xl_threshold);
+            }
         }
+        else
+          stripped_pattern = text_pattern(splits[0]);
 
-        unusual_monster_items.erase(unusual_monster_items.begin() + i);
+        unusual_item_patterns.push_back({stripped_pattern, vuln_brand, xl_threshold});
     }
 }
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3167,6 +3167,7 @@ void game_options::update_consumable_shortcuts()
 // Extract 'vulnerable brand' options from unusual_monster_items
 void game_options::process_unusual_items()
 {
+    vulnerable_brand_warning.clear();
     for (int i = (int)unusual_monster_items.size() - 1; i >= 0; --i)
     {
         text_pattern& pattern = unusual_monster_items[i];

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -751,25 +751,30 @@ bool item_is_branded(const item_def& item)
     }
 }
 
-static bool _immune_to_brand(brand_type brand)
+static bool _is_dangerous_brand(brand_type brand)
 {
     switch (brand)
     {
         case SPWPN_HOLY_WRATH:
-            return !you.holy_wrath_susceptible();
+            return you.holy_wrath_susceptible();
 
         case SPWPN_VENOM:
-            return you.res_poison() == 3;
+            return you.res_poison() < 3;
 
         case SPWPN_DRAINING:
         case SPWPN_PAIN:
-            return you.res_negative_energy() == 3;
+        case SPWPN_VAMPIRISM:
+            return you.res_negative_energy() < 3;
 
         case SPWPN_ELECTROCUTION:
-            return you.res_elec() >= 1;
+            return you.res_elec() < 1;
+        case SPWPN_FLAMING:
+          return you.res_fire() < 1;
+        case SPWPN_FREEZING:
+          return you.res_cold() < 1;
 
         case SPWPN_ENTANGLING:
-            return you.res_constrict();
+            return !you.res_constrict();
 
         default:
             return false;
@@ -778,25 +783,31 @@ static bool _immune_to_brand(brand_type brand)
 
 bool item_is_unusual(const item_def& item)
 {
-    if (item.base_type == OBJ_WEAPONS)
-    {
-        for (auto& match : Options.vulnerable_brand_warning)
+    // All items need to be checked for satisfying XL requirements, but checking for brand vulnerability
+    // and regex match is not necessary - item needs to satisfy either brand + XL or XL + regex.
+    // This means that menu prefix matching won't work for entries that specify "vulnerable:". There is
+    // probably never a legitimate need to filter for both at the same time.
+
+    return any_of(begin(Options.unusual_item_patterns), end(Options.unusual_item_patterns),
+                      [&](const unusual_item_pattern &entry) -> bool
         {
-            if (get_weapon_brand(item) == match.first
-                && you.experience_level <= match.second
-                && !_immune_to_brand(match.first))
-            {
-                return true;
-            }
-        }
-    }
+          bool vuln_to_brand = false;
+          if (item.base_type == OBJ_WEAPONS && entry.brand != SPWPN_FORBID_BRAND)
+          {
+            if (get_weapon_brand(item) != entry.brand || !_is_dangerous_brand(entry.brand))
+              return false;
+            vuln_to_brand = true;
+          }
 
-    const auto &patterns = Options.unusual_monster_items;
-    const string name = item.name(DESC_A, false, false, true, false);
+          if (entry.xl_threshold > 0 && you.experience_level > entry.xl_threshold)
+            return false;
 
-    return any_of(begin(patterns), end(patterns),
-                  [&](const text_pattern &p) -> bool
-                  { return p.matches(name); });
+          if (vuln_to_brand)
+            return true;
+
+          const string name = item.name(DESC_A, false, false, true, false);
+          return entry.pattern.matches(item_prefix(item, false) + name);
+        });
 }
 
 bool item_is_worth_listing(const item_def& item)

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -313,6 +313,13 @@ struct opt_parse_state
     }
 };
 
+struct unusual_item_pattern
+{
+    text_pattern pattern;
+    brand_type brand;
+    int xl_threshold;
+};
+
 /// This class is used to separate out general option handling (parsing,
 /// meta-state, include file loading, lua handling) from specific option field
 /// handling; the latter should be implemented on the subclass `game_options`.
@@ -555,10 +562,9 @@ public:
     bool        reduce_animations;   // if true, don't show interim steps for animations
     bool        drop_disables_autopickup;   // if true, automatically remove drops from autopickup
 
-    vector<text_pattern> unusual_monster_items; // which monster items to
-                                                // highlight as unusual
-    vector<pair<brand_type, int>> vulnerable_brand_warning; // Monster brands to hilight the monster
-                                                // as having, below a given XL, while vulnerable
+    vector<text_pattern> unusual_monster_items;         // raw entries from the options file
+    vector<unusual_item_pattern> unusual_item_patterns; // structured entries with brand
+                                                        // vulnerability and XL thresholds
 
     int         hp_warning;      // percentage hp for danger warning
     int         magic_point_warning;    // percentage mp for danger warning


### PR DESCRIPTION
Right now the list for brand vulnerability is first assembled before the values from .rc are read, and is not reset, which makes it impossible to disable or narrow the default "vulnerable:holy_wrath" and "vulnerable:entangling" options. The vulnerability check or it's XL adjustment also isn't documented anywhere, nor is the default value of the option present in the options_guide, breaking the convention.