### PR TITLE
Handle unicode characters in the monster list pane.

### DIFF
--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -1914,14 +1914,14 @@ static void _print_next_monster_desc(const vector<monster_info>& mons,
             mons_to_string_pane(desc, desc_colour, zombified,
                                 mons, start, count);
             textcolour(desc_colour);
-            if (static_cast<int>(desc.length()) > crawl_view.mlistsz.x - printed)
+            if (strwidth(desc) > crawl_view.mlistsz.x - printed
+                && 1 < crawl_view.mlistsz.x - printed)
             {
-                ASSERT(crawl_view.mlistsz.x - 2 - printed >= 0);
-                desc.resize(crawl_view.mlistsz.x - 2 - printed, ' ');
+                desc = chop_string(desc, crawl_view.mlistsz.x - 2 - printed);
                 desc += "…)";
             }
             else
-                desc.resize(crawl_view.mlistsz.x - printed, ' ');
+                desc = chop_string(desc, crawl_view.mlistsz.x - printed);
             CPRINTF("%s", desc.c_str());
         }
     }


### PR DESCRIPTION
Use unicode-aware functions to calculate the length of a monster description in the monster list and resize it where needed.

Don't crash if there's somehow only 1 character left for a monster's name in the monster list. It can't happen at present, but it seems like an odd ASSERT().

I don't know if the unicode issue occurs in normal play, but it's easy to see in wizard mode:

Create two monsters (&m):
1: cyan very ugly thing name:in_red_négligée name_suffix
2: polar bear name:Käptn_Blaubär name_replace name_definite

Destroy (&G) ugly

The name of 1 should include an invalid character (only part of an é code is printed). The final ")" of 1 should be left behind after the monster is destroyed (Crawl overestimates how long 2's name is).
