### PR TITLE
extend explore_greedy_visit to control visiting shops and faded altars

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -891,16 +891,15 @@ travel_avoid_terrain = (shallow water | deep water)
         This option supports list syntax.
 
 explore_greedy = true
-        Greedy explore travels to items that are eligible for
-        autopickup in addition to exploring the level, but is
-        otherwise identical to regular explore. Explore greed is
-        disabled if autopickup is off (Ctrl-A).
+        Greedy explore travels to items that are eligible for autopickup and
+        features configured by explore_greedy_visit in addition to exploring
+        the level, but is otherwise identical to regular explore. Explore
+        greed is disabled if autopickup is off (Ctrl-A).
 
-explore_greedy_visit = artefacts,glowing_items
+explore_greedy_visit = artefacts,glowing_items,shops,faded_altars
 explore_greedy_visit += stacks
         (List option)
-        Greedy exploration will visit squares with items based on
-        these conditions.
+        Greedy exploration will visit squares based on these conditions.
 
         stacks: makes explore_greedy visit all stacks even if they don't
         necessarily have target auto pickup items
@@ -911,10 +910,16 @@ explore_greedy_visit += stacks
         artefacts: makes explore_greedy visit artefacts, even
         if not in a stack
 
+        shops: makes explore_greedy visit and enter shops whose inventory
+        is not yet known
+
+        faded_altars: makes explore_greedy visit and interact with faded
+        altars whose selection of gods is not yet known
+
 explore_item_greed = 10
-        Greedy exploration treats items as if they were this much closer (or
-        further away, if negative) when deciding whether to visit a square with
-        an item or explore a new square.
+        Greedy exploration treats  targets as if they were this much
+        closer (or further away, if negative) when deciding whether to visit
+        their square or explore a new square.
 
 explore_stop  = items,stairs,shops,altars,portals,branches,runed_doors
 explore_stop += greedy_pickup_smart,greedy_visited_item_stack

--- a/crawl-ref/source/explore-greedy-options.h
+++ b/crawl-ref/source/explore-greedy-options.h
@@ -13,4 +13,10 @@ enum explore_greedy_options
 
     // Greedy explore visits artefact items
     EG_ARTEFACT = 0x0004,
+
+    // Greedy explore visits and enters shops with unknown inventories
+    EG_SHOP = 0x0008,
+
+    // Greedy explore visits faded altars with unknown god selections
+    EG_FADED_ALTAR = 0x0010,
 };

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -568,7 +568,7 @@ const vector<GameOption*> game_options::build_options_list()
             false,
             [this]() { update_explore_stop_conditions(); }),
         new ListGameOption<string>(ON_SET_NAME(explore_greedy_visit),
-            {"glowing", "artefact"},
+            {"glowing", "artefact", "shop", "faded_altar"},
             false,
             [this]() { update_explore_greedy_visit_conditions(); }),
         new ListGameOption<string>(ON_SET_NAME(travel_avoid_terrain), {}, false,
@@ -3325,6 +3325,9 @@ void game_options::update_explore_greedy_visit_conditions()
         { "artifact", EG_ARTEFACT }, { "artifacts", EG_ARTEFACT },
         { "stack", EG_STACK }, { "stacks", EG_STACK },
         { "pile", EG_STACK }, { "piles", EG_STACK },
+        { "shop", EG_SHOP }, { "shops", EG_SHOP },
+        { "faded_altar", EG_FADED_ALTAR },
+        { "faded_altars", EG_FADED_ALTAR },
     };
     int conditions = EG_NONE;
     for (const string &stop : explore_greedy_visit_option)

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -4074,11 +4074,20 @@ static void _choose_ecu_gods(CrawlVector &gods)
         gods.push_back(possible_gods[i]);
 }
 
