### PR TITLE
Fix teleport closets

### DIFF
--- a/crawl-ref/docs/develop/levels/syntax.txt
+++ b/crawl-ref/docs/develop/levels/syntax.txt
@@ -353,6 +353,12 @@ TAGS:     Tags go on a TAGS: line and are space-separated. You can have several
              have a vault that can be used more than once, use allow_dup to tell
              the dungeon builder that the vault can be reused. This is tracked
              separately for the abyss and the rest of the dungeon.
+          * "allow_tele_closets": Exempts the vault from teleport-closet
+             masking. The builder normally finds regions a random teleport
+             could strand the player in (with no way to walk or fly back to a
+             stair) and marks them no_tele_into. Cells inside a vault with this
+             tag are not marked in this way. Also available as a KMASK to
+             exempt only particular symbols.
           * "chance_FOO": Maps can be tagged chance_ with any unique suffix
              to indicate that if the map's CHANCE roll is made, one of the maps
              tagged chance_FOO should be picked.
@@ -1490,6 +1496,9 @@ KMASK:    Z = no_monster_gen
              symbol. The symbol is considered impassable for level-building
              purposes. A "transparent" vault with a deliberately disconnected
              region must use this mask on the disconnected part.
+          * "allow_tele_closets": Exempts the symbol from teleport closet
+             detection, like the tag of the same name but for particular
+             symbols rather than the whole vault.
 
           For example
 

--- a/crawl-ref/source/cio.cc
+++ b/crawl-ref/source/cio.cc
@@ -21,6 +21,7 @@
 #include "viewgeom.h"
 #ifdef USE_TILE_LOCAL
 #include "tilefont.h"
+#include "windowmanager.h"
 #endif
 #include "ui.h"
 
@@ -920,6 +921,15 @@ void line_reader::insert_char_at_cursor(int ch)
     }
 }
 
