### PR TITLE
i18n: HUD captions

### DIFF
--- a/crawl-ref/source/MSVC/crawl.vcxproj
+++ b/crawl-ref/source/MSVC/crawl.vcxproj
@@ -463,6 +463,7 @@ python.exe util/gen-all.py</Command>
       <PrecompiledHeader>Use</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\loading-screen.cc" />
+    <ClCompile Include="..\localise.cc" />
     <ClCompile Include="..\los.cc" />
     <ClCompile Include="..\los-def.cc" />
     <ClCompile Include="..\losparam.cc" />
@@ -807,6 +808,7 @@ python.exe util/gen-all.py</Command>
     <ClInclude Include="..\libutil.h" />
     <ClInclude Include="..\libw32c.h" />
     <ClInclude Include="..\loading-screen.h" />
+    <ClInclude Include="..\localise.h" />
     <ClInclude Include="..\lookup-help.h" />
     <ClInclude Include="..\los-def.h" />
     <ClInclude Include="..\los-type.h" />

--- a/crawl-ref/source/MSVC/crawl.vcxproj.filters
+++ b/crawl-ref/source/MSVC/crawl.vcxproj.filters
@@ -639,6 +639,9 @@
     <ClCompile Include="..\l-spells.cc">
       <Filter>cc</Filter>
     </ClCompile>
+    <ClCompile Include="..\localise.cc">
+      <Filter>cc</Filter>
+    </ClCompile>
     <ClCompile Include="..\losparam.cc">
       <Filter>cc</Filter>
     </ClCompile>
@@ -1477,6 +1480,9 @@
       <Filter>h</Filter>
     </ClInclude>
     <ClInclude Include="..\loading-screen.h">
