### PR TITLE
Fix Antimagic Gaze description

### DIFF
--- a/crawl-ref/source/dat/descript/spells.txt
+++ b/crawl-ref/source/dat/descript/spells.txt
@@ -54,8 +54,7 @@ will leaving the floor.
 Antimagic Gaze spell
 
 Causes the target's magic to leak into the air, as though they were hit by an
-antimagic weapon, and heals the caster for the amount of magic drained,
-with no direct line of fire required.
+antimagic weapon, with no direct line of fire required.
 %%%%
 Apportation spell
 


### PR DESCRIPTION
Antimagic(Draining) gaze was only healing ghost moth and this special case was removed in 0.31. See d43dddf.