+#ifdef USE_TILE_LOCAL
+void line_reader::clipboard_paste()
+{
+    if (wm && wm->has_clipboard())
+        for (char ch : wm->get_clipboard())
+            process_key(ch);
+}
+#endif
+
 int line_reader::process_key(int ch)
 {
 
@@ -1045,6 +1055,11 @@ int line_reader::process_key(int ch)
         calc_pos();
         cursorto(pos);
         break;
+#ifdef USE_TILE_LOCAL
+    case CONTROL('V'):
+        clipboard_paste();
+        break;
+#endif
     case CK_MOUSE_CLICK:
         // FIXME: ought to move cursor to click location, if it's within the input
         return -1;

--- a/crawl-ref/source/cio.h
+++ b/crawl-ref/source/cio.h
@@ -382,6 +382,9 @@ public:
 
     void insert_char_at_cursor(int ch);
     void overwrite_char_at_cursor(int ch);
+#ifdef USE_TILE_LOCAL
+    void clipboard_paste();
+#endif
 #ifdef USE_TILE_WEB
     void set_tag(const string &tag);
 #endif

--- a/crawl-ref/source/dat/des/altar/overflow.des
+++ b/crawl-ref/source/dat/des/altar/overflow.des
@@ -8098,7 +8098,8 @@ ENDMAP
 
 NAME: nicolae_overflow_hidden_temple
 TAGS: temple_overflow_generic_5 temple_overflow_generic_4 temple_overflow_generic_3 \
-      temple_overflow_generic_2 temple_overflow_generic_1 no_monster_gen no_descent
+      temple_overflow_generic_2 temple_overflow_generic_1 no_monster_gen no_descent \
+      transparent
 {{
   local altarcount = 1
   if is_validating() then

--- a/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
+++ b/crawl-ref/source/dat/des/branches/vaults_rooms_hard.des
@@ -1986,6 +1986,7 @@ ITEM:    scroll of teleportation pre_id q:2 w:20 / \
 SHUFFLE: %!'"
 NSUBST:  % = 1:d / * = %$, ! = 1:d / * = %$, ' = 1:d / * = %$, " = 1:e / * = %$
 KMASK:   %$de = opaque
+KMASK:   %$de = allow_tele_closets
 TILE:    m = dngn_transparent_wall_green
 : vaults_hard_standard(_G)
 FTILE:   R = floor_metal_gold

--- a/crawl-ref/source/dat/des/variable/large_abstract.des
+++ b/crawl-ref/source/dat/des/variable/large_abstract.des
@@ -705,6 +705,7 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ENDMAP
 
 NAME:    minmay_isolated_rectangles_in_corner
+TAGS:    transparent
 ORIENT:  southeast
 DEPTH:   D:12-, !D:$, Depths, !Depths:$
 SHUFFLE: ([{)]}, *$

--- a/crawl-ref/source/dat/des/variable/large_themed.des
+++ b/crawl-ref/source/dat/des/variable/large_themed.des
@@ -108,7 +108,7 @@ ENDMAP
 # hidden cave vault with statue
 #
 NAME:    statuecave_lemuel
-TAGS:    no_descent
+TAGS:    no_descent allow_tele_closets
 ORIENT:  northeast
 DEPTH:   D:7-, Lair, Crypt:1-4
 : if you.in_branch("Crypt") then
@@ -192,6 +192,7 @@ ENDMAP
 # Dragon's cave
 #
 NAME:    dragon1_lemuel
+TAGS:    allow_tele_closets
 ORIENT:  northeast
 DEPTH:   D:9-, Lair
 MONS:    patrolling fire dragon, patrolling ice dragon

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1327,11 +1327,20 @@ static int _count_tele_closets(vector<coord_def> *closets, bool flying,
             continue;
 
         ++nclosets;
+        const coord_def &landing = landings[0];
         if (closets)
-            closets->push_back(landings[0]);
+            closets->push_back(landing);
         if (mask)
             for (const coord_def &c : landings)
                 env.pgrid(c) |= FPROP_NO_TELE_INTO;
+
+        dprf(DIAG_DNGN, "%s teleport closet at (%d, %d)%s%s",
+             flying ? "Flying" : "Walking", landing.x, landing.y,
+             dgn_vault_at(landing)
+                 ? (" in vault "
+                    + dgn_vault_at(landing)->map_name_at(landing)).c_str()
+                 : "",
+             mask ? " (masked)" : "");
     }
     return nclosets;
 }

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1314,8 +1314,11 @@ static int _count_tele_closets(vector<coord_def> *closets, bool flying,
         vector<coord_def> landings;
         auto note_target = [&landings, flying](const coord_def &c)
         {
-            if (_dgn_square_is_tele_target(c, flying))
+            if (_dgn_square_is_tele_target(c, flying)
+                && !(env.level_map_mask(c) & MMT_NO_TELE_CLOSET))
+            {
                 landings.push_back(c);
+            }
         };
         // _dgn_fill_zone records every square but the seed, so check it here.
         note_target(seed);
@@ -1482,6 +1485,10 @@ dgn_register_place(const vault_placement &place, bool register_vault)
                         && count(place.exits.begin(), place.exits.end(), c);
                 });
         }
+
+        // Opt out of teleport closet detection.
+        if (place.map.has_tag("allow_tele_closets"))
+            _mask_vault(place, MMT_NO_TELE_CLOSET);
     }
 
     // Find tags matching properties.

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1281,7 +1281,8 @@ int dgn_count_tele_zones(bool choose_stairless)
 // in, with no way back to an exit stair.
 //
 // Connectivity is less stringent than for most checks - if you can get out of
