### PR TITLE
Fix typo in purified mutation catalyst message for death form

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -3315,7 +3315,7 @@ void get_feature_desc(const coord_def &pos, describe_info &inf, bool include_ext
         else if (you.form == transformation::death)
         {
             long_desc += make_stringf(
-            "\nYou must first return to come back to life before you may mutate.");
+            "\nYou must first come back to life before you may mutate.");
         }
         else if (you.is_lifeless_undead()
              && you.get_mutation_level(MUT_MUTATION_RESISTANCE) != 3)


### PR DESCRIPTION
Remove one of the two redundant synonyms in the sentence "You must first return to come back to life..." that was introduced in commit b14e334c730fdf035bb291f3800f4597fa88c802.