### PR TITLE
Do not show freezing cloud cast warning if player is immune to clouds.

### DIFF
--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -1498,7 +1498,7 @@ bool stop_attack_prompt(targeter &hitfunc, const char* verb,
         }
     }
 
-    const bool hits_player = include_player && hitfunc.is_affected(you.pos());
+    const bool hits_player = include_player && hitfunc.is_affected(you.pos()) && affects(&you);
 
     if (victims.empty() && !hits_player)
         return false;

--- a/crawl-ref/source/spl-clouds.cc
+++ b/crawl-ref/source/spl-clouds.cc
@@ -105,7 +105,7 @@ spret cast_freezing_cloud(int pow, const coord_def& target, bool fail)
     hitfunc.set_aim(target);
 
     if (stop_attack_prompt(hitfunc, "conjure a freezing cloud",
-                            [](const actor *act) { return act->is_player() || act->res_cold() < 3;},
+                            [](const actor *act) { return (act->is_player() || act->res_cold() < 3) && !act->cloud_immune();},
                             nullptr, nullptr, false, true))
     {
         return spret::abort;


### PR DESCRIPTION
Noticed that even when worshipping Qazlal, freezing cloud still warns when casting it on yourself.
Here the problem is two-fold:
* Check on cloud immunity was missing from lambda, could be useful for monsters too
* Lambda was never called for player.

It seems like `include_player` is true only for freezing cloud check so it should not affect anything else.