### PR TITLE
Only say the ground has solidified when it has.

### DIFF
--- a/crawl-ref/source/duration-data.h
+++ b/crawl-ref/source/duration-data.h
@@ -97,6 +97,13 @@ static void _end_exegesis()
     you.props.erase(EXEGESIS_SPELL);
 }
 
+static void _end_liquefaction()
+{
+    const char *prep = liquefied(you.pos(), true) ? "beneath" : "around";
+    mprf(MSGCH_DURATION, "The ground is no longer liquid %s you.", prep);
+    invalidate_agrid(false);
+}
+
 // properties of the duration.
 enum duration_flags : uint32_t
 {
@@ -427,9 +434,7 @@ static const duration_def duration_data[] =
       LIGHTBLUE, "Liquid",
       "liquefying", "",
       "You are liquefying the ground beneath you.", D_DISPELLABLE,
-      {{ "The ground is no longer liquid beneath you.", []() {
-          invalidate_agrid(false);
-      }}}},
+      {{"", _end_liquefaction}}},
     { DUR_HEROISM,
       LIGHTBLUE, "Hero",
       "heroic", "heroism",


### PR DESCRIPTION
If Leda's Liquefaction does not affect the terrain at the player's location, nothing changes as it expires.

Reflect this in this case by saying that the ground "around" you is no longer liquid rather than specifically that "beneath" you.

This mirrors the message given when the spell is cast.