### PR TITLE
Rework making sure squares don't get bad flavour during level gen

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -153,8 +153,6 @@ static dungeon_feature_type _vault_inspect_mapspec(vault_placement &place,
 static dungeon_feature_type _vault_inspect_glyph(int vgrid);
 
 static const map_def *_dgn_random_map_for_place(bool minivault);
-static void _dgn_load_colour_grid();
-static void _dgn_map_colour_fixup();
 
 static void _dgn_unregister_vault(const map_def &map);
 static void _remember_vault_placement(const vault_placement &place);
@@ -203,33 +201,7 @@ static int  dgn_zones = 0;
 static vector<string> _you_all_vault_list;
 #endif
 
-struct coloured_feature
-{
-    dungeon_feature_type feature;
-    int                  colour;
-
-    coloured_feature() : feature(DNGN_UNSEEN), colour(BLACK) { }
-    coloured_feature(dungeon_feature_type f, int c)
-        : feature(f), colour(c)
-    {
-    }
-};
-
-struct dgn_colour_override_manager
-{
-    dgn_colour_override_manager()
-    {
-        _dgn_load_colour_grid();
-    }
-
-    ~dgn_colour_override_manager()
-    {
-        _dgn_map_colour_fixup();
-    }
-};
-
-typedef FixedArray< coloured_feature, GXM, GYM > dungeon_colour_grid;
-static unique_ptr<dungeon_colour_grid> dgn_colour_grid;
+static FixedArray<dungeon_feature_type, GXM, GYM> _vault_placed_features;
 
 static string branch_epilogues[NUM_BRANCHES];
 FixedVector<string_set, NUM_BRANCHES> branch_uniq_map_tags;
@@ -436,6 +408,28 @@ bool builder(bool enable_random_maps)
     return false;
 }
 
+static void _dgn_fixup_map_flavour()
+{
+    for (rectangle_iterator ri(0); ri; ++ri)
+    {
+        const coord_def pos = *ri;
+
+        if (_vault_placed_features(pos) == DNGN_UNSEEN)
+            continue;
+
+        if (_vault_placed_features(pos) == env.grid(pos))
+            continue;
+
+        // The feature has been changed since the vault placed it. Reset any
+        // flavour that doesn't make sense for the new feature.
+        tile_env.flv(pos).feat = 0;
+        tile_env.flv(pos).feat_idx = 0;
+        tile_env.flv(pos).special = 0;
+        env.grid_colours(pos) = 0;
+        // It might be good to clear some pgrid flags as well.
+    }
+}
+
 void dgn_record_veto(const dgn_veto_exception &e)
 {
     string error = make_stringf("%s: %s",
@@ -517,8 +511,6 @@ static bool _build_level_vetoable(bool enable_random_maps)
     env.level_uniq_map_tags.clear();
     // Copy final tags set back over to the branch list
     branch_uniq_map_tags[you.where_are_you] = env.branch_uniq_map_tags;
-
-    _dgn_map_colour_fixup();
 
     // Call the branch epilogue, if any.
     if (!branch_epilogues[you.where_are_you].empty())
@@ -646,6 +638,7 @@ static void _dgn_postprocess_level()
     _builder_assertions();
     _calc_density();
     _mark_solid_squares();
+    _dgn_fixup_map_flavour();
 }
 
 void dgn_clear_vault_placements()
@@ -787,60 +780,6 @@ void dgn_reset_player_data()
     you.seen_armour.init(0);
     you.seen_misc.reset();
     you.seen_talisman.reset();
-}
-
-static void _dgn_load_colour_grid()
-{
-    dgn_colour_grid.reset(new dungeon_colour_grid);
-    dungeon_colour_grid &dcgrid(*dgn_colour_grid);
-    for (int y = Y_BOUND_1; y <= Y_BOUND_2; ++y)
-        for (int x = X_BOUND_1; x <= X_BOUND_2; ++x)
-            if (env.grid_colours[x][y] != BLACK)
-            {
-                dcgrid[x][y]
-                    = coloured_feature(env.grid[x][y], env.grid_colours[x][y]);
-            }
-}
-
-static void _dgn_map_colour_fixup()
-{
-    if (!dgn_colour_grid)
-        return;
-
-    // If the original coloured feature has been changed, reset the colour.
-    const dungeon_colour_grid &dcgrid(*dgn_colour_grid);
-    for (int y = Y_BOUND_1; y <= Y_BOUND_2; ++y)
-        for (int x = X_BOUND_1; x <= X_BOUND_2; ++x)
-            if (dcgrid[x][y].colour != BLACK
-                && env.grid[x][y] != dcgrid[x][y].feature
-                && dcgrid[x][y].feature != DNGN_FLOOR)
-            {
-                env.grid_colours[x][y] = BLACK;
-            }
-
-    dgn_colour_grid.reset(nullptr);
-}
-
-void dgn_set_grid_colour_at(const coord_def &c, int colour)
-{
-    if (colour != BLACK)
-    {
-        env.grid_colours(c) = colour;
-        if (!dgn_colour_grid)
-            dgn_colour_grid.reset(new dungeon_colour_grid);
-
-        (*dgn_colour_grid)(c) = coloured_feature(env.grid(c), colour);
-    }
-}
-
-static void _set_grd(const coord_def &c, dungeon_feature_type feat)
-{
-    // It might be good to clear some pgrid flags as well.
-    tile_env.flv(c).feat    = 0;
-    tile_env.flv(c).feat_idx = 0;
-    tile_env.flv(c).special = 0;
-    env.grid_colours(c) = 0;
-    env.grid(c) = feat;
 }
 
 static void _dgn_register_vault(const string &name, const unordered_set<string> &tags)
