### PR TITLE
fix: Blorkula mitosis bug (Nnyef)

### DIFF
--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -5769,8 +5769,8 @@ bool monster::do_shaft()
     if (!is_valid_shaft_level())
         return false;
 
-    // Tentacles are immune to shafting
-    if (mons_is_tentacle_or_tentacle_segment(type))
+    // Tentacles and Blorkula bats are immune to shafting
+    if (mons_is_tentacle_or_tentacle_segment(type) || props.exists(BLORKULA_REVIVAL_TIMER_KEY))
         return false;
 
     level_id lev = shaft_dest();


### PR DESCRIPTION
### Note: I reached out to .deekay in the roguelikes discord a few days ago to ask how they would like to be credited. They haven't responded to me. Nnyef is the online crawl account name they were using when they encountered the bug.

---

If Blorkula the Orcula split into bats and one of the bats was shafted, that vampire bat would turn into a copy of Blorkula on another floor complete with duplicated gear!

Make Blorkula's bats shaft immune to prevent this.