### PR TITLE
Allow PoG on decorative terrain.

### DIFF
--- a/crawl-ref/source/spl-transloc.cc
+++ b/crawl-ref/source/spl-transloc.cc
@@ -1635,7 +1635,7 @@ spret cast_apportation(int pow, bolt& beam, bool fail)
 bool golubria_valid_cell(coord_def p, bool just_check)
 {
     return in_bounds(p)
-           && env.grid(p) == DNGN_FLOOR
+           && feat_is_floor(env.grid(p))
            && (!monster_at(p) || just_check && !you.can_see(*monster_at(p)))
            && cell_see_cell(you.pos(), p, LOS_NO_TRANS);
 }
@@ -1662,6 +1662,8 @@ spret cast_golubrias_passage(int pow, const coord_def& where, bool fail)
         return spret::abort;
     }
 
+    // XXX: this can abort nondeterministically and should be rewritten to use
+    //reservoir sampling or something
     int tries = 0;
     int tries2 = 0;
     const int range = GOLUBRIA_FUZZ_RANGE;

--- a/crawl-ref/source/terrain.cc
+++ b/crawl-ref/source/terrain.cc
@@ -77,6 +77,7 @@ bool feat_is_floor(dungeon_feature_type feat)
 {
     return feat == DNGN_FLOOR
             || feat == DNGN_DECORATIVE_FLOOR
+            || feat == DNGN_RUNELIGHT
             || feat_is_fountain(feat)
             || feat_is_food(feat);
 }
@@ -2213,7 +2214,7 @@ static bool _revert_terrain_to(coord_def pos, dungeon_feature_type feat)
 
 // If ctype == NUM_TERRAIN_CHANGE_TYPES, will revert *all* terrain changes on
 // the given pos.
-bool revert_terrain_change(coord_def pos, terrain_change_type ctype)
+bool revert_terrain_change(coord_def pos, terrain_change_type ctype, bool expire)
 {
     dungeon_feature_type newfeat = DNGN_UNSEEN;
     unsigned short newfeat_flv = 0;
@@ -2256,7 +2257,7 @@ bool revert_terrain_change(coord_def pos, terrain_change_type ctype)
     if (feat_is_door(newfeat) && env.grid(pos) == DNGN_OPEN_DOOR)
         return false;
 
-    if (env.grid(pos) == DNGN_PASSAGE_OF_GOLUBRIA)
+    if (env.grid(pos) == DNGN_PASSAGE_OF_GOLUBRIA && expire)
     {
         if (you.see_cell(pos))
             mpr("Your passage of Golubria closes with a snap!");

--- a/crawl-ref/source/terrain.h
+++ b/crawl-ref/source/terrain.h
@@ -167,7 +167,8 @@ void temp_change_terrain(coord_def pos, dungeon_feature_type newfeat, int dur,
                          terrain_change_type type = TERRAIN_CHANGE_GENERIC,
                          int mid = MID_NOBODY);
 bool revert_terrain_change(coord_def pos,
-                           terrain_change_type ctype = NUM_TERRAIN_CHANGE_TYPES);
+                           terrain_change_type ctype = NUM_TERRAIN_CHANGE_TYPES,
+                           bool expire = true);
 bool is_temp_terrain(coord_def pos);
 
 bool plant_forbidden_at(const coord_def &p, bool connectivity_only = false);

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -677,7 +677,8 @@ void destroy_trap(const coord_def& pos)
     if (!feat_is_trap(env.grid(pos)))
         return;
 
-    dungeon_terrain_changed(pos, DNGN_FLOOR);
+    if (!revert_terrain_change(pos, TERRAIN_CHANGE_GOLUBRIA, false))
+        dungeon_terrain_changed(pos, DNGN_FLOOR);
     if (you.see_cell(pos))
     {
         update_terrain_knowledge(pos);


### PR DESCRIPTION
Make use of the new feat_is_floor function and extend it to runelights. Closes #5120.