@@ -1200,7 +1139,7 @@ static void _fill_zone(int zone_num, const fill_config &cfg)
             dprf("Nuke item stack at (%d, %d)", c.x, c.y);
             lose_item_stack(c);
         }
-        _set_grd(c, cfg.fill);
+        env.grid(c) = cfg.fill;
         if (env.mgrid(c) != NON_MONSTER
             && !env.mons[env.mgrid(c)].is_habitable_feat(cfg.fill))
         {
@@ -1415,7 +1354,7 @@ static void _fixup_hell_stairs()
         if (feat_is_stone_stair_up(env.grid(*ri))
             || env.grid(*ri) == DNGN_ESCAPE_HATCH_UP)
         {
-            _set_grd(*ri, branches[you.where_are_you].escape_feature);
+            env.grid(*ri) = branches[you.where_are_you].escape_feature;
         }
     }
 }
@@ -1427,7 +1366,7 @@ static void _fixup_pandemonium_stairs()
         if (feat_is_stone_stair_up(env.grid(*ri))
             || env.grid(*ri) == DNGN_ESCAPE_HATCH_UP)
         {
-            _set_grd(*ri, DNGN_TRANSIT_PANDEMONIUM);
+            env.grid(*ri) = DNGN_TRANSIT_PANDEMONIUM;
         }
     }
 }
