### PR TITLE
Fix summon forest vine tile bugs

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -964,6 +964,49 @@ void bolt::burn_wall_effect()
         }
     }
 
+    // When burning a tree, check for any vines it is supporting. These must
+    // find a new home or die.
+    for (adjacent_iterator ai(pos()); ai; ai++)
+    {
+        monster *m = monster_at(*ai);
+        if (!m || (m->type != MONS_SNAPLASHER_VINE
+                   && m->type != MONS_SNAPLASHER_VINE_SEGMENT))
+        {
+            continue;
+        }
+
+        if (!m->props.exists(TREE_POSITION_KEY)
+            || m->props[TREE_POSITION_KEY].get_coord() != pos())
+        {
+            continue;
+        }
+
+        // Try to find a new tree for the vine.
+        coord_def new_tree;
+        for (adjacent_iterator tree_it(*ai); tree_it; tree_it++)
+        {
+            if (feat_is_tree(env.grid(*tree_it)))
+            {
+                new_tree = *tree_it;
+                break;
+            }
+        }
+
+        if (new_tree.origin())
+            monster_die(*m, agent());
+        else
+        {
+            // Walk the vine fixing the tree positions.
+            while (m)
+            {
+                m->props[TREE_POSITION_KEY].get_coord() = new_tree;
+                if (!m->props.exists(OUTWARDS_KEY))
+                    break;
+                m = monster_by_mid(m->props[OUTWARDS_KEY].get_int());
+            }
+        }
+    }
+
     obvious_effect = true;
 
     finish_beam();

--- a/crawl-ref/source/defines.h
+++ b/crawl-ref/source/defines.h
@@ -314,6 +314,7 @@ const char * const THUNDERBOLT_AIM_KEY     = "thunderbolt_aim";
 #define OUTWARDS_KEY "outwards"
 #define INWARDS_KEY "inwards"
 #define BASE_POSITION_KEY "base_position"
+#define TREE_POSITION_KEY "tree_position"
 #define SUMMON_ID_KEY "summon_id"
 #define FLAY_BLOOD_KEY "flay_blood"
 #define IDEAL_RANGE_KEY "ideal_range"

--- a/crawl-ref/source/mon-cast.cc
+++ b/crawl-ref/source/mon-cast.cc
@@ -4154,6 +4154,15 @@ static bool _awaken_vines(monster* mon, bool test_only = false)
                         MG_FORCE_PLACE, mon->god)
             .set_summoned(mon, SPELL_AWAKEN_VINES, random_range(250, 380), false)))
         {
+            // Stash a tree position so that we can draw the vine connecting to it.
+            for (adjacent_iterator ai(spot); ai; ++ai)
+            {
+                if (feat_is_tree(env.grid(*ai)))
+                {
+                    vine->props[TREE_POSITION_KEY].get_coord() = *ai;
+                    break;
+                }
+            }
             --num_vines;
             if (you.can_see(*vine))
                 seen = true;

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -255,7 +255,8 @@ static bool _is_public_key(string key)
      || key == POLY_SET_KEY
      || key == NOBODY_MEMORIES_KEY
      || key == ORIGINAL_TYPE_KEY
-     || key == SPLINTERFROST_POWER_KEY)
+     || key == SPLINTERFROST_POWER_KEY
+     || key == TREE_POSITION_KEY)
     {
         return true;
     }

