### PR TITLE
fix spell key test

### DIFF
--- a/crawl-ref/source/adjust.cc
+++ b/crawl-ref/source/adjust.cc
@@ -146,11 +146,7 @@ static void _adjust_spell()
         // without spells from this menu.
         // XX this does not really work well with new menu code
         if (keyin == '?' || keyin == '*')
-        {
             keyin = list_spells(true, false, false, false, "adjust it to");
-            if (keyin < 'a' || keyin > 'Z')
-                continue;
-        }
     }
 
     const int input_2 = keyin;


### PR DESCRIPTION
Uppercase letters come before lowercase, not after.
And it's irrelevant anyway, because it ends up at in the loop's own `isaalpha()` check either way.