+      <Filter>h</Filter>
+    </ClInclude>
+    <ClInclude Include="..\localise.h">
       <Filter>h</Filter>
     </ClInclude>
     <ClInclude Include="..\lookup-help.h">

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1596,6 +1596,7 @@ endif
 	for LANG in $(LANGUAGES); \
 		do $(COPY) dat/descript/$$LANG/*.txt $(datadir_fp)/dat/descript/$$LANG; \
 	done
+	$(COPY_R) dat/translate $(datadir_fp)/dat/
 	mkdir -p $(datadir_fp)/dat/dist_bones
 	$(COPY) dat/dist_bones/* $(datadir_fp)/dat/dist_bones/
 	$(COPY) ../docs/*.txt $(datadir_fp)/docs/

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -127,6 +127,7 @@ lang-fake.o \
 lev-pand.o \
 libutil.o \
 loading-screen.o \
+localise.o \
 lookup-help.o \
 los.o \
 los-def.o \

--- a/crawl-ref/source/android-project/jni/src/Android.mk
+++ b/crawl-ref/source/android-project/jni/src/Android.mk
@@ -146,6 +146,7 @@ LOCAL_SRC_FILES := $(SDL_PATH)/src/main/android/SDL_android_main.c \
     $(CRAWL_PATH)/lev-pand.cc \
     $(CRAWL_PATH)/libutil.cc \
     $(CRAWL_PATH)/loading-screen.cc \
+    $(CRAWL_PATH)/localise.cc \
     $(CRAWL_PATH)/lookup-help.cc \
     $(CRAWL_PATH)/los.cc \
     $(CRAWL_PATH)/los-def.cc \

--- a/crawl-ref/source/cio.cc
+++ b/crawl-ref/source/cio.cc
@@ -10,6 +10,7 @@
 #include <queue>
 
 #include "libutil.h"
+#include "localise.h"
 #include "macro.h"
 #include "message.h"
 #include "options.h"
@@ -241,6 +242,7 @@ void nowrap_eol_cprintf(const char *s, ...)
     va_list args;
     va_start(args, s);
     string buf = vmake_stringf(s, args);
+    buf = localise(buf);
     va_end(args);
 
     cprintf("%s", chop_string(buf, max(wrapcol + 1 - wherex(), 0), false).c_str());
@@ -326,6 +328,7 @@ void wrapcprintf(int wrapcol, const char *s, ...)
     va_list args;
     va_start(args, s);
     string buf = vmake_stringf(s, args);
+    buf = localise(buf);
     va_end(args);
     wrapcprint_skipping(0, wrapcol, buf);
 }
@@ -345,6 +348,7 @@ void wrapcprintf(const char *s, ...)
     va_list args;
     va_start(args, s);
     string buf = vmake_stringf(s, args);
+    buf = localise(buf);
     va_end(args);
     wrapcprint_skipping(0, cgetsize(get_cursor_region()).x, buf);
 }

--- a/crawl-ref/source/dat/translate/de/ui.txt
+++ b/crawl-ref/source/dat/translate/de/ui.txt
@@ -1,0 +1,110 @@
+###############################################################################
+#
+# Translations for user interfaces
+#
+###############################################################################
+
+###############################################################
+# Player Stats (aka HUD)
+#
+# --------------------------------------------
+# Bob the Chopper                            |
+# Minotaur of Trog  *.....                   |
+# Health: 120/200   ======================== |
+# Magic:  20/20                              |
+# AC: 27            Str: 31                  |
+# EV: 12            Int: 4                   |
+# SH: 14            Dex: 10                  |
+# XL: 11 Next: 83%  Place: Dungeon:15        |
+# Noise: ---------  Time: 72030.9 (0.0)      |
+# a) +0 hand axe                             |
+# -) Nothing quivered                        |
+# Berserk                                    |
+# --------------------------------------------
+#
+###############################################################
+
+%%%%
+Health:
+Gesund:
+%%%%
+# Health changes to HP when more space is needed (e.g. need to show HP drain)
+# Hit points = Trefferpunkte
+HP:
+TP:
+%%%%
+Magic:
+Magie:
+%%%%
+# Magic changes to MP when more more space is needed
+# Magic points = Magiepunkte
+MP:
+MP:
+%%%%
+# Armour Class = Rüstungsklasse
+AC:
+RK:
+%%%%
+# Evasion = Ausweichen
+EV:
+AW:
+%%%%
+# Shields = Schilde
+SH:
+Sch:
+%%%%
+# eXperience Level = Erfahrungsstufe
+XL:
+St:
+%%%%
+# percentage progress to next XL
+# Next = Nächste, but that's too long, so I used Komm for Kommende
+Next:
+Komm:
+%%%%
+Noise:
+Lärm:
+%%%%
+# If silenced, this shows instead of noise bar
+Silenced
+Stille
+%%%%
+# There is an option to show equipment instead of noise
+# equipment = Ausrüstung
+Equip:
+Ausr:
+%%%%
+# Equipment abbreviated for octopodes
+Eq:
+Ar:
+%%%%
+# Strength = Stärke
+Str:
+Stä:
+%%%%
+# Intelligence = Intelligenz
+%%%%
+Int:
+Int:
+%%%%
+# Dexterity = Geschicklichkeit
+Dex:
+Ges:
+%%%%
+Place:
+Ort:
+%%%%
+Time:
+Zeit:
+%%%%
+Turn:
+Runde:
+%%%%
+# this shows if god is Gozag
+Gold:
+Gold:
+%%%%
+# short from of Gold
+Gd
+Gd
+%%%%

--- a/crawl-ref/source/dat/translate/de/ui.txt
+++ b/crawl-ref/source/dat/translate/de/ui.txt
@@ -83,7 +83,6 @@ Str:
 Stä:
 %%%%
 # Intelligence = Intelligenz
-%%%%
 Int:
 Int:
 %%%%

--- a/crawl-ref/source/dat/translate/ui.txt
+++ b/crawl-ref/source/dat/translate/ui.txt
@@ -85,6 +85,9 @@ Place:
 Time:
 
 %%%%
+Turn:
+
+%%%%
 # this shows if god is Gozag
 Gold:
 

--- a/crawl-ref/source/dat/translate/ui.txt
+++ b/crawl-ref/source/dat/translate/ui.txt
@@ -1,0 +1,95 @@
+###############################################################################
+#
+# Translations for user interfaces
+#
+###############################################################################
+
+###############################################################
+# Player Stats (aka HUD)
+#
+# --------------------------------------------
+# Bob the Chopper                            |
+# Minotaur of Trog  *.....                   |
+# Health: 120/200   ======================== |
+# Magic:  20/20                              |
+# AC: 27            Str: 31                  |
+# EV: 12            Int: 4                   |
+# SH: 14            Dex: 10                  |
+# XL: 11 Next: 83%  Place: Dungeon:15        |
+# Noise: ---------  Time: 72030.9 (0.0)      |
+# a) +0 hand axe                             |
+# -) Nothing quivered                        |
+# Berserk                                    |
+# --------------------------------------------
+#
+###############################################################
+
+%%%%
+Health:
+
+%%%%
+# Health changes to HP when more space is needed (e.g. need to show HP drain)
+HP:
+
+%%%%
+Magic:
+
+%%%%
+# Magic changes to MP when more more space is needed
+MP:
+
+%%%%
+AC:
+
+%%%%
+EV:
+
+%%%%
+SH:
+
+%%%%
+XL:
+
+%%%%
+# percentage progress to next XL
+Next:
+
+%%%%
+Noise:
+
+%%%%
+# If silenced, this shows instead of noise bar
+Silenced
+
+%%%%
+# There is an option to show equipment instead of noise
+Equip:
+
+%%%%
+# Equipment abbreviated for octopodes
+Eq:
+
+%%%%
+Str:
+
+%%%%
+Int:
+
+%%%%
+Dex:
+
+%%%%
+Place:
+
+%%%%
+Time:
+
+%%%%
+# this shows if god is Gozag
+Gold:
+
+%%%%
+# short from of Gold
+Gd
+
+%%%%

--- a/crawl-ref/source/database.cc
+++ b/crawl-ref/source/database.cc
@@ -216,6 +216,12 @@ bool TextDB::open_db()
 
 void TextDB::init()
 {
+    if (Options.language == lang_t::EN && string(_db_name) == "translate")
+    {
+        // don't initialise the translate db if language is English
+        return;
+    }
+
     if (Options.lang_name && !_parent)
     {
         translation = new TextDB(this);

--- a/crawl-ref/source/database.cc
+++ b/crawl-ref/source/database.cc
@@ -62,7 +62,7 @@ public:
 
 // Convenience functions for (read-only) access to generic
 // berkeley DB databases.
-static void _store_text_db(const string &in, DBM *db);
+static void _store_text_db(const string &in, DBM *db, bool is_direct_translation);
 
 static string _query_database(TextDB &db, string key, bool canonicalise_key,
                               bool run_lua, bool untranslated = false);
@@ -152,6 +152,11 @@ static TextDB AllDBs[] =
     TextDB("egos", "descript/",
           { "egos.txt",     // weapon/armour/missile egos
             }),
+
+    // in this db, the keys are English strings to be translated
+    TextDB("translate", "translate/",
+          { "ui.txt", // UI
+            }),
 };
 
 static TextDB& DescriptionDB = AllDBs[0];
@@ -165,6 +170,7 @@ static TextDB& HelpDB        = AllDBs[7];
 static TextDB& FAQDB         = AllDBs[8];
 static TextDB& HintsDB       = AllDBs[9];
 static TextDB& EgosDB        = AllDBs[10];
+static TextDB& TranslateDB   = AllDBs[11];
 
 static string _db_cache_path(string db, const char *lang)
 {
@@ -311,6 +317,9 @@ void TextDB::_regenerate_db()
     unlink_u(full_db_path.c_str());
 #endif
 
+    // in the "translate" db, the key is an English string rather than an
+    // internal id, and the value is a translation of the key
+    bool is_direct_translation = string(_db_name) == "translate";
     string ts;
     if (!(_db = dbm_open(db_path.c_str(), O_RDWR | O_CREAT, 0660)))
         end(1, true, "Unable to open DB: %s", db_path.c_str());
@@ -325,7 +334,7 @@ void TextDB::_regenerate_db()
         {
             snprintf(buf, sizeof(buf), ":%" PRId64, (int64_t)mtime);
             ts += buf;
-            _store_text_db(full_input_path, _db);
+            _store_text_db(full_input_path, _db, is_direct_translation);
         }
     }
     _add_entry(_db, "TIMESTAMP", ts);
@@ -509,7 +518,7 @@ static void _add_entry(DBM *db, const string &k, string &v)
         end(1, true, "Error storing %s", k.c_str());
 }
 
-static void _parse_text_db(LineInput &inf, DBM *db)
+static void _parse_text_db(LineInput &inf, DBM *db, bool is_direct_translation)
 {
     string key;
     string value;
@@ -539,12 +548,16 @@ static void _parse_text_db(LineInput &inf, DBM *db)
         {
             key = line;
             trim_string(key);
-            lowercase(key);
+            // If the key is the English string to translate, don't mess with it
+            if (!is_direct_translation)
+                lowercase(key);
         }
         else
         {
             trim_string_right(line);
-            value += line + "\n";
+            value += line;
+            if (!is_direct_translation)
+                value += "\n";
         }
     }
 
@@ -552,13 +565,13 @@ static void _parse_text_db(LineInput &inf, DBM *db)
         _add_entry(db, key, value);
 }
 
-static void _store_text_db(const string &in, DBM *db)
+static void _store_text_db(const string &in, DBM *db, bool is_direct_translation)
 {
     UTF8FileLineInput inf(in.c_str());
     if (inf.error())
         end(1, true, "Unable to open input file: %s", in.c_str());
 
-    _parse_text_db(inf, db);
+    _parse_text_db(inf, db, is_direct_translation);
 }
 
 static string _chooseStrByWeight(const string &entry, int fixed_weight = -1)
@@ -941,4 +954,16 @@ string getHintString(const string &key)
 string getEgoString(const string &key)
 {
     return unwrap_desc(_query_database(EgosDB, key, true, true));
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Translate DB specific functions.
+
+string getTranslatedString(const string &original)
+{
+    if (Options.language == lang_t::EN)
+        return original;
+
+    string result = _query_database(TranslateDB, original, false, false);
+    return trim_string_right(result);
 }

--- a/crawl-ref/source/database.cc
+++ b/crawl-ref/source/database.cc
@@ -62,7 +62,7 @@ public:
 
 // Convenience functions for (read-only) access to generic
 // berkeley DB databases.
-static void _store_text_db(const string &in, DBM *db, bool is_direct_translation);
+static void _store_text_db(const string &in, DBM *db, bool value_translates_key);
 
 static string _query_database(TextDB &db, string key, bool canonicalise_key,
                               bool run_lua, bool untranslated = false);
@@ -218,7 +218,7 @@ void TextDB::init()
 {
     if (Options.language == lang_t::EN && string(_db_name) == "translate")
     {
-        // don't initialise the translate db if language is English
+        // No need for the translate db if language is English
         return;
     }
 
@@ -325,7 +325,7 @@ void TextDB::_regenerate_db()
 
     // in the "translate" db, the key is an English string rather than an
     // internal id, and the value is a translation of the key
-    bool is_direct_translation = string(_db_name) == "translate";
+    bool value_translates_key = string(_db_name) == "translate";
     string ts;
     if (!(_db = dbm_open(db_path.c_str(), O_RDWR | O_CREAT, 0660)))
         end(1, true, "Unable to open DB: %s", db_path.c_str());
@@ -340,7 +340,7 @@ void TextDB::_regenerate_db()
         {
             snprintf(buf, sizeof(buf), ":%" PRId64, (int64_t)mtime);
             ts += buf;
-            _store_text_db(full_input_path, _db, is_direct_translation);
+            _store_text_db(full_input_path, _db, value_translates_key);
         }
     }
     _add_entry(_db, "TIMESTAMP", ts);
@@ -524,7 +524,7 @@ static void _add_entry(DBM *db, const string &k, string &v)
         end(1, true, "Error storing %s", k.c_str());
 }
 
-static void _parse_text_db(LineInput &inf, DBM *db, bool is_direct_translation)
+static void _parse_text_db(LineInput &inf, DBM *db, bool value_translates_key)
 {
     string key;
     string value;
@@ -555,14 +555,14 @@ static void _parse_text_db(LineInput &inf, DBM *db, bool is_direct_translation)
             key = line;
             trim_string(key);
             // If the key is the English string to translate, don't mess with it
-            if (!is_direct_translation)
+            if (!value_translates_key)
                 lowercase(key);
         }
         else
         {
             trim_string_right(line);
             value += line;
-            if (!is_direct_translation)
+            if (!value_translates_key)
                 value += "\n";
         }
     }
@@ -571,13 +571,13 @@ static void _parse_text_db(LineInput &inf, DBM *db, bool is_direct_translation)
         _add_entry(db, key, value);
 }
 
-static void _store_text_db(const string &in, DBM *db, bool is_direct_translation)
+static void _store_text_db(const string &in, DBM *db, bool value_translates_key)
 {
     UTF8FileLineInput inf(in.c_str());
     if (inf.error())
         end(1, true, "Unable to open input file: %s", in.c_str());
 
-    _parse_text_db(inf, db, is_direct_translation);
+    _parse_text_db(inf, db, value_translates_key);
 }
 
 static string _chooseStrByWeight(const string &entry, int fixed_weight = -1)

--- a/crawl-ref/source/database.h
+++ b/crawl-ref/source/database.h
@@ -54,3 +54,6 @@ string getEgoString(const string &key);
 vector<string> getAllFAQKeys();
 string getFAQ_Question(const string &key);
 string getFAQ_Answer(const string &question);
+
+// get a translation of an English string into the user's current language
+string getTranslatedString(const string &original);

--- a/crawl-ref/source/localise.cc
+++ b/crawl-ref/source/localise.cc
@@ -1,0 +1,36 @@
+/**
+ * @file localise.cc
+ * @brief String localisation (translation)
+ **/
+
+#include "AppHdr.h"
+#include "database.h"
+#include "localise.h"
+#include "options.h"
+#include "stringutil.h"
+
+bool localisation_active()
+{
+    return Options.language != lang_t::EN;
+}
+
+string localise(const string &s)
+{
+    if (!localisation_active() || s.empty())
+        return s;
+
+    // check for leading/trailing whitespace
+    string trimmed = trimmed_string(s);
+    if (trimmed.length() != s.length())
+    {
+        if (trimmed.empty())
+        {
+            // all whitespace
+            return s;
+        }
+        return replace_all(s, trimmed, localise(trimmed));
+    }
+
+    string result = getTranslatedString(s);
+    return result == "" ? s : result;
+}

