### PR TITLE
Fix Mad Mage Mauler align

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -865,8 +865,8 @@ static string _format_dbrand(string dbrand)
         {
             ASSERT(brand.size() == 2);
             const string &desc = brand[1];
-            const int prefix_len = max(MAX_ARTP_NAME_LEN + 1, (int)brand[0].size() + 2);
-            const string pre = padded_str(brand[0] + ":", prefix_len);
+            const int prefix_min_len = MAX_ARTP_NAME_LEN + 1;
+            const string pre = padded_str(brand[0] + ": ", prefix_min_len);
             out.push_back(_format_prop_desc(pre, desc));
         }
     }


### PR DESCRIPTION
_format_dbrand() didn't calculate the width of unicode characters accurately. padded_str() does, so let that handle the width.

This means that the two DESCR lines for the Mad Mage's Maulers are now aligned in the same way.