@@ -1436,7 +1375,7 @@ static void _fixup_descent_hatches()
 {
     for (rectangle_iterator ri(1); ri; ++ri)
         if (env.grid(*ri) == DNGN_ESCAPE_HATCH_UP)
-            _set_grd(*ri, DNGN_FLOOR);
+            env.grid(*ri) = DNGN_FLOOR;
 }
 
 static void _dgn_place_feature_at_random_floor_square(dungeon_feature_type feat,
@@ -1446,7 +1385,7 @@ static void _dgn_place_feature_at_random_floor_square(dungeon_feature_type feat,
     if (place.origin())
         throw dgn_veto_exception("Cannot place feature at random floor square.");
     else
-        _set_grd(place, feat);
+        env.grid(place) = feat;
 }
 
 static void _place_dungeon_exit()
@@ -1701,7 +1640,7 @@ void dgn_reset_level(bool enable_random_maps)
     env.level_build_method.clear();
     env.level_layout_types.clear();
     level_clear_vault_memory();
-    dgn_colour_grid.reset(nullptr);
+    _vault_placed_features.init(DNGN_UNSEEN);
 
     use_random_maps = enable_random_maps;
     dgn_check_connectivity = false;
@@ -1966,13 +1905,13 @@ static void _fixup_branch_stairs()
         if (bottom && (feat_is_stone_stair_down(env.grid(*ri))
                        || env.grid(*ri) == DNGN_ESCAPE_HATCH_DOWN))
         {
-            _set_grd(*ri, escape_replacement);
+            env.grid(*ri) = escape_replacement;
         }
 
         if (top)
         {
             if (env.grid(*ri) == DNGN_ESCAPE_HATCH_UP)
-                _set_grd(*ri, escape_replacement);
+                env.grid(*ri) = escape_replacement;
             else if (feat_is_stone_stair_up(env.grid(*ri)))
             {
 #ifdef DEBUG_DIAGNOSTICS
@@ -1985,7 +1924,7 @@ static void _fixup_branch_stairs()
                 if (root)
                 {
                     env.markers.add(new map_feature_marker(*ri, env.grid(*ri)));
-                    _set_grd(*ri, exit);
+                    env.grid(*ri) = exit;
                 }
                 else
                 {
@@ -2010,9 +1949,9 @@ static void _fixup_branch_stairs()
             shuffle_array(stairs);
             coord_def coord = *(stairs.begin());
             env.markers.add(new map_feature_marker(coord, env.grid(coord)));
-            _set_grd(coord, exit);
+            env.grid(coord) = exit;
             for (auto it = stairs.begin() + 1; it != stairs.end(); it++)
-                _set_grd(*it, DNGN_FLOOR);
+                env.grid(*it) = DNGN_FLOOR;
         }
     }
 }
@@ -2087,7 +2026,7 @@ static void _cull_redundant_stairs(list<coord_def> &stairs,
 
             dprf(DIAG_DNGN,
                  "Too many stairs -- removing one of a connected pair.");
-            _set_grd(s2_loc, replacement);
+            env.grid(s2_loc) = replacement;
             stairs.erase(being_examined);
         }
     }
@@ -2140,7 +2079,7 @@ static void _cull_random_stairs(list<coord_def> &stairs,
         }
 
         dprf(DIAG_DNGN, "Too many stairs -- removing one blindly.");
-        _set_grd(stairs.front(), replacement);
+        env.grid(stairs.front()) = replacement;
         stairs.pop_front();
     }
 }
@@ -2249,7 +2188,7 @@ static bool _fixup_stone_stairs(bool preserve_vault_stairs,
 
         dprf(DIAG_DNGN, "Adding stair %d at (%d,%d)", s, gc.x, gc.y);
         // base gets fixed up to be the right stone stair below...
-        _set_grd(gc, base);
+        env.grid(gc) = base;
         stairs.push_back(gc);
     }
 
@@ -2277,8 +2216,9 @@ static bool _fixup_stone_stairs(bool preserve_vault_stairs,
         const coord_def s2_loc = stairs.back();
         if (env.grid(s1_loc) == env.grid(s2_loc))
         {
-            _set_grd(s2_loc, (dungeon_feature_type)
-                     (base + (env.grid(s2_loc)-base+1) % needed_stairs));
+            dungeon_feature_type stair = (dungeon_feature_type)(base
+                + (env.grid(s2_loc) - base + 1) % needed_stairs);
+            env.grid(s2_loc) = stair;
         }
 
         stairs.push_back(stairs.front());
@@ -2355,7 +2295,7 @@ static bool _add_feat_if_missing(bool (*iswanted)(const coord_def &),
                 if (travel_point_distance[rnd.x][rnd.y] != nzones)
                     continue;
 
-                _set_grd(rnd, feat);
+                env.grid(rnd) = feat;
                 found_feature = true;
                 break;
             }
@@ -2371,7 +2311,7 @@ static bool _add_feat_if_missing(bool (*iswanted)(const coord_def &),
                 if (travel_point_distance[ri->x][ri->y] != nzones)
                     continue;
 
-                _set_grd(*ri, feat);
+                env.grid(*ri) = feat;
                 found_feature = true;
                 break;
             }
@@ -2813,7 +2753,7 @@ static void _ruin_level(Iterator iter,
                 // isolated transparent or rtele_into square.
                 env.level_map_mask(p) |= cfeat.mask;
                 env.pgrid(p) |= cfeat.prop;
-                _set_grd(p, replacement);
+                env.grid(p) = replacement;
             }
 
             // but remove doors if we've removed all adjacent walls
@@ -2832,7 +2772,7 @@ static void _ruin_level(Iterator iter,
                     {
                         env.level_map_mask(p) |= cfeat.mask;
                         env.pgrid(p) |= cfeat.prop;
-                        _set_grd(*wai, DNGN_FLOOR);
+                        env.grid(*wai) = DNGN_FLOOR;
                     }
                 }
             }