--- a/crawl-ref/source/localise.h
+++ b/crawl-ref/source/localise.h
@@ -1,0 +1,15 @@
+/**
+ * @file localise.h
+ * @brief String localisation (translation)
+ **/
+
+#pragma once
+
+#include <string>
+
+using std::string;
+
+// Is localisation active?
+bool localisation_active();
+
+string localise(const string &s);

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -828,9 +828,11 @@ static void _print_stats_noise(int x, int y)
         CGOTOXY(x + bar_position, y, GOTO_STAT);
         textcolour(LIGHTMAGENTA);
 
-        // This needs to be one extra wide in case silence happens
-        // immediately after super-loud (magenta) noise
-        CPRINTF("Silenced  ");
+        // Erase the noise bar
+        CPRINTF("          ");
+        CGOTOXY(x + bar_position, y, GOTO_STAT);
+
+        CPRINTF("Silenced");
         Noise_Bar.reset(); // so it doesn't display a change bar after silence ends
     }
     else

--- a/crawl-ref/source/output.cc
+++ b/crawl-ref/source/output.cc
@@ -31,6 +31,7 @@
 #include "jobs.h"
 #include "lang-fake.h"
 #include "libutil.h"
+#include "localise.h"
 #include "macro.h" // command_to_string
 #include "menu.h"
 #include "message.h"
