### PR TITLE
Do not allow firing inner flame at monsters the player can't harm.

### DIFF
--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3720,6 +3720,9 @@ string mons_inner_flame_immune_reason(const monster *mons)
                             mons->name(DESC_THE).c_str());
     }
 
+    if (!could_harm(&you, mons))
+        return make_stringf("You cannot harm %s.", mons->name(DESC_THE).c_str());
+
     return "";
 }
 


### PR DESCRIPTION
This was always a useless cast ("nothing happens" or "X avoids your attack"). Now we explain this in the targetter and do not allow targetting.