### PR TITLE
Fix different races getting different unrands in seeded game (khaemere)

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -1245,7 +1245,7 @@ int acquirement_create_item(object_class_type class_wanted,
             want_arts = false;
 
         thing_created = items(want_arts, class_wanted, type_wanted,
-                              item_level, force_ego, agent);
+                              item_level, force_ego, agent, true);
 
         if (thing_created == NON_ITEM)
         {

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -1772,7 +1772,39 @@ static int _unrand_weight(int unrand_index, int item_level)
     return item_level <= pref_max_level ? 100 : 1;
 }
 
-int find_okay_unrandart(uint8_t aclass, uint8_t atype, int item_level, bool in_abyss)
+static bool _unrand_is_compatible(const unrandart_entry& unrand,
+                                  object_class_type aclass,
+                                  uint8_t atype,
+                                  bool acquirement)
+{
+    if (unrand.base_type != aclass)
+        return false;
+    if (atype == OBJ_RANDOM)
+        return true;
+    if (aclass != OBJ_WEAPONS)
+        return unrand.sub_type == atype;
+
+    item_def required_item;
+    required_item.base_type = aclass;
+    required_item.sub_type = atype;
+
+    item_def unrand_item;
+    unrand_item.base_type = unrand.base_type;
+    unrand_item.sub_type = unrand.sub_type;
+
+    if (item_attack_skill(required_item) != item_attack_skill(unrand_item))
+        return false;
+    if (acquirement)
+    {
+        return you.hands_reqd(required_item, true)
+               == you.hands_reqd(unrand_item, true);
+    }
+    return basic_hands_reqd(required_item, SIZE_MEDIUM)
+           == basic_hands_reqd(unrand_item, SIZE_MEDIUM);
+}
+
+int find_okay_unrandart(uint8_t aclass, uint8_t atype, int item_level,
+                        bool in_abyss, bool acquirement)
 {
     int chosen_unrand_idx = -1;
 
@@ -1822,16 +1854,8 @@ int find_okay_unrandart(uint8_t aclass, uint8_t atype, int item_level, bool in_a
             continue;
         }
 
-        if (entry->base_type != aclass
-            || atype != OBJ_RANDOM && entry->sub_type != atype
-               // Acquirement.
-               && (aclass != OBJ_WEAPONS
-                   || item_attack_skill(entry->base_type, atype) !=
-                      item_attack_skill(entry->base_type, entry->sub_type)
-                   || hands_reqd(&you, entry->base_type,
-                                 atype) !=
-                      hands_reqd(&you, entry->base_type,
-                                 entry->sub_type)))
+        if (!_unrand_is_compatible(*entry, (object_class_type)aclass, atype,
+                                   acquirement))
         {
             continue;
         }

--- a/crawl-ref/source/artefact.h
+++ b/crawl-ref/source/artefact.h
@@ -106,7 +106,7 @@ string make_artefact_name(const item_def &item, bool appearance = false);
 string replace_name_parts(const string &name_in, const item_def& item);
 
 int find_okay_unrandart(uint8_t aclass, uint8_t atype, int item_level,
-                        bool in_abyss);
+                        bool in_abyss, bool acquirement);
 
 typedef FixedVector< int, ART_PROPERTIES >  artefact_properties_t;
 

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -5123,6 +5123,7 @@ int dgn_place_item(const item_spec &spec,
 
                 item_made = items(spec.allow_uniques, base_type,
                                   spec.sub_type, level, spec.ego, NO_AGENT,
+                                  spec.level == ISPEC_ACQUIREMENT,
                                   _get_custom_name(spec), fixed_props);
 
                 if (spec.level == ISPEC_MUNDANE)
@@ -5228,7 +5229,7 @@ static void _dgn_give_mon_spec_items(mons_spec &mspec, monster *mon)
 
                 item_made = items(spec.allow_uniques, spec.base_type,
                                   spec.sub_type, item_level, spec.ego, NO_AGENT,
-                                  _get_custom_name(spec), fixed_props);
+                                  false, _get_custom_name(spec), fixed_props);
 
                 if (spec.level == ISPEC_MUNDANE)
                     squash_plusses(item_made);

--- a/crawl-ref/source/makeitem.cc
+++ b/crawl-ref/source/makeitem.cc
@@ -162,7 +162,8 @@ static weapon_type _determine_weapon_subtype(int item_level)
     }
 }
 