@@ -3062,7 +3002,7 @@ static void _check_doors()
                 solid_count++;
 
         if (solid_count < 2)
-            _set_grd(*ri, DNGN_FLOOR);
+            env.grid(*ri) = DNGN_FLOOR;
     }
 }
 
@@ -3104,7 +3044,7 @@ static void _prepare_water()
     }
 
     for (coord_def pos : fix_positions)
-        _set_grd(pos, DNGN_SHALLOW_WATER);
+        env.grid(pos) = DNGN_SHALLOW_WATER;
 }
 
 static bool _vault_can_use_layout(const map_def *vault, const map_def *layout)
@@ -3851,7 +3791,7 @@ static void _adjust_slime_stairs()
                     --down_stairs_needed;
             }
             else
-                _set_grd(*ri, DNGN_FLOOR);
+                env.grid(*ri) = DNGN_FLOOR;
         }
     }
 
@@ -3878,7 +3818,7 @@ static void _adjust_slime_stairs()
             return;
         else
         {
-            _set_grd(place, static_cast<dungeon_feature_type>(i));
+            env.grid(place) = static_cast<dungeon_feature_type>(i);
             existing[i - stair_start] = place;
         }
     }
@@ -3927,7 +3867,7 @@ static void _adjust_slime_stairs()
         while (valid[rng].origin())
             rng = random2(valid.size());
 
-        _set_grd(valid[rng], static_cast<dungeon_feature_type>(i));
+        env.grid(valid[rng]) = static_cast<dungeon_feature_type>(i);
         valid[rng].reset();
     }
 }
@@ -4641,19 +4581,6 @@ static void _pick_float_exits(vault_placement &place, vector<coord_def> &targets
     }
 }
 
-static void _fixup_after_vault()
-{
-    _dgn_set_floor_colours();
-
-    link_items();
-    env.markers.activate_all();
-
-    // Force teleport to place the player somewhere sane.
-    you_teleport_now();
-
-    setup_environment_effects();
-}
-
 // Places a map on the current level (minivault or regular vault).
 //
 // You can specify the centre of the map using "where" for floating vaults
@@ -4677,55 +4604,71 @@ const vault_placement *dgn_place_map(const map_def *mdef,
     if (!mdef)
         return nullptr;
 
-    const dgn_colour_override_manager colour_man;
+    if (crawl_state.generating_level)
+    {
+        return _build_secondary_vault(mdef, check_collision, make_no_exits,
+                                      where);
+    }
 
-    if (mdef->orient == MAP_ENCOMPASS && !crawl_state.generating_level)
+    bool is_encompass = mdef->orient == MAP_ENCOMPASS;
+
+    unwind_bool levgen(crawl_state.generating_level, is_encompass);
+    if (is_encompass)
     {
         if (check_collision)
         {
             mprf(MSGCH_DIAGNOSTICS,
-                 "Cannot generate encompass map '%s' with check_collision=true",
-                 mdef->name.c_str());
+                "Cannot generate encompass map '%s' with check_collision=true",
+                mdef->name.c_str());
 
             return nullptr;
         }
 
         // For encompass maps, clear the entire level.
-        unwind_bool levgen(crawl_state.generating_level, true);
         dgn_reset_level();
         dungeon_events.clear();
-        const vault_placement *vault_place =
-            dgn_place_map(mdef, check_collision, make_no_exits, where);
-        if (vault_place)
-            _fixup_after_vault();
-        return vault_place;
     }
+    else
+        _vault_placed_features.init(DNGN_UNSEEN);
 
