### PR TITLE
Do not show breath status if player can't use it in current form

### DIFF
--- a/crawl-ref/source/status.cc
+++ b/crawl-ref/source/status.cc
@@ -251,7 +251,7 @@ bool fill_status_info(int status, status_info& inf)
 
     case STATUS_DRACONIAN_BREATH:
     {
-        if ((!species::is_draconian(you.species) || you.experience_level < 7)
+        if ((!species::is_draconian(you.species) || you.experience_level < 7 || form_changes_anatomy())
                 && you.form != transformation::dragon)
         {
             break;


### PR DESCRIPTION
The information about how many charges breath has seems irrelevant if we cannot use it.
Note that for dragon form breath status will still be shown due to second line of the condition.