### PR TITLE
Fix door breaking logic for larger doors

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -3100,8 +3100,18 @@ static void _mons_open_door(monster& mons, const coord_def &pos)
     find_connected_identical(pos, all_door);
     get_door_description(all_door.size(), &adj, &noun);
 
+    bool player_adj_to_door = false;
+    for (const auto &door_pos : all_door)
+    {
+        if (adjacent(you.pos(), door_pos))
+        {
+            player_adj_to_door = true;
+            break;
+        }
+    }
+
     const bool broken = mons.foe == MHITYOU
-                            && ((adjacent(you.pos(), pos) && one_chance_in(3))
+                            && ((player_adj_to_door && one_chance_in(3))
                                 || mons.berserk());
     for (const auto &dc : all_door)
     {


### PR DESCRIPTION
the adjacency logic only checked if the player was next to the door tile the monster had just interacted with. since the function only checked if the player was next to that one tile, if the door was larger than 1 tile the logic could not count the player as being adjacent to it

this pr fixes that issue by checking if the player is near any of the door's tiles, not just the one the monster interacted with

fixes #5309