-    const vault_placement *vault_place =
-        _build_secondary_vault(mdef, check_collision,
-                               make_no_exits, where);
+    // XXX: if this calls into dgn_place_map again via lua and
+    // crawl_state.generating_level is not set, _vault_placed_features will be
+    // reset before we use it in _dgn_fixup_map_flavour.
+    const vault_placement* vault_place =
+        _build_secondary_vault(mdef, check_collision, make_no_exits, where);
+    if (!vault_place)
+        return nullptr;
 
-    // Activate any markers within the map.
-    if (vault_place && !crawl_state.generating_level)
-    {
 #ifdef ASSERTS
-        if (mdef->name != vault_place->map.name)
-        {
-            die("Placed map '%s', yet vault_placement is '%s'",
-                mdef->name.c_str(), vault_place->map.name.c_str());
-        }
+    if (mdef->name != vault_place->map.name)
+    {
+        die("Placed map '%s', yet vault_placement is '%s'",
+            mdef->name.c_str(), vault_place->map.name.c_str());
+    }
 #endif
 
+    if (is_encompass)
+    {
+        _dgn_set_floor_colours();
+
+        link_items();
+        env.markers.activate_all();
+
+        // Force teleport to place the player somewhere sane.
+        you_teleport_now();
+    }
+    else
+    {
         for (vault_place_iterator vpi(*vault_place); vpi; ++vpi)
         {
             const coord_def p = *vpi;
             env.markers.activate_markers_at(p);
             set_terrain_changed(p);
         }
-
-        setup_environment_effects();
-        _dgn_postprocess_level();
     }
+
+    setup_environment_effects();
+    _dgn_postprocess_level();
 
     return vault_place;
 }
@@ -5835,7 +5778,10 @@ static void _vault_grid_mapspec(vault_placement &place, const coord_def &where,
     else if (f.glyph >= 0)
         _vault_grid_glyph(place, where, f.glyph);
     else if (f.shop)
-        place_spec_shop(where, *f.shop);
+    {
+        make_spec_shop(where, *f.shop);
+        env.grid(where) = DNGN_ENTER_SHOP;
+    }
     else
         env.grid(where) = DNGN_FLOOR;
 
@@ -6330,10 +6276,10 @@ static dungeon_feature_type _pick_an_altar()
     return altar_for_god(god);
 }
 
-void place_spec_shop(const coord_def& where, shop_type force_type)
+void make_spec_shop(const coord_def& where, shop_type force_type)
 {
     shop_spec spec(force_type);
-    place_spec_shop(where, spec);
+    make_spec_shop(where, spec);
 }
 
 int greed_for_shop_type(shop_type shop, int level_number)
@@ -6603,15 +6549,15 @@ static shop_type _random_shop()
 
 
 /**
- * Attempt to place a shop in a given location.
+ * Creates a shop. Doesn't update env.grid
  *
- * @param where             The location to place the shop.
+ * @param where             The location of the shop.
  * @param spec              The details of the shop.
  *                          Would be const if not for list method nonsense.
  * @param shop_level        The effective depth to use for the shop.
 
  */
