### PR TITLE
Fix monsters acting to early when you do an uncancellable action

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -324,8 +324,9 @@ struct ability_def
 
 static int _lookup_ability_slot(ability_type abil);
 static spret _do_ability(const ability_def& abil, bool fail, dist *target,
-                         bolt& beam);
-static void _finalize_ability_costs(const ability_def& abil, int mp_cost, int hp_cost);
+                         bolt& beam, int piety_cost, int mp_cost, int hp_cost);
+static void _finalize_ability_costs(const ability_def& abil, int piety_cost,
+                                    int mp_cost, int hp_cost);
 
 static vector<ability_def> &_get_ability_list()
 {
@@ -2853,6 +2854,76 @@ static bool _not_free_religious_ability(ability_type ability)
                    || abil.get_mp_cost() > 0);
 }
 
+bool handle_post_ability_effects(ability_type ability,
+                                 spret ability_result,
+                                 int piety_cost,
+                                 int mp_cost,
+                                 int hp_cost,
+                                 bool is_invocation)
+{
+    const ability_def& abil = get_ability_def(ability);
+
+    switch (ability_result)
+    {
+        case spret::success:
+        {
+            practise_using_ability(abil.ability);
+            _finalize_ability_costs(abil, piety_cost, mp_cost, hp_cost);
+
+            // Ephemeral Shield activates on any invocation with a cost,
+            // even if that's just a cooldown or small amounts of HP.
+            // No rapidly wall-jumping or renaming your ancestor, alas.
+            if (_not_free_religious_ability(abil.ability)
+                && you.has_mutation(MUT_EPHEMERAL_SHIELD))
+            {
+                you.set_duration(DUR_EPHEMERAL_SHIELD, random_range(3, 5));
+                you.redraw_armour_class = true;
+            }
+
+            if (_not_free_religious_ability(abil.ability)
+                && you.unrand_equipped(UNRAND_DRAGONMASK)
+                && there_are_monsters_nearby(true, true, false))
+            {
+                if (x_chance_in_y(10 + 2 * abil.avg_piety_cost(), 100))
+                    _invoke_dragons();
+            }
+
+            // XXX: Merge Dismiss Apostle #1/2/3 into a single count
+            ability_type log_type = abil.ability;
+            if (log_type == ABIL_BEOGH_DISMISS_APOSTLE_2
+                || log_type == ABIL_BEOGH_DISMISS_APOSTLE_3)
+            {
+                log_type = ABIL_BEOGH_DISMISS_APOSTLE_1;
+            }
+
+            count_action(is_invocation ? CACT_INVOKE : CACT_ABIL, log_type);
+            return true;
+        }
+        case spret::fail:
+            if (!testbits(abil.flags, abflag::quiet_fail))
+                mpr("You fail to use your ability.");
+            you.turn_is_over = true;
+            if (mp_cost)
+                refund_mp(mp_cost);
+            if (hp_cost)
+                refund_hp(hp_cost);
+            return false;
+        case spret::abort:
+            crawl_state.zero_turns_taken();
+            if (mp_cost)
+                refund_mp(mp_cost);
+            if (hp_cost)
+                refund_hp(hp_cost);
+            return false;
+        case spret::seen_hups:
+            return false;
+        case spret::none:
+        default:
+            die("Weird ability return type");
+            return false;
+    }
+}
+
 bool activate_talent(const talent& tal, dist *target)
 {
     const ability_def& abil = get_ability_def(tal.which);
@@ -2948,6 +3019,7 @@ bool activate_talent(const talent& tal, dist *target)
     // cancelled.
     const int hp_cost = abil.get_hp_cost();
     const int mp_cost = abil.get_mp_cost();
+    const int piety_cost = abil.piety_cost.cost();
 
     if (mp_cost)
         pay_mp(mp_cost);
@@ -2955,65 +3027,11 @@ bool activate_talent(const talent& tal, dist *target)
     if (hp_cost)
         pay_hp(hp_cost);
 
-    const spret ability_result = _do_ability(abil, fail, target, beam);
-    switch (ability_result)
-    {
-        case spret::success:
-        {
-            ASSERT(!fail);
-            practise_using_ability(abil.ability);
-            _finalize_ability_costs(abil, mp_cost, hp_cost);
-
-            // Ephemeral Shield activates on any invocation with a cost,
-            // even if that's just a cooldown or small amounts of HP.
-            // No rapidly wall-jumping or renaming your ancestor, alas.
-            if (_not_free_religious_ability(abil.ability)
-                && you.has_mutation(MUT_EPHEMERAL_SHIELD))
-            {
-                you.set_duration(DUR_EPHEMERAL_SHIELD, random_range(3, 5));
-                you.redraw_armour_class = true;
-            }
-
-            if (_not_free_religious_ability(abil.ability)
-                && you.unrand_equipped(UNRAND_DRAGONMASK)
-                && there_are_monsters_nearby(true, true, false))
-            {
-                if (x_chance_in_y(10 + 2 * abil.avg_piety_cost(), 100))
-                    _invoke_dragons();
-            }
-
-            // XXX: Merge Dismiss Apostle #1/2/3 into a single count
-            ability_type log_type = abil.ability;
-            if (log_type == ABIL_BEOGH_DISMISS_APOSTLE_2
-                || log_type == ABIL_BEOGH_DISMISS_APOSTLE_3)
-            {
-                log_type = ABIL_BEOGH_DISMISS_APOSTLE_1;
-            }
-
-            count_action(tal.is_invocation ? CACT_INVOKE : CACT_ABIL, log_type);
-            return true;
-        }
-        case spret::fail:
-            if (!testbits(abil.flags, abflag::quiet_fail))
-                mpr("You fail to use your ability.");
-            you.turn_is_over = true;
-            if (mp_cost)
-                refund_mp(mp_cost);
-            if (hp_cost)
-                refund_hp(hp_cost);
-            return false;
-        case spret::abort:
-            crawl_state.zero_turns_taken();
-            if (mp_cost)
-                refund_mp(mp_cost);
-            if (hp_cost)
-                refund_hp(hp_cost);
-            return false;
-        case spret::none:
-        default:
-            die("Weird ability return type");
-            return false;
-    }
+    const spret ability_result = _do_ability(abil, fail, target, beam,
+                                             piety_cost, mp_cost, hp_cost);
+    ASSERT(!(ability_result == spret::success && fail));
+    return handle_post_ability_effects(tal.which, ability_result, piety_cost,
+                                       mp_cost, hp_cost, tal.is_invocation);
 }
 
 /// If the player is stationary, print 'You cannot move.' and return true.
@@ -3236,6 +3254,14 @@ public:
     }
 };
 