@@ -309,6 +310,7 @@ static void _cprintf_touchui(const char *format, ...)
     vector<string> parts;
     va_start(args, format);
     buf = vmake_stringf(format, args);
+    buf = localise(buf);
 
     switch (TOUCH_UI_STATE)
     {
@@ -388,6 +390,7 @@ static void _nowrap_eol_cprintf_touchui(const char *format, ...)
     string  buf;
     va_start(args, format);
     buf = vmake_stringf(format, args);
+    buf = localise(buf);
 
     // N.B. this should really be factored out and merged with the other switch-case above
     switch (TOUCH_UI_STATE)

--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -33,6 +33,7 @@
 #include "json-wrapper.h"
 #include "lang-fake.h"
 #include "libutil.h"
+#include "localise.h"
 #include "macro.h"
 #include "map-knowledge.h"
 #include "menu.h"
@@ -991,6 +992,40 @@ static void _send_ui_state(WebtilesUIState state)
     tiles.json_open_object();
     tiles.json_write_string("msg", "ui_state");
     tiles.json_write_int("state", state);
+    tiles.json_close_object();
+    tiles.finish_message();
+}
+
+static void _send_hud_captions()
+{
+    if (!localisation_active())
+    {
+        // No need to send the captions
+        // web server will use the default hardcoded English ones
+        return;
+    }
+
+    tiles.json_open_object();
+    tiles.json_write_string("msg", "stats_captions");
+    tiles.json_write_string("health", localise("Health:"));
+    tiles.json_write_string("hp", localise("HP:"));
+    tiles.json_write_string("magic", localise("Magic:"));
+    tiles.json_write_string("mp", localise("MP:"));
+    tiles.json_write_string("ac", localise("AC:"));
+    tiles.json_write_string("ev", localise("EV:"));
+    tiles.json_write_string("sh", localise("SH:"));
+    tiles.json_write_string("xl", localise("XL:"));
+    tiles.json_write_string("progress", localise("Next:"));
+    tiles.json_write_string("noise", localise("Noise:"));
+    tiles.json_write_string("silenced", localise("Silenced"));
+    tiles.json_write_string("equip", localise("Equip:"));
+    tiles.json_write_string("eq", localise("Eq:"));
+    tiles.json_write_string("str", localise("Str:"));
+    tiles.json_write_string("int", localise("Int:"));
+    tiles.json_write_string("dex", localise("Dex:"));
+    tiles.json_write_string("place", localise("Place:"));
+    tiles.json_write_string("time", localise("Time:"));
+    tiles.json_write_string("gold", localise("Gold:"));
     tiles.json_close_object();
     tiles.finish_message();
 }
