### PR TITLE
Make Pandemonium finite

### DIFF
--- a/crawl-ref/source/branch-data.h
+++ b/crawl-ref/source/branch-data.h
@@ -241,8 +241,8 @@ const Branch branches[NUM_BRANCHES] =
       'J', { RUNE_ABYSSAL }, branch_noise::normal, DEFAULT_MON_DIE_SIZE,
       {} },
 
-    { BRANCH_PANDEMONIUM, NUM_BRANCHES, -1, -1, 1, 24,
-      brflag::no_x_level_travel,
+    { BRANCH_PANDEMONIUM, NUM_BRANCHES, -1, -1, 11, 24,
+      brflag::no_x_level_travel | brflag::no_shafts,
       DNGN_ENTER_PANDEMONIUM, DNGN_EXIT_PANDEMONIUM, DNGN_TRANSIT_PANDEMONIUM,
       "Pandemonium", "Pandemonium", "Pan",
       "You enter the halls of Pandemonium!\n"

--- a/crawl-ref/source/daction-type.h
+++ b/crawl-ref/source/daction-type.h
@@ -54,6 +54,7 @@ enum daction_type
     DACT_REMOVE_IGNIS_ALTARS,
     DACT_BEOGH_VENGEANCE_CLEANUP,
     DACT_BANE_MORTALITY_CLEANUP,
+    DACT_REMOVE_PAN_GATES,
     NUM_DACTIONS,
     // If you want to add a new daction, you need to
     // add a corresponding entry to *daction_names[]

--- a/crawl-ref/source/dactions.cc
+++ b/crawl-ref/source/dactions.cc
@@ -79,6 +79,7 @@ static const char *daction_names[] =
     "remove Ignis altars",
     "cleanup Beogh vengeance markers",
     "cleanup Bane of Mortality summons",
+    "remove Pandemonium gates",
 };
 #endif
 
@@ -369,6 +370,11 @@ static void _apply_daction(daction_type act)
         for (rectangle_iterator ri(1); ri; ++ri)
             if (env.grid(*ri) == DNGN_ALTAR_IGNIS)
                 env.grid(*ri) = DNGN_FLOOR;
+        break;
+    case DACT_REMOVE_PAN_GATES:
+        for (rectangle_iterator ri(1); ri; ++ri)
+            if (env.grid(*ri) == DNGN_ENTER_PANDEMONIUM)
+                env.grid(*ri) = DNGN_STONE_ARCH;
         break;
     case DACT_ROT_CORPSES:
         for (auto &item : env.item)

--- a/crawl-ref/source/dat/des/altar/altar.des
+++ b/crawl-ref/source/dat/des/altar/altar.des
@@ -381,11 +381,7 @@ DEPTH:    D:3-, Depths, Crypt, Zot, Pan, Geh, Coc, Dis, Tar
 WEIGHT:   2
 KMONS:    q = lurking_horror
 KFEAT:    p = altar_lugonu
-: if you.in_branch("Pandemonium") then
-KFEAT:    r = exit_through_abyss
-: else
 KFEAT:    r = enter_abyss
-: end
 : if crawl.coinflip() then
 SUBST:    ' = xxx'.
 : else

--- a/crawl-ref/source/dat/des/branches/pan.des
+++ b/crawl-ref/source/dat/des/branches/pan.des
@@ -197,6 +197,7 @@ colour.add_colour("disco", function(rand, x, y)
 end)
 
 function pan_demonic_rune(e, glyph, place_lord)
+    e.tags('pan_lair')
     e.subst(glyph .. ' = ' .. (place_lord and glyph or '.') .. ':6 O:1 N:2')
     e.kitem('O = demonic rune of Zot')
     e.kfeat('N = exit_pandemonium')
@@ -1610,11 +1611,12 @@ ENDMAP
 # Tagging these levels also ensures they won't be generated in the main
 # dungeon.
 #
-# The first block consists of repeating vaults featuring a rune and Pan lord.
+# The first block consists of repeating vaults featuring a possible rune and
+# Pan lord.
 # TAG: allow_dup
-# : pan_demonic(_G, 'P', true)     -- place the rune with a pandemonium lord
-# : pan_demonic(_G, 'P')           -- place the rune without lord; have to
-#                                  -- put down the Pan lord manually
+# : pan_demonic_rune(_G, 'P', true) -- place the rune with a pandemonium lord
+# : pan_demonic_rune(_G, 'P')       -- place the rune without lord; have to
+#                                   -- put down the Pan lord manually
 #
 # Of these maps, rand_demon_1 to rand_demon_9 are ancient heritage.
 
@@ -2567,7 +2569,7 @@ ENDMAP
 # If you already have the demonic rune, it's got a selection of randarts for
 # you instead.
 NAME:    nicolae_pan_bazaar_rune
-TAGS:    patrolling transparent no_item_gen
+TAGS:    patrolling transparent no_item_gen pan_lair
 WEIGHT:  5
 ORIENT:  float
 {{
@@ -2690,7 +2692,7 @@ epilogue{{
 
 # Concept inherited from lemuel_draining_boxes.
 NAME:   regret_index_pan_draining_boxed
-TAGS:   pan_fixed_rune_boxes pan_fixed_lure_boxes transparent
+TAGS:   pan_fixed_rune_boxes pan_fixed_lure_boxes transparent pan_lair
 ORIENT: float
 MONS:   pandemonium lord, ghost moth
 MONS:   demonspawn soul scholar, sin beast, any demon, wyrmhole
@@ -2786,7 +2788,7 @@ ENDMAP
 ###################################
 
 NAME:    lemuel_hellion_island
-TAGS:    pan_fixed_rune_hellions pan_fixed_lure_hellions
+TAGS:    pan_fixed_rune_hellions pan_fixed_lure_hellions pan_lair
 ORIENT:  float
 MONS:    fire bat, hellion, hellephant
 KMONS:   O = pandemonium lord
@@ -2864,7 +2866,7 @@ ENDMAP
 ########################################
 
 NAME:    lemuel_hall_of_pain
-TAGS:    pan_fixed_rune_pain pan_fixed_lure_pain
+TAGS:    pan_fixed_rune_pain pan_fixed_lure_pain pan_lair
 ORIENT:  float
 MONS:    pandemonium lord, brimstone fiend
 MONS:    tormentor, smoke demon, any demon
@@ -2932,7 +2934,7 @@ ENDMAP
 ########################################
 
 NAME:   grunt_pan_frozen_over
-TAGS:   pan_fixed_rune_frozen pan_fixed_lure_frozen
+TAGS:   pan_fixed_rune_frozen pan_fixed_lure_frozen pan_lair
 TAGS:   no_pool_fixup no_monster_gen transparent
 ORIENT: float
 MONS:   blizzard demon, demonspawn soul scholar
@@ -3024,7 +3026,7 @@ ENDMAP
 ########################################
 
 NAME:    pan_disco_hall
-TAGS:    pan_fixed_rune_disco pan_fixed_lure_disco no_rotate
+TAGS:    pan_fixed_rune_disco pan_fixed_lure_disco no_rotate pan_lair
 ORIENT:  southeast
 MONS:    rakshasa, demonspawn corrupter, demonspawn blood saint
 MONS:    dancing weapon ; demon trident good_item ego:distortion
@@ -4210,7 +4212,7 @@ ENDMAP
 # portal vault (for pan, even).
 #
 NAME:   evilmike_holy_pan
-TAGS:   no_pool_fixup
+TAGS:   no_pool_fixup pan_lair
 ORIENT: encompass
 MONS:   angel
 MONS:   cherub

--- a/crawl-ref/source/dat/des/branches/pan.des
+++ b/crawl-ref/source/dat/des/branches/pan.des
@@ -547,35 +547,9 @@ xx..2..2..xx
 ENDMAP
 
 ##############################################################################
-# Random unguarded exits
+# Pan vaults
 ##############################################################################
 default-depth: Pan
-
-NAME:   pan_exit
-TAGS:   extra allow_dup transparent no_dump
-CHANCE: 100%
-{{
-local exit_chance = 5 + 3*count_pan_runes()
-local floor_chance = 100 - exit_chance
-kfeat("O = exit_pandemonium w:" .. exit_chance .. " / floor w:" .. floor_chance)
-}}
-MAP
-O
-ENDMAP
-
-NAME:   pan_to_abyss
-TAGS:   extra allow_dup transparent no_dump
-CHANCE: 100%
-{{
-local exit_chance = 25 + 10*count_pan_runes()
-local floor_chance = 100 - exit_chance
-kfeat("O = exit_through_abyss w:" .. exit_chance ..
-      " / floor w:" .. floor_chance)
-}}
-MAP
-O
-ENDMAP
-
 
 ##############################################################################
 # Pan Demon Lairs
@@ -3863,33 +3837,6 @@ MAP
 .b...........b.
 .ababababababa.
 ...............
-ENDMAP
-
-NAME:    nicolae_pan_sick_transit
-TAGS:    transparent extra decor allow_dup pandec
-DEPTH:   Pan
-SHUFFLE: Aai/Bbj/Cck/Ddl/Eem/Ffn/Ggo/Hhp, Ffn/Qqr/Qqr, Ggo/Sst/Sst
-SHUFFLE: Hhp/Uuv/Uuv
-SUBST:   ABCDFGHijklnop = x, abcdfgh = -, EQSU = @, emqrstuv = .
-SUBST:   I : x., J : x., K : x., L: x., M: x., N : x.
-KFEAT:   - = transit_pandemonium w:36 / trap_teleport_permanent w:1 / \
-             exit_pandemonium w:1 / exit_through_abyss w:1
-MAP
-    xxxAxxx
-   xxxxaxxxx
-  Hpx.....xjB
- xph..I.I..bjx
-xxx..KJ.JK..xxx
-xx..KLM.MLK..xx
-xx.IJMN.NMJI.xx
-Gg...........cC
-xx.IJMN.NMJI.xx
-xx..KLM.MLK..xx
-xxx..KJ.JK..xxx
- xnf..I.I..dlx
-  Fnx.....xlD
-   xxxxexxxx
-    xxxExxx
 ENDMAP
 
 NAME: nicolae_pan_strange_glyphs

--- a/crawl-ref/source/dat/des/builder/layout.des
+++ b/crawl-ref/source/dat/des/builder/layout.des
@@ -408,14 +408,6 @@ TAGS:   uniq_open_layout
         end
     end
 
-    -- Do we still want this special case here?
-    if you.where() == "Pan" and crawl.coinflip() then
-        mapgrd[40][36] = 'O'
-        mapgrd[41][36] = 'O'
-        nsubst('O = 1:O / *:.')
-        kfeat('O = exit_through_abyss')
-    end
-
     theme.level_material(_G)
 }}
 # Enforce minimum floor size - otherwise we get very tiny floors sometimes

--- a/crawl-ref/source/dat/des/builder/layout_pan_divisions.des
+++ b/crawl-ref/source/dat/des/builder/layout_pan_divisions.des
@@ -899,8 +899,7 @@ SHUFFLE: pqy / uuu
 SUBST:   pq = x
 SUBST:   y = +
 SUBST:   ruz = .
-SUBST:   A : .:35 I:5 Y:10
-KFEAT:   I = exit_pandemonium
+SUBST:   A : .:40 Y:10
 MAP
    ..   ..
   .........

--- a/crawl-ref/source/dbg-scan.cc
+++ b/crawl-ref/source/dbg-scan.cc
@@ -624,8 +624,6 @@ void check_map_validity()
         // crosscheck with _add_missing_branches when changing
         if (you.depth == 1)
             portal = DNGN_ENTER_HELL;
-        else if (you.depth == 2)
-            portal = DNGN_ENTER_PANDEMONIUM;
         else if (you.depth == 3)
             portal = DNGN_ENTER_ABYSS;
     }

--- a/crawl-ref/source/defines.h
+++ b/crawl-ref/source/defines.h
@@ -357,6 +357,8 @@ const char * const THUNDERBOLT_AIM_KEY     = "thunderbolt_aim";
 
 #define FORCE_MINIVAULT_KEY "force_minivault"
 #define FORCE_MAP_KEY "force_map"
+
+#define PAN_LORD_FLOORS_KEY "pan_lord_floors"
 #define DEBUG_BUILDER_LOGS_KEY "debug_builder_logs"
 
 #define NEEDS_AUTOPICKUP_KEY "needs_autopickup"

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -3073,7 +3073,7 @@ static bool _pan_level()
                                    false, false);
     }
     else
