### PR TITLE
Mapstat improvements and dungeon connectivity checks

### DIFF
--- a/crawl-ref/source/dbg-maps.cc
+++ b/crawl-ref/source/dbg-maps.cc
@@ -13,8 +13,11 @@
 #include "dbg-objstat.h"
 #include "dungeon.h"
 #include "env.h"
+#include "files.h"
 #include "initfile.h"
+#include "item-prop.h"
 #include "libutil.h"
+#include "los.h"
 #include "maps.h"
 #include "map-knowledge.h"
 #include "message.h"
@@ -49,6 +52,8 @@ static int levels_tried = 0, levels_failed = 0;
 static int build_attempts = 0, level_vetoes = 0;
 // Map from message to counts.
 static map<string, int> veto_messages;
+// Map from message to one (seed, level) example of it happening.
+static map<string, pair<uint64_t, level_id>> veto_examples;
 
 void mapstat_report_map_build_start()
 {
@@ -60,6 +65,8 @@ void mapstat_report_map_veto(const string &message)
 {
     level_vetoes++;
     ++veto_messages[message];
+    veto_examples.emplace(message,
+                           make_pair(crawl_state.seed, level_id::current()));
     map_builds[level_id::current()].second++;
 }
 
@@ -94,6 +101,9 @@ static bool _do_build_level()
         mprf(MSGCH_WARN, "User requested cancel");
         return false;
     }
+
+    // Invalidate the LoS cache for the new level.
+    los_changed();
 
     ++levels_tried;
     if (!builder())
@@ -181,24 +191,26 @@ static bool _do_build_level()
     return true;
 }
 
-static void _dungeon_places()
+static void _populate_generated_levels()
 {
     generated_levels.clear();
     branch_count = 0;
-    for (branch_iterator it; it; ++it)
+    set<branch_type> handled;
+
+    auto add_branch = [&](branch_type br)
     {
-        if (brdepth[it->id] == -1)
-            continue;
+        if (br == NUM_BRANCHES || brdepth[br] == -1 || !handled.insert(br).second)
+            return;
 #if TAG_MAJOR_VERSION == 34
         // Don't want to include branches that no longer generate.
-        if (branch_is_unfinished(it->id))
-            continue;
+        if (branch_is_unfinished(br))
+            return;
 #endif
 
         bool new_branch = true;
-        for (int depth = 1; depth <= brdepth[it->id]; ++depth)
+        for (int depth = 1; depth <= brdepth[br]; ++depth)
         {
-            level_id l(it->id, depth);
+            level_id l(br, depth);
             if (SysEnv.map_gen_range && !SysEnv.map_gen_range->is_usable_in(l))
                 continue;
             generated_levels.push_back(l);
@@ -206,7 +218,39 @@ static void _dungeon_places()
                 ++branch_count;
             new_branch = false;
         }
+    };
+
+    // First go through the real game's generation order.
+    for (branch_type br : dgn_branch_generation_order())
+        if (dgn_branch_will_generate(br))
+            add_branch(br);
+    // These portals will be added from the branches as we go.
+    const auto &portals = dgn_portal_generation_order();
+    // Now generate everything that we didn't generate before.
+    for (branch_iterator it; it; ++it)
+    {
+        if (find(portals.begin(), portals.end(), it->id) != portals.end())
+            continue;
+        add_branch(it->id);
     }
+}
+
+static bool _build_portals_entered_from(const level_id &parent)
+{
+    update_portal_entrances();
+    for (branch_type b : dgn_portal_generation_order())
+    {
+        if (brentry[b] != parent || brdepth[b] == -1)
+            continue;
+        for (int depth = 1; depth <= brdepth[b]; ++depth)
+        {
+            you.where_are_you = b;
+            you.depth = depth;
+            if (!_do_build_level())
+                return false;
+        }
+    }
+    return true;
 }
 
 static bool _build_dungeon()