@@ -2213,7 +2248,10 @@ void TilesFramework::_send_everything()
     _send_cursor(CURSOR_MOUSE);
     _send_cursor(CURSOR_TUTORIAL);
 
-     // Player
+    // i18n: Translated HUD captions
+    _send_hud_captions();
+
+    // Player
     _send_player(true);
 
     // Map is sent after player, otherwise HP/MP bar can be left behind in the
@@ -2328,6 +2366,7 @@ void TilesFramework::redraw()
 
     m_text_menu.send();
 
+    _send_hud_captions();
     _send_player();
     _send_messages();
 

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -4,6 +4,8 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
     "use strict";
 
     var player = {}, last_time;
+    // i18n: HUD labels ("Health:", etc.) in the user's language
+    var stats_captions = {};
 
     var stat_boosters = {
         "str": "vitalised",
@@ -102,7 +104,7 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
             noise_cat = "blank";
             // I couldn't get this to work just directly putting the text in #stats_noise_bar,
             // because clearing the text later will adjust the span width.
-            $("#stats_noise_status").text("Silenced");
+            $("#stats_noise_status").text(stats_captions.silenced || "Silenced");
         } else {
             $("#stats_noise_status").text("");
         }
@@ -424,7 +426,7 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
 
         if (player.god == "Gozag")
         {
-            $("#stats_gozag_gold_label").text(" Gold: ");
+            $("#stats_gozag_gold_label").text(stats_captions.gold || " Gold: ");
             $("#stats_gozag_gold_label").css("padding-left", "0.5em");
             $("#stats_gozag_gold").text(player.gold);
         } else {
@@ -441,8 +443,12 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         for (var i = 0; i < simple_stats.length; ++i)
             $("#stats_" + simple_stats[i]).text(player[simple_stats[i]]);
 
-        $("#stats_hpline > .stats_caption").text(
-            (player.real_hp_max != player.hp_max) ? "HP:" : "Health:");
+        let hp_caption = "";
+        if (player.real_hp_max != player.hp_max)
+            hp_caption = stats_captions.hp || "HP:";
+        else
+            hp_caption = stats_captions.health || "Health:"
+        $("#stats_hp_caption").text(hp_caption);
 
         if (player.real_hp_max != player.hp_max)
             $("#stats_real_hp_max").text("(" + player.real_hp_max + ")");
@@ -479,12 +485,12 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
 
         if (options.get("show_game_time") === true)
         {
-            $("#stats_time_caption").text("Time:");
+            $("#stats_time_caption").text(stats_captions.time || "Time:");
             $("#stats_time").text((player.time / 10.0).toFixed(1));
         }
         else
         {
-            $("#stats_time_caption").text("Turn:");
+            $("#stats_time_caption").text(stats_captions.turn || "Turn:");
             $("#stats_time").text(player.turn);
         }
 
@@ -584,6 +590,27 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         }
     }
 