-// it by walking over traps or through transporters, it is not a closet.
+// it by walking over traps, through transporters, or onto a permanent teleport
+// trap, it is not a closet.
 static int _count_tele_closets(vector<coord_def> *closets, bool flying,
                                bool mask)
 {
@@ -1295,8 +1296,11 @@ static int _count_tele_closets(vector<coord_def> *closets, bool flying,
     // Floodfill back from the exits to mark everywhere that isn't a closet.
     memset(travel_point_distance, 0, sizeof(travel_distance_grid_t));
     for (rectangle_iterator ri(0); ri; ++ri)
-        if (_is_exit_stair(*ri) && !travel_point_distance[ri->x][ri->y])
+        if ((_is_exit_stair(*ri) || env.grid(*ri) == DNGN_TRAP_TELEPORT_PERMANENT)
+            && !travel_point_distance[ri->x][ri->y])
+        {
             _dgn_fill_zone(*ri, 1, _dgn_point_record_stub, passable, nullptr, true);
+        }
 
     // Now search for closets we didn't reach.
     int nclosets = 0;

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1285,10 +1285,11 @@ int dgn_count_tele_zones(bool choose_stairless)
 static int _count_tele_closets(vector<coord_def> *closets, bool flying,
                                bool mask)
 {
-    bool (*passable)(const coord_def &) =
-        flying ? [](const coord_def &c)
+    using passable_fn = bool (*)(const coord_def &);
+    passable_fn passable =
+        flying ? (passable_fn) [](const coord_def &c)
                  { return _dgn_square_is_closet_passable(c, true); }
-               : [](const coord_def &c)
+               : (passable_fn) [](const coord_def &c)
                  { return _dgn_square_is_closet_passable(c, false); };
 
     // Floodfill back from the exits to mark everywhere that isn't a closet.

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -2840,6 +2840,15 @@ static void _post_vault_build()
             depth -= 3;
         } while (depth > 0);
     }
+
+    if (!player_in_branch(BRANCH_COCYTUS)
+        && !player_in_branch(BRANCH_SWAMP)
+        && !player_in_branch(BRANCH_SHOALS))
+    {
+        _prepare_water();
+        if (player_in_branch(BRANCH_LAIR) || !one_chance_in(4))
+            _prepare_water();
+    }
 }
 
 static void _build_dungeon_level()
@@ -2934,15 +2943,6 @@ static void _build_dungeon_level()
 
     fixup_misplaced_items();
     link_items();
-
-    if (!player_in_branch(BRANCH_COCYTUS)
-        && !player_in_branch(BRANCH_SWAMP)
-        && !player_in_branch(BRANCH_SHOALS))
-    {
-        _prepare_water();
-        if (player_in_branch(BRANCH_LAIR) || !one_chance_in(4))
-            _prepare_water();
-    }
 
     if (player_in_hell())
         _fixup_hell_stairs();

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -917,6 +917,25 @@ static bool _dgn_square_is_tele_connected(const coord_def &c)
         && dgn_square_travel_ok(c);
 }
 