@@ -216,6 +260,9 @@ static bool _build_dungeon()
         you.where_are_you = lid.branch;
         you.depth = lid.depth;
         if (!_do_build_level())
+            return false;
+
+        if (!_build_portals_entered_from(lid))
             return false;
     }
     return true;
@@ -236,8 +283,6 @@ static bool _build_dungeon()
 */
 bool mapstat_build_levels()
 {
-    if (!generated_levels.size())
-        _dungeon_places();
     printf("Iteration: ");
     fflush(stdout);
     for (int i = 0; i < SysEnv.map_gen_iters; ++i)
@@ -272,7 +317,11 @@ bool mapstat_build_levels()
         rng::reset();
         you.game_seed = crawl_state.seed;
 
+        initialise_item_sets(true);
+
         initial_dungeon_setup();
+
+        _populate_generated_levels();
 
         if (!_build_dungeon())
             return false;
@@ -422,7 +471,12 @@ static void _write_map_stats()
             sortedreasons.insert(make_pair(entry.second, entry.first));
 
         for (auto i = sortedreasons.rbegin(); i != sortedreasons.rend(); ++i)
-            fprintf(outf, "%3d) %s\n", i->first, i->second.c_str());
+        {
+            const auto &example = veto_examples[i->second];
+            fprintf(outf, "%3d) %s (e.g. seed %" PRIu64 " on %s)\n", i->first,
+                    i->second.c_str(), example.first,
+                    example.second.describe().c_str());
+        }
     }
 
     if (!unused_maps.empty() && !SysEnv.map_gen_range)
@@ -529,13 +583,10 @@ void mapstat_generate_stats()
         return;
 
     initialise_item_descriptions();
-    initialise_branch_depths();
 
     // We have to run map preludes ourselves.
     run_map_global_preludes();
     run_map_local_preludes();
-
-    _dungeon_places();
 
     clear_messages();
     mpr("Generating dungeon map stats");

--- a/crawl-ref/source/dbg-maps.cc
+++ b/crawl-ref/source/dbg-maps.cc
@@ -224,24 +224,22 @@ static void _populate_generated_levels()
     for (branch_type br : dgn_branch_generation_order())
         if (dgn_branch_will_generate(br))
             add_branch(br);
-    // These portals will be added from the branches as we go.
-    const auto &portals = dgn_portal_generation_order();
-    // Now generate everything that we didn't generate before.
+    // Now add everything else. Note that in the case of portals, we may build
+    // them before we reach them in the order, in which case they'll be
+    // skipped.
     for (branch_iterator it; it; ++it)
-    {
-        if (find(portals.begin(), portals.end(), it->id) != portals.end())
-            continue;
         add_branch(it->id);
-    }
 }
 
