### PR TITLE
fix sound conditional in initfile.cc

### DIFF
--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3491,7 +3491,7 @@ sound_mapping::sound_mapping(const string &s)
         mprf(MSGCH_ERROR, "Options error: invalid sound mapping '%s'", s.c_str());
         return;
     }
-#if !defined(USE_SOUND) || !defined(WINMM_PLAY_SOUNDS) || !defined(SOUND_PLAY_COMMAND) || !defined(USE_SDL)
+#if !(defined(USE_SOUND) && (defined(WINMM_PLAY_SOUNDS) || defined(SOUND_PLAY_COMMAND) || defined(USE_SDL)))
     static bool _sound_warning_issued = false;
     if (!_sound_warning_issued)
     {


### PR DESCRIPTION
As currently written, all four defines must exist. But three of them are intended to be platform-specific and it's not really expected that more than one of them be defined.