### PR TITLE
Fix vainglory crumbling not unequipping rings

### DIFF
--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1396,38 +1396,42 @@ static void _maybe_remove_equipment(mutation_type mut)
 {
     vector<item_def*> to_remove = you.equipment.get_forced_removal_list();
 
-    for (item_def* item : to_remove)
+    while (!to_remove.empty())
     {
-        if (mut == MUT_MISSING_HAND)
+        for (item_def* item : to_remove)
         {
-            mprf("You can no longer %s %s!",
-                    item->base_type == OBJ_JEWELLERY ? "wear" : "hold",
-                    item->name(DESC_YOUR).c_str());
-        }
-        else
-        {
-            if (item_is_melded(*item))
+            if (mut == MUT_MISSING_HAND)
             {
-                mprf("%s is forced from your body%s!",
-                        item->name(DESC_YOUR).c_str(),
-                        item->cursed() ? ", shattering the curse!" : "");
+                mprf("You can no longer %s %s!",
+                        item->base_type == OBJ_JEWELLERY ? "wear" : "hold",
+                        item->name(DESC_YOUR).c_str());
             }
             else
             {
-                mprf("%s falls away%s!", item->name(DESC_YOUR).c_str(),
-                        item->cursed() ? ", shattering the curse!" : "");
+                if (item_is_melded(*item))
+                {
+                    mprf("%s is forced from your body%s!",
+                            item->name(DESC_YOUR).c_str(),
+                            item->cursed() ? ", shattering the curse!" : "");
+                }
+                else
+                {
+                    mprf("%s falls away%s!", item->name(DESC_YOUR).c_str(),
+                            item->cursed() ? ", shattering the curse!" : "");
+                }
+
+                // A mutation made us not only lose an equipment slot
+                // but actually removed a worn item: Funny!
+                xom_is_stimulated(is_artefact(*item) ? 200 : 100);
             }
 
-            // A mutation made us not only lose an equipment slot
-            // but actually removed a worn item: Funny!
-            xom_is_stimulated(is_artefact(*item) ? 200 : 100);
+            unequip_item(*item, false);
         }
 
-        unequip_item(*item, false);
+        // Update slot counts, even if no item was changed.
+        you.equipment.update();
+        to_remove = you.equipment.get_forced_removal_list(true);
     }
-
-    // Update slot counts, even if no item was changed.
-    you.equipment.update();
 }
 
 // Tries to give you the mutation by deleting a conflicting


### PR DESCRIPTION
Vainglory falling off because of a mutation would decrease num_slot to 2. Thus another call for 'get_forced_removal_list' was needed to check if any rings had to be removed. But since removing vainglory updated the num_slot to 2, forced_removal_list had to called with the force_full_check flag to ensure the rings get returned by the function

This change will fix any other cascading issues caused by removing equipment, not just vainglory. BUT it is quite a dirty fix imo!
Feel free to just close this pr if you know of a cleaner way to solve this

Fixes #5324