+    function update_caption(id, value) {
+        if (value)
+            $("#" + id).text(value);
+    }
+
+    function handle_stats_captions_message(data) {
+        $.extend(stats_captions, data);
+
+        update_caption("stats_mp_caption", stats_captions.magic);
+        update_caption("stats_ac_caption", stats_captions.ac);
+        update_caption("stats_ev_caption", stats_captions.ev);
+        update_caption("stats_sh_caption", stats_captions.sh);
+        update_caption("stats_xl_caption", stats_captions.xl);
+        update_caption("stats_progress_caption", stats_captions.progress);
+        update_caption("stats_noise_caption", stats_captions.noise);
+        update_caption("stats_str_caption", stats_captions.str);
+        update_caption("stats_int_caption", stats_captions.int);
+        update_caption("stats_dex_caption", stats_captions.dex);
+        update_caption("stats_place_caption", stats_captions.place);
+    }
+
     options.add_listener(function ()
     {
         if (player.name !== "")
@@ -607,6 +634,7 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
 
     comm.register_handlers({
         "player": handle_player_message,
+        "stats_captions": handle_stats_captions_message,
     });
 
     $(document).off("game_init.player")

--- a/crawl-ref/source/webserver/game_data/templates/game.html
+++ b/crawl-ref/source/webserver/game_data/templates/game.html
@@ -63,7 +63,7 @@
       <div id="stats_hpline">
         <!-- These <span>s must be on the same logical line to prevent rendering bugs -->
         <span id="stats_hp_bar" class="bar" style="float: right; width: 55%; height: 1em"><span id="stats_hp_bar_full"></span><span id="stats_hp_bar_poison"></span><span id="stats_hp_bar_decrease"></span><span id="stats_hp_bar_increase"></span></span>
-        <span class="stats_caption">HP:</span>
+        <span id="stats_hp_caption" class="stats_caption">HP:</span>
         <!-- These <span>s must be on the same logical line to prevent rendering bugs -->
         <span id="stats_hp"></span><span id="stats_hp_separator">/</span><span id="stats_hp_max"></span>
         <span id="stats_real_hp_max"></span>
@@ -71,7 +71,7 @@
       <div id="stats_mpline">
         <!-- These <span>s must be on the same logical line to prevent rendering bugs -->
         <span id="stats_mp_bar" class="bar" style="float: right; width: 55%; height: 1em"><span id="stats_mp_bar_full"></span><span id="stats_mp_bar_decrease"></span><span id="stats_mp_bar_increase"></span></span>
-        <span class="stats_caption">Magic:</span>
+        <span id="stats_mp_caption" class="stats_caption">Magic:</span>
         <!-- These <span>s must be on the same logical line to prevent rendering bugs -->
         <span id="stats_mp"></span><span id="stats_mp_separator">/</span><span id="stats_mp_max"></span>
         <span id="stats_dd_real_mp_max"></span>
@@ -79,18 +79,18 @@
       <div>
         <div id="stats_leftcolumn" style="float: left; width: 45%">
           <div>
-            <span class="stats_caption">AC:</span> <span id="stats_ac"></span>
+            <span id = "stats_ac_caption" class="stats_caption">AC:</span> <span id="stats_ac"></span>
           </div>
           <div>
-            <span class="stats_caption">EV:</span> <span id="stats_ev"></span>
+            <span id = "stats_ev_caption" class="stats_caption">EV:</span> <span id="stats_ev"></span>
           </div>
           <div>
-            <span class="stats_caption">SH:</span> <span id="stats_sh"></span>
+            <span id = "stats_sh_caption" class="stats_caption">SH:</span> <span id="stats_sh"></span>
           </div>
           <div>
-            <span class="stats_caption">XL:</span>
+            <span id = "stats_xl_caption" class="stats_caption">XL:</span>
             <span id="stats_xl"></span>
-            <span class="stats_caption">Next:</span>
+            <span id = "stats_progress_caption" class="stats_caption">Next:</span>
             <span id="stats_progress"></span>%
           </div>
           <div id="stats_noise" style="float: left; width: 95%">
@@ -108,24 +108,24 @@
               id="stats_noise_status"
               style="float: right; width: 0%"
             ></span>
-            <span class="stats_caption">Noise:</span>
+            <span id="stats_noise_caption" class="stats_caption">Noise:</span>
             <span id="stats_noise_num"></span>
           </div>
         </div>
         <div id="stats_rightcolumn" style="float: right; width: 55%">
           <div>
-            <span class="stats_caption">Str:</span> <span id="stats_str"></span>
+            <span id="stats_str_caption" class="stats_caption">Str:</span> <span id="stats_str"></span>
             <span id="stats_doom_ui"><span class="stats_caption" style="margin-left:2.2em">Doom:</span><span id="stats_doom"></span></span>
           </div>
           <div>
-            <span class="stats_caption">Int:</span> <span id="stats_int"></span>
+            <span id="stats_int_caption" class="stats_caption">Int:</span> <span id="stats_int"></span>
             <span id="stats_contam_ui"><span class="stats_caption" style="margin-left:1.1em">Contam:</span><span id="stats_contam"></span></span>
           </div>
           <div>
-            <span class="stats_caption">Dex:</span> <span id="stats_dex"></span>
+            <span id="stats_dex_caption" class="stats_caption">Dex:</span> <span id="stats_dex"></span>
           </div>
           <div>
-            <span class="stats_caption">Place:</span>
+            <span id="stats_place_caption" class="stats_caption">Place:</span>
             <span id="stats_place"></span>
           </div>
           <div>


### PR DESCRIPTION
This pull request is intended to be the first in a series that will ultimately bring full internationalisation (i18n) to Crawl (as discussed on #crawl-dev).

The solution will be based on that used in the Alphabet Soup project, but with some modifications based on lessons learned in the course of that project.

This PR handles a fairly simple use case - that of translating the HUD captions - but serves to bring in some of the required infrastructure.

## Overview of the proposed solution

### From the translators' POV:
- translations will be in plain text (UTF-8) files under dat/translate/{langcode}
- these files will use the same dbm format used in dat/descript and dat/database
- this has the advantage that the game will automatically detect any changes on restart, and there's no need to compile the translations into some intermediate format like the gettext .po format
- the keys for the entries will be the English strings to be translated rather than internal ids. This approach was chosen in order to avoid the massive amount of code changes which would be required to replace every string in the code with an identifier.
- Since there's no need to translate English into English, the "English" versions of the files in the top-level directory (dat/translate) will not be used by the game, and will contain keys only (no values). They will serve as templates for the translators to fill in and place in the relevant sub-directory.

### From the programmers' POV:
- in most cases, translation will be achieved by calling localise(str)
- wherever possible, this call will be embedded at a low level in functions like mprf, in order to minimise code changes
- there will also be a function localise_contextual for some special cases (see below)

### A note about regex
This solution will make heavy use of regular expressions (regex). Unfortunately, Crawl builds with different regex implementations based on OS - PCRE on Windows, POSIX otherwise. This is annoying because they are not functionally identical and use somewhat different syntax. Also, the POSIX implementation is notorious for performance issues. Ideally, we would standardise on PCRE across all OSes, but it's not a mandatory requirement. Also, while PCRE supports UTF-8, Crawl's fork of PCRE builds with UTF-8 support disabled. We will need to change that.

## More Details

There are a number of challenges when translating strings for an application. I will go through some of the main ones and show how they will be addressed.

### The problem of context
Sometimes the translation of a particular string will depend on context. For example, the word "fire" as in flames would likely have a different translation to the command "fire" meaning to shoot.

This will be addressed by allowing an optional context to be provided for translations. For the translator, it would look like this (German example):
```
%%%%
fire
Feuer
%%%%
{cmd}fire
Schießen
%%%%
```
In this case, the default translation of "fire" is the German word meaning fire as in flames, but we provide a specific contextual translation for the command "fire" (as in shoot). In the case of the command, the code would have to call:
```
localise_contextual("cmd", "fire");
```

The context mechanism is a key part of the solution, and allows us to solve a number of other problems.

### Grammatical Gender

In many languages, nouns have gender. This often affects the associated articles (the/a) and adjectives.

Handling the articles is fairly straightforward. Example (French):
```
%%%%
the bat
la chauve-souris
%%%%
the butterfly
le papillon
%%%%
```
We can even handle exceptions:
```
%%%%
the orc
l'orc
%%%%
```

Of course, there are situations where we would want these nouns with the indefinite article (a/an) or no article. It would be tedious to manually define all the possible forms. For this reason there will be the capability to generate the other forms using regular expression rules. Any exceptions to the rules can be explicitly defined (explicit definitions always override regex-generated translations).
Simplified example (French):
```
# generate indefinite form from definite form
%%%%
PREGENERATE:1

SELECT_BY_KEY:/^the /

# transform key (English)
KEY:/^the /a /

# transform value (French)
/^le /un /
/^la /une /
%%%%
```

But then how do we handle adjectives? By setting a context, indicating the noun gender, in the translation of the noun, and then translating the adjective with that context.
```
%%%%
the bat
{f}la chauve-souris
%%%%
the butterfly
{m}le papillon
%%%%


%%%%
{m}charmed
charmé
%%%%
{f}charmed
charmée
%%%%
```
Note that the contexts {f} and {m} are not hardcoded. The translator is free to use whatever they want.

### Adjective placement

French also has another challenge where some adjectives come before the noun and some after.
We indicate this by putting a space after adjectives that come before the noun, and before adjectives that come after the noun.
This requires quoting the strings so that the whitespace doesn't get stripped.
```
%%%%
"{m}charmed "
" charmé"
%%%%
"{f}charmed "
" charmée"
%%%%
```

### Grammatical Case
In some languages, like German, the form of a noun and its associated articles and adjectives is affected by grammatical case, which is related to the role that the noun plays in the sentence. For example, in German, if a monster is hitting you then it's in the nominative case, but if you're hitting the monster then its in the accusative case. This can also be solved with the context mechanism:
```
%%%%
# nominative
the orc
der Ork
%%%%
# accusative
{acc}the orc
den Ork
%%%%

%%%%
@the_monster@ hits you
@the_monster@ trifft dich
%%%%
You hit @the_monster@ 
Du triffst {acc}@the_monster@ 
%%%%
```

Note that I have deliberately not used a context for the nominative case - this makes it the default.
And, as per the gender example, the context {acc} is not hardcoded. The translator can use whatever they want.


## Limitations/Outside the inital scope
- ~~some languages have more than just singular and plural. For example, Russian uses the "dual" form for 2-4 (and 12-14). I implemented a solution to this in Alphabet Soup, but it was rather clunky. I will have to rethink this.~~ Edit: This is implemented, so now in scope.
- character set: The local tiles build uses a font that only has Latin, Greek and Cyrillic scripts (and Arabic, but that has another issue... see below), which means other scripts like Chinese/Japanese/Korean are not currently supported by local tiles. For the console version, it depends on system fonts. I'm not sure what the story with the fonts in web tiles is.
- Text direction: Some scripts like Arabic and Hebrew are written right to left. I don't have a solution for this. Handling this would require rejigging the layout of the HUD and other components.