+static string _ecu_altar_key(coord_def pos)
+{
+    return make_stringf("ecu-%d,%d", pos.x, pos.y);
+}
+
+bool faded_altar_is_visited(coord_def pos)
+{
+    return env.properties.exists(_ecu_altar_key(pos));
+}
+
 /// Returns a list of gods the player might get from the ecu altar at the given position.
 vector<god_type> get_ecu_gods(coord_def pos)
 {
-    const string key = make_stringf("ecu-%d,%d", pos.x, pos.y);
-    CrawlVector &saved_gods = env.properties[key].get_vector();
+    CrawlVector &saved_gods = env.properties[_ecu_altar_key(pos)].get_vector();
     if (saved_gods.empty())
         _choose_ecu_gods(saved_gods);
     vector<god_type> gods;

--- a/crawl-ref/source/religion.h
+++ b/crawl-ref/source/religion.h
@@ -77,6 +77,7 @@ void join_religion(god_type which_god);
 void god_pitch(god_type which_god);
 god_type choose_god(god_type def_god = NUM_GODS);
 vector<god_type> get_ecu_gods(coord_def pos);
+bool faded_altar_is_visited(coord_def pos);
 
 static inline bool you_worship(god_type god)
 {

--- a/crawl-ref/source/stash.cc
+++ b/crawl-ref/source/stash.cc
@@ -831,7 +831,8 @@ bool LevelStashes::shop_needs_visit(const coord_def& c) const
     return shop && !shop->is_visited();
 }
 
-bool LevelStashes::needs_visit(const coord_def& c, bool autopickup) const
+bool LevelStashes::needs_visit(const coord_def& c, bool autopickup,
+                              bool visit_shops) const
 {
     const Stash *s = find_stash(c);
     if (s && (s->unvisited()
@@ -839,7 +840,7 @@ bool LevelStashes::needs_visit(const coord_def& c, bool autopickup) const
     {
         return true;
     }
-    return shop_needs_visit(c);
+    return visit_shops && shop_needs_visit(c);
 }
 
 bool LevelStashes::needs_stop(const coord_def &c) const

--- a/crawl-ref/source/stash.h
+++ b/crawl-ref/source/stash.h
@@ -193,7 +193,8 @@ public:
 
     // Returns true if the square at c contains potentially interesting
     // swag that merits a personal visit (for EXPLORE_GREEDY).
-    bool  needs_visit(const coord_def& c, bool autopickup) const;
+    bool  needs_visit(const coord_def& c, bool autopickup,
+                      bool visit_shops) const;
     bool  shop_needs_visit(const coord_def& c) const;
 
     // Returns true if the items at c are not fully known to the stash-tracker

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -662,7 +662,8 @@ static bool _faded_altar_needs_visit(const coord_def& where)
 {
     return Options.explore_greedy_visit & EG_FADED_ALTAR
            && env.map_knowledge(where).feat() == DNGN_ALTAR_ECUMENICAL
-           && !faded_altar_is_visited(where);
+           && !faded_altar_is_visited(where)
+           && !you.has_mutation(MUT_FORLORN);
 }
 
 static bool _is_valid_explore_target(const coord_def& where)

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -658,6 +658,13 @@ void stop_running(bool clear_delays)
     you.running.stop(clear_delays);
 }
 
+static bool _faded_altar_needs_visit(const coord_def& where)
+{
+    return Options.explore_greedy_visit & EG_FADED_ALTAR
+           && env.map_knowledge(where).feat() == DNGN_ALTAR_ECUMENICAL
+           && !faded_altar_is_visited(where);
+}
+
 static bool _is_valid_explore_target(const coord_def& where)
 {
     // If a square in LOS is unmapped, it's valid.
@@ -668,7 +675,9 @@ static bool _is_valid_explore_target(const coord_def& where)
     if (you.running == RMODE_EXPLORE_GREEDY)
     {
         LevelStashes *lev = StashTrack.find_current_level();
-        return lev && lev->needs_visit(where, can_autopickup());
+        return (lev && lev->needs_visit(where, can_autopickup(),
+                       Options.explore_greedy_visit & EG_SHOP))
+               || _faded_altar_needs_visit(where);
     }
 
     return false;
@@ -1165,11 +1174,19 @@ command_type travel()
         }
 
         // Exploring.
-        if (env.grid(you.pos()) == DNGN_ENTER_SHOP
-            && you.running == RMODE_EXPLORE_GREEDY)
+        if (you.running == RMODE_EXPLORE_GREEDY)
         {
-            LevelStashes *lev = StashTrack.find_current_level();
-            if (lev && lev->shop_needs_visit(you.pos()))
+            bool auto_visit = false;
+            if (env.grid(you.pos()) == DNGN_ENTER_SHOP)
+            {
+                LevelStashes *lev = StashTrack.find_current_level();
+                auto_visit = Options.explore_greedy_visit & EG_SHOP
+                             && lev && lev->shop_needs_visit(you.pos());
+            }
+            else if (_faded_altar_needs_visit(you.pos()))
+                auto_visit = true;
+
+            if (auto_visit)
             {
                 you.running = 0;
                 return CMD_GO_UPSTAIRS;
@@ -1350,7 +1367,9 @@ travel_pathfind::~travel_pathfind()
 static bool _is_greed_inducing_square(const LevelStashes *ls,
                                       const coord_def &c, bool autopickup)
 {
-    return ls && ls->needs_visit(c, autopickup);
+    return (ls && ls->needs_visit(c, autopickup,
+                   Options.explore_greedy_visit & EG_SHOP))
+           || _faded_altar_needs_visit(c);
 }
 
 bool travel_pathfind::is_greed_inducing_square(const coord_def &c) const


### PR DESCRIPTION
i think it would be nice if autoexplore also visited ecumenical (faded) altars. Also added an option to control whether it visits shops.