-        vault = random_map_in_depth(level_id::current(), false, false);
+        vault = random_map_for_tag("pan_lair", false, false);
 
     // Every Pan level should have a primary vault.
     ASSERT(vault);

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1254,16 +1254,81 @@ static void _fixup_hell_stairs()
     }
 }
 
+// Tags marking the four unique rune lord vaults.
+static const char *pandemon_level_names[] =
+    { "mnoleg", "lom_lobon", "cerebov", "gloorx_vloq", };
+
+// Whether this level was built around one of the unique rune lords.
+static bool _has_unique_pan_lord_vault()
+{
+    for (auto &vp : env.level_vaults)
+        for (const char *lord : pandemon_level_names)
+            if (vp->map.has_tag(lord))
+                return true;
+    return false;
+}
+
+static const vault_placement *_primary_vault()
+{
+    return env.level_vaults.empty() ? nullptr : env.level_vaults[0].get();
+}
+
+static bool _is_pan_portal_candidate(dungeon_feature_type feat)
+{
+    return feat_is_stone_stair_up(feat)
+        || feat == DNGN_ESCAPE_HATCH_UP
+        || feat == DNGN_TRANSIT_PANDEMONIUM
+        || feat == DNGN_EXIT_PANDEMONIUM;
+}
+
 static void _fixup_pandemonium_stairs()
 {
+    // On floors of pan belonging to the unique rune lords, we turn upstairs
+    // into transit portals.
+    //
+    // On other floors, we place a single portal in the pan lord vault, which
+    // must contain a stair or we will veto the map.
+    const dungeon_feature_type portal =
+        you.depth >= brdepth[BRANCH_PANDEMONIUM] ? DNGN_EXIT_PANDEMONIUM
+                                                 : DNGN_TRANSIT_PANDEMONIUM;
+
+    vector<coord_def> candidates;
     for (rectangle_iterator ri(1); ri; ++ri)
     {
-        if (feat_is_stone_stair_up(env.grid(*ri))
-            || env.grid(*ri) == DNGN_ESCAPE_HATCH_UP)
-        {
-            _set_grd(*ri, DNGN_TRANSIT_PANDEMONIUM);
-        }
+        const dungeon_feature_type feat = env.grid(*ri);
+        if (_is_pan_portal_candidate(feat))
+            candidates.push_back(*ri);
+        else if (feat_is_stone_stair_down(feat) || feat == DNGN_ESCAPE_HATCH_DOWN)
+            _set_grd(*ri, DNGN_FLOOR);
     }
+
+    // Unique pan lord levels turn everything into a portal.
+    if (_has_unique_pan_lord_vault())
+    {
+        for (const coord_def &c : candidates)
+            _set_grd(c, portal);
+        return;
+    }
+
+    // Find the stair in the Pan lord's lair to keep. The lair is always the
+    // primary vault.
+    const vault_placement *lair = _primary_vault();
+    if (!lair)
+        throw dgn_veto_exception("Did not find a pan lord lair.");
+
+    bool placed = false;
+    for (const coord_def &c : candidates)
+    {
+        if (!placed && dgn_vault_at(c) == lair)
+        {
+            placed = true;
+            _set_grd(c, portal);
+        }
+        else
+            _set_grd(c, DNGN_FLOOR);
+    }
+    if (!placed)
+        throw dgn_veto_exception("No portal location in lair " + lair->map.name);
 }
 
 static void _fixup_descent_hatches()
