### PR TITLE
Use latest Windows SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,17 +533,6 @@ jobs:
       # But isn't in the path, so fix that:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
-      # From the troubleshooting tips:
-      # This link is Windows 8.1 SDK
-      # See e.g. https://github.com/actions/runner-images/issues/842#issuecomment-643382166
-      # and https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/
-      # TODO: Newer SDKs, such as Windows 10 and 11, are preinstalled
-      # Do we want to continue supporting 8.1?
-      - name: Install Windows 8.1 SDK
-        shell: powershell
-        run: |
-          Invoke-WebRequest -Method Get -Uri https://go.microsoft.com/fwlink/p/?LinkId=323507 -OutFile sdksetup.exe -UseBasicParsing
-          Start-Process -Wait sdksetup.exe -ArgumentList "/q", "/norestart", "/features", "OptionId.WindowsDesktopSoftwareDevelopmentKit", "OptionId.NetFxSoftwareDevelopmentKit"
       # Steps 5&6 from INSTALL.md's Visual Studio Section
       # See https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference?view=vs-2022
       - name: Build

--- a/crawl-ref/INSTALL.md
+++ b/crawl-ref/INSTALL.md
@@ -431,11 +431,7 @@ MSVC solution files are finicky. Opening the "All Configurations" or
 Troubleshooting tips:
 
 - Make sure Windows Universal C Runtime is installed in MSVC.
-- Make sure the Windows 8.1 SDK is installed in Visual Studio. This
-  doesn't appear to be available in the latest version of Visual Studio.
-  You can download it separately [from microsoft](
-  https://developer.microsoft.com/en-us/windows/downloads/sdk-archive/index-legacy#earlier-releases).
-- Use "Rebuild Solution" to make sure all files are rewritten
+- Make sure a Windows 10 or 11 SDK is installed in Visual Studio.
 - Make sure all projects use `/MD` (or `/MDd` for the debug version)
 - Make sure the appropriate (`/MD` or `/MDd`) CRT libraries are included for
   SDL, crawl, and

--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -38,7 +38,7 @@
     <ProjectGuid>{3189AF12-90EF-4D3E-BFEC-4AB90D7D32DA}</ProjectGuid>
     <RootNamespace>crawlref</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>

--- a/crawl-ref/source/MSVC/tilegen.vcxproj
+++ b/crawl-ref/source/MSVC/tilegen.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{DAE92A45-087B-445B-8E94-BA864173A73F}</ProjectGuid>
     <RootNamespace>tilegen</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/crawl-ref/source/contrib/MSVC/SDL.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/SDL.vcxproj
@@ -22,7 +22,7 @@
     <ProjectName>SDL2</ProjectName>
     <ProjectGuid>{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}</ProjectGuid>
     <RootNamespace>SDL</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="Common.props" />

--- a/crawl-ref/source/contrib/MSVC/SDL_image.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/SDL_image.vcxproj
@@ -22,7 +22,7 @@
     <ProjectName>SDL2_image</ProjectName>
     <ProjectGuid>{2BD5534E-00E2-4BEA-AC96-D9A92EA24696}</ProjectGuid>
     <RootNamespace>SDL2_image</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="Common.props" />

--- a/crawl-ref/source/contrib/MSVC/SDLmain.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/SDLmain.vcxproj
@@ -22,7 +22,7 @@
     <ProjectName>SDL2main</ProjectName>
     <ProjectGuid>{DA956FD3-E142-46F2-9DD5-C78BEBB56B7A}</ProjectGuid>
     <RootNamespace>SDLmain</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="Common.props" />

--- a/crawl-ref/source/contrib/MSVC/freetype.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/freetype.vcxproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Multithreaded|Win32'" Label="Configuration">

--- a/crawl-ref/source/contrib/MSVC/libpng.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/libpng.vcxproj
@@ -38,7 +38,7 @@
     <ProjectGuid>{D6973076-9317-4EF2-A0B8-B7A18AC0713E}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libpng</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="zlib.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/crawl-ref/source/contrib/MSVC/lua.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/lua.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A61349B6-4099-4688-AA1A-00D91397857D}</ProjectGuid>
     <RootNamespace>lua</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/crawl-ref/source/contrib/MSVC/pcre.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/pcre.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{A0FDC72E-0BE5-4542-B381-6A482DAC2125}</ProjectGuid>
     <RootNamespace>pcre</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/crawl-ref/source/contrib/MSVC/sqlite.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/sqlite.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{5783572B-479A-4EE8-8F16-1FDB24DDD1A0}</ProjectGuid>
     <RootNamespace>sqlite</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/crawl-ref/source/contrib/MSVC/zlib.vcxproj
+++ b/crawl-ref/source/contrib/MSVC/zlib.vcxproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3D9F174B-2909-4834-A3D7-892E8D442A5D}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='LIB Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Using the old Windows 8.1 SDK was causing MSVC build errors.