### PR TITLE
Don't spend a turn when aborting channeling.

### DIFF
--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -1321,12 +1321,13 @@ static void _input()
         you.turn_is_over = false;
 #endif
 
+    if (you.turn_is_over && !handle_channelled_spell())
+        you.turn_is_over = false;
+
     if (you.turn_is_over)
     {
         if (you.apply_berserk_penalty)
             _do_berserk_no_combat_penalty();
-
-        handle_channelled_spell();
 
         world_reacts();
     }

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -3447,15 +3447,23 @@ void start_channelling_spell(spell_type spell, string reminder_msg, bool do_effe
     }
 }
 
-void handle_channelled_spell()
+static void _update_east_wind_for_channeling()
+{
+    if (you.duration[DUR_STAMPEDE] && you.has_mutation(MUT_EAST_WIND))
+        you.duration[DUR_STAMPEDE] += you.time_taken;
+}
+
+// return false if we must abort a channeled spell due to a warning prompt
+// return true otherwise, even if not channeling a spell
+bool handle_channelled_spell()
 {
     if (you.attribute[ATTR_CHANNELLED_SPELL] == SPELL_NO_SPELL)
-        return;
+        return true;
 
     // Skip processing at the end of the turn this is cast (since that already
     // happened *as* it was cast and shouldn't happen a second time.)
     if (++you.attribute[ATTR_CHANNEL_DURATION] == 1)
-        return;
+        return true;
 
     const spell_type spell = (spell_type)you.attribute[ATTR_CHANNELLED_SPELL];
 
@@ -3469,7 +3477,7 @@ void handle_channelled_spell()
     if (turn > 1 && crawl_state.prev_cmd != CMD_WAIT || !can_cast_spells(true))
     {
         stop_channelling_spells();
-        return;
+        return true;
     }
 
     if ((spell == SPELL_FLAME_WAVE || spell == SPELL_SEARING_RAY)
@@ -3478,33 +3486,38 @@ void handle_channelled_spell()
         mprf("Without enough magic to sustain it, your %s dissipates.",
              spell_title(spell));
         stop_channelling_spells(true);
-        return;
+        return true;
     }
-
-    if (you.duration[DUR_STAMPEDE] && you.has_mutation(MUT_EAST_WIND))
-        you.duration[DUR_STAMPEDE] += you.time_taken;
 
     switch (you.attribute[ATTR_CHANNELLED_SPELL])
     {
         case SPELL_MAXWELLS_COUPLING:
             handle_maxwells_coupling();
-            return;
+            _update_east_wind_for_channeling();
+            return true;
 
         case SPELL_FLAME_WAVE:
-            handle_flame_wave(turn);
-            return;
+            if (!handle_flame_wave(turn))
+                return false;
+            _update_east_wind_for_channeling();
+            return true;
 
         case SPELL_SEARING_RAY:
-            handle_searing_ray(you, turn);
-            return;
+            if (!handle_searing_ray(you, turn))
+                return false;
+            _update_east_wind_for_channeling();
+            return true;
 
         case SPELL_CLOCKWORK_BEE:
             handle_clockwork_bee_spell(turn);
-            return;
+            _update_east_wind_for_channeling();
+            return true;
 
         default:
             mprf(MSGCH_WARN, "Attempting to channel buggy spell: %s", spell_title(spell));
     }
+
+    return true;
 }
 
 void stop_channelling_spells(bool quiet)

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -155,6 +155,6 @@ void do_demonic_magic(int pow, int rank);
 bool channelled_spell_active(spell_type spell);
 void start_channelling_spell(spell_type spell, string reminder_msg = "", bool do_effect = true);
 void stop_channelling_spells(bool quiet = false);
-void handle_channelled_spell();
+bool handle_channelled_spell();
 
 bool warn_about_contam_cost(int max_contam);

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3860,14 +3860,15 @@ spret cast_flame_wave(int pow, bool fail)
     return spret::success;
 }
 
-void handle_flame_wave(int lvl)
+// return false if aborting due to warning prompt
+bool handle_flame_wave(int lvl)
 {
     const int pow = you.props[FLAME_WAVE_POWER_KEY].get_int();
     bolt beam;
     if (!_prep_flame_wave(beam, pow, lvl, lvl == 1))
     {
         stop_channelling_spells();
-        return;
+        return false;
     }
 
     beam.apply_beam_conducts();
@@ -3886,6 +3887,8 @@ void handle_flame_wave(int lvl)
         mpr("Your wave of flame reaches its maximum intensity and dissipates.");
         stop_channelling_spells(true);
     }
+
+    return true;
 }
 
 spret cast_searing_ray(actor& agent, int pow, bolt &beam, bool fail)

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -130,7 +130,7 @@ void seeker_attack(monster& seeker, actor& target,
 spret cast_hailstorm(int pow, bool fail, bool tracer=false);
 
 spret cast_flame_wave(int pow, bool fail);
-void handle_flame_wave(int lvl);
+bool handle_flame_wave(int lvl);
 
 spret cast_imb(int pow, bool fail);
 


### PR DESCRIPTION
When channeling stops due to the player saying no to a prompt, don't take time.
Closes #3506.