### PR TITLE
Add an `explore_stop` option to stop at traps when they enter your LOS

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -916,7 +916,7 @@ explore_item_greed = 10
         further away, if negative) when deciding whether to visit a square with
         an item or explore a new square.
 
-explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors,traps
+explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack
         (List option)
         Explore will stop for one of these conditions. Whatever you

--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -916,7 +916,7 @@ explore_item_greed = 10
         further away, if negative) when deciding whether to visit a square with
         an item or explore a new square.
 
-explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
+explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors,traps
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack
         (List option)
         Explore will stop for one of these conditions. Whatever you
@@ -968,6 +968,9 @@ explore_stop += greedy_pickup_smart,greedy_visited_item_stack
         artefacts: like items, but only for artefacts.
 
         runes: like items, but only for runes.
+
+        traps: like items, but only for unsafe traps. Does not stop at
+        shafts or webs or other traps if you are immune to them.
 
 explore_stop_pickup_ignore += <regex>, <regex>, ...
         (List option)

--- a/crawl-ref/source/explore-stop-options.h
+++ b/crawl-ref/source/explore-stop-options.h
@@ -49,4 +49,6 @@ enum explore_stop_options
     ES_TRANSPORTER               = 0x10000,
     ES_RUNELIGHT                 = 0x20000,
     ES_MUTATION_CATALYST         = 0x40000,
+    ES_TRAP                      = 0x80000,
+
 };

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3296,6 +3296,7 @@ void game_options::update_explore_stop_conditions()
         { "artefact", ES_ARTEFACT }, { "artefacts", ES_ARTEFACT },
         { "artifact", ES_ARTEFACT }, { "artifacts", ES_ARTEFACT },
         { "rune", ES_RUNE }, { "runes", ES_RUNE },
+        { "trap", ES_TRAP }, { "traps", ES_TRAP },
     };
     // convert the options list into a bitfield, and save it by side-effect
     // into game_options::explore_stop. List processing is handled by the

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -111,6 +111,13 @@ bool trap_is_safe(dungeon_feature_type type, const actor* act)
     return false;
 }
 
+bool trap_is_safe_from_afar(dungeon_feature_type type, const actor* act)
+{
+    return (type == DNGN_TRAP_SHAFT
+            || type == DNGN_TRAP_WEB
+            || trap_is_safe(type, act));
+}
+
 // When giving AF_CHAOTIC to monsters, skip holy monsters due to potential vamp
 // or draining attacks. They also need attacks that aren't already chaos brand.
 bool chaos_lace_criteria (monster* mon) {

--- a/crawl-ref/source/traps.cc
+++ b/crawl-ref/source/traps.cc
@@ -113,9 +113,11 @@ bool trap_is_safe(dungeon_feature_type type, const actor* act)
 
 bool trap_is_safe_from_afar(dungeon_feature_type type, const actor* act)
 {
-    return (type == DNGN_TRAP_SHAFT
-            || type == DNGN_TRAP_WEB
-            || trap_is_safe(type, act));
+    return type == DNGN_TRAP_SHAFT
+           || type == DNGN_TRAP_WEB
+           || type == DNGN_TRAP_TELEPORT
+           || type == DNGN_TRAP_TELEPORT_PERMANENT
+           || trap_is_safe(type, act);
 }
 
 // When giving AF_CHAOTIC to monsters, skip holy monsters due to potential vamp

--- a/crawl-ref/source/traps.h
+++ b/crawl-ref/source/traps.h
@@ -25,6 +25,7 @@ class monster;
 
 bool trap_is_bad_for_player(dungeon_feature_type trap);
 bool trap_is_safe(dungeon_feature_type trap, const actor* act = 0);
+bool trap_is_safe_from_afar(dungeon_feature_type trap, const actor* act = 0);
 void trigger_trap(actor& triggerer);
 
 bool chaos_lace_criteria(monster* mon);

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -5091,7 +5091,11 @@ void explore_discoveries::found_feature(const coord_def &pos,
         es_flags |= ES_MUTATION_CATALYST;
     }
     else if (ES_trap && feat_is_trap(feat) && !trap_is_safe(feat))
+    {
+        string desc = cleaned_feature_description(pos);
+        marked_feats.push_back(desc + ".");
         es_flags |= ES_TRAP;
+    }
 }
 
 void explore_discoveries::add_stair(

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -609,6 +609,7 @@ static bool _is_branch_stair(const coord_def& pos, const level_id &from)
 #define ES_branch (Options.explore_stop & ES_BRANCH)
 #define ES_rdoor  (Options.explore_stop & ES_RUNED_DOOR)
 #define ES_stack  (Options.explore_stop & ES_GREEDY_VISITED_ITEM_STACK)
+#define ES_trap   (Options.explore_stop & ES_TRAP)
 
 // Adds interesting stuff on the point p to explore_discoveries.
 static inline void _check_interesting_square(const coord_def pos,
@@ -5089,6 +5090,8 @@ void explore_discoveries::found_feature(const coord_def &pos,
         mutation_catalysts.emplace_back(cleaned_feature_description(pos), 1);
         es_flags |= ES_MUTATION_CATALYST;
     }
+    else if (ES_trap && feat_is_trap(feat) && !trap_is_safe(feat))
+        es_flags |= ES_TRAP;
 }
 
 void explore_discoveries::add_stair(

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -5090,7 +5090,7 @@ void explore_discoveries::found_feature(const coord_def &pos,
         mutation_catalysts.emplace_back(cleaned_feature_description(pos), 1);
         es_flags |= ES_MUTATION_CATALYST;
     }
-    else if (ES_trap && feat_is_trap(feat) && !trap_is_safe(feat))
+    else if (ES_trap && feat_is_trap(feat) && !trap_is_safe_from_afar(feat))
     {
         string desc = cleaned_feature_description(pos);
         marked_feats.push_back(desc + ".");

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -5092,8 +5092,7 @@ void explore_discoveries::found_feature(const coord_def &pos,
     }
     else if (ES_trap && feat_is_trap(feat) && !trap_is_safe_from_afar(feat))
     {
-        string desc = cleaned_feature_description(pos);
-        marked_feats.push_back(desc + ".");
+        traps.emplace_back(cleaned_feature_description(pos), 1);
         es_flags |= ES_TRAP;
     }
 }
@@ -5279,6 +5278,7 @@ bool explore_discoveries::stop_explore() const
     say_any(apply_quantities(runed_doors), "runed door");
     say_any(apply_quantities(runelights), "runelights");
     say_any(apply_quantities(mutation_catalysts), "mutation catalysts");
+    say_any(apply_quantities(traps), "traps");
 
     return true;
 }

--- a/crawl-ref/source/travel.h
+++ b/crawl-ref/source/travel.h
@@ -200,6 +200,7 @@ private:
     vector< named_thing<int> > transporters;
     vector< named_thing<int> > runelights;
     vector< named_thing<int> > mutation_catalysts;
+    vector< named_thing<int> > traps;
 
     vector<string> marker_msgs;
     vector<string> marked_feats;


### PR DESCRIPTION
This gives players the option to automatically stop the first time a trap is encountered while autoexploring. It is turned on by adding `explore_stop += traps` to the rc file.