### PR TITLE
Don't wait infinitely to regenerate HP/MP in &O

### DIFF
--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -645,7 +645,7 @@ static int _debug_time_explore()
 {
     viewwindow();
     update_screen();
-    start_explore(false);
+    start_explore(false, true);
 
     unwind_var<int> es(Options.explore_stop, 0);
 


### PR DESCRIPTION
The wizmode version of autoexplore doesn't regen (in fact, it does nothing other than exploring), but start_explore is called without skipping autorest, causing the game to wait indefinitely trying to recover HP to full and crash upon reaching 2000 turns.

Fixes #4028.

(Duh, made a dumb mistake. force-pushed.)