-static bool _build_portals_entered_from(const level_id &parent)
+static bool _build_portals_entered_from(const level_id &parent,
+                                        set<branch_type> &built_portals)
 {
     update_portal_entrances();
     for (branch_type b : dgn_portal_generation_order())
     {
         if (brentry[b] != parent || brdepth[b] == -1)
             continue;
+        built_portals.insert(b);
         for (int depth = 1; depth <= brdepth[b]; ++depth)
         {
             you.where_are_you = b;
@@ -255,15 +253,27 @@ static bool _build_portals_entered_from(const level_id &parent)
 
 static bool _build_dungeon()
 {
+    set<branch_type> built_portals;
     for (const level_id &lid: generated_levels)
     {
+        // Skip if this is a portal already built.
+        if (built_portals.count(lid.branch))
+            continue;
+
         you.where_are_you = lid.branch;
         you.depth = lid.depth;
         if (!_do_build_level())
             return false;
 
-        if (!_build_portals_entered_from(lid))
+        // If building the whole dungeon, build portals off the side. This
+        // allows us to perfectly match a game's pregeneration.
+        // Since we don't pregenerate multiple use portals, we do still end
+        // up building each portal exactly once.
+        if (!SysEnv.map_gen_range
+            && !_build_portals_entered_from(lid, built_portals))
+        {
             return false;
+        }
     }
     return true;
 }
@@ -590,6 +600,10 @@ void mapstat_generate_stats()
 
     clear_messages();
     mpr("Generating dungeon map stats");
+
+    // Populate level generation order to get the count.
+    initial_dungeon_setup();
+    _populate_generated_levels();
     printf("Generating map stats for %d iteration(s) of %d level(s) over "
            "%d branch(es).\n", SysEnv.map_gen_iters,
            (int) generated_levels.size(), branch_count);

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -2446,6 +2446,13 @@ static void _dgn_verify_connectivity(unsigned nvaults)
         }
     }
 
+    if (_branch_needs_stairs() && !_fixup_stone_stairs(true))
+    {
+        dprf(DIAG_DNGN, "Warning: failed to preserve vault stairs.");
+        if (!_fixup_stone_stairs(false))
+            throw dgn_veto_exception("Failed to fix stone stairs.");
+    }
+
     // Also check for isolated regions that have no stairs.
     if (player_in_connected_branch()
         && !(branches[you.where_are_you].branch_flags & brflag::islanded)
@@ -2464,13 +2471,6 @@ static void _dgn_verify_connectivity(unsigned nvaults)
                                        _dgn_square_is_passable_with_traps) > 0)
     {
         throw dgn_veto_exception("Isolated trap areas with no stairs.");
-    }
-
-    if (_branch_needs_stairs() && !_fixup_stone_stairs(true))
-    {
-        dprf(DIAG_DNGN, "Warning: failed to preserve vault stairs.");
-        if (!_fixup_stone_stairs(false))
-            throw dgn_veto_exception("Failed to fix stone stairs.");
     }
 
     if (!_branch_entrances_are_connected())

--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -1111,7 +1111,7 @@ static bool _is_upwards_exit_stair(const coord_def &c)
     }
 }
 
-static bool _is_exit_stair(const coord_def &c)
+static bool _is_exit_stair(const coord_def &c, bool allow_hatch)
 {
     const dungeon_feature_type feat = feat_at_no_mimic(c);
 
@@ -1122,7 +1122,7 @@ static bool _is_exit_stair(const coord_def &c)
     // stairs here, as they do not provide an exit (in a transitive sense) from
     // the current level.
     if (feat_is_stone_stair(feat)
-        || feat_is_escape_hatch(feat)
+        || (allow_hatch && feat_is_escape_hatch(feat))
         || feat_is_branch_exit(feat))
     {
         return true;
@@ -1139,61 +1139,148 @@ static bool _is_exit_stair(const coord_def &c)
     }
 }
 