--- a/crawl-ref/source/mon-tentacle.cc
+++ b/crawl-ref/source/mon-tentacle.cc
@@ -290,6 +290,9 @@ static void _establish_connection(monster* tentacle,
 
             if (head->holiness() & MH_UNDEAD)
                 connect->flags |= MF_FAKE_UNDEAD;
+
+            if (head->props.exists(TREE_POSITION_KEY))
+                connect->props[TREE_POSITION_KEY].get_coord() = head->props[TREE_POSITION_KEY].get_coord();
         }
         else
         {

--- a/crawl-ref/source/mon-tentacle.cc
+++ b/crawl-ref/source/mon-tentacle.cc
@@ -242,6 +242,9 @@ static void _establish_connection(monster* tentacle,
 
             connect->max_hit_points = tentacle->max_hit_points;
             connect->hit_points = tentacle->hit_points;
+
+            if (head->props.exists(TREE_POSITION_KEY))
+                connect->props[TREE_POSITION_KEY].get_coord() = head->props[TREE_POSITION_KEY].get_coord();
         }
         else
         {

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -351,6 +351,7 @@ enum tag_minor_version
     TAG_MINOR_REMOVE_MORTAR_MARKERS, // Remove map_hellfire_mortar_lava_marker and refactor again
     TAG_MINOR_FIX_VENGEANCE_CLEANUP, // Fix a crash when changing levels due to old vengeance targets
     TAG_MINOR_FLAVOUR_KNOWLEDGE,   // Save player knowledge of feature flavour
+    TAG_MINOR_TREE_POSITIONS,      // Save tree positions for forest vines
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -7209,6 +7209,28 @@ static void _fixup_cloud_varieties(MapKnowledge& map_knowledge)
             ci->variety = get_vortex_phase(*ri);
     }
 }
+
+static void _fixup_tree_positions(MapKnowledge& map_knowledge)
+{
+    for (rectangle_iterator ri(0); ri; ++ri)
+    {
+        monster_info* mi = map_knowledge(*ri).monsterinfo();
+        if (mi
+            && (mi->type == MONS_SNAPLASHER_VINE
+                || mi->type == MONS_SNAPLASHER_VINE_SEGMENT)
+            && !mi->props.exists(INWARDS_KEY))
+        {
+            for (adjacent_iterator ai(mi->pos); ai; ++ai)
+            {
+                if (feat_is_tree(env.grid(*ai)))
+                {
+                    mi->props[TREE_POSITION_KEY].get_coord() = *ai;
+                    break;
+                }
+            }
+        }
+    }
+}
 #endif
 
 static void _tag_read_level(reader &th)
@@ -7273,6 +7295,8 @@ static void _tag_read_level(reader &th)
         _fixup_blood_knowledge(env.map_knowledge);
     if (th.getMinorVersion() <= TAG_MINOR_FIX_POLAR_VORTEX_INFO_LEAK)
         _fixup_cloud_varieties(env.map_knowledge);
+    if (th.getMinorVersion() < TAG_MINOR_TREE_POSITIONS)
+        _fixup_tree_positions(env.map_knowledge);
 #endif
 
 #if TAG_MAJOR_VERSION == 34
@@ -8273,6 +8297,46 @@ static void _tag_read_level_monsters(reader &th)
             }
             if (mons_is_tentacle_or_tentacle_segment(mi->type))
                 mi->tentacle_connect = env.mons[mi->tentacle_connect].mid;
+        }
+    }
+    if (th.getMinorVersion() < TAG_MINOR_TREE_POSITIONS)
+    {
+        for (monster_iterator mi; mi; ++mi)
+        {
+            if (mi->type != MONS_SNAPLASHER_VINE
+                && mi->type != MONS_SNAPLASHER_VINE_SEGMENT)
+            {
+                continue;
+            }
+
+            if (mi->props.exists(INWARDS_KEY)
+                && mi->props[INWARDS_KEY].get_int() != MID_NOBODY)
+            {
+                continue;
+            }
+
+            coord_def tree_pos;
+            for (adjacent_iterator ai(mi->pos()); ai; ++ai)
+            {
+                if (feat_is_tree(env.grid(*ai)))
+                {
+                    tree_pos = *ai;
+                    break;
+                }
+            }
+
+            if (tree_pos.origin())
+                continue;
+
+            mi->props[TREE_POSITION_KEY].get_coord() = tree_pos;
+            // Walk outwards fixing all the tree positions.
+            int midx = mi->props[OUTWARDS_KEY].get_int();
+            while (midx != MID_NOBODY)
+            {
+                monster *m = monster_by_mid(midx);
+                m->props[TREE_POSITION_KEY] = tree_pos;
+                midx = m->props[OUTWARDS_KEY].get_int();
+            }
         }
     }
 #endif

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1023,19 +1023,33 @@ tileidx_t tileidx_tentacle(const monster_info& mon)
         // Get the parent tentacle's location.
         h_pos = t_pos + mon.props[INWARDS_KEY].get_coord();
     }
