### PR TITLE
Fix missing space between prefix and text in menu_colour()

### DIFF
--- a/crawl-ref/source/menu.cc
+++ b/crawl-ref/source/menu.cc
@@ -3490,7 +3490,14 @@ void Menu::webtiles_write_item(const MenuEntry* me) const
 
 int menu_colour(const string &text, const string &prefix, const string &tag, bool strict)
 {
-    const string tmp_text = prefix + text;
+    bool extra_space = false;
+    if ((!text.empty() && text.front() != ' ') 
+        && (!prefix.empty() && prefix.back() != ' '))
+    {
+        extra_space = true;
+    }
+
+    const string tmp_text = prefix + (extra_space ? " " : "") + text;
 
     for (const colour_mapping &cm : Options.menu_colour_mappings)
     {


### PR DESCRIPTION
menu_colour() initially didn't check if there was a space between prefix and text before jamming them together. this pr makes menu_colour() first check if there is at least one space between the two (and if not adds a space)

fixes #5303