+spret run_ability_uncancel(uncancellable_type kind, int piety_cost,
+                           int mp_cost, int hp_cost)
+{
+    uncancellable uc{kind, piety_cost, mp_cost, hp_cost};
+    bool succeeded = run_uncancel(uc);
+    return succeeded ? spret::success : spret::seen_hups;
+}
+
 /*
  * Use an ability.
  *
@@ -3246,7 +3272,7 @@ public:
  *  or was canceled (spret::abort). Never returns spret::none.
  */
 static spret _do_ability(const ability_def& abil, bool fail, dist *target,
-                         bolt& beam)
+                         bolt& beam, int piety_cost, int mp_cost, int hp_cost)
 {
     // Note: the costs will not be applied until after this switch
     // statement... it's assumed that only failures have returned! - bwr
@@ -3336,11 +3362,11 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
     case ABIL_IMPRINT_WEAPON:
         {
             item_def *wpn = nullptr;
-            auto success = use_an_item_menu(wpn, OPER_ANY, OSEL_ARTEFACT_WEAPON,
+            spret success = use_an_item_menu(wpn, OPER_ANY, OSEL_ARTEFACT_WEAPON,
                                 "Select an artefact weapon to imprint upon your Paragon.",
                                 [=](){return true;});
 
-            if (success == OPER_NONE)
+            if (success != spret::success)
                 return spret::abort;
 
             if (god_forbids_item(*wpn))
@@ -3843,13 +3869,13 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         break;
 
     case ABIL_NEMELEX_TRIPLE_DRAW:
-        return deck_triple_draw(fail);
+        return deck_triple_draw(fail, piety_cost, mp_cost, hp_cost);
 
     case ABIL_NEMELEX_DEAL_FOUR:
         return deck_deal(fail);
 
     case ABIL_NEMELEX_STACK_FIVE:
-        return deck_stack(fail);
+        return deck_stack(fail, piety_cost, mp_cost, hp_cost);
 
     case ABIL_BEOGH_SMITING:
         return your_spells(SPELL_SMITING, _beogh_smiting_power(),
@@ -3950,12 +3976,12 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
         return dithmenos_nightfall(fail);
 
     case ABIL_GOZAG_POTION_PETITION:
-        run_uncancel(UNC_POTION_PETITION, 0);
-        break;
+        return run_ability_uncancel(UNC_POTION_PETITION, piety_cost, mp_cost,
+                                    hp_cost);
 
     case ABIL_GOZAG_CALL_MERCHANT:
-        run_uncancel(UNC_CALL_MERCHANT, 0);
-        break;
+        return run_ability_uncancel(UNC_CALL_MERCHANT, piety_cost, mp_cost,
+                                    hp_cost);
 
     case ABIL_GOZAG_BRIBE_BRANCH:
         if (!gozag_bribe_branch())
@@ -4147,10 +4173,9 @@ static spret _do_ability(const ability_def& abil, bool fail, dist *target,
 
 // Pay piety and time costs, and flush UI for HP/MP costs which have already
 // been paid.
-static void _finalize_ability_costs(const ability_def& abil, int mp_cost, int hp_cost)
+static void _finalize_ability_costs(const ability_def& abil, int piety_cost,
+                                    int mp_cost, int hp_cost)
 {
-    const int piety_cost = abil.piety_cost.cost();
-
     dprf("Cost: mp=%d; hp=%d; piety=%d",
          mp_cost, hp_cost, piety_cost);
 

--- a/crawl-ref/source/ability.h
+++ b/crawl-ref/source/ability.h
@@ -75,6 +75,14 @@ bool check_ability_possible(const ability_type ability, bool quiet = false);
 bool ability_has_targeter(ability_type abil);
 unique_ptr<targeter> find_ability_targeter(ability_type ability);
 bool activate_talent(const talent& tal, dist *target = nullptr);
+bool handle_post_ability_effects(ability_type ability,
+                                 spret ability_result,
+                                 int piety_cost,
+                                 int mp_cost,
+                                 int hp_cost,
+                                 bool is_invocation);
+spret run_ability_uncancel(uncancellable_type kind, int piety_cost,
+                           int mp_cost, int hp_cost);
 bool is_religious_ability(ability_type abil);
 bool is_card_ability(ability_type abil);
 bool player_has_ability(ability_type abil, bool include_unusable = false);

--- a/crawl-ref/source/decks.cc
+++ b/crawl-ref/source/decks.cc
@@ -645,7 +645,7 @@ bool deck_draw(deck_type deck)
     return true;
 }
 
-spret deck_stack(bool fail)
+spret deck_stack(bool fail, int piety_cost, int mp_cost, int hp_cost)
 {
     if (crawl_state.is_replaying_keys())
     {
@@ -681,8 +681,7 @@ spret deck_stack(bool fail)
     fail_check();
 
     you.props[NEMELEX_STACK_KEY].get_vector().clear();
-    run_uncancel(UNC_STACK_FIVE, min(total_cards, 5));
-    return spret::success;
+    return run_ability_uncancel(UNC_STACK_FIVE, piety_cost, mp_cost, hp_cost);
 }
 
 class StackFiveMenu : public Menu
@@ -828,9 +827,16 @@ static void _draw_stack(int to_stack)
     deck_menu.show(false);
 }
 
-bool stack_five(int to_stack)
+bool stack_five()
 {
     auto& stack = you.props[NEMELEX_STACK_KEY].get_vector();
+
+    int total_cards = 0;
+    for (int i = FIRST_PLAYER_DECK; i <= LAST_PLAYER_DECK; ++i)
+        total_cards += deck_cards((deck_type)i);
+    total_cards += stack.size();
+
+    int to_stack = min(total_cards, 5);
 
     // TODO: this loop makes me sad
     while (stack.size() < to_stack)
@@ -903,7 +909,7 @@ spret deck_deal(bool fail)
 }
 
 // Draw the next three cards, discard two and pick one.
-spret deck_triple_draw(bool fail)
+spret deck_triple_draw(bool fail, int piety_cost, int mp_cost, int hp_cost)
 {
     if (crawl_state.is_replaying_keys())
     {
@@ -951,8 +957,7 @@ spret deck_triple_draw(bool fail)
     for (int i = 0; i < num_to_draw; ++i)
         draw.push_back(_random_card(choice));
 
-    run_uncancel(UNC_DRAW_THREE, 0);
-    return spret::success;
+    return run_ability_uncancel(UNC_DRAW_THREE, piety_cost, mp_cost, hp_cost);
 }
 
 bool draw_three()

--- a/crawl-ref/source/decks.h
+++ b/crawl-ref/source/decks.h
@@ -71,12 +71,12 @@ void reset_cards();
 string deck_summary();
 
 bool deck_draw(deck_type deck);
-spret deck_triple_draw(bool fail);
+spret deck_triple_draw(bool fail, int piety_cost, int mp_cost, int hp_cost);
 spret deck_deal(bool fail);
-spret deck_stack(bool fail);
+spret deck_stack(bool fail, int piety_cost, int mp_cost, int hp_cost);
 
 bool draw_three();
-bool stack_five(int slot);
+bool stack_five();
 
 void card_effect(card_type which_card, bool dealt = false,
         bool punishment = false,

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3578,8 +3578,8 @@ static string _describe_gozag_shop(int index)
 /**
  * Let the player choose from the currently available merchants to call.
  *
- * @param   The index of the chosen shop; -1 if none was chosen (due to e.g.
- *          a seen_hup).
+ * @param   The index of the chosen shop; -1 if we had to return early
+ *          due to seen_hup being set.
  */
 static int _gozag_choose_shop()
 {

--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -1015,11 +1015,9 @@ bool use_an_item(operation_types oper, item_def *target)
             target = jewellery[0];
     }
 
-    if (!target)
-        oper = use_an_item_menu(target, oper);
-
-    if (oper == OPER_NONE)
-        return false; // abort menu
+    spret result = use_an_item_menu(target, oper);
+    if (result != spret::success)
+        return false;
 
     if (oper == OPER_EQUIP)
         oper = item_to_oper(target);
@@ -1724,17 +1722,18 @@ static bool _try_unwield_weapons()
  *                    function. If it returns false, continue the prompt rather
  *                    than returning null.
  *
- * @return an operation to apply to the chosen item, OPER_NONE if the menu
- *         was aborted
+ * @return spret::success if an item was chosen, spret::abort if the player
+ *         does not wish to choose an item, spret::seen_hups if we had to
+ *         terminate early due to hups.
  */
-operation_types use_an_item_menu(item_def *&target, operation_types oper, int item_type,
-                      const char* prompt, function<bool ()> allowcancel)
+spret use_an_item_menu(item_def *&target, operation_types oper, int item_type,
+                       const char* prompt, function<bool ()> allowcancel)
 {
     UseItemMenu menu(oper, item_type, prompt);
 
     // First bail if there's nothing appropriate to choose in inv or on floor
     if (menu.empty_check())
-        return OPER_NONE;
+        return spret::abort;
 
     bool choice_made = false;
     item_def *tmp_tgt = nullptr; // We'll change target only if the player
@@ -1789,6 +1788,8 @@ operation_types use_an_item_menu(item_def *&target, operation_types oper, int it
 
         if (!choice_made)
         {
+            if (crawl_state.seen_hups)
+                return spret::seen_hups;
             if (!allowcancel())
                 continue;
             prompt_failed(PROMPT_ABORT);
@@ -1801,7 +1802,7 @@ operation_types use_an_item_menu(item_def *&target, operation_types oper, int it
 
     ASSERT(!choice_made || target || menu.show_unarmed());
 
-    return choice_made ? menu.oper : OPER_NONE;
+    return choice_made ? spret::success : spret::fail;
 }
 
 bool auto_wield()
@@ -2229,23 +2230,19 @@ static void _brand_weapon(item_def &wpn)
     return;
 }
 
-static item_def* _choose_target_item_for_scroll(bool scroll_known, object_selector selector,
-                                                const char* prompt)
+static spret _choose_target_item_for_scroll(bool scroll_known, object_selector selector,
+                                            const char* prompt, item_def*& target)
 {
-    item_def *target = nullptr;
-
-    auto success = use_an_item_menu(target, OPER_ANY, selector, prompt,
+    return use_an_item_menu(target, OPER_ANY, selector, prompt,
                        [=]()
                        {
                            if (scroll_known
-                               || crawl_state.seen_hups
                                || yesno("Really abort (and waste the scroll)?", false, 0))
                            {
                                return true;
                            }
                            return false;
                        });
-    return success != OPER_NONE ? target : nullptr;
 }
 
 static object_selector _enchant_selector(scroll_type scroll)
@@ -2257,29 +2254,27 @@ static object_selector _enchant_selector(scroll_type scroll)
     die("Invalid scroll type %d for _enchant_selector", (int)scroll);
 }
 
-// Returns nullptr if no weapon was chosen.
-static item_def* _scroll_choose_weapon(bool alreadyknown, const string &pre_msg,
-                                       scroll_type scroll)
+static spret _scroll_choose_weapon(bool alreadyknown, const string &pre_msg,
+                                       scroll_type scroll, item_def*& target)
 {
     const bool branding = scroll == SCR_BRAND_WEAPON;
 
-    item_def* target = _choose_target_item_for_scroll(alreadyknown, _enchant_selector(scroll),
-                                                      branding ? "Brand which weapon?"
-                                                               : "Enchant which weapon?");
-    if (!target)
-        return target;
+    spret result = _choose_target_item_for_scroll(alreadyknown, _enchant_selector(scroll),
+                                                  branding ? "Brand which weapon?"
+                                                           : "Enchant which weapon?",
+                                                  target);
 
-    if (alreadyknown)
+    if (alreadyknown && result == spret::success)
         mpr(pre_msg);
 
-    return target;
+    return result;
 }
 
-// Returns true if succesful
-static bool _handle_brand_weapon(bool alreadyknown, const string &pre_msg)
+static spret _handle_brand_weapon(bool alreadyknown, const string &pre_msg)
 {
     item_def* weapon = nullptr;
     string letter = "";
+    spret result = spret::success;
     if (!clua.callfn("c_choose_brand_weapon", ">s", &letter))
     {
         if (!clua.error.empty())
@@ -2293,18 +2288,22 @@ static bool _handle_brand_weapon(bool alreadyknown, const string &pre_msg)
     }
 
     if (!weapon)
-        weapon = _scroll_choose_weapon(alreadyknown, pre_msg, SCR_BRAND_WEAPON);
+    {
+        result = _scroll_choose_weapon(alreadyknown, pre_msg, SCR_BRAND_WEAPON,
+                                       weapon);
+    }
 
-    if (!weapon)
-        return false;
+    if (result != spret::success)
+        return result;
 
     _brand_weapon(*weapon);
-    return true;
+    return result;
 }
 
 bool uncancel_brand_weapon()
 {
-    return _handle_brand_weapon(false, "");
+    spret result = _handle_brand_weapon(false, "");
+    return result != spret::seen_hups;
 }
 
 bool enchant_weapon(item_def &wpn, bool quiet)
@@ -2341,13 +2340,14 @@ bool enchant_weapon(item_def &wpn, bool quiet)
  * @param alreadyknown  Did we know that this was an ID scroll before we
  *                      started reading it?
  * @param pre_msg       'As you read the scroll of foo, it crumbles to dust.'
- * @return  true if the scroll is used up. (That is, whether it was used or
- *          whether it was previously unknown (& thus uncancellable).)
+ * @return  spret::success if the scroll is used up. (That is, whether it was
+ *          used or whether it was previously unknown (& thus uncancellable).)
  */
-static bool _identify(bool alreadyknown, const string &pre_msg)
+static spret _identify(bool alreadyknown, const string &pre_msg)
 {
     item_def* itemp = nullptr;
     string letter = "";
+    spret result = spret::success;
     if (!clua.callfn("c_choose_identify", ">s", &letter))
     {
         if (!clua.error.empty())
@@ -2376,12 +2376,12 @@ static bool _identify(bool alreadyknown, const string &pre_msg)
 
     if (!itemp)
     {
-        itemp = _choose_target_item_for_scroll(alreadyknown, OSEL_UNIDENT,
-            "Identify which item? (\\ to view known items)");
+        result = _choose_target_item_for_scroll(alreadyknown, OSEL_UNIDENT,
+            "Identify which item? (\\ to view known items)", itemp);
     }
 
-    if (!itemp)
-        return false;
+    if (result != spret::success)
+        return result;
 
     item_def& item = *itemp;
     if (alreadyknown)
@@ -2408,18 +2408,20 @@ static bool _identify(bool alreadyknown, const string &pre_msg)
     else
         mprf_nocap("%s", menu_colour_item_name(item, DESC_A).c_str());
 
-    return true;
+    return result;
 }
 
 bool uncancel_identify()
 {
-    return _identify(false, "");
+    spret result = _identify(false, "");
+    return result != spret::seen_hups;
 }
 
-static bool _handle_enchant_weapon(bool alreadyknown, const string &pre_msg)
+static spret _handle_enchant_weapon(bool alreadyknown, const string &pre_msg)
 {
     item_def* weapon = nullptr;
     string letter = "";
+    spret result = spret::success;
     if (!clua.callfn("c_choose_enchant_weapon", ">s", &letter))
     {
         if (!clua.error.empty())
@@ -2434,12 +2436,12 @@ static bool _handle_enchant_weapon(bool alreadyknown, const string &pre_msg)
 
     if (!weapon)
     {
-        weapon = _scroll_choose_weapon(alreadyknown, pre_msg,
-                                       SCR_ENCHANT_WEAPON);
+        result = _scroll_choose_weapon(alreadyknown, pre_msg,
+                                       SCR_ENCHANT_WEAPON, weapon);
     }
 
-    if (!weapon)
-        return false;
+    if (result != spret::success)
+        return result;
 
     const bool success = enchant_weapon(*weapon, false);
     if (success && weapon->plus == MAX_WPN_ENCHANT)
@@ -2447,12 +2449,13 @@ static bool _handle_enchant_weapon(bool alreadyknown, const string &pre_msg)
         crawl_state.cancel_cmd_again();
         crawl_state.cancel_cmd_repeat();
     }
-    return true;
+    return result;
 }
 
 bool uncancel_enchant_weapon()
 {
-    return _handle_enchant_weapon(false, "");
+    spret result = _handle_enchant_weapon(false, "");
+    return result != spret::seen_hups;
 }
 
 bool enchant_armour(item_def &arm, bool quiet)
@@ -2484,11 +2487,11 @@ bool enchant_armour(item_def &arm, bool quiet)
     return true;
 }
 
-/// Returns whether the scroll is used up.
-static bool _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
+static spret _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
 {
     item_def* target= nullptr;
     string letter = "";
+    spret result = spret::success;
     if (!clua.callfn("c_choose_enchant_armour", ">s", &letter))
     {
         if (!clua.error.empty())
@@ -2503,12 +2506,12 @@ static bool _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
 
     if (!target)
     {
-        target = _choose_target_item_for_scroll(alreadyknown,
-            OSEL_ENCHANTABLE_ARMOUR, "Enchant which item?");
+        result = _choose_target_item_for_scroll(alreadyknown,
+            OSEL_ENCHANTABLE_ARMOUR, "Enchant which item?", target);
     }
 
-    if (!target)
-        return false;
+    if (result != spret::success)
+        return result;
 
     // Okay, we may actually (attempt to) enchant something.
     if (alreadyknown)
@@ -2516,7 +2519,7 @@ static bool _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
 
     const bool success = enchant_armour(*target, false);
     if (!success)
-        return true;
+        return result;
 
     you.redraw_armour_class = true;
     if (!is_enchantable_armour(*target))
@@ -2525,12 +2528,13 @@ static bool _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
         crawl_state.cancel_cmd_repeat();
     }
 
-    return true;
+    return result;
 }
 
 bool uncancel_enchant_armour()
 {
-    return _handle_enchant_armour(false, "");
+    spret result = _handle_enchant_armour(false, "");
+    return result != spret::seen_hups;
 }
 
 static void _vulnerability_scroll()
@@ -2554,7 +2558,7 @@ static void _vulnerability_scroll()
     mpr("A wave of despondency washes over your surroundings.");
 }
 
-static bool _handle_amnesia(bool alreadyknown)
+static spret _handle_amnesia(bool alreadyknown)
 {
     while (true)
     {
@@ -2564,21 +2568,22 @@ static bool _handle_amnesia(bool alreadyknown)
         if (!alreadyknown)
         {
             if (crawl_state.seen_hups)
-                return false;
+                return spret::seen_hups;
             if (!yesno("Really abort (and waste the scroll)?", false, 0))
                 continue;
         }
 
         // The scroll has been aborted
         canned_msg(MSG_OK);
-        return false;
+        return spret::abort;
     }
-    return true;
+    return spret::success;
 }
 
 bool uncancel_amnesia()
 {
-    return _handle_amnesia(false);
+    spret result = _handle_amnesia(false);
+    return result != spret::seen_hups;
 }
 
 bool uncancel_blinking()
@@ -2833,6 +2838,16 @@ static bool _scroll_has_forced_targeter(scroll_type scroll)
             || Options.force_scroll_targeter.count(scroll) > 0;
 }
 
+static spret _run_read_scroll_uncancel(uncancellable_type kind,
+                                       const item_def& scroll)
+{
+    bool in_player_inv = in_inventory(scroll);
+    int scroll_index = in_player_inv ? scroll.link : scroll.index();
+    uncancellable uc{kind, in_player_inv ? 1 : 0, scroll_index, 0};
+    bool succeeded = run_uncancel(uc);
+    return succeeded ? spret::success : spret::seen_hups;
+}
+
 /**
  * Read the provided scroll.
  *
@@ -2855,8 +2870,10 @@ bool read(item_def* scroll, dist *target)
     ASSERT(scroll);
 
     const scroll_type which_scroll = static_cast<scroll_type>(scroll->sub_type);
+    const bool alreadyknown = item_type_known(*scroll);
+
     // Handle player cancels before we waste time
-    if (item_type_known(*scroll))
+    if (alreadyknown)
     {
         const bool hostile_check = scroll_hostile_check(which_scroll);
         string verb_object = "read the " + scroll->name(DESC_DBNAME);
@@ -2867,7 +2884,7 @@ bool read(item_def* scroll, dist *target)
                                     || is_bad_item(*scroll))
                             && Options.bad_item_prompt
                             // Don't double-prompt if we're already asking for confirmation.
-                            && !_scroll_has_forced_targeter(static_cast<scroll_type>(scroll->sub_type));
+                            && !_scroll_has_forced_targeter(which_scroll);
 
         if (stop_attack_prompt(hitfunc, verb_object.c_str(),
                                [which_scroll] (const actor* m)
@@ -2920,11 +2937,6 @@ bool read(item_def* scroll, dist *target)
     }
 
     // Ok - now we FINALLY get to read a scroll !!! {dlb}
-    you.turn_is_over = true;
-
-    const int prev_quantity = scroll->quantity;
-    int link = in_inventory(*scroll) ? scroll->link : -1;
-    const bool alreadyknown = item_type_known(*scroll);
 
     if (alreadyknown
         && scroll_has_targeter(which_scroll)
@@ -2938,13 +2950,11 @@ bool read(item_def* scroll, dist *target)
         {
             // a targeter can't be used for unid'd or uncancellable scrolls, so
             // we can skip the rest of the function
-            you.turn_is_over = false;
             return false;
         }
     }
 
-    const bool is_loud = you.has_mutation(MUT_BOOMING_VOICE)
-                         && there_are_monsters_nearby(true, true, false);
+    const bool is_loud = you.has_mutation(MUT_BOOMING_VOICE) && nearby_mons;
     const coord_def original_pos = you.pos();
 
     // For cancellable scrolls leave printing this message to their
@@ -2963,7 +2973,7 @@ bool read(item_def* scroll, dist *target)
     const bool dangerous = player_in_a_dangerous_place();
 
     // ... but some scrolls may still be cancelled afterwards.
-    bool cancel_scroll = false;
+    spret result = spret::success;
     bool bad_effect = false; // for Xom: result is bad (or at least dangerous)
 
     switch (which_scroll)
@@ -2982,14 +2992,13 @@ bool read(item_def* scroll, dist *target)
         {
             mpr(pre_succ_msg);
 
-            run_uncancel(UNC_BLINKING);
+            result = _run_read_scroll_uncancel(UNC_BLINKING, *scroll);
         }
         else
         {
-            cancel_scroll = (controlled_blink(alreadyknown, target)
-                == spret::abort);
+            result = controlled_blink(alreadyknown, target);
 
-            if (!cancel_scroll)
+            if (result != spret::abort)
                 mpr(pre_succ_msg); // ordering is iffy but w/e
         }
     }
@@ -3022,11 +3031,12 @@ bool read(item_def* scroll, dist *target)
         if (feat_eliminates_items(env.grid(you.pos())))
         {
             mpr("Anything you acquired here would fall and be lost!");
-            cancel_scroll = true;
+            result = spret::abort;
             break;
         }
 
-        cancel_scroll = !acquirement_menu();
+        if (!acquirement_menu())
+            result = spret::abort;
         break;
 
     case SCR_FEAR:
@@ -3039,12 +3049,11 @@ bool read(item_def* scroll, dist *target)
         break;
 
     case SCR_SUMMONING:
-        cancel_scroll = summon_shadow_creatures() == spret::abort
-                        && alreadyknown;
+        result = summon_shadow_creatures();
         break;
 
     case SCR_BUTTERFLIES:
-        cancel_scroll = summon_butterflies() == spret::abort && alreadyknown;
+        result = summon_butterflies();
         break;
 
     case SCR_FOG:
@@ -3062,7 +3071,7 @@ bool read(item_def* scroll, dist *target)
     case SCR_TORMENT:
         torment(&you, TORMENT_SCROLL, you.pos());
 
-        if (!item_type_known(*scroll))
+        if (!alreadyknown)
             god_forgive_inadvertent_act(FORBID_EVIL);
         bad_effect = !you.res_torment();
         break;
@@ -3094,9 +3103,8 @@ bool read(item_def* scroll, dist *target)
 
     case SCR_POISON:
     {
-        const spret result = scroll_of_poison(!alreadyknown);
-        cancel_scroll = result == spret::abort;
-        if (!cancel_scroll)
+        result = scroll_of_poison(!alreadyknown);
+        if (result != spret::abort)
             mpr(pre_succ_msg);
         // amusing to Xom, at least
         bad_effect = result == spret::success && !player_res_poison();
@@ -3110,10 +3118,10 @@ bool read(item_def* scroll, dist *target)
             mpr("It is a scroll of enchant weapon.");
             // included in default force_more_message (to show it before menu)
 
-            run_uncancel(UNC_ENCHANT_WEAPON);
+            result = _run_read_scroll_uncancel(UNC_ENCHANT_WEAPON, *scroll);
         }
         else
-            cancel_scroll = !_handle_enchant_weapon(alreadyknown, pre_succ_msg);
+            result = _handle_enchant_weapon(alreadyknown, pre_succ_msg);
 
         break;
 
@@ -3124,10 +3132,10 @@ bool read(item_def* scroll, dist *target)
             mpr("It is a scroll of brand weapon.");
             // included in default force_more_message (to show it before menu)
 
-            run_uncancel(UNC_BRAND_WEAPON);
+            result = _run_read_scroll_uncancel(UNC_BRAND_WEAPON, *scroll);
         }
         else
-            cancel_scroll = !_handle_brand_weapon(alreadyknown, pre_succ_msg);
+            result = _handle_brand_weapon(alreadyknown, pre_succ_msg);
 
         break;
 
@@ -3140,10 +3148,10 @@ bool read(item_def* scroll, dist *target)
             // Do this here so it doesn't turn up in the ID menu.
             identify_item(*scroll);
 
-            run_uncancel(UNC_IDENTIFY);
+            result = _run_read_scroll_uncancel(UNC_IDENTIFY, *scroll);
         }
         else
-            cancel_scroll = !_identify(alreadyknown, pre_succ_msg);
+            result = _identify(alreadyknown, pre_succ_msg);
 
         break;
 
@@ -3154,10 +3162,10 @@ bool read(item_def* scroll, dist *target)
             mpr("It is a scroll of enchant armour.");
             // included in default force_more_message (to show it before menu)
 
-            run_uncancel(UNC_ENCHANT_ARMOUR);
+            result = _run_read_scroll_uncancel(UNC_ENCHANT_ARMOUR, *scroll);
         }
         else
-            cancel_scroll = !_handle_enchant_armour(alreadyknown, pre_succ_msg);
+            result = _handle_enchant_armour(alreadyknown, pre_succ_msg);
 
         break;
 #if TAG_MAJOR_VERSION == 34
@@ -3169,7 +3177,7 @@ bool read(item_def* scroll, dist *target)
     case SCR_HOLY_WORD:
     {
         mpr("This item has been removed, sorry!");
-        cancel_scroll = true;
+        result = spret::abort;
         break;
     }
 #endif
@@ -3196,9 +3204,9 @@ bool read(item_def* scroll, dist *target)
         }
 
         if (!alreadyknown)
-            run_uncancel(UNC_AMNESIA);
+            result = _run_read_scroll_uncancel(UNC_AMNESIA, *scroll);
         else
-            cancel_scroll = !_handle_amnesia(alreadyknown);
+            result = _handle_amnesia(alreadyknown);
 
         break;
 
@@ -3207,15 +3215,37 @@ bool read(item_def* scroll, dist *target)
         break;
     }
 
-    if (cancel_scroll)
-        you.turn_is_over = false;
+    if (alreadyknown && result == spret::seen_hups)
+        result = spret::abort;
+    ASSERT(result != spret::seen_hups || has_uncancel());
+
+    handle_post_scroll_effects(scroll, result, original_pos,
+                               nearby_mons, alreadyknown, dangerous,
+                               bad_effect);
+
+    return true;
+}
+
+void handle_post_scroll_effects(item_def* scroll, spret read_result,
+                                coord_def original_pos, bool nearby_mons,
+                                bool alreadyknown, bool dangerous,
+                                bool bad_effect)
+{
+    if (read_result == spret::seen_hups)
+        return;
+
+    if (read_result != spret::abort)
+        you.turn_is_over = true;
 
     identify_item(*scroll);
 
     string scroll_name = scroll->name(DESC_QUALNAME);
+    const bool is_loud = you.has_mutation(MUT_BOOMING_VOICE) && nearby_mons;
 
-    if (!cancel_scroll)
+    if (read_result != spret::abort)
     {
+        int link = in_inventory(*scroll) ? scroll->link : -1;
+
         if (in_inventory(*scroll))
             dec_inv_item_quantity(link, 1);
         else
@@ -3228,6 +3258,8 @@ bool read(item_def* scroll, dist *target)
             noisy(40, original_pos, MID_PLAYER);
     }
 
+    const scroll_type which_scroll = static_cast<scroll_type>(scroll->sub_type);
+
     if (!alreadyknown
         && which_scroll != SCR_BRAND_WEAPON
         && which_scroll != SCR_ENCHANT_WEAPON
@@ -3237,7 +3269,7 @@ bool read(item_def* scroll, dist *target)
         && which_scroll != SCR_ACQUIREMENT)
     {
         mprf("It %s %s.",
-             scroll->quantity < prev_quantity ? "was" : "is",
+             read_result == spret::abort ? "is" : "was",
              article_a(scroll_name).c_str());
     }
 
@@ -3261,14 +3293,13 @@ bool read(item_def* scroll, dist *target)
     // Reading with hostile visible mons nearby resets unrand "Victory" stats.
     if (you.unrand_equipped(UNRAND_VICTORY, true)
         && nearby_mons
-        && !cancel_scroll)
+        && read_result != spret::abort)
     {
         you.props[VICTORY_CONDUCT_KEY] = true;
     }
 
     if (!alreadyknown)
         auto_assign_item_slot(*scroll);
-    return true;
 }
 
 class targeter_invisibility : public targeter_multimonster

--- a/crawl-ref/source/item-use.h
+++ b/crawl-ref/source/item-use.h
@@ -14,11 +14,12 @@
 #include "object-selector-type.h"
 #include "operation-types.h"
 #include "player-equip.h"
+#include "spl-cast.h" // spret
 #include "unwind.h"
 
 const int ARMOUR_EQUIP_DELAY = 5;
 
-operation_types use_an_item_menu(item_def *&target, operation_types oper,
+spret use_an_item_menu(item_def *&target, operation_types oper,
                 int item_type=OSEL_ANY,
                 const char* prompt=nullptr,
                 function<bool ()> allowcancel = [](){ return true; });
@@ -33,6 +34,10 @@ bool god_hates_brand(const brand_type brand);
 bool scroll_hostile_check(scroll_type which_scroll);
 bool scroll_has_targeter(scroll_type which_scroll);
 bool read(item_def* scroll = nullptr, dist *target=nullptr);
+void handle_post_scroll_effects(item_def* scroll, spret read_result,
+                                coord_def original_pos, bool nearby_mons,
+                                bool alreadyknown, bool dangerous,
+                                bool bad_effect);
 
 bool auto_wield();
 

--- a/crawl-ref/source/main.cc
+++ b/crawl-ref/source/main.cc
@@ -492,8 +492,6 @@ NORETURN static void _launch_game()
     tiles.redraw();
 #endif
 
-    run_uncancels();
-
     cursor_control ccon(!Options.use_fake_player_cursor);
     while (true)
         _input();
@@ -1130,6 +1128,18 @@ static void _input()
     update_monsters_in_view();
 
     hints_new_turn();
+
+    if (has_uncancel())
+    {
+        resume_uncancel();
+        if (you.turn_is_over)
+        {
+            if (you.berserk())
+                _do_berserk_no_combat_penalty();
+            world_reacts();
+            return;
+        }
+    }
 
     if (you.cannot_act())
     {

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -36,7 +36,7 @@
 #include "stat-type.h"
 #include "timed-effect-type.h"
 #include "transformation.h"
-#include "uncancellable-type.h"
+#include "uncancel.h"
 #include "unique-creature-list-type.h"
 #include "unique-item-status-type.h"
 
@@ -420,7 +420,7 @@ public:
 
     // Prompts or actions the player must answer before continuing.
     // A stack -- back() is the first to go.
-    vector<pair<uncancellable_type, int> > uncancel;
+    vector<uncancellable> uncancel;
 
     // Hash seed for deterministic stuff.
     uint64_t game_seed;

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -72,6 +72,7 @@ enum class spret
     abort = 0,            // should be left as 0
     fail,
     success,
+    seen_hups,
     none,                 // spell was not handled
 };
 

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -360,6 +360,7 @@ enum tag_minor_version
     TAG_MINOR_MAX_PIETY_LOGGING,   // Separately log stepdown events and max piety wastage
     TAG_MINOR_INVIS_REFORM,        // Improve player tracking of invisible monsters
     TAG_MINOR_LURKER_MONSTERS,     // Add support for lurker monsters
+    TAG_MINOR_FIX_UNCANCELS,       // Fix monsters sometimes getting their turn before the effect of the players action
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1972,10 +1972,12 @@ static void _tag_construct_you(writer &th)
     marshallUByte(th, you.octopus_king_rings);
 
     marshallUnsigned(th, you.uncancel.size());
-    for (const pair<uncancellable_type, int>& unc : you.uncancel)
+    for (const uncancellable& unc : you.uncancel)
     {
-        marshallUByte(th, unc.first);
-        marshallInt(th, unc.second);
+        marshallUByte(th, unc.kind);
+        marshallInt(th, unc.piety_cost_or_in_inventory);
+        marshallInt(th, unc.mp_cost_or_item_index);
+        marshallInt(th, unc.hp_cost);
     }
 
     marshallUByte(th, 1); // number of seeds, for historical reasons: always 1
@@ -3048,6 +3050,61 @@ static void _read_old_player_equipment(reader &th)
     {
         for (int i = 0; i < count; ++i)
             old_attuned.push_back(false);
+    }
+}
+
+static void _read_old_uncancels(reader& th)
+{
+    if (th.getMinorVersion() < TAG_MINOR_UNCANCELLABLES
+        || th.getMinorVersion() == TAG_MINOR_0_11)
+    {
+        return;
+    }
+
+    vector<pair<uint8_t, int>> uncancel;
+    int count = unmarshallUnsigned(th);
+    ASSERT_RANGE(count, 0, 16); // sanity check
+    uncancel.resize(count);
+    for (int i = 0; i < count; i++)
+    {
+        uncancel[i].first = unmarshallUByte(th);
+        uncancel[i].second = unmarshallInt(th);
+    }
+
+    uint8_t old_unc_acquirement = 0;
+    uint8_t old_unc_mercenary = 3;
+    erase_if(uncancel,
+             [=](const pair<uint8_t, int> uc)
+             {
+                 return uc.first == old_unc_acquirement
+                        || uc.first == old_unc_mercenary;
+             });
+    for (pair<uint8_t, int>& uc : uncancel)
+    {
+        uint8_t to_reduce = 0;
+        if (uc.first > old_unc_acquirement)
+            ++to_reduce;
+        if (uc.first > old_unc_mercenary)
+            ++to_reduce;
+
+        uc.first -= to_reduce;
+    }
+
+    // Cancel any item-based deck manipulations
+    if (th.getMinorVersion() < TAG_MINOR_REMOVE_DECKS)
+    {
+        erase_if(uncancel,
+                 [](const pair<uint8_t, int> uc) {
+                    return uc.first == UNC_DRAW_THREE
+                           || uc.first == UNC_STACK_FIVE;
+                });
+    }
+
+    you.uncancel.reserve(uncancel.size());
+    for (pair<uint8_t, int> uc : uncancel)
+    {
+        uncancellable unc{(uncancellable_type)uc.first, -1, -1, -1};
+        you.uncancel.push_back(unc);
     }
 }
 #endif
@@ -4610,31 +4667,29 @@ static void _tag_read_you(reader &th)
     }
 #endif
 
+    you.uncancel.clear();
 #if TAG_MAJOR_VERSION == 34
-    if (th.getMinorVersion() >= TAG_MINOR_UNCANCELLABLES
-        && th.getMinorVersion() != TAG_MINOR_0_11)
+    if (th.getMinorVersion() < TAG_MINOR_FIX_UNCANCELS)
+        _read_old_uncancels(th);
+    else
     {
 #endif
-    count = unmarshallUnsigned(th);
-    ASSERT_RANGE(count, 0, 16); // sanity check
-    you.uncancel.resize(count);
-    for (int i = 0; i < count; i++)
-    {
-        you.uncancel[i].first = (uncancellable_type)unmarshallUByte(th);
-        you.uncancel[i].second = unmarshallInt(th);
-    }
+        count = unmarshallUnsigned(th);
+        ASSERT_RANGE(count, 0, 16); // sanity check
+        you.uncancel.resize(count);
+        for (int i = 0; i < count; ++i)
+        {
+            uncancellable& unc = you.uncancel[i];
+            unc.kind = (uncancellable_type)unmarshallUByte(th);
+            unc.piety_cost_or_in_inventory = unmarshallInt(th);
+            unc.mp_cost_or_item_index = unmarshallInt(th);
+            unc.hp_cost = unmarshallInt(th);
+        }
 #if TAG_MAJOR_VERSION == 34
-    // Cancel any item-based deck manipulations
-    if (th.getMinorVersion() < TAG_MINOR_REMOVE_DECKS)
-    {
-        erase_if(you.uncancel,
-                 [](const pair<uncancellable_type, int> uc) {
-                    return uc.first == UNC_DRAW_THREE
-                           || uc.first == UNC_STACK_FIVE;
-                });
     }
-    }
+#endif
 
+#if TAG_MAJOR_VERSION == 34
     if (th.getMinorVersion() >= TAG_MINOR_INCREMENTAL_RECALL
         && th.getMinorVersion() < TAG_MINOR_NO_INCREMENTAL_RECALL)
     {

--- a/crawl-ref/source/uncancel.cc
+++ b/crawl-ref/source/uncancel.cc
@@ -9,96 +9,129 @@
 #include "mpr.h"
 #include "uncancel.h"
 
+#include "ability.h"
 #include "acquire.h"
 #include "decks.h"
+#include "env.h"
 #include "god-abil.h"
 #include "item-use.h"
 #include "libutil.h"
+#include "nearby-danger.h"
 #include "state.h"
 #include "tag-version.h"
 #include "unwind.h"
 
-void add_uncancel(uncancellable_type kind, int arg)
+bool has_uncancel()
 {
-    you.uncancel.emplace_back(kind, arg);
+    return !you.uncancel.empty();
 }
 
-static bool running = false;
-
-void run_uncancels()
+static bool _resume_uncancel(bool run_success_effect)
 {
+    if (!has_uncancel())
+        return false;
+
+    static bool running = false;
     // Run uncancels iteratively rather than recursively.
     if (running)
-        return;
+        return false;
     unwind_bool run(running, true);
 
-    while (!you.uncancel.empty() && !crawl_state.seen_hups)
+    const size_t index = you.uncancel.size() - 1;
+
+    // Beware of race conditions: it is not enough to check seen_hups as it
+    // might have been set after the action succeeded or failed for unrelated
+    // reasons.
+
+    uncancellable copy = you.uncancel[index];
+    dprf("Running uncancel type=%d", copy.kind);
+
+    const coord_def original_pos = you.pos();
+    bool nearby_mons = there_are_monsters_nearby(true, true, false);
+    const bool dangerous = player_in_a_dangerous_place();
+    ability_type ability = ABIL_NON_ABILITY;
+
+    bool succeeded = true;
+    switch (copy.kind)
     {
-        // changed to -1 if we pop prematurely
-        int act = you.uncancel.size() - 1;
-
-        // Beware of race conditions: it is not enough to check seen_hups,
-        // the action must actually fail as well!  And if it fails but there
-        // was no HUP, it's due to some other reason.
-
-        int arg = you.uncancel[act].second;
-        dprf("Running uncancel type=%d arg=%d", you.uncancel[act].first, arg);
-
-        switch (you.uncancel[act].first)
-        {
-        case UNC_DRAW_THREE:
-            if (!draw_three() && crawl_state.seen_hups)
-                return;
-            break;
-
-        case UNC_STACK_FIVE:
-            if (!stack_five(arg) && crawl_state.seen_hups)
-                return;
-            break;
-
-#if TAG_MAJOR_VERSION == 34
-        case UNC_MERCENARY:
-        case UNC_ACQUIREMENT:
-            break;
-
-#endif
-        case UNC_POTION_PETITION:
-            if (!gozag_potion_petition() && crawl_state.seen_hups)
-                return;
-            break;
-
-        case UNC_CALL_MERCHANT:
-            if (!gozag_call_merchant() && crawl_state.seen_hups)
-                return;
-            break;
-
-        case UNC_ENCHANT_WEAPON:
-            if (!uncancel_enchant_weapon() && crawl_state.seen_hups)
-                return;
-            break;
-        case UNC_ENCHANT_ARMOUR:
-            if (!uncancel_enchant_armour() && crawl_state.seen_hups)
-                return;
-            break;
-        case UNC_BRAND_WEAPON:
-            if (!uncancel_brand_weapon() && crawl_state.seen_hups)
-                return;
-            break;
-        case UNC_AMNESIA:
-            if (!uncancel_amnesia() && crawl_state.seen_hups)
-                return;
-            break;
-        case UNC_BLINKING:
-            if (!uncancel_blinking() && crawl_state.seen_hups)
-                return;
-            break;
-        case UNC_IDENTIFY:
-            if (!uncancel_identify() && crawl_state.seen_hups)
-                return;
-            break;
-        }
-
-        if (act != -1)
-            erase_any(you.uncancel, act);
+    case UNC_DRAW_THREE:
+        succeeded = draw_three();
+        ability = ABIL_NEMELEX_TRIPLE_DRAW;
+        break;
+    case UNC_STACK_FIVE:
+        succeeded = stack_five();
+        ability = ABIL_NEMELEX_STACK_FIVE;
+        break;
+    case UNC_POTION_PETITION:
+        succeeded = gozag_potion_petition();
+        ability = ABIL_GOZAG_POTION_PETITION;
+        break;
+    case UNC_CALL_MERCHANT:
+        succeeded = gozag_call_merchant();
+        ability = ABIL_GOZAG_CALL_MERCHANT;
+        break;
+    case UNC_ENCHANT_WEAPON:
+        succeeded = uncancel_enchant_weapon();
+        break;
+    case UNC_ENCHANT_ARMOUR:
+        succeeded = uncancel_enchant_armour();
+        break;
+    case UNC_BRAND_WEAPON:
+        succeeded = uncancel_brand_weapon();
+        break;
+    case UNC_AMNESIA:
+        succeeded = uncancel_amnesia();
+        break;
+    case UNC_BLINKING:
+        succeeded = uncancel_blinking();
+        break;
+    case UNC_IDENTIFY:
+        succeeded = uncancel_identify();
+        break;
     }
+
+    if (!succeeded)
+        return false;
+
+    // We used to have a bug where we would sometimes run the success effects
+    // before running the uncanel. If this has happened, don't run them after
+    // as well
+#if TAG_MAJOR_VERSION == 34
+    if (copy.piety_cost_or_in_inventory < 0)
+        run_success_effect = false;
+#endif
+
+    if (run_success_effect)
+    {
+        if (ability != ABIL_NON_ABILITY)
+        {
+            int piety_cost = copy.piety_cost_or_in_inventory;
+            int mp_cost = copy.mp_cost_or_item_index;
+            handle_post_ability_effects(ability, spret::success, piety_cost,
+                                        mp_cost, copy.hp_cost, true);
+        }
+        else
+        {
+            bool in_inv = (bool)copy.piety_cost_or_in_inventory;
+            int scroll_index = copy.mp_cost_or_item_index;
+            item_def& scroll = in_inv ? you.inv[scroll_index]
+                                      : env.item[scroll_index];
+            handle_post_scroll_effects(&scroll, spret::success, original_pos,
+                                       nearby_mons, false, dangerous, false);
+        }
+    }
+
+    you.uncancel.erase(you.uncancel.begin() + index);
+    return true;
+}
+
+void resume_uncancel()
+{
+    _resume_uncancel(true);
+}
+
+bool run_uncancel(uncancellable uc)
+{
+    you.uncancel.push_back(uc);
+    return _resume_uncancel(false);
 }

--- a/crawl-ref/source/uncancel.h
+++ b/crawl-ref/source/uncancel.h
@@ -8,11 +8,14 @@
 
 #include "uncancellable-type.h"
 
-void add_uncancel(uncancellable_type kind, int arg = 0);
-void run_uncancels();
-
-static inline void run_uncancel(uncancellable_type kind, int arg = 0)
+struct uncancellable
 {
-    add_uncancel(kind, arg);
-    run_uncancels();
-}
+    uncancellable_type kind;
+    int piety_cost_or_in_inventory;
+    int mp_cost_or_item_index;
+    int hp_cost;
+};
+
+bool has_uncancel();
+void resume_uncancel();
+bool run_uncancel(uncancellable uc);

--- a/crawl-ref/source/uncancellable-type.h
+++ b/crawl-ref/source/uncancellable-type.h
@@ -1,24 +1,16 @@
 #pragma once
 
-#include "tag-version.h"
-
 enum uncancellable_type
 {
-#if TAG_MAJOR_VERSION == 34
-    UNC_ACQUIREMENT,           // arg is AQ_SCROLL
-#endif
-    UNC_DRAW_THREE,            // arg is ignored
-    UNC_STACK_FIVE,            // arg is number of cards to stack
-#if TAG_MAJOR_VERSION == 34
-    UNC_MERCENARY,             // arg is mid of the monster
-#endif
-    UNC_POTION_PETITION,       // arg is ignored
-    UNC_CALL_MERCHANT,         // arg is ignored
+    UNC_DRAW_THREE,
+    UNC_STACK_FIVE,
+    UNC_POTION_PETITION,
+    UNC_CALL_MERCHANT,
 
-    UNC_ENCHANT_WEAPON,        // arg is ignored
-    UNC_ENCHANT_ARMOUR,        // arg is ignored
-    UNC_BRAND_WEAPON,          // arg is ignored
-    UNC_AMNESIA,               // arg is ignored
-    UNC_BLINKING,                 // arg is ignored
-    UNC_IDENTIFY,              // arg is ignored
+    UNC_ENCHANT_WEAPON,
+    UNC_ENCHANT_ARMOUR,
+    UNC_BRAND_WEAPON,
+    UNC_AMNESIA,
+    UNC_BLINKING,
+    UNC_IDENTIFY,
 };


### PR DESCRIPTION
If the player starts an uncancellable action that requires player input such as Gozag's potion petition, exits the game (e.g. by losing connection to the server or closing the game window), and then reloads the game, the monsters would get to act as the game was exiting but the player's action wouldn't happen until after it was reloaded. Even worse, if the player died as a result of the monsters acting early, they wouldn't see the game over screen or the monsters acting as they had already left the game and when they went to resume the game it would seem like their save file had mysteriously disappeared.