+    // Vines next to trees don't have an inwards key, but they remember
+    // the position of the tree they spawned from.
     if (no_head_connect && (mon.type == MONS_SNAPLASHER_VINE
                             || mon.type == MONS_SNAPLASHER_VINE_SEGMENT))
     {
-        // Find an adjacent tree to pretend we're connected to.
-        for (adjacent_iterator ai(t_pos); ai; ++ai)
+        if (mon.props.exists(TREE_POSITION_KEY))
         {
-            if (feat_is_tree(env.grid(*ai)))
+            h_pos = mon.props[TREE_POSITION_KEY].get_coord();
+            no_head_connect = false;
+        }
+#if TAG_MAJOR_VERSION == 34
+        else
+        {
+            // Find an adjacent tree to pretend we're connected to.
+            // This is only needed for upgraded save compatibility, for
+            // segments without the key.
+            for (adjacent_iterator ai(t_pos); ai; ++ai)
             {
-                h_pos = *ai;
-                no_head_connect = false;
-                break;
+                if (feat_is_tree(env.grid(*ai)))
+                {
+                    h_pos = *ai;
+                    no_head_connect = false;
+                    break;
+                }
             }
         }
+#endif
     }
 
     // Is there a connection to the given direction?

--- a/crawl-ref/source/tilepick.cc
+++ b/crawl-ref/source/tilepick.cc
@@ -1025,31 +1025,13 @@ tileidx_t tileidx_tentacle(const monster_info& mon)
     }
     // Vines next to trees don't have an inwards key, but they remember
     // the position of the tree they spawned from.
-    if (no_head_connect && (mon.type == MONS_SNAPLASHER_VINE
-                            || mon.type == MONS_SNAPLASHER_VINE_SEGMENT))
+    if (no_head_connect
+        && (mon.type == MONS_SNAPLASHER_VINE
+            || mon.type == MONS_SNAPLASHER_VINE_SEGMENT)
+        && mon.props.exists(TREE_POSITION_KEY))
     {
-        if (mon.props.exists(TREE_POSITION_KEY))
-        {
-            h_pos = mon.props[TREE_POSITION_KEY].get_coord();
-            no_head_connect = false;
-        }
-#if TAG_MAJOR_VERSION == 34
-        else
-        {
-            // Find an adjacent tree to pretend we're connected to.
-            // This is only needed for upgraded save compatibility, for
-            // segments without the key.
-            for (adjacent_iterator ai(t_pos); ai; ++ai)
-            {
-                if (feat_is_tree(env.grid(*ai)))
-                {
-                    h_pos = *ai;
-                    no_head_connect = false;
-                    break;
-                }
-            }
-        }
-#endif
+        h_pos = mon.props[TREE_POSITION_KEY].get_coord();
+        no_head_connect = false;
     }
 
     // Is there a connection to the given direction?


### PR DESCRIPTION
Summon forest vines, like all tentacles, pick their tile based on their parent and child tentacles. For vines, the parent can be a tree.

Before this commit, the first vine in the chain finds its parent by looking for an adjacent tree. This has interesting consequences when there isn't such a tree, which can happen in two ways: 1) If the tree is destroyed, or
2) If the spell has ended (but the tentacle is out of LoS so still assumed to be there).

When this happens, the vine gets a half-submerged kraken tile (because this is the only tentacle with no parent, or at least it was when submerging was a thing), and then adjusts it by shifting by <START_VINE>-<START_KRAKEN> tiles. However, because vines don't _have_ half-submerged tiles, this takes us out of the vine section of tiles altogether, leading to starspawn tiles.

We fix this by making vines know what tree they came from. It is worth highlighting two edge cases with this:
- If the tree is destroyed, the vine will still appear to come from it (whereas before it would have displayed some silly tile)
- If the tree is destroyed, but another tree is next to the vine is still there, the vine will appear to come from the destroyed tree (whereas before it would have switched to the still-present one)