@@ -2951,13 +3016,29 @@ static const map_def *_pick_layout(const map_def *vault)
     return layout;
 }
 
+// Assign each unique rune lord to a distinct Pandemonium floor, so they are
+// met (and somewhat spread out) while fighting down the branch.
+static void _schedule_pan_lord_floors()
+{
+    if (you.props.exists(PAN_LORD_FLOORS_KEY))
+        return;
+
+    const int band_min[] = { 2, 5, 7, 9 };
+    const int band_max[] = { 4, 6, 8, 10 };
+    int band_order[] = { 0, 1, 2, 3 };
+    shuffle_array(band_order, 4);
+
+    CrawlVector &floors = you.props[PAN_LORD_FLOORS_KEY].new_vector(SV_INT);
+    for (int i = 0; i < 4; i++)
+    {
+        const int band = band_order[i];
+        floors.push_back(random_range(band_min[band], band_max[band]));
+    }
+}
+
 static bool _pan_level()
 {
-    const char *pandemon_level_names[] =
-        { "mnoleg", "lom_lobon", "cerebov", "gloorx_vloq", };
     int which_demon = -1;
-    const PlaceInfo &place_info = you.get_place_info();
-    bool all_demons_generated = true;
 
     if (you.props.exists(FORCE_MAP_KEY))
     {
@@ -2969,27 +3050,19 @@ static bool _pan_level()
         return vault->orient != MAP_ENCOMPASS;
     }
 
+    _schedule_pan_lord_floors();
+
+    // Place this floor's scheduled rune lord, if any (and if not already met).
+    const CrawlVector &floors = you.props[PAN_LORD_FLOORS_KEY].get_vector();
     for (int i = 0; i < 4; i++)
     {
-        if (!get_uniq_map_tags().count(string("uniq_") + pandemon_level_names[i]))
+        if (floors[i].get_int() == you.depth
+            && !get_uniq_map_tags().count(string("uniq_")
+                                          + pandemon_level_names[i]))
         {
-            all_demons_generated = false;
+            which_demon = i;
             break;
         }
-    }
-
-    // Unique pan lords become more common as you travel through pandemonium.
-    // On average it takes about 14 levels to see all four, and on average
-    // about 5 levels to see your first.
-    if (x_chance_in_y(1 + place_info.levels_seen, 20 + place_info.levels_seen)
-        && !all_demons_generated)
-    {
-        do
-        {
-            which_demon = random2(4);
-        }
-        while (get_uniq_map_tags().count(string("uniq_")
-                                       + pandemon_level_names[which_demon]));
     }
 
     const map_def *vault = nullptr;

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1848,7 +1848,6 @@ static const vector<branch_type> branch_generation_order =
     BRANCH_COCYTUS,
     BRANCH_DIS,
     BRANCH_GEHENNA,
-    BRANCH_PANDEMONIUM,
     BRANCH_ZIGGURAT,
     NUM_BRANCHES,
 };