+// Is this square passable for the purposes of getting out of teleport closets?
+static bool _dgn_square_is_closet_passable(const coord_def &c, bool flying)
+{
+    dungeon_feature_type feat = feat_at_no_mimic(c);
+    return dgn_square_travel_ok(c) || feat_is_trap(feat)
+           || (flying && (feat_is_deep_water(feat) || feat_is_lava(feat)));
+}
+
+// Can the player teleport here?
+static bool _dgn_square_is_tele_target(const coord_def &c, bool flying)
+{
+    dungeon_feature_type feat = feat_at_no_mimic(c);
+    if (env.pgrid(c) & FPROP_NO_TELE_INTO)
+        return false;
+    if (feat_is_solid(feat))
+        return false;
+    return flying || !(feat_is_deep_water(feat) || feat_is_lava(feat));
+}
+
 static bool _dgn_square_is_passable(const coord_def &c)
 {
     // [enne] Why does this function check these flags?
@@ -972,11 +991,13 @@ static bool _dgn_square_is_ever_passable(const coord_def &c)
 static inline void _dgn_point_record_stub(const coord_def &) { }
 
 template <class point_record>
+// Calculate which points "start" is reachable from.
 static bool _dgn_fill_zone(
     const coord_def &start, int zone,
     point_record &record_point,
     bool (*passable)(const coord_def &) = _dgn_square_is_passable,
-    bool (*iswanted)(const coord_def &) = nullptr)
+    bool (*iswanted)(const coord_def &) = nullptr,
+    bool follow_transporters = false)
 {
     bool ret = false;
     list<coord_def> points[2];
@@ -985,8 +1006,34 @@ static bool _dgn_fill_zone(
     int found_points = 0;
 #endif
 
+    // Build a map from transporter destinations to sources.
+    map<coord_def, vector<coord_def>> transporter_sources;
+    if (follow_transporters)
+    {
+        for (rectangle_iterator ri(0); ri; ++ri)
+        {
+            if (env.grid(*ri) != DNGN_TRANSPORTER)
+                continue;
+            if (map_position_marker *mark =
+                    get_position_marker_at(*ri, DNGN_TRANSPORTER))
+            {
+                if (map_bounds(mark->dest))
+                    transporter_sources[mark->dest].push_back(*ri);
+            }
+        }
+    }
+
     // No bounds checks, assuming the level has at least one layer of
     // rock border.
+
+    auto enqueue = [&](const coord_def &cp)
+    {
+        if (!map_bounds(cp) || travel_point_distance[cp.x][cp.y] || !passable(cp))
+            return;
+        travel_point_distance[cp.x][cp.y] = zone;
+        record_point(cp);
+        points[!cur].push_back(cp);
+    };
 
     for (points[cur].push_back(start); !points[cur].empty();)
     {
@@ -1001,17 +1048,14 @@ static bool _dgn_fill_zone(
                 ret = true;
 
             for (adjacent_iterator ai(c); ai; ++ai)
-            {
-                const coord_def& cp = *ai;
-                if (!map_bounds(cp)
-                    || travel_point_distance[cp.x][cp.y] || !passable(cp))
-                {
-                    continue;
-                }
+                enqueue(*ai);
 
-                travel_point_distance[cp.x][cp.y] = zone;
-                record_point(cp);
-                points[!cur].push_back(cp);
+            if (follow_transporters)
+            {
+                auto it = transporter_sources.find(c);
+                if (it != transporter_sources.end())
+                    for (const coord_def &src : it->second)
+                        enqueue(src);
             }
         }
 
@@ -1231,6 +1275,60 @@ int dgn_count_tele_zones(bool choose_stairless)
     dprf("Counting teleport zones");
     return _process_disconnected_zones(0, 0, GXM-1, GYM-1, choose_stairless,
                                     DNGN_UNSEEN, _dgn_square_is_tele_connected);
+}
+
+// Count "teleport closets": regions a random teleport could strand the player
+// in, with no way back to an exit stair.
+//
+// Connectivity is less stringent than for most checks - if you can get out of
+// it by walking over traps or through transporters, it is not a closet.
+static int _count_tele_closets(vector<coord_def> *closets, bool flying,
+                               bool mask)
+{
+    bool (*passable)(const coord_def &) =
+        flying ? [](const coord_def &c)
+                 { return _dgn_square_is_closet_passable(c, true); }
+               : [](const coord_def &c)
+                 { return _dgn_square_is_closet_passable(c, false); };
+
+    // Floodfill back from the exits to mark everywhere that isn't a closet.
+    memset(travel_point_distance, 0, sizeof(travel_distance_grid_t));
+    for (rectangle_iterator ri(0); ri; ++ri)
+        if (_is_exit_stair(*ri) && !travel_point_distance[ri->x][ri->y])
+            _dgn_fill_zone(*ri, 1, _dgn_point_record_stub, passable, nullptr, true);
+
+    // Now search for closets we didn't reach.
+    int nclosets = 0;
+    for (rectangle_iterator ri(0); ri; ++ri)
+    {
+        const coord_def seed = *ri;
+        if (travel_point_distance[seed.x][seed.y] || !passable(seed))
+            continue;
+
+        // Collect every landing spot in this stranded region.
+        vector<coord_def> landings;
+        auto note_target = [&landings, flying](const coord_def &c)
+        {
+            if (_dgn_square_is_tele_target(c, flying))
+                landings.push_back(c);
+        };
+        // _dgn_fill_zone records every square but the seed, so check it here.
+        note_target(seed);
+        // Mark the region visited (any nonzero zone id) so it is counted once.
+        _dgn_fill_zone(seed, 2, note_target, passable);
+
+        // A region a teleport can't land in isn't a closet.
+        if (landings.empty())
+            continue;
+
+        ++nclosets;
+        if (closets)
+            closets->push_back(landings[0]);
+        if (mask)
+            for (const coord_def &c : landings)
+                env.pgrid(c) |= FPROP_NO_TELE_INTO;
+    }
+    return nclosets;
 }
 
 // Count number of mutually isolated zones. If choose_stairless, only count
@@ -2359,6 +2457,26 @@ static void _dgn_verify_connectivity(unsigned nvaults)
 
     if (!_add_connecting_escape_hatches())
         throw dgn_veto_exception("Failed to add connecting escape hatches.");
+
+    // Check for zones you can teleport into and not walk/fly out of.
+    if (player_in_connected_branch()
+        && !(branches[you.where_are_you].branch_flags & brflag::islanded))
+    {
+        const bool mask = !crawl_state.map_stat_veto_closets;
+        vector<coord_def> closets;
+        const int nclosets = _count_tele_closets(&closets, false, mask)
+                           + _count_tele_closets(&closets, true, mask);
+        if (!mask && nclosets > 0)
+        {
+            // If the closet sits inside a vault, name it so the offending map
+            // is easy to find in mapstat output.
+            const vault_placement *vp = dgn_vault_at(closets[0]);
+            const string in_vault =
+                vp ? " in vault " + vp->map_name_at(closets[0]) : "";
+            throw dgn_veto_exception(make_stringf(
+                "Teleport closet with no stairs%s.", in_vault.c_str()));
+        }
+    }
 
     // XXX: Interlevel connectivity fixup relies on being the last
     //      point at which a level may be vetoed.

--- a/crawl-ref/source/dungeon.h
+++ b/crawl-ref/source/dungeon.h
@@ -52,7 +52,7 @@ enum map_mask_type
     MMT_NO_ITEM         = 0x02,  // Random items should not be placed here.
     MMT_NO_MONS         = 0x04,  // Random monsters should not be placed here.
     MMT_NO_POOL         = 0x08,  // Pool fixup should not be applied here.
-                       // 0x10,  // Unused
+    MMT_NO_TELE_CLOSET  = 0x10,  // Exempt from teleport closet detection.
     MMT_NO_WALL         = 0x20,  // Wall fixup should not be applied here.
     MMT_OPAQUE          = 0x40,  // Vault may impede connectivity.
     MMT_NO_TRAP         = 0x80,  // No trap generation

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -4822,6 +4822,7 @@ enum commandline_option_type
     CLO_MACRO,
     CLO_MAPSTAT,
     CLO_MAPSTAT_DUMP_DISCONNECT,
+    CLO_MAPSTAT_VETO_CLOSETS,
     CLO_OBJSTAT,
     CLO_ITERATIONS,
     CLO_FORCE_MAP,
@@ -4883,6 +4884,7 @@ static set<commandline_option_type> clo_headless_ok = {
     CLO_EDIT_BONES,
     CLO_MAPSTAT,
     CLO_MAPSTAT_DUMP_DISCONNECT,
+    CLO_MAPSTAT_VETO_CLOSETS,
     CLO_OBJSTAT,
 #ifndef USE_TILE_LOCAL
 // TODO: still too crashy in local tiles to enable
@@ -4904,8 +4906,9 @@ static const char *cmd_ops[] =
 {
     "scores", "name", "species", "background", "dir", "rc", "rcdir", "tscores",
     "vscores", "scorefile", "morgue", "macro", "mapstat", "dump-disconnect",
-    "objstat", "iters", "force-map", "arena", "dump-maps", "test", "script",
-    "builddb", "help", "version", "seed", "pregen", "save-version", "sprint",
+    "veto-closets", "objstat", "iters", "force-map", "arena", "dump-maps",
+    "test", "script", "builddb", "help", "version", "seed", "pregen",
+    "save-version", "sprint",
     "extra-opt-first", "extra-opt-last", "sprint-map", "edit-save",
     "print-charset", "tutorial", "wizard", "explore", "no-save",
     "no-player-bones", "gdb", "no-gdb", "nogdb", "throttle", "no-throttle",
@@ -5893,6 +5896,14 @@ bool parse_args(int argc, char **argv, bool rc_only)
 #else
             end(1, false, "%s", dbg_stat_err);
 #endif
+        case CLO_MAPSTAT_VETO_CLOSETS:
+#ifdef DEBUG_STATISTICS
+            crawl_state.map_stat_veto_closets = true;
+            break;
+#else
+            end(1, false, "%s", dbg_stat_err);
+#endif
+
         case CLO_MAPSTAT_DUMP_DISCONNECT:
 #ifdef DEBUG_STATISTICS
             crawl_state.map_stat_dump_disconnect = true;

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -586,6 +586,9 @@ static void _show_commandline_options_help()
     puts("  -dump-disconnect    In mapstat when a disconnected level is "
          "generated, dump");
     puts("      map to map.dump and exit");
+    puts("  -veto-closets       In mapstat, veto levels with teleport closets "
+         "rather than");
+    puts("      masking the closets as in normal play");
     puts("  -objstat [<levels>] run monster and item stats on the given range "
          "of levels");
     puts("      Defaults to entire dungeon; same level syntax as -mapstat.");

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -6290,7 +6290,7 @@ string keyed_mapspec::set_mask(const string &s, bool /*garbage*/)
         // Be sure to change the order of map_mask_type to match!
         static string flag_list[] =
             {"vault", "no_item_gen", "no_monster_gen", "no_pool_fixup",
-             "UNUSED",
+             "allow_tele_closets",
              "no_wall_fixup", "opaque", "no_trap_gen", ""};
         map_mask |= map_flags::parse(flag_list, s);
     }

--- a/crawl-ref/source/state.cc
+++ b/crawl-ref/source/state.cc
@@ -40,6 +40,7 @@ game_state::game_state()
       smallterm(false),
 #endif
       seen_hups(0), map_stat_gen(false), map_stat_dump_disconnect(false),
+      map_stat_veto_closets(false),
       obj_stat_gen(false), type(GAME_TYPE_NORMAL),
       last_type(GAME_TYPE_UNSPECIFIED), last_game_exit(game_exit::unknown),
       marked_as_won(false), arena_suspended(false),

--- a/crawl-ref/source/state.h
+++ b/crawl-ref/source/state.h
@@ -70,6 +70,8 @@ struct game_state
     bool map_stat_gen;      // Set if we're generating stats on maps.
     bool map_stat_dump_disconnect; // Set if we dump disconnected maps and exit
                                    // under mapstat.
+    bool map_stat_veto_closets; // Set if mapstat should veto levels with
+                                // teleport closets rather than masking them.
     bool obj_stat_gen;      // Set if we're generating object stats.
 
     string force_map;       // Set if we're forcing a specific map to generate.


### PR DESCRIPTION
This PR adds a check to explicitly search for teleport closets - regions the player can be teleported into and not out of.

Teleport closets are not rare - the typical game generates several, though most of them are very small and so teleports into them are rare. They arise in two main ways:
- Vaults which have made a mistake and failed to mask dangerous squares
- Vaults which do procedural generation that can generate isolated squares (e.g. in water)

The way we fix these is mask found teleport closets. This is preferable to vetoing their generation, because this would silently veto many vaults, only some of which are fixable.

We also support a mapstat mode -veto-closets, which vetos these closets instead of masking. Running this is useful for tracking down vaults which generate closets.

There are a few vaults which clearly deliberately generate closets, generating items for their escape. For these vaults, we add a tag "allow_tele_closets", which we apply to the instances we found.

We attach a CSV of vaults found by this mapstat, along with a diagnosis of whether the teleport closets are real and how they arise:
[closet_vaults.csv](https://github.com/user-attachments/files/29470158/closet_vaults.csv)

As well as the deliberate closets, there are a few cases where the masking is harmless but unnecessary, e.g. because of permanent clouds on the relevant squares.