### PR TITLE
Show owned counts for potions, scrolls, wand charges and throwables in shops

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -322,6 +322,7 @@ catch2-tests/test_player_fixture.o \
 catch2-tests/test_randbook.o \
 catch2-tests/test_stringutil.o \
 catch2-tests/test_species.o \
+catch2-tests/test_shopping.o \
 catch2-tests/test_tags.o \
 catch2-tests/test_tilecell.o \
 catch2-tests/test_ui.o \

--- a/crawl-ref/source/catch2-tests/test_shopping.cc
+++ b/crawl-ref/source/catch2-tests/test_shopping.cc
@@ -1,0 +1,67 @@
+#include "catch_amalgamated.hpp"
+
+#include "AppHdr.h"
+
+#include "items.h"
+#include "item-status-flag-type.h"
+#include "player.h"
+#include "shopping.h"
+
+#include "test_player_fixture.h"
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count sums matching scroll stacks", "[shopping]")
+{
+    item_def fear_scroll;
+    get_item_by_exact_name(fear_scroll, "scroll of fear");
+    fear_scroll.quantity = 3;
+    you.inv[0] = fear_scroll;
+
+    item_def identify_scroll;
+    get_item_by_exact_name(identify_scroll, "scroll of identify");
+    identify_scroll.quantity = 2;
+    you.inv[1] = identify_scroll;
+
+    item_def another_fear_scroll = fear_scroll;
+    another_fear_scroll.quantity = 2;
+    you.inv[2] = another_fear_scroll;
+
+    REQUIRE(shop_owned_consumable_count(fear_scroll) == 5);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count sums matching potion stacks", "[shopping]")
+{
+    item_def haste_potion;
+    get_item_by_exact_name(haste_potion, "potion of haste");
+    haste_potion.quantity = 2;
+    you.inv[0] = haste_potion;
+
+    REQUIRE(shop_owned_consumable_count(haste_potion) == 2);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count does not reveal unknown item types", "[shopping]")
+{
+    item_def inventory_scroll;
+    get_item_by_exact_name(inventory_scroll, "scroll of fear");
+    inventory_scroll.quantity = 3;
+    inventory_scroll.flags &= ~ISFLAG_IDENTIFIED;
+    you.inv[0] = inventory_scroll;
+
+    item_def shop_scroll;
+    get_item_by_exact_name(shop_scroll, "scroll of fear");
+
+    REQUIRE(shop_owned_consumable_count(shop_scroll) == 0);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count is limited to potions and scrolls", "[shopping]")
+{
+    item_def dagger;
+    get_item_by_exact_name(dagger, "dagger");
+    dagger.quantity = 2;
+    you.inv[0] = dagger;
+
+    REQUIRE(shop_owned_consumable_count(dagger) == 0);
+}

--- a/crawl-ref/source/catch2-tests/test_shopping.cc
+++ b/crawl-ref/source/catch2-tests/test_shopping.cc
@@ -37,11 +37,10 @@ TEST_CASE_METHOD(MockPlayerYouTestsFixture,
 }
 
 TEST_CASE_METHOD(MockPlayerYouTestsFixture,
-                 "Shop owned count is limited to potions and scrolls", "[shopping]")
+                 "Shop owned count ignores nonstackable items", "[shopping]")
 {
     item_def dagger;
     get_item_by_exact_name(dagger, "dagger");
-    dagger.quantity = 2;
     you.inv[0] = dagger;
 
     REQUIRE(shop_owned_consumable_count(dagger) == 0);

--- a/crawl-ref/source/catch2-tests/test_shopping.cc
+++ b/crawl-ref/source/catch2-tests/test_shopping.cc
@@ -4,33 +4,14 @@
 
 #include "items.h"
 #include "item-status-flag-type.h"
+#include "item-name.h"
 #include "player.h"
 #include "shopping.h"
 
 #include "test_player_fixture.h"
 
 TEST_CASE_METHOD(MockPlayerYouTestsFixture,
-                 "Shop owned count sums matching scroll stacks", "[shopping]")
-{
-    item_def fear_scroll;
-    get_item_by_exact_name(fear_scroll, "scroll of fear");
-    fear_scroll.quantity = 3;
-    you.inv[0] = fear_scroll;
-
-    item_def identify_scroll;
-    get_item_by_exact_name(identify_scroll, "scroll of identify");
-    identify_scroll.quantity = 2;
-    you.inv[1] = identify_scroll;
-
-    item_def another_fear_scroll = fear_scroll;
-    another_fear_scroll.quantity = 2;
-    you.inv[2] = another_fear_scroll;
-
-    REQUIRE(shop_owned_consumable_count(fear_scroll) == 5);
-}
-
-TEST_CASE_METHOD(MockPlayerYouTestsFixture,
-                 "Shop owned count sums matching potion stacks", "[shopping]")
+                 "Shop owned count returns matching potion stack quantity", "[shopping]")
 {
     item_def haste_potion;
     get_item_by_exact_name(haste_potion, "potion of haste");
@@ -64,4 +45,47 @@ TEST_CASE_METHOD(MockPlayerYouTestsFixture,
     you.inv[0] = dagger;
 
     REQUIRE(shop_owned_consumable_count(dagger) == 0);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count returns charges for a matching known wand",
+                 "[shopping]")
+{
+    item_def flame_wand;
+    get_item_by_exact_name(flame_wand, "wand of flame");
+    flame_wand.charges = 5;
+    flame_wand.flags |= ISFLAG_IDENTIFIED;
+    you.type_ids[OBJ_WANDS][flame_wand.sub_type] = true;
+    you.inv[0] = flame_wand;
+
+    REQUIRE(shop_owned_consumable_count(flame_wand) == 5);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count returns matching throwable quantity",
+                 "[shopping]")
+{
+    item_def javelin;
+    get_item_by_exact_name(javelin, "javelin");
+    javelin.quantity = 3;
+    you.inv[0] = javelin;
+
+    REQUIRE(shop_owned_consumable_count(javelin) == 3);
+}
+
+TEST_CASE_METHOD(MockPlayerYouTestsFixture,
+                 "Shop owned count hides an unknown shop wand", "[shopping]")
+{
+    item_def shop_wand;
+    get_item_by_exact_name(shop_wand, "wand of iceblast");
+    shop_wand.flags |= ISFLAG_IDENTIFIED;
+    you.type_ids[OBJ_WANDS][shop_wand.sub_type] = false;
+
+    item_def inventory_wand = shop_wand;
+    inventory_wand.flags &= ~ISFLAG_IDENTIFIED;
+    inventory_wand.charges = 4;
+    you.inv[0] = inventory_wand;
+
+    REQUIRE(shop_item_unknown(shop_wand));
+    REQUIRE(shop_owned_consumable_count(shop_wand) == 0);
 }

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -862,6 +862,23 @@ static int _count_identical(const vector<item_def>& stock, const item_def& item)
     return count;
 }
 
+int shop_owned_consumable_count(const item_def& item)
+{
+    if (item.base_type != OBJ_POTIONS && item.base_type != OBJ_SCROLLS)
+        return 0;
+
+    int count = 0;
+    for (const item_def& inv : you.inv)
+    {
+        if (inv.base_type == item.base_type && inv.sub_type == item.sub_type
+            && inv.is_identified() == item.is_identified())
+        {
+            count += inv.quantity;
+        }
+    }
+    return count;
+}
+
 /** Buy an item from a shop!
  *
  *  @param shop  the shop to purchase from.
@@ -1021,7 +1038,11 @@ class ShopEntry : public InvEntry
         const string keystr = colour_to_str(keycol);
         const string itemstr =
             colour_to_str(menu_colour(text, item_prefix(*item, false), tag, false));
-        return make_stringf(" <%s>%c %c </%s><%s>%4d gold   %s%s</%s>",
+        const int owned = shop_owned_consumable_count(*item);
+        const string ownedstr = owned > 0
+            ? make_stringf("  <cyan>(owned: %d)</cyan>", owned)
+            : "";
+        return make_stringf(" <%s>%c %c </%s><%s>%4d gold   %s%s%s</%s>",
                             keystr.c_str(),
                             hotkeys[0],
                             selected() ? '+' : on_list ? '$' : '-',
@@ -1030,6 +1051,7 @@ class ShopEntry : public InvEntry
                             cost,
                             text.c_str(),
                             shop_item_unknown(*item) ? " (unknown)" : "",
+                            ownedstr.c_str(),
                             itemstr.c_str());
     }
 

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -864,36 +864,20 @@ static int _count_identical(const vector<item_def>& stock, const item_def& item)
 
 int shop_owned_consumable_count(const item_def& item)
 {
-    if (item.base_type == OBJ_POTIONS || item.base_type == OBJ_SCROLLS)
+    if (item.base_type == OBJ_WANDS)
     {
-        for (const item_def& inv : you.inv)
-        {
-            if (inv.base_type == item.base_type && inv.sub_type == item.sub_type
-                && inv.is_identified() == item.is_identified())
-            {
-                return inv.quantity;
-            }
-        }
-        return 0;
-    }
+        if (!item_type_known(item))
+            return 0;
 
-    if (item.base_type == OBJ_MISSILES && is_throwable(&you, item))
-    {
         for (const item_def& inv : you.inv)
-            if (items_stack(inv, item))
-                return inv.quantity;
-        return 0;
-    }
-
-    if (item.base_type == OBJ_WANDS && item_type_known(item))
-    {
-        for (const item_def& inv : you.inv)
-        {
             if (inv.base_type == OBJ_WANDS && inv.sub_type == item.sub_type)
                 return inv.charges;
-        }
         return 0;
     }
+
+    for (const item_def& inv : you.inv)
+        if (items_stack(inv, item))
+            return inv.quantity;
 
     return 0;
 }
@@ -1060,9 +1044,9 @@ class ShopEntry : public InvEntry
         const int owned = shop_owned_consumable_count(*item);
         const string ownedstr = owned > 0
             ? item->base_type == OBJ_WANDS
-                ? make_stringf("  (owned: %d charge%s)", owned,
+                ? make_stringf(" (owned: %d charge%s)", owned,
                                owned == 1 ? "" : "s")
-                : make_stringf("  (owned: %d)", owned)
+                : make_stringf(" (owned: %d)", owned)
             : "";
         return make_stringf(" <%s>%c %c </%s><%s>%4d gold   %s%s%s</%s>",
                             keystr.c_str(),

--- a/crawl-ref/source/shopping.cc
+++ b/crawl-ref/source/shopping.cc
@@ -864,19 +864,38 @@ static int _count_identical(const vector<item_def>& stock, const item_def& item)
 
 int shop_owned_consumable_count(const item_def& item)
 {
-    if (item.base_type != OBJ_POTIONS && item.base_type != OBJ_SCROLLS)
-        return 0;
-
-    int count = 0;
-    for (const item_def& inv : you.inv)
+    if (item.base_type == OBJ_POTIONS || item.base_type == OBJ_SCROLLS)
     {
-        if (inv.base_type == item.base_type && inv.sub_type == item.sub_type
-            && inv.is_identified() == item.is_identified())
+        for (const item_def& inv : you.inv)
         {
-            count += inv.quantity;
+            if (inv.base_type == item.base_type && inv.sub_type == item.sub_type
+                && inv.is_identified() == item.is_identified())
+            {
+                return inv.quantity;
+            }
         }
+        return 0;
     }
-    return count;
+
+    if (item.base_type == OBJ_MISSILES && is_throwable(&you, item))
+    {
+        for (const item_def& inv : you.inv)
+            if (items_stack(inv, item))
+                return inv.quantity;
+        return 0;
+    }
+
+    if (item.base_type == OBJ_WANDS && item_type_known(item))
+    {
+        for (const item_def& inv : you.inv)
+        {
+            if (inv.base_type == OBJ_WANDS && inv.sub_type == item.sub_type)
+                return inv.charges;
+        }
+        return 0;
+    }
+
+    return 0;
 }
 
 /** Buy an item from a shop!
@@ -1040,7 +1059,10 @@ class ShopEntry : public InvEntry
             colour_to_str(menu_colour(text, item_prefix(*item, false), tag, false));
         const int owned = shop_owned_consumable_count(*item);
         const string ownedstr = owned > 0
-            ? make_stringf("  <cyan>(owned: %d)</cyan>", owned)
+            ? item->base_type == OBJ_WANDS
+                ? make_stringf("  (owned: %d charge%s)", owned,
+                               owned == 1 ? "" : "s")
+                : make_stringf("  (owned: %d)", owned)
             : "";
         return make_stringf(" <%s>%c %c </%s><%s>%4d gold   %s%s%s</%s>",
                             keystr.c_str(),

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -13,6 +13,7 @@
 using std::vector;
 
 struct shop_struct;
+struct item_def;
 
 int artefact_value(const item_def &item);
 
@@ -26,6 +27,8 @@ int item_price(const item_def& item, const shop_struct& shop);
 // curse scrolls are worthless for everyone, most potions aren't worthless
 // for mummies, etcetera.
 bool is_worthless_consumable(const item_def &item);
+// Return how many matching potions or scrolls are currently in the inventory.
+int shop_owned_consumable_count(const item_def &item);
 
 void shop();
 void shop(shop_struct& shop, const level_pos& pos);

--- a/crawl-ref/source/shopping.h
+++ b/crawl-ref/source/shopping.h
@@ -27,7 +27,7 @@ int item_price(const item_def& item, const shop_struct& shop);
 // curse scrolls are worthless for everyone, most potions aren't worthless
 // for mummies, etcetera.
 bool is_worthless_consumable(const item_def &item);
-// Return how many matching potions or scrolls are currently in the inventory.
+// Return how many matching items are currently in the inventory.
 int shop_owned_consumable_count(const item_def &item);
 
 void shop();


### PR DESCRIPTION
When looking through a shop, it is useful to know how
many of an item are already in your inventory. This adds that count to
the shop entry when it is non-zero.

For example:
potion of haste  (owned: 2)

The count is  shown for potions, scrolls, wand charges and throwables. It also respects
identification state, so it cannot reveal the type of an unknown item.

Tested with make catch2-tests, and manually in wizard mode with spawned shops.