@@ -3279,6 +3278,28 @@ static bool _restore_game(const string& filename)
     _convert_obsolete_species();
 
     const int minorVersion = crawl_state.minor_version;
+
+#if TAG_MAJOR_VERSION == 34
+    // Pandemonium became a multi-level branch. Its single saved level was
+    // stored under the chunk name "Pan"; it is now looked up as "Pan:1".
+    // Rename the chunk and its visited-state key.
+    if (minorVersion < TAG_MINOR_PANDEMONIUM_DEPTH)
+    {
+        const string old_name = branches[BRANCH_PANDEMONIUM].abbrevname;
+        const string new_name = level_id(BRANCH_PANDEMONIUM, 1).describe();
+        if (you.save->has_chunk(old_name))
+        {
+            you.save->rename_chunk(old_name, new_name);
+
+            auto &visited = you.props[VISITED_LEVELS_KEY].get_table();
+            if (visited.exists(old_name))
+            {
+                visited[new_name] = true;
+                visited.erase(old_name);
+            }
+        }
+    }
+#endif
 
     if (you.save->has_chunk(CHUNK("st", "stashes")))
     {

--- a/crawl-ref/source/package.cc
+++ b/crawl-ref/source/package.cc
@@ -388,6 +388,24 @@ void package::delete_chunk(const string &name)
     directory.erase(name);
 }
 
