### PR TITLE
Make a note if the a noteworthy skill level is passed through.

### DIFF
--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -1692,7 +1692,7 @@ static void _sdump_skill_gains(dump_params &par)
             xl = note.first;
         else if (note.type == NOTE_GAIN_SKILL || note.type == NOTE_LOSE_SKILL)
         {
-            skill_type skill = static_cast<skill_type>(note.first);
+            skill_type skill = str_to_skill(note.name);
             int skill_level = note.second;
             if (skill_gains.find(skill) == skill_gains.end())
                 skill_order.push_back(skill);

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -795,6 +795,7 @@ static void _sdump_screenshots(dump_params &par)
 
     text += "Illustrated notes\n\n";
 
+    Note::reset();
     for (const Note &note : note_list)
     {
         if (note.hidden() || note.type != NOTE_USER_NOTE || note.screen.length() == 0)
@@ -818,6 +819,7 @@ static void _sdump_notes(dump_params &par)
     text += "Notes\n";
     text += "Turn   | Place    | Note\n";
     text += "-------+----------+-------------------------------------------\n";
+    Note::reset();
     for (const Note &note : note_list)
     {
         if (note.hidden())
@@ -1953,6 +1955,7 @@ void display_notes()
     const string tag = "notes";
     scr.set_tag(tag);
     _add_text(scr, tag, "Turn   | Place    | Note\n");
+    Note::reset();
     for (const Note &note : note_list)
     {
         if (note.hidden())

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -32,15 +32,11 @@
 vector<Note> note_list;
 int last_screen_turn = -1;
 
-static bool _is_highest_skill(int skill)
+static bool _is_highest_skill(int level)
 {
-    for (int i = 0; i < NUM_SKILLS; ++i)
-    {
-        if (i == skill)
-            continue;
-        if (you.skills[i] >= you.skills[skill])
-            return false;
-    }
+    if (level <= Note::max_skill)
+        return false;
+    Note::max_skill = level;
     return true;
 }
 
@@ -460,7 +456,7 @@ bool Note::hidden() const
             if (Options.note_skill_levels[i])
                 return false;
         return !(Options.note_all_skill_levels
-                 || Options.note_skill_max && _is_highest_skill(first));
+                 || Options.note_skill_max && _is_highest_skill(second));
     }
     // Hide gems being shattered by default.
     if (type == NOTE_GEM_LOST)
@@ -541,6 +537,7 @@ void Note::load(reader& inf)
 
 }
 
+int Note::max_skill = 0;
 static bool notes_active = false;
 
 bool notes_are_active()

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -292,8 +292,7 @@ string Note::describe(bool when, bool where, bool what) const
                    << (first == 1 ? "" : "s") << " to Zin";
             break;
         case NOTE_GAIN_SKILL:
-            result << "Reached skill level " << second
-                   << " in " << skill_name(static_cast<skill_type>(first));
+            result << "Reached skill level " << second << " in " << name;
             break;
         case NOTE_LOSE_SKILL:
             result << "Reduced skill "
@@ -457,8 +456,10 @@ bool Note::hidden() const
     // Hide skill gains that are not enabled by options.
     if (type == NOTE_GAIN_SKILL || type == NOTE_LOSE_SKILL)
     {
+        for (int i = first + 1; i <= second; ++i)
+            if (Options.note_skill_levels[i])
+                return false;
         return !(Options.note_all_skill_levels
-                 || second <= 27 && Options.note_skill_levels[second]
                  || Options.note_skill_max && _is_highest_skill(first));
     }
     // Hide gems being shattered by default.

--- a/crawl-ref/source/notes.cc
+++ b/crawl-ref/source/notes.cc
@@ -531,6 +531,20 @@ void Note::load(reader& inf)
 #if TAG_MAJOR_VERSION == 34
     if (inf.getMinorVersion() >= TAG_MINOR_MORGUE_SCREENSHOTS)
         screen = unmarshallString(inf);
+    if (inf.getMinorVersion() < TAG_MINOR_SKILL_CHANGE_RANGE
+        && (NOTE_GAIN_SKILL == type || NOTE_LOSE_SKILL == type))
+    {
+        name = skill_name(static_cast<skill_type>(first));
+        first = 0;
+        for (auto np = note_list.rbegin(); np < note_list.rend(); ++np)
+        {
+            if (type == np->type && name == np->name)
+            {
+                first = np->second;
+                break;
+            }
+        }
+    }
 #else
     screen = unmarshallString(inf);
 #endif

--- a/crawl-ref/source/notes.h
+++ b/crawl-ref/source/notes.h
@@ -97,6 +97,9 @@ struct Note
     string name;
     string desc;
     string screen;
+
+    static int max_skill;
+    static void reset() { max_skill = 0; }
 };
 
 extern vector<Note> note_list;

--- a/crawl-ref/source/skills.cc
+++ b/crawl-ref/source/skills.cc
@@ -322,10 +322,11 @@ static void _change_skill_level(skill_type exsk, int n)
     ASSERT(n != 0);
     bool need_reset = false;
 
+    unsigned old_skill_level = you.skills[exsk];
     you.skills[exsk] = max(0, you.skills[exsk] + n);
 
     take_note(Note(n > 0 ? NOTE_GAIN_SKILL : NOTE_LOSE_SKILL,
-                   exsk, you.skills[exsk]));
+                   old_skill_level, you.skills[exsk], skill_name(exsk)));
 
     // are you drained/crosstrained/ash'd in the relevant skill?
     const bool specify_base = you.skill(exsk, 1) != you.skill(exsk, 1, true);

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -362,6 +362,7 @@ enum tag_minor_version
     TAG_MINOR_LURKER_MONSTERS,     // Add support for lurker monsters
     TAG_MINOR_FIX_UNCANCELS,       // Fix monsters sometimes getting their turn before the effect of the players action
     TAG_MINOR_MIMIC_PROP,          // Move flag for mimics from env.level_map_mask to env.pgrid
+    TAG_MINOR_SKILL_CHANGE_RANGE,  // Skill change notes list an X-Y range.
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1


### PR DESCRIPTION
Generate a note for passing through a skill level in the note_skill_levels option as well as for reaching one. As before, the note states the skill level reached.

This means that (say) in Arena of Blood with default options, the message "Your Fighting skill gained 11 levels and is now at level 13!" is accompanied by the note "Reached skill level 13 in Fighting" rather than no note at all.
