### PR TITLE
Webtiles: Receive HUD species+god line from executable (i18n support)

### DIFF
--- a/crawl-ref/source/tileweb.cc
+++ b/crawl-ref/source/tileweb.cc
@@ -1176,6 +1176,12 @@ void TilesFramework::_send_player(bool force_full)
     _update_int(force_full, c.piety_rank, prank, "piety_rank");
     _update_int(force_full, c.ostracism_pips, ostracism_pips(), "ostracism_pips");
 
+    // Species/god line (e.g. "Minotaur of Trog")
+    string species_god = player_species_name();
+    if (!you_worship(GOD_NO_GOD))
+        species_god += " of " + god;
+    _update_string(force_full, c.species_god, species_god, "species_god");
+
     _update_int(force_full, c.form, (uint8_t) you.form, "form");
 
     _update_int(force_full, c.hp, you.hp, "hp");

--- a/crawl-ref/source/tileweb.h
+++ b/crawl-ref/source/tileweb.h
@@ -52,6 +52,9 @@ struct player_info
     int piety_rank;
     int ostracism_pips;
 
+    // species god line (e.g. "Minotaur of Trog")
+    string species_god;
+
     uint8_t form;
 
     int hp, hp_max, real_hp_max, poison_survival;

--- a/crawl-ref/source/webserver/game_data/static/player.js
+++ b/crawl-ref/source/webserver/game_data/static/player.js
@@ -397,9 +397,18 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
                                     + player.title);
         $("#stats_wizmode").text(player.wizard ? "*WIZARD*" : player.explore ? "*EXPLORE*" : "");
 
-        var species_god = player.species_display_name;
-        if (player.god != "")
-            species_god += " of " + player.god;
+        // i18n: if the game sends the (potentially translated) species+god line, use it
+        // otherwise build it ourselves for backward compatibility
+        var species_god;
+        if (player.species_god)
+            species_god = player.species_god
+        else
+        {
+            species_god = player.species_display_name;
+            if (player.god != "")
+                species_god += " of " + player.god;
+        }
+
         if (player.god == "Xom")
         {
             if (player.piety_rank >=0)
@@ -613,7 +622,7 @@ function ($, comm, client, enums, map_knowledge, messages, options, util) {
         .on("game_init.player", function () {
             $.extend(player, {
                 name: "", god: "", title: "", species: "",
-                species_display_name: "",
+                species_display_name: "", species_god: "",
                 hp: 0, hp_max: 0, real_hp_max: 0, poison_survival: 0,
                 mp: 0, mp_max: 0, dd_real_mp_max: 0,
                 ac: 0, ev: 0, sh: 0,


### PR DESCRIPTION
This is a small change to support future internationalisation.

It allows the web server to receive the (potentially translated) HUD species+god line (e.g. "Minotaur of Trog") from the Crawl executable.

For backwards compatibility with older Crawl executables, if the web server doesn't receive this line from the Crawl executable, it will build it itself, as before.

This change also keeps the Crawl executable backwards compatible with older versions of the web server. If the executable sends the string, but the web server isn't looking for it, then nothing breaks. It's just ignored.