### PR TITLE
Rework lightning rod damage

### DIFF
--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -932,8 +932,8 @@ lightning rod
 A rod that allows its wielder to fire unavoidable blasts of lightning.
 Consecutive evocations cause the discharge to be sustained, which increases the
 power level up to four times and allows the blast to be redirected to affect an
-area. The strength of the blast increases with Evocations skill and, for
-redirected blasts, decreases with the size of the affected area.
+area. Redirected blasts deal half damage to those outside the main beam. The
+strength of the blast increases with Evocations skill.
 %%%%
 long sword
 

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -3118,7 +3118,7 @@ static dice_def _spell_damage(spell_type spell, int power)
         case SPELL_BOULDER:
             return boulder_damage(power, false);
         case SPELL_THUNDERBOLT:
-            return thunderbolt_damage(power, 1);
+            return thunderbolt_damage(power, true, false);
         case SPELL_HELLFIRE_MORTAR:
             return hellfire_mortar_damage(power);
         case SPELL_FORGE_LIGHTNING_SPIRE:

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -3378,7 +3378,7 @@ static void _set_thunderbolt_last_aim(actor *caster, coord_def aim)
     last_aim = aim;
 }
 
-dice_def thunderbolt_damage(int power, int arc)
+dice_def thunderbolt_damage(int power, bool main_beam, bool sample)
 {
     const int &charges = you.props[THUNDERBOLT_CHARGES_KEY].get_int();
     ASSERT(charges <= LIGHTNING_MAX_CHARGE);
@@ -3387,11 +3387,16 @@ dice_def thunderbolt_damage(int power, int arc)
     if (in_bounds(get_thunderbolt_last_aim(&you)))
         charge_boost = charges;
 
-    const int dice = div_rand_round(
-        (spell_mana(SPELL_THUNDERBOLT, false) + charge_boost)
-            * LIGHTNING_CHARGE_MULT,
-        LIGHTNING_CHARGE_MULT);
-    return dice_def(dice, div_rand_round(45 + power / 4, arc + 2));
+    const int dice = 2 + charge_boost;
+    int scale = 100;
+    int dice_damage = 13 * scale + power * scale / 14;
+    if (!main_beam)
+        dice_damage = dice_damage / 2;
+    dice_damage = sample
+                    ? div_rand_round(dice_damage, scale)
+                    : div_round_near(dice_damage, scale);
+
+    return dice_def(dice, dice_damage);
 }
 
 spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
@@ -3454,14 +3459,10 @@ spret cast_thunderbolt(actor *caster, int pow, coord_def aim, bool fail)
         if (!actor_at(entry.first))
             continue;
 
-        int arc = hitfunc.arc_length[entry.first.distance_from(hitfunc.origin)];
-        ASSERT(arc > 0);
-        dprf("at distance %d, arc length is %d",
-             entry.first.distance_from(hitfunc.origin), arc);
         beam.source = beam.target = entry.first;
         beam.source.x -= sgn(beam.source.x - hitfunc.origin.x);
         beam.source.y -= sgn(beam.source.y - hitfunc.origin.y);
-        beam.damage = thunderbolt_damage(pow, arc);
+        beam.damage = thunderbolt_damage(pow, entry.second == AFF_YES);
         beam.fire();
     }
 

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -96,7 +96,7 @@ void polar_vortex_damage(actor *caster, int dur);
 dice_def polar_vortex_dice(int pow, bool random);
 void cancel_polar_vortex();
 coord_def get_thunderbolt_last_aim(actor *caster);
-dice_def thunderbolt_damage(int power, int arc);
+dice_def thunderbolt_damage(int power, bool main_beam, bool sample = true);
 spret cast_thunderbolt(actor *caster, int pow, coord_def aim,
                             bool fail);
 bool mons_should_fire_permafrost(int pow, const actor &agent);

--- a/crawl-ref/source/target.cc
+++ b/crawl-ref/source/target.cc
@@ -1303,8 +1303,6 @@ bool targeter_thunderbolt::set_aim(coord_def a)
     if (a == origin)
         return false;
 
-    arc_length.init(0);
-
     ray_def ray;
     coord_def p; // ray.pos() does lots of processing, cache it
 
@@ -1314,10 +1312,7 @@ bool targeter_thunderbolt::set_aim(coord_def a)
            && map_bounds(p) && opc_solid_see(p) < OPC_OPAQUE)
     {
         if (p != origin && zapped[p] <= 0)
-        {
             zapped[p] = AFF_YES;
-            arc_length[origin.distance_from(p)]++;
-        }
         ray.advance();
     }
 
@@ -1329,10 +1324,7 @@ bool targeter_thunderbolt::set_aim(coord_def a)
            && map_bounds(p) && opc_solid_see(p) < OPC_OPAQUE)
     {
         if (p != origin && zapped[p] <= 0)
-        {
-            zapped[p] = AFF_MAYBE; // fully affected, we just want to highlight cur
-            arc_length[origin.distance_from(p)]++;
-        }
+            zapped[p] = AFF_MAYBE;
         ray.advance();
     }
 
@@ -1350,8 +1342,6 @@ bool targeter_thunderbolt::set_aim(coord_def a)
             if (left_of(a1, r) && left_of(r, a2))
             {
                 (p = r) += origin;
-                if (!zapped.count(p))
-                    arc_length[r.rdist()]++;
                 if (zapped[p] <= 0 && cell_see_cell(origin, p, LOS_NO_TRANS))
                     zapped[p] = AFF_MAYBE;
             }

--- a/crawl-ref/source/target.h
+++ b/crawl-ref/source/target.h
@@ -299,7 +299,6 @@ public:
     bool set_aim(coord_def a) override;
     aff_type is_affected(coord_def loc) override;
     map<coord_def, aff_type> zapped;
-    FixedVector<int, LOS_RADIUS + 1> arc_length;
 private:
     coord_def prev;
     int range;

--- a/crawl-ref/source/xp-evoker-data.h
+++ b/crawl-ref/source/xp-evoker-data.h
@@ -6,7 +6,6 @@
 #include "item-prop-enum.h"
 
 // Used in spl-damage.cc for lightning rod damage calculations
-const int LIGHTNING_CHARGE_MULT = 100;
 const int LIGHTNING_MAX_CHARGE = 4;
 
 struct recharge_messages


### PR DESCRIPTION
The current damage from lightning rod sheet lightning is quite counterintuitive; it does reduced damage to each enemy according to the number of tiles hit at the same distance from the player.

This is quite hard to think about, and it means that using the lightning rod to hit a large area is usually less effective than using it for single beam damage. It also has fiddly targetting shenanigans where it is good to decrease the number of squares hit.

We update this so that:
* The main beam does full damage every cast
* Squares off the main beam take half damage

This is intended to incentivise more use of AoE; as long as the player has sensible targets for the main beam they should want to move the beam in a wide arc to deal some damage to more targets. It also makes moving the beam for single target damage more effective, e.g. if the first target is dead.

Since this should be a buff for lightning rod, we nudge the single-beam damage numbers down to compensate.

Also make the displayed damage deterministic.