### PR TITLE
Show the in-game colours in the monster help lookup.

### DIFF
--- a/crawl-ref/source/lookup-help.cc
+++ b/crawl-ref/source/lookup-help.cc
@@ -651,7 +651,7 @@ static MenuEntry* _monster_menu_gen(char letter, const string &str,
     mslot = fake_mon;
 
 #ifndef USE_TILE_LOCAL
-    int colour = mons_class_colour(m_type);
+    int colour = fake_mon.colour();
     if (colour == BLACK)
         colour = LIGHTGREY;
 


### PR DESCRIPTION
As things stood, monsters were set to be shown using the character used in the game, but with the default colour for that monster (if you set "mon_glyph += rat : white U", a rat would appear as a white U in-game but as a brown U in the help).

Make it reflect the preferences.