+void package::rename_chunk(const string &name, const string &newname)
+{
+    if (name == newname || !has_chunk(name))
+        return;
+
+    vector<char> buf;
+    {
+        chunk_reader in(this, name);
+        in.read_all(buf);
+    }
+    {
+        chunk_writer out(this, newname);
+        if (!buf.empty())
+            out.write(&buf[0], buf.size());
+    }
+    delete_chunk(name);
+}
+
 plen_t package::write_directory()
 {
     delete_chunk("");

--- a/crawl-ref/source/package.h
+++ b/crawl-ref/source/package.h
@@ -80,6 +80,7 @@ public:
     chunk_reader* reader(const string &name);
     void commit();
     void delete_chunk(const string &name);
+    void rename_chunk(const string &name, const string &newname);
     bool has_chunk(const string &name);
     vector<string> list_chunks();
     void abort();

--- a/crawl-ref/source/stairs.cc
+++ b/crawl-ref/source/stairs.cc
@@ -15,6 +15,7 @@
 #include "chardump.h"
 #include "colour.h"
 #include "coordit.h"
+#include "dactions.h"
 #include "database.h"
 #include "delay.h"
 #include "dgn-overview.h"
@@ -876,6 +877,9 @@ void floor_transition(dungeon_feature_type how,
     if (how == DNGN_ENTER_ZIGGURAT)
         dungeon_terrain_changed(you.pos(), DNGN_STONE_ARCH);
 
+    if (how == DNGN_ENTER_PANDEMONIUM)
+        add_daction(DACT_REMOVE_PAN_GATES);
+
     if (how == DNGN_ENTER_PANDEMONIUM
         || how == DNGN_ENTER_ABYSS
         || feat_is_portal_entrance(how))
@@ -1259,15 +1263,13 @@ level_id stair_destination(dungeon_feature_type feat, const string &dst,
     case DNGN_STONE_STAIRS_DOWN_I:
     case DNGN_STONE_STAIRS_DOWN_II:
     case DNGN_STONE_STAIRS_DOWN_III:
+    case DNGN_TRANSIT_PANDEMONIUM:
     {
         ASSERT(!at_branch_bottom());
         level_id lev = level_id::current();
         lev.depth++;
         return lev;
     }
-
-    case DNGN_TRANSIT_PANDEMONIUM:
-        return level_id(BRANCH_PANDEMONIUM);
 
     case DNGN_EXIT_THROUGH_ABYSS:
         return level_id(BRANCH_ABYSS);

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -358,6 +358,7 @@ enum tag_minor_version
     TAG_MINOR_FIX_DOOR_INFO_LEAK,  // Don't leak whether an out of view door has been covered in temporary terrain
     TAG_MINOR_SWIFTNESS_REFACTOR,  // Split swiftness's backlash into DUR_ANTISWIFT
     TAG_MINOR_MAX_PIETY_LOGGING,   // Separately log stepdown events and max piety wastage
+    TAG_MINOR_PANDEMONIUM_DEPTH,   // Pandemonium became a finite branch
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1241,7 +1241,7 @@ static void _ensure_exit(branch_type br)
     die("no downstairs on %s???", level_id::current().describe().c_str());
 }
 
-static void _add_missing_branches()
+static void _add_missing_branches(const reader &th)
 {
     if (crawl_state.game_is_descent())
         return;
@@ -1257,8 +1257,14 @@ static void _add_missing_branches()
     // crosscheck with check_map_validity when changing
     if (lc == level_id(BRANCH_DEPTHS, 1) || lc == level_id(BRANCH_DUNGEON, 21))
         _ensure_entry(BRANCH_VESTIBULE);
-    if (lc == level_id(BRANCH_DEPTHS, 2) || lc == level_id(BRANCH_DUNGEON, 24))
-        _ensure_entry(BRANCH_PANDEMONIUM);
+#
+    // Only place missing Pan entrances if we are in a version where they don't
+    // disappear.
+    if (th.getMinorVersion() < TAG_MINOR_PANDEMONIUM_DEPTH)
+    {
+        if (lc == level_id(BRANCH_DEPTHS, 2) || lc == level_id(BRANCH_DUNGEON, 24))
+            _ensure_entry(BRANCH_PANDEMONIUM);
+    }
     if (lc == level_id(BRANCH_DEPTHS, 3) || lc == level_id(BRANCH_DUNGEON, 25))
         _ensure_entry(BRANCH_ABYSS);
     if (player_in_branch(BRANCH_VESTIBULE))
@@ -1565,7 +1571,7 @@ void tag_read(reader &inf, tag_type tag_id)
         _tag_read_level_monsters(th);
         EAT_CANARY;
 #if TAG_MAJOR_VERSION == 34
-        _add_missing_branches();
+        _add_missing_branches(th);
 
         // If an eleionoma destroyed the Swamp exit due to the bug fixed in
         // 0d5cf04, put the branch exit on the closest floor or shallow water
@@ -5445,6 +5451,10 @@ static void _tag_read_you_dungeon(reader &th)
     // generated as the place shifts.
     if (crawl_state.game_is_normal() && th.getMinorVersion() <= TAG_MINOR_ABYSS_SEVEN)
         brdepth[BRANCH_ABYSS] = 7;
+
+    // Pandemonium became a finite branch. Place the player in Pan:1.
+    if (th.getMinorVersion() < TAG_MINOR_PANDEMONIUM_DEPTH)
+        brdepth[BRANCH_PANDEMONIUM] = branches[BRANCH_PANDEMONIUM].numlevels;
 #endif
 
     ASSERT(you.depth <= brdepth[you.where_are_you]);


### PR DESCRIPTION
This makes Pan an 11-floor branch, with non-unique-rune floors having exactly one exit in their lord's lair vault, and an exit from Pan:11

Known outstanding issues:
* The demonic rune logic has not changed, so it sometimes generates and sometimes doesn't.
* Not all Pan lair vaults generate a downstair. In particular, grunt_pan_frozen_over, lemuel_hall_of_pain and evilmike_mini_pan_diamond don't, so they get vetoed at the moment.
* For Holy Pan, the "lord's lair vault" is the entire level, so the exit just spawns anywhere.