### PR TITLE
Fix a bug with penance titles

### DIFF
--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -2317,7 +2317,10 @@ string skill_title_by_rank(skill_type best_skill, uint8_t skill_rank,
         {
             god_type betrayed_god = static_cast<god_type>(
                 you.attribute[ATTR_TRAITOR]);
-            result = god_title(betrayed_god, species, 0);
+
+            // good gods shouldn't traitor title you unless wrath is active
+            if (!is_good_god(betrayed_god) || active_penance(betrayed_god))
+                result = god_title(betrayed_god, species, 0);
         }
 
         if (conducts)


### PR DESCRIPTION
Good gods don't wrath you unless you join an evil (or chaotic with Zin) god but were applying the traitor title regardless of religion if you abandoned for any non-good god. Rather annoying, since the penance would last forever in that case and prevent getting any other title. Check that wrath is active for good god penance titles to avoid this behavior.

Fixes #5316 