### PR TITLE
Say dragon-coil talismans turn low level draconians into golden dragons

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -621,7 +621,7 @@ dragon-coil talisman
 An intricate carving, inlaid with dragon tooth and scale. {{
     local desc = "Transforms the wearer into a mighty"
 
-    if you.race():find("Draconian") then
+    if you.race():find(" Draconian") then
         desc = desc .. " dragon. The wearer retains their innate colour, " ..
                        "becomes resistant to poison, and their breath weapon's " ..
                        "power and recharge rate are greatly increased."

--- a/crawl-ref/source/transform.cc
+++ b/crawl-ref/source/transform.cc
@@ -1950,10 +1950,16 @@ static void _on_enter_form(transformation which_trans)
     case transformation::dragon:
         // The first time the player becomes a dragon, given them a charge of
         // their breath weapon so they can actually use them.
-        if (!you.props.exists(HAS_USED_DRAGON_TALISMAN_KEY)
-            && !species::is_draconian(you.species))
+        if (!you.props.exists(HAS_USED_DRAGON_TALISMAN_KEY))
         {
-            gain_draconian_breath_uses(1);
+            if (!species::is_draconian(you.species))
+                gain_draconian_breath_uses(1);
+            // Level 7 to match level_change().
+            if (SP_BASE_DRACONIAN == you.species)
+            {
+                mpr("You will transform on reaching level 7, even in dragon"
+                    " form.");
+            }
             you.props[HAS_USED_DRAGON_TALISMAN_KEY] = true;
         }
         break;


### PR DESCRIPTION
Use the default description of dragon-coil talismans for draconians before level 7. This reflects what the game actually does.

Print a message about the level 7 change when a low-level draconian uses a dragon-coil talisman for the first time. You may suddenly plummet, but you can't say you weren't warned.

Level 7 is very early to make use of a dragon-coil talisman, but it could be practical for a draconian who has found some experience potions.