### PR TITLE
Break an infinite loop in handle_monsters (#3975)

### DIFF
--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -4172,9 +4172,12 @@ static bool _monster_move(monster* mons, coord_def& delta)
                 dprf("BUG: %s was marked as follower when not following!",
                      mons->name(DESC_PLAIN).c_str());
             }
-            else
+            // If the monster is not adjacent, it can spend its energy
+            // approaching the player. It'll later be untagged for following if
+            // it fails to catch up.
+            else if (adjacent(mons->pos(), you.pos()))
             {
-                ret    = true;
+                ret = false;
                 delta.reset();
 
                 dprf("%s is skipping movement in order to follow.",
@@ -4182,8 +4185,10 @@ static bool _monster_move(monster* mons, coord_def& delta)
             }
         }
 
-        // Check for attacking another monster.
-        if (monster* targ = monster_at(mons->pos() + delta))
+        // Check for attacking *another* monster
+        // Confused self-hit handled below
+        monster* targ = monster_at(mons->pos() + delta);
+        if (targ && !delta.origin())
         {
             if ((mons_aligned(mons, targ) || mons_is_seeker(*targ))
                 && !(mons->has_ench(ENCH_FRENZIED)
@@ -4193,13 +4198,10 @@ static bool _monster_move(monster* mons, coord_def& delta)
                 delta.reset();  // Swapping can fail, but even if it does, we
                                 // shouldn't try hitting our ally later on.
             }
-            else if (!delta.origin()) // confused self-hit handled below
+            else if (mons_fight(mons, targ))
             {
-                if (mons_fight(mons, targ))
-                {
-                    ret = true;
-                    delta.reset();
-                }
+                ret = true;
+                delta.reset();
             }
         }
 


### PR DESCRIPTION
(a bit more than the commit message)

When disjunction blinks a frenzied dragon away after the player starts taking stairs, its immediate destination is not the player's position, so the game treats it as heading elsewhere instead of following through stairs (this covers batty creatures normally). Previously, "skipped movement" (according to the dprf) set `ret` to true, suggesting energy was spent, but without actually modifying energy, causing the monster to be re-queued because it still has_action_energy.

The crash is masked because the next if-block set `ret` to false again when `mons == targ` in non-frenzied state (immediately returned from _monster_swap_places because mons_aligned() is true). It seemed unclear to me whether this if-statement had intended to cover cases where mons and targ are identical or not: the condition didn't rule this out, and "// confused self-hit handled below" implied that the possibility of mons and targ being identical was taken into consideration; but "checking for attacking **another** monster" and some other code suggested otherwise. If it had, then it had overlooked the specific case involved in this crash. Anyway, simply restricting it to distinct monsters looks ok to me.

This commit makes skipped movement set `ret` to false and ensures the swap-or-fight logic only handles two different monsters. As a result, a adjacent monster will not follow through stairs when disjunction is active, unless it is so fast that it catches up with the player again before they finish taking stairs.

Hopefully fixes #3975.