### PR TITLE
Add a flag to friendly battlespheres if they can see a target.

### DIFF
--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -2130,6 +2130,12 @@ static string _condition_string(int num, int count,
         return make_stringf("%d %s", num, word.c_str());
 }
 
+static bool _is_your_battlesphere_with_target(const monster_info &mi)
+{
+    return MONS_BATTLESPHERE == mi.type && MID_PLAYER == mi.summoner_id
+           && trigger_battlesphere(&you, true);
+}
+
 void mons_conditions_string(string& desc, const vector<monster_info>& mi,
                             int start, int count, bool equipment)
 {
@@ -2238,6 +2244,13 @@ void mons_conditions_string(string& desc, const vector<monster_info>& mi,
             conditions.push_back(_condition_string(num, count, name));
     }
 
+    monster_info_flag_name aiming({NUM_MB_FLAGS, "aiming", "aiming", "aiming"});
+    int num = 0;
+    for (int j = start; j < start+count; j++)
+        if (_is_your_battlesphere_with_target(mi[j]))
+            num++;
+    if (num > 0)
+        conditions.push_back(_condition_string(num, count, aiming));
 
     if (conditions.empty())
         return;

--- a/crawl-ref/source/spl-summoning.cc
+++ b/crawl-ref/source/spl-summoning.cc
@@ -1939,7 +1939,7 @@ static void _fire_battlesphere(monster* battlesphere, bolt& beam)
         end_battlesphere(battlesphere, false);
 }
 
-bool trigger_battlesphere(actor* agent)
+bool trigger_battlesphere(actor* agent, bool just_check)
 {
     monster* battlesphere = find_battlesphere(agent);
 
@@ -1961,12 +1961,15 @@ bool trigger_battlesphere(actor* agent)
     if (targets.empty())
         return false;
 
-    shuffle_array(targets);
-    sort(targets.begin( ), targets.end( ), [](actor* a, actor* b)
+    if (!just_check)
     {
-        return a->stat_maxhp() - a->stat_hp()
-               > b->stat_maxhp() - b->stat_hp();
-    });
+        shuffle_array(targets);
+        sort(targets.begin( ), targets.end( ), [](actor* a, actor* b)
+        {
+            return a->stat_maxhp() - a->stat_hp()
+                   > b->stat_maxhp() - b->stat_hp();
+        });
+    }
 
     actor* target = targets[0];
 
@@ -1994,7 +1997,8 @@ bool trigger_battlesphere(actor* agent)
     // First, just try to fire from our present position
     if (_battlesphere_should_fire(target, battlesphere->pos(), beam, fallback_pos))
     {
-        _fire_battlesphere(battlesphere, beam);
+        if (!just_check)
+            _fire_battlesphere(battlesphere, beam);
         return true;
     }
 
@@ -2017,6 +2021,9 @@ bool trigger_battlesphere(actor* agent)
 
         if (_battlesphere_should_fire(target, *di, beam, fallback_pos))
         {
+            if (just_check)
+                return true;
+
             const coord_def old_pos = battlesphere->pos();
             battlesphere->move_to(*di, MV_DELIBERATE, true);
 
@@ -2029,6 +2036,8 @@ bool trigger_battlesphere(actor* agent)
             battlesphere->finalise_movement();
             return true;
         }
+        else if (just_check && !fallback_pos.origin())
+            return true;
     }
 
     // We didn't find any reachable spot that fires on our primary target, but
@@ -2046,7 +2055,7 @@ bool trigger_battlesphere(actor* agent)
         return true;
     }
 
-    return true;
+    return false;
 }
 
 int prism_hd(int pow, bool random)

--- a/crawl-ref/source/spl-summoning.h
+++ b/crawl-ref/source/spl-summoning.h
@@ -105,7 +105,7 @@ spret cast_battlesphere(actor* agent, int pow, bool fail);
 void end_battlesphere(monster* mons, bool killed);
 bool battlesphere_can_mirror(spell_type spell);
 vector<spell_type> player_battlesphere_spells();
-bool trigger_battlesphere(actor* agent);
+bool trigger_battlesphere(actor* agent, bool just_check = false);
 dice_def battlesphere_damage_from_power(int pow);
 dice_def battlesphere_damage_from_hd(int hd);
 


### PR DESCRIPTION
If you summon a battlesphere, it only fires if it can see a target you also see when you cast a spell, and if it can reach a spot where it can make a direct shot at it.

Add some text to mons_conditions_string() to show that a battlesphere has a target. This text appears in the (console-only) monster list and the character dump, and is available to Lua.

### Notes

As written, update_monster_pane() calls trigger_battlesphere() with the just_check parameter whenever there's a friendly battlesphere around. This is quite involved and could be cached, but I don't know if it would be worthwhile, and I note that calling update_monster_pane() less often would be another approach.

I changed what trigger_battlesphere() returns, but nothing looked at it before this.

This could be adapted for tiles, but I don't know how the tile-specific code works.