### PR TITLE
feat: tweak messaging for Yred on zero-kill floors

### DIFF
--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -1568,7 +1568,10 @@ void yred_end_conquest()
     // Print a message about how happy Yred is about our performance this floor
     string msg = "You offer up the Black Torch's flame,";
 
-    if (ratio > 90)
+    // Presumably an all-undead level, such as an ossuary
+    if (kills == 0 && souls_remaining == 0)
+        msg+= " and feel that Yredelemnul wasn't entirely sure if that was necessary.";
+    else if (ratio > 90)
         msg+= " and Yredelemnul is glorified by your conquest!";
     else if (ratio > 65)
         msg+= " and Yredelemnul is satisfied with your conquest.";


### PR DESCRIPTION
If you use Black Torch on a floor that only has unspectralisable creatures (such as somewhere with all undead, like an ossuary) you'd end up getting a message saying you "feel Yredelemnul's disdain for your failure", which felt a bit odd.

Now there's a slightly witty message for the case of finishing a Black Torch use on a floor you reaped zero kills on and which has zero eligible souls remaining. This would also occur if you use Black Torch on a floor that you've already killed everything on, which is a slight information leak but a pretty minor one at that.

Open to alternate messages as well if this one is too whimsical.