### PR TITLE
Hide tile-only keys in the level map help outside tile mode.

### DIFF
--- a/crawl-ref/source/dat/database/help.txt
+++ b/crawl-ref/source/dat/database/help.txt
@@ -157,8 +157,10 @@ level-map
              (Moves cursor to the staircase destination if a known staircase is
              highlighted.)
 <w>G</w>          : View another level by choosing a branch and depth.
-<w>o</w>          : Move the cursor to the next autoexplore target.
-<w>{</w> or <w>}</w>     : Zoom out or in (tiles only).
+<w>o</w>          : Move the cursor to the next autoexplore target.{{
+if crawl.is_tiles() then
+    return "\n<w>{</w> or <w>}</w>     : Zoom out or in."
+end }}
 
 <h>Travel exclusions</h>
 <w>e</w>          : Create a travel exclusion, change its radius, or remove it.


### PR DESCRIPTION
The [ and ] keys had been included in the help for the level map command with "(tiles only)" in their description. Drop this, and only show the text in tile modes.

This seems like an obvious improvement to me, but there may be a reason why it wasn't done years ago.