-void place_spec_shop(const coord_def& where, shop_spec &spec, int shop_level)
+void make_spec_shop(const coord_def& where, shop_spec &spec, int shop_level)
 {
     rng::subgenerator shop_rng; // isolate shop rolls from levelgen
     no_notes nx;
@@ -6631,8 +6577,6 @@ void place_spec_shop(const coord_def& where, shop_spec &spec, int shop_level)
         shop.type = _random_shop();
     shop.greed = _shop_greed(shop.type, level_number, spec.greed);
     shop.pos = where;
-
-    _set_grd(where, DNGN_ENTER_SHOP);
 
     const int num_items = _shop_num_items(spec);
 
@@ -7513,8 +7457,9 @@ static bool _fixup_interlevel_connectivity()
     // Reassign up stair numbers as needed.
     for (int i = 0; i < up_region_max; i++)
     {
-        _set_grd(up_gc[i],
-            (dungeon_feature_type)(DNGN_STONE_STAIRS_UP_I + assign_cur[i]));
+        dungeon_feature_type stair = (dungeon_feature_type)(
+            DNGN_STONE_STAIRS_UP_I + assign_cur[i]);
+        env.grid(up_gc[i]) = stair;
     }
 
     // Fill in connectivity and regions.
@@ -7598,6 +7543,8 @@ void vault_placement::apply_grid()
 
             keyed_mapspec *mapsp = map.mapspec_at(dp);
             _vault_grid(*this, feat, *ri, mapsp);
+
+            _vault_placed_features(*ri) = env.grid(*ri);
 
             if (!crawl_state.generating_level)
             {

--- a/crawl-ref/source/dungeon.h
+++ b/crawl-ref/source/dungeon.h
@@ -220,8 +220,6 @@ coord_def dgn_find_feature_marker(dungeon_feature_type feat);
 // Generate 3 stone stairs in both directions.
 void dgn_place_stone_stairs(bool maybe_place_hatches = false);
 
-void dgn_set_grid_colour_at(const coord_def &c, int colour);
-
 const vault_placement *dgn_place_map(const map_def *map,
                                      bool check_collision,
                                      bool make_no_exits,
@@ -238,8 +236,8 @@ void level_clear_vault_memory();
 void run_map_epilogues();
 
 struct shop_spec;
-void place_spec_shop(const coord_def& where, shop_type force_type);
-void place_spec_shop(const coord_def& where, shop_spec &spec, int shop_level = 0);
+void make_spec_shop(const coord_def& where, shop_type force_type);
+void make_spec_shop(const coord_def& where, shop_spec &spec, int shop_level = 0);
 int greed_for_shop_type(shop_type shop, int level_number);
 object_class_type item_in_shop(shop_type shop_type);
 bool seen_destroy_feat(dungeon_feature_type old_feat);

--- a/crawl-ref/source/god-abil.cc
+++ b/crawl-ref/source/god-abil.cc
@@ -3639,7 +3639,8 @@ static void _gozag_place_shop(int index)
     feature_spec feat = kmspec.get_feat();
     if (!feat.shop)
         die("Invalid shop spec?");
-    place_spec_shop(you.pos(), *feat.shop, you.experience_level);
+    make_spec_shop(you.pos(), *feat.shop, you.experience_level);
+    dungeon_terrain_changed(you.pos(), DNGN_ENTER_SHOP);
 
     link_items();
     env.markers.add(new map_feature_marker(you.pos(), DNGN_ABANDONED_SHOP));

--- a/crawl-ref/source/mapdef.cc
+++ b/crawl-ref/source/mapdef.cc
@@ -618,7 +618,7 @@ void map_lines::apply_grid_overlay(const coord_def &c, bool is_layout)
 
             const int colour = (*overlay)(x, y).colour;
             if (colour)
-                dgn_set_grid_colour_at(gc, colour);
+                env.grid_colours(gc) = colour;
 
             const terrain_property_t property = (*overlay)(x, y).property;
             if (property.flags >= FPROP_BLOODY)

--- a/crawl-ref/source/wiz-dgn.cc
+++ b/crawl-ref/source/wiz-dgn.cc
@@ -471,7 +471,8 @@ bool debug_make_shop(const coord_def& pos)
     if (!menu.run(true))
         return false;
 
-    place_spec_shop(pos, static_cast<shop_type>(menu.result()));
+    make_spec_shop(pos, static_cast<shop_type>(menu.result()));
+    dungeon_terrain_changed(you.pos(), DNGN_ENTER_SHOP);
     mpr("Done.");
     return true;
 }


### PR DESCRIPTION
If a vault places a feature and then level generation replaces the feature, we need to remove the tile override and also reset the squares colour.

Unfortunately, we had multiple ways of achieving this. The first way was that we would call _set_grd to replace the feature. However, some places that replaced a feature did so by directly altering env.grid and making sure every where that needed to call _set_grd did was rather hard. The second way was that we would not show "feat" tile overrides on floor tiles so that if a squares that had a "feat" tile override was replaced with a floor the incorrect tile override wouldn't be shown. The third way was that we would keep track of which features had been placed by vaults and reset the squares colour after generating the level if the feature was different from what the vault had placed.

The third way can be adapted to handle resetting tile overrides, allowing us to remove the first and second ways. However, I haven't yet allowed floors to show "feat" tile overrides as we still have a few ways that these can end up incorrect on floors outside of level generation.