### PR TITLE
Revert the removal of "merged slime creature" pseudo-monster.

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -3080,6 +3080,7 @@ mon_glyph -= <monster name or symbol>
              player
              sensed monster
              {trivial,easy,tough,nasty,friendly} sensed monster
+             merged slime creature
 
         Playable species that normally have no monster of the same name can
         also be redefined, for use with show_player_species = true.

--- a/crawl-ref/source/dat/mons/merged-slime-creature.yaml
+++ b/crawl-ref/source/dat/mons/merged-slime-creature.yaml
@@ -1,0 +1,17 @@
+name: "merged slime creature"
+glyph: {char: "J", colour: lightgreen}
+flags: [cant_spawn]
+exp: 236
+holiness: [nonliving]
+will: 10
+attacks:
+hd: 0
+hp_10x: 0
+ac: 0
+ev: 0
+has_corpse: true
+intelligence: brainless
+speed: 0
+size: medium
+shape: misc
+tile: program_bug

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -1446,6 +1446,13 @@ int mons_class_colour(monster_type mc)
     {
         return Options.mon_glyph_overrides[MONS_PLAYER].col;
     }
+    // Ditto for merged slime creatures.
+    if (mc == MONS_MERGED_SLIME_CREATURE
+        && Options.mon_glyph_overrides.count(MONS_MERGED_SLIME_CREATURE)
+        && Options.mon_glyph_overrides[MONS_MERGED_SLIME_CREATURE].col)
+    {
+        return Options.mon_glyph_overrides[MONS_MERGED_SLIME_CREATURE].col;
+    }
     else
         return monster_symbols[mc].colour;
 }

--- a/crawl-ref/source/monster-type.h
+++ b/crawl-ref/source/monster-type.h
@@ -1074,9 +1074,7 @@ enum monster_type                      // env.mons[].type
     MONS_SEISMOSAURUS_EGG,
 #endif
     MONS_HELL_LORD,             // genus
-#if TAG_MAJOR_VERSION == 34
     MONS_MERGED_SLIME_CREATURE, // used only for recolouring
-#endif
     MONS_SENSED,                // dummy monster for unspecified sensed mons
     MONS_SENSED_TRIVIAL,
     MONS_SENSED_EASY,

--- a/crawl-ref/source/showsymb.cc
+++ b/crawl-ref/source/showsymb.cc
@@ -152,6 +152,8 @@ static unsigned short _cell_feat_show_colour(const map_cell& cell,
 
 static monster_type _show_mons_type(const monster_info& mi)
 {
+    if (mi.type == MONS_SLIME_CREATURE && mi.slime_size > 1)
+        return MONS_MERGED_SLIME_CREATURE;
     if (mi.type == MONS_SENSED)
         return mi.base_type;
     else
@@ -174,9 +176,7 @@ static int _get_mons_colour(const monster_info& mi)
     // assuming the user has not remapped their colour.
     if (col == mons_class_colour(mi.type))
     {
-        if (mi.type == MONS_SLIME_CREATURE && mi.slime_size > 1)
-            col = LIGHTGREEN;
-        else if (mi.type == MONS_ZOMBIE && mons_zombie_size(mi.base_type) == Z_BIG)
+        if (mi.type == MONS_ZOMBIE && mons_zombie_size(mi.base_type) == Z_BIG)
             col = YELLOW;
         else if (mi.type == MONS_SIMULACRUM && mons_zombie_size(mi.base_type) == Z_BIG)
             col = LIGHTCYAN;
@@ -185,6 +185,11 @@ static int _get_mons_colour(const monster_info& mi)
         else if (mi.type == MONS_SPECTRAL_THING && mons_zombie_size(mi.base_type) == Z_BIG)
             col = LIGHTGREEN;
     }
+
+    // Exception to the above for display-only "merged slime creature" pseudo-monster,
+    // so that their colour can be set independently of the base slime creature's colour.
+    if (mi.type == MONS_SLIME_CREATURE && mi.slime_size > 1)
+        col = mons_class_colour(MONS_MERGED_SLIME_CREATURE);
 
     if (mi.is(MB_ROLLING))
         col = ETC_BONE;

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -2007,6 +2007,7 @@ tileidx_t tileidx_monster_base(int type, int mon_id, bool in_water, int colour,
     case MONS_SLYMDRA:
         return tileidx_mon_clamp(TILEP_MONS_SLYMDRA, number - 1);
     case MONS_SLIME_CREATURE:
+    case MONS_MERGED_SLIME_CREATURE:
         return tileidx_mon_clamp(TILEP_MONS_SLIME_CREATURE, number - 1);
     case MONS_LERNAEAN_HYDRA:
         // Step down the number of heads to get the appropriate tile:

--- a/crawl-ref/source/util/mon-gen/header.txt
+++ b/crawl-ref/source/util/mon-gen/header.txt
@@ -156,7 +156,6 @@ static monsterentry mondata[] =
     AXED_MON(MONS_SKELETON_LARGE, "large skeleton")
     AXED_MON(MONS_SIMULACRUM_SMALL, "small simulacrum")
     AXED_MON(MONS_SIMULACRUM_LARGE, "large simulacrum")
-    AXED_MON(MONS_MERGED_SLIME_CREATURE, "merged slime creature")
     AXED_MON(MONS_PSYCHE, "psyche")
     AXED_MON(MONS_GIANT_COCKROACH, "giant cockroach")
     AXED_MON(MONS_INSUBSTANTIAL_WISP, "insubstantial wisp")


### PR DESCRIPTION
With this removal, there is currently no way to distinguish base slime monsters from their merged variants. Merged variants are by design near-guaranteed to appear alongside their regular counterparts, are prone to subtly changing their state and/or position and can be very punishing to have been confused with base slimes. This makes tracking them in console a headache, especially if you can't distinguish well between green and lightgreen due to terminal theme or color blindness. I have used the merged_slime_creature mon_glyph override since I found about it and have no alternative solution now that it's gone. I reversed the removal of this pseudo-monster only and added the ability to override its color as well as the glyph (previously it would always be lightgreen, ignoring color overrides for both base and merged slimes).