-// Counts the number of mutually unreachable areas in the map,
-// excluding isolated zones within vaults (we assume the vault author
-// knows what she's doing). This is an easy way to check whether a map
-// has isolated parts of the level that were not formerly isolated.
-//
-// All squares within vaults are treated as non-reachable, to simplify
-// life, because vaults may change the level layout and isolate
-// different areas without changing the number of isolated areas.
-// Here's a before and after example of such a vault that would cause
-// problems if we considered floor in the vault as non-isolating (the
-// vault is represented as V for walls and o for floor squares in the
-// vault).
-//
-// Before:
-//
-//   xxxxx    xxxxx
-//   x<..x    x.2.x
-//   x.1.x    xxxxx  3 isolated zones
-//   x>..x    x.3.x
-//   xxxxx    xxxxx
-//
-// After:
-//
-//   xxxxx    xxxxx
-//   x<1.x    x.2.x
-//   VVVVVVVVVVoooV  3 isolated zones, but the isolated zones are different.
-//   x>3.x    x...x
-//   xxxxx    xxxxx
-//
-// If count_stairless is true, returns the number of regions that have no
-// stairs in them.
-//
-// If fill is non-zero, it fills any disconnected regions with fill.
-//
-// TODO: refactor this to something more usable
-static int _process_disconnected_zones(int x1, int y1, int x2, int y2,
+static bool _is_exit_stair_or_hatch(const coord_def &c)
+{
+    return _is_exit_stair(c, true);
+}
+
+static bool _is_exit_stair_no_hatch(const coord_def &c)
+{
+    return _is_exit_stair(c, false);
+}
+
+// How _process_disconnected_zones should overwrite a disconnected zone it
+// finds, if at all.
+struct fill_config
+{
+    fill_config(dungeon_feature_type fill_ = DNGN_UNSEEN,
+                bool (*fill_check_)(const coord_def &) = nullptr,
+                int fill_small_zones_ = 0)
+        : fill(fill_), fill_check(fill_check_),
+          fill_small_zones(fill_small_zones_)
+    {
+    }
+
+    // The feature to overwrite the zone with. DNGN_UNSEEN means don't fill.
+    dungeon_feature_type fill;
+    // If set, only squares passing this check are overwritten.
+    bool (*fill_check)(const coord_def &);
+    // If positive, only zones up to this size are filled.
+    int fill_small_zones;
+};
+
+// Fill in a zone, if it has no vaults.
+static void _fill_zone(int zone_num, const fill_config &cfg)
+{
+    vector<coord_def> coords;
+    dprf("Filling zone %d", zone_num);
+    for (int fy = 0; fy < GYM; ++fy)
+    {
+        for (int fx = 0; fx < GXM; ++fx)
+        {
+            if (travel_point_distance[fx][fy] != zone_num)
+                continue;
+            if (map_masked(coord_def(fx, fy), MMT_VAULT))
+                return;
+            if (!cfg.fill_check || cfg.fill_check(coord_def(fx, fy)))
+                coords.emplace_back(fx, fy);
+        }
+    }
+
+    for (auto c : coords)
+    {
+        // For normal builder scenarios items shouldn't be
+        // placed yet, but it could (if not careful) happen
+        // in weirder cases, such as the abyss.
+        if (env.igrid(c) != NON_ITEM
+            && (!feat_is_traversable(cfg.fill)
+                || feat_destroys_items(cfg.fill)))
+        {
+            // Alternatively, could place floor instead?
+            dprf("Nuke item stack at (%d, %d)", c.x, c.y);
+            lose_item_stack(c);
+        }
+        _set_grd(c, cfg.fill);
+        if (env.mgrid(c) != NON_MONSTER
+            && !env.mons[env.mgrid(c)].is_habitable_feat(cfg.fill))
+        {
+            monster_die(env.mons[env.mgrid(c)],
+                        KILL_RESET, NON_MONSTER, true, false,
+                        true);
+        }
+    }
+}
+
+/**
+ * Counts the number of mutually unreachable areas in the map,
+ * excluding isolated zones within vaults (we assume the vault author
+ * knows what she's doing). This is an easy way to check whether a map
+ * has isolated parts of the level that were not formerly isolated.
+ *
+ * All squares within vaults are treated as non-reachable, to simplify
+ * life, because vaults may change the level layout and isolate
+ * different areas without changing the number of isolated areas.
+ * Here's a before and after example of such a vault that would cause
+ * problems if we considered floor in the vault as non-isolating (the
+ * vault is represented as V for walls and o for floor squares in the
+ * vault).
+ *
+ * Before:
+ *
+ *   xxxxx    xxxxx
+ *   x<..x    x.2.x
+ *   x.1.x    xxxxx  3 isolated zones
+ *   x>..x    x.3.x
+ *   xxxxx    xxxxx
+ *
+ * After:
+ *
+ *   xxxxx    xxxxx
+ *   x<1.x    x.2.x
+ *   VVVVVVVVVVoooV  3 isolated zones, but the isolated zones are different.
+ *   x>3.x    x...x
+ *   xxxxx    xxxxx
+ *
+ * @param choose_stairless  If true, only count zones with no exit stair.
+ * @param fill_cfg          Whether and how to fill disconnected zones.
+ * @param passable          Whether a square can be walked through for
+ *                          connectivity.
+ * @param is_seed           Whether a square can start a new zone flood-fill;
+ *                          defaults to passable. This means that zones that
+ *                          are entirely passable but with no is_seed points
+ *                          will be ignored/
+ * @param count_hatches     For choose_stairless, whether hatches count as
+ *                          stairs.
+ * @param isolated_point    If choose_stairless, reports an arbirtary point in
+ *                          an arbitrary stairless zone.
+ * @return The number of zones.
+ */
+static int _process_disconnected_zones(
                 bool choose_stairless,
-                dungeon_feature_type fill,
+                const fill_config &fill_cfg,
                 bool (*passable)(const coord_def &) = _dgn_square_is_passable,
-                bool (*fill_check)(const coord_def &) = nullptr,
-                int fill_small_zones = 0)
+                bool (*is_seed)(const coord_def &) = nullptr,
+                bool count_hatches = true,
+                coord_def *isolated_point = nullptr)
 {
     memset(travel_point_distance, 0, sizeof(travel_distance_grid_t));
     int nzones = 0;
     int ngood = 0;
-    for (int y = y1; y <= y2 ; ++y)
+    if (!is_seed)
+        is_seed = passable;
+
+    bool (*stair_func)(const coord_def &) =
+                    !choose_stairless  ? nullptr :
+                    at_branch_bottom() ? _is_upwards_exit_stair :
+                    count_hatches      ? _is_exit_stair_or_hatch
+                                       : _is_exit_stair_no_hatch;
+
+    for (int y = 0; y < GYM; ++y)
     {
-        for (int x = x1; x <= x2; ++x)
+        for (int x = 0; x < GXM; ++x)
         {
-            if (!map_bounds(x, y)
-                || travel_point_distance[x][y]
-                || !passable(coord_def(x, y)))
-            {
+            if (travel_point_distance[x][y] || !is_seed(coord_def(x, y)))
                 continue;
-            }
 
             int zone_size = 0;
             auto inc_zone_size = [&zone_size](const coord_def &) { zone_size++; };
@@ -1202,66 +1289,22 @@ static int _process_disconnected_zones(int x1, int y1, int x2, int y2,
                 _dgn_fill_zone(coord_def(x, y), ++nzones,
                                inc_zone_size,
                                passable,
-                               choose_stairless ? (at_branch_bottom() ?
-                                                   _is_upwards_exit_stair :
-                                                   _is_exit_stair) : nullptr);
+                               stair_func);
 
             // If we want only stairless zones, screen out zones that did
             // have stairs.
             if (choose_stairless && found_exit_stair)
                 ++ngood;
-            else if (fill
-                && (fill_small_zones <= 0 || zone_size <= fill_small_zones))
+            else
             {
-                // Don't fill in areas connected to vaults.
-                // We want vaults to be accessible; if the area is disconnected
-                // from the rest of the level, this will cause the level to be
-                // vetoed later on.
-                bool veto = false;
-                vector<coord_def> coords;
-                dprf("Filling zone %d", nzones);
-                for (int fy = y1; fy <= y2 ; ++fy)
+                if (choose_stairless && isolated_point)
+                    *isolated_point = coord_def(x, y);
+
+                if (fill_cfg.fill
+                    && (fill_cfg.fill_small_zones <= 0
+                        || zone_size <= fill_cfg.fill_small_zones))
                 {
-                    for (int fx = x1; fx <= x2; ++fx)
-                    {
-                        if (travel_point_distance[fx][fy] == nzones)
-                        {
-                            if (map_masked(coord_def(fx, fy), MMT_VAULT))
-                            {
-                                veto = true;
-                                break;
-                            }
-                            else if (!fill_check || fill_check(coord_def(fx, fy)))
-                                coords.emplace_back(fx, fy);
-                        }
-                    }
-                    if (veto)
-                        break;
-                }
-                if (!veto)
-                {
-                    for (auto c : coords)
-                    {
-                        // For normal builder scenarios items shouldn't be
-                        // placed yet, but it could (if not careful) happen
-                        // in weirder cases, such as the abyss.
-                        if (env.igrid(c) != NON_ITEM
-                            && (!feat_is_traversable(fill)
-                                || feat_destroys_items(fill)))
-                        {
-                            // Alternatively, could place floor instead?
-                            dprf("Nuke item stack at (%d, %d)", c.x, c.y);
-                            lose_item_stack(c);
-                        }
-                        _set_grd(c, fill);
-                        if (env.mgrid(c) != NON_MONSTER
-                            && !env.mons[env.mgrid(c)].is_habitable_feat(fill))
-                        {
-                            monster_die(env.mons[env.mgrid(c)],
-                                        KILL_RESET, NON_MONSTER, true, false,
-                                        true);
-                        }
-                    }
+                    _fill_zone(nzones, fill_cfg);
                 }
             }
         }
@@ -1273,8 +1316,8 @@ static int _process_disconnected_zones(int x1, int y1, int x2, int y2,
 int dgn_count_tele_zones(bool choose_stairless)
 {
     dprf("Counting teleport zones");
-    return _process_disconnected_zones(0, 0, GXM-1, GYM-1, choose_stairless,
-                                    DNGN_UNSEEN, _dgn_square_is_tele_connected);
+    return _process_disconnected_zones(choose_stairless,
+                                    {}, _dgn_square_is_tele_connected);
 }
 
 // Count "teleport closets": regions a random teleport could strand the player
@@ -1296,7 +1339,7 @@ static int _count_tele_closets(vector<coord_def> *closets, bool flying,
     // Floodfill back from the exits to mark everywhere that isn't a closet.
     memset(travel_point_distance, 0, sizeof(travel_distance_grid_t));
     for (rectangle_iterator ri(0); ri; ++ri)
-        if ((_is_exit_stair(*ri) || env.grid(*ri) == DNGN_TRAP_TELEPORT_PERMANENT)
+        if ((_is_exit_stair_or_hatch(*ri) || env.grid(*ri) == DNGN_TRAP_TELEPORT_PERMANENT)
             && !travel_point_distance[ri->x][ri->y])
         {
             _dgn_fill_zone(*ri, 1, _dgn_point_record_stub, passable, nullptr, true);
@@ -1349,13 +1392,10 @@ static int _count_tele_closets(vector<coord_def> *closets, bool flying,
 }
 
 // Count number of mutually isolated zones. If choose_stairless, only count
-// zones with no stairs in them. If fill is set to anything other than
-// DNGN_UNSEEN, chosen zones will be filled with the provided feature.
-int dgn_count_disconnected_zones(bool choose_stairless,
-                                 dungeon_feature_type fill)
+// zones with no stairs in them.
+int dgn_count_disconnected_zones(bool choose_stairless)
 {
-    return _process_disconnected_zones(0, 0, GXM-1, GYM-1, choose_stairless,
-                                       fill);
+    return _process_disconnected_zones(choose_stairless, {});
 }
 
 static void _fill_small_disconnected_zones()
@@ -1363,10 +1403,9 @@ static void _fill_small_disconnected_zones()
     // debugging tip: change the feature to something like lava that will be
     // very noticeable.
     // TODO: make even more aggressive, up to ~25?
-    _process_disconnected_zones(0, 0, GXM-1, GYM-1, true, DNGN_ROCK_WALL,
-                                       _dgn_square_is_passable,
-                                       _dgn_square_is_boring,
-                                       10);
+    _process_disconnected_zones(true,
+                                {DNGN_ROCK_WALL, _dgn_square_is_boring, 10},
+                                _dgn_square_is_passable);
 }
 
 static void _fixup_hell_stairs()
@@ -2466,9 +2505,8 @@ static void _dgn_verify_connectivity(unsigned nvaults)
     // stairs, counting traps as passable.
     if (player_in_connected_branch()
         && !(branches[you.where_are_you].branch_flags & brflag::islanded)
-        && _process_disconnected_zones(0, 0, GXM - 1, GYM - 1, true,
-                                       DNGN_UNSEEN,
-                                       _dgn_square_is_passable_with_traps) > 0)
+        && _process_disconnected_zones(true,
+                                       {}, _dgn_square_is_passable_with_traps) > 0)
     {
         throw dgn_veto_exception("Isolated trap areas with no stairs.");
     }
@@ -2478,6 +2516,28 @@ static void _dgn_verify_connectivity(unsigned nvaults)
 
     if (!_add_connecting_escape_hatches())
         throw dgn_veto_exception("Failed to add connecting escape hatches.");
+
+    // Finally check that we don't have regions with solid floor that can't be
+    // reached, even by flying over lava/deep water, without non-hatch stairs.
+    // This aims to remove areas that the player will never see.
+    if (player_in_connected_branch()
+        && !(branches[you.where_are_you].branch_flags & brflag::islanded))
+    {
+        coord_def isolated_point;
+        if (_process_disconnected_zones(true,
+                                        {}, _dgn_square_is_ever_passable,
+                                        _dgn_square_is_passable,
+                                        false,
+                                        &isolated_point) > 0)
+        {
+
+            const vault_placement *vp = dgn_vault_at(isolated_point);
+            const string in_vault =
+                vp ? " in vault " + vp->map_name_at(isolated_point) : "";
+            throw dgn_veto_exception(make_stringf(
+                "Isolated areas%s without non-hatch stairs.", in_vault.c_str()));
+        }
+    }
 
     // Check for zones you can teleport into and not walk/fly out of.
     if (player_in_connected_branch()
@@ -4895,13 +4955,13 @@ static const vault_placement *_build_vault_impl(const map_def *vault,
     if (!build_only && (placed_vault_orientation != MAP_ENCOMPASS || is_layout)
         && player_in_branch(BRANCH_SWAMP))
     {
-        _process_disconnected_zones(0, 0, GXM-1, GYM-1, true, DNGN_MANGROVE);
+        _process_disconnected_zones(true, {DNGN_MANGROVE});
         // do a second pass to remove tele closets consisting of deep water
         // created by the first pass -- which will not fill in deep water
         // because it is treated as impassable.
         // TODO: get zonify to prevent these?
         // TODO: does this come up anywhere outside of swamp?
-        _process_disconnected_zones(0, 0, GXM-1, GYM-1, true, DNGN_MANGROVE,
+        _process_disconnected_zones(true, {DNGN_MANGROVE},
                 _dgn_square_is_ever_passable);
     }
 

--- a/crawl-ref/source/dungeon.h
+++ b/crawl-ref/source/dungeon.h
@@ -267,9 +267,7 @@ void dgn_reset_level(bool enable_random_maps = true);
 const vault_placement *dgn_register_place(const vault_placement &place,
                                           bool register_vault);
 
-int dgn_count_disconnected_zones(
-    bool choose_stairless,
-    dungeon_feature_type fill = DNGN_UNSEEN);
+int dgn_count_disconnected_zones(bool choose_stairless);
 
 int dgn_count_tele_zones(bool choose_stairless);
 

--- a/crawl-ref/source/files.cc
+++ b/crawl-ref/source/files.cc
@@ -1628,6 +1628,11 @@ static const vector<branch_type> portal_generation_order =
     BRANCH_DESOLATION,
 };
 
+const vector<branch_type> &dgn_portal_generation_order()
+{
+    return portal_generation_order;
+}
+
 void update_portal_entrances()
 {
     unordered_set<branch_type, std::hash<int>> seen_portals;
@@ -1853,6 +1858,19 @@ static const vector<branch_type> branch_generation_order =
     NUM_BRANCHES,
 };
 
+const vector<branch_type> &dgn_branch_generation_order()
+{
+    return branch_generation_order;
+}
+
+bool dgn_branch_will_generate(branch_type br)
+{
+    return br < NUM_BRANCHES &&
+        (brentry[br].is_valid()
+         || br == BRANCH_DUNGEON || br == BRANCH_VESTIBULE
+         || !is_connected_branch(br));
+}
+
 static bool _branch_pregenerates(branch_type b)
 {
     if (!you.deterministic_levelgen)
@@ -1911,10 +1929,7 @@ bool pregen_dungeon(const level_id &stopping_point)
         // `initialise_branch_depths` for some reason. The vestibule is invalid
         // because its depth isn't set until the player actually enters a
         // portal, similarly for other portal branches.
-        if (br < NUM_BRANCHES &&
-            (brentry[br].is_valid()
-             || br == BRANCH_DUNGEON || br == BRANCH_VESTIBULE
-             || !is_connected_branch(br)))
+        if (dgn_branch_will_generate(br))
         {
             for (int i = 1; i <= brdepth[br]; i++)
             {

--- a/crawl-ref/source/files.h
+++ b/crawl-ref/source/files.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "branch-type.h"
 #include "maybe-bool.h"
 
 struct player_save_info;
@@ -90,6 +91,9 @@ void update_portal_entrances();
 void reset_portal_entrances();
 bool generate_level(const level_id &l);
 bool pregen_dungeon(const level_id &stopping_point);
+const vector<branch_type> &dgn_branch_generation_order();
+const vector<branch_type> &dgn_portal_generation_order();
+bool dgn_branch_will_generate(branch_type br);
 bool load_level(dungeon_feature_type stair_taken, load_mode_type load_mode,
                 const level_id& old_level);
 void delete_level(const level_id &level);

--- a/crawl-ref/source/test/bstair-gen.lua
+++ b/crawl-ref/source/test/bstair-gen.lua
@@ -19,6 +19,5 @@ end
 
 test_branch_stair_places(niters,
                  { { "Depths:$", "enter_zot" },
-                   { "Depths:3", "enter_abyss" },
                    { "Depths:2", "enter_pandemonium" },
                    { "Depths:1", "enter_hell" } })


### PR DESCRIPTION
In this PR, we:

- Improve mapstat, to make it log seeds with behaviour matching a seeded game. This is helpful for understanding dungeon generation.
- Add a new connectivity check, that aims to prevent areas the player will never see at all without mapping etc
- Move stair culling before connectivity checks that rely on those stairs

For the new connectivity check, the veto rate is rather low - approximately 0.03% of all levels, or one every 20 or so games. In a random sample of 10 of these, 8 seem good and the other 2 are acceptable false positive from opaque vaults.

Here are a few examples of things it vetoes, which are roughly representative of the distribution:

Tiny disconnected area:
<img width="508" height="448" alt="image" src="https://github.com/user-attachments/assets/2f12e4a1-a4b0-4035-9c1d-3af0816a7b68" />

Large disconnected area:
<img width="512" height="449" alt="image" src="https://github.com/user-attachments/assets/28cd6afd-dac3-4628-9ff3-f8e87e9a1ff0" />

Disconnected Zig:
<img width="512" height="216" alt="image" src="https://github.com/user-attachments/assets/8d7845c8-e39a-49a5-b8c8-753482e480a0" />

False positive - appears disconnected to level gen due to an opaque vault:
<img width="512" height="366" alt="image" src="https://github.com/user-attachments/assets/7ba7ad4d-ac72-488d-9b3f-9d07350ac99a" />