-static bool _try_make_item_unrand(item_def& item, int &force_type, int item_level, int agent)
+static bool _try_make_item_unrand(item_def& item, int &force_type,
+                                  int item_level, int agent, bool acquirement)
 {
     if (player_in_branch(BRANCH_PANDEMONIUM) && agent == NO_AGENT)
         return false;
@@ -171,7 +172,7 @@ static bool _try_make_item_unrand(item_def& item, int &force_type, int item_leve
     const bool include_abyssed = player_in_branch(BRANCH_ABYSS)
                                  && agent == NO_AGENT;
     const int idx = find_okay_unrandart(item.base_type, force_type, item_level,
-                                        include_abyssed);
+                                        include_abyssed, acquirement);
     if (idx == -1)
         return false;
 
@@ -196,7 +197,7 @@ static bool _weapon_disallows_randart(int sub_type)
 // Return whether we made an artefact.
 static bool _try_make_weapon_artefact(item_def& item, int force_type,
                                       int item_level, bool force_randart,
-                                      int agent)
+                                      int agent, bool acquirement)
 {
     const int old_ego = item.brand;
     if (item_level > 0 && x_chance_in_y(101 + item_level * 3, 4000)
@@ -208,8 +209,11 @@ static bool _try_make_weapon_artefact(item_def& item, int force_type,
         if (one_chance_in(item_level == ISPEC_GOOD_ITEM ? 7 : 20)
             && !force_randart)
         {
-            if (_try_make_item_unrand(item, force_type, item_level, agent))
+            if (_try_make_item_unrand(item, force_type, item_level, agent,
+                                      acquirement))
+            {
                 return true;
+            }
             if (item.base_type == OBJ_STAVES)
             {
                 // TODO: this is a bit messy: a fallback randart for an unrand
@@ -422,7 +426,8 @@ void set_artefact_brand(item_def &item, int brand)
 
 static void _generate_weapon_item(item_def& item, bool allow_uniques,
                                   int force_type, int item_level,
-                                  int agent = NO_AGENT)
+                                  int agent = NO_AGENT,
+                                  bool acquirement = false)
 {
     // Determine weapon type.
     if (force_type != OBJ_RANDOM)
@@ -439,7 +444,8 @@ static void _generate_weapon_item(item_def& item, bool allow_uniques,
     {
         int ego = item.brand;
         for (int i = 0; i < 100; ++i)
-            if (_try_make_weapon_artefact(item, force_type, 0, true, agent))
+            if (_try_make_weapon_artefact(item, force_type, 0, true, agent,
+                                          acquirement))
             {
                 if (ego > SPWPN_NORMAL)
                     set_artefact_brand(item, ego);
@@ -461,7 +467,8 @@ static void _generate_weapon_item(item_def& item, bool allow_uniques,
 
     // If we make the unique roll, no further generation necessary.
     if (allow_uniques
-        && _try_make_weapon_artefact(item, force_type, item_level, false, agent))
+        && _try_make_weapon_artefact(item, force_type, item_level, false,
+                                     agent, acquirement))
     {
         return;
     }
@@ -740,7 +747,7 @@ static bool _try_make_armour_artefact(item_def& item, int force_type,
     if (one_chance_in(item_level == ISPEC_GOOD_ITEM ? 7 : 20)
         && !force_randart)
     {
-        if (_try_make_item_unrand(item, force_type, item_level, agent))
+        if (_try_make_item_unrand(item, force_type, item_level, agent, false))
             return true;
     }
 
@@ -1566,7 +1573,8 @@ static void _roll_stave_type(item_def& item)
 }
 
 static void _try_make_staff_artefact(item_def& item, bool allow_uniques,
-                                     int item_level, int agent)
+                                     int item_level, int agent,
+                                     bool acquirement)
 {
     const bool force_randart = item_level == ISPEC_RANDART;
 
@@ -1578,8 +1586,11 @@ static void _try_make_staff_artefact(item_def& item, bool allow_uniques,
         // TODO: ???
         item.base_type = OBJ_WEAPONS;
         int fake_force_type = WPN_STAFF;
-        if (_try_make_item_unrand(item, fake_force_type, item_level, agent))
+        if (_try_make_item_unrand(item, fake_force_type, item_level, agent,
+                                  acquirement))
+        {
             return;
+        }
         // We failed. Go back to trying a staff.
         // TODO: support hypothetical fallback to a specific staff type
         item.base_type = OBJ_STAVES;
@@ -1595,14 +1606,16 @@ static void _try_make_staff_artefact(item_def& item, bool allow_uniques,
 }
 
 static void _generate_staff_item(item_def& item, bool allow_uniques,
-                                 int force_type, int item_level, int agent)
+                                 int force_type, int item_level, int agent,
+                                 bool acquirement)
 {
     if (force_type == OBJ_RANDOM)
         _roll_stave_type(item);
     else
         item.sub_type = force_type;
 
-    _try_make_staff_artefact(item, allow_uniques, item_level, agent);
+    _try_make_staff_artefact(item, allow_uniques, item_level, agent,
+                             acquirement);
 }
 
 static void _generate_rune_item(item_def& item, int force_type)
@@ -1661,7 +1674,7 @@ static bool _try_make_jewellery_unrandart(item_def& item, int force_type,
         && one_chance_in(20)
         && x_chance_in_y(101 + item_level * 3, 2000))
     {
-        if (_try_make_item_unrand(item, type, item_level, agent))
+        if (_try_make_item_unrand(item, type, item_level, agent, false))
             return true;
     }
 
@@ -2003,6 +2016,7 @@ static void _setup_fallback_randart(const int unrand_id,
  * @param item_level How powerful the item is allowed to be
  * @param force_ego The desired ego/brand
  * @param agent The agent creating the item (Example: Xom) or -1 if NA
+ * @param acquirement Whether the item should be tailored to fit the player
  * @param custom_name A custom name for the item
  * @param props Any special item props
  *
@@ -2014,6 +2028,7 @@ int items(bool allow_uniques,
           int item_level,
           int force_ego,
           int agent,
+          bool acquirement,
           string custom_name,
           CrawlHashTable const *fixed_props)
 {
@@ -2115,7 +2130,7 @@ int items(bool allow_uniques,
     {
     case OBJ_WEAPONS:
         _generate_weapon_item(item, allow_uniques, force_type, item_level,
-                              agent);
+                              agent, acquirement);
         break;
 
     case OBJ_MISSILES:
@@ -2152,7 +2167,7 @@ int items(bool allow_uniques,
         // Don't generate unrand staves this way except through acquirement,
         // since they also generate as OBJ_WEAPONS.
         _generate_staff_item(item, (agent != NO_AGENT), force_type,
-                             item_level, agent);
+                             item_level, agent, acquirement);
         break;
 
     case OBJ_ORBS:              // always forced in current setup {dlb}
@@ -2340,7 +2355,7 @@ void lucky_upgrade_item(item_def& item)
     if (item.base_type == OBJ_ARMOUR)
         did_upgrade = _try_make_armour_artefact(item, 0, ISPEC_RANDART, 0);
     else if (item.base_type == OBJ_WEAPONS)
-        did_upgrade = _try_make_weapon_artefact(item, 0, ISPEC_RANDART, true, 0);
+        did_upgrade = _try_make_weapon_artefact(item, 0, ISPEC_RANDART, true, 0, true);
     else
         did_upgrade = make_item_randart(item);
 

--- a/crawl-ref/source/makeitem.h
+++ b/crawl-ref/source/makeitem.h
@@ -18,6 +18,7 @@ int create_item_named(string name, coord_def pos, string *error);
 
 int items(bool allow_uniques, object_class_type force_class, int force_type,
           int item_level, int force_ego = 0, int agent = NO_AGENT,
+          bool acquirement = false,
           string custom_name = "",
           CrawlHashTable const *fixed_props = nullptr);
 

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -1439,7 +1439,7 @@ int make_mons_weapon(monster_type type, int level, bool melee_only)
     // and subtype and create a new item. - bwr
     const int thing_created =
         ((force_item) ? get_mitm_slot() : items(false, xitc, xitt, level,
-                                                item.brand, NO_AGENT,
+                                                item.brand, NO_AGENT, false,
                                                 custom_name));
 
     if (thing_created == NON_ITEM)


### PR DESCRIPTION
When upgrading a weapon into an unrand, we only consider unrand weapons that use the same attack skill and number of hands as the weapon we are upgrading. However, different races differ in the number of hands they need to use a weapon (e.g. formicids use almost all weapons in one hand) sometimes resulting in us picking a different unrand.

To fix this, require that the unrand uses the same number of hands for a medium size player with no mutations when upgrading weapons for non-acquirement items.

Resolves #5119