### PR TITLE
Prevent pain bond dealing infinite damage

### DIFF
--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -5548,42 +5548,53 @@ int max_mons_charge(monster_type m)
     }
 }
 
-// Deal out damage to nearby pain-bonded monsters based on the distance between them.
-void radiate_pain_bond(const monster& mon, int damage, const monster* original_target)
+void radiate_pain_bond(const monster& mon, int damage)
 {
-    for (actor_near_iterator ai(mon.pos(), LOS_NO_TRANS); ai; ++ai)
+    set<mid_t> affected;
+    affected.insert(mon.mid);
+
+    vector<pair<const monster*, int>> wave;
+    wave.emplace_back(&mon, damage);
+
+    // Spread the damage outward in breadth-first waves.
+    while (!wave.empty())
     {
-        if (!ai->is_monster())
-            continue;
-
-        monster* target = ai->as_monster();
-
-        if (&mon == target) // no self-sharing
-            continue;
-
-        // Only other pain-bonded monsters are affected.
-        if (!target->has_ench(ENCH_PAIN_BOND))
-            continue;
-
-        int distance = target->pos().distance_from(mon.pos());
-        if (distance > 3)
-            continue;
-
-        damage = max(0, div_rand_round(damage * (4 - distance), 5));
-
-        if (damage > 0)
+        map<monster*, int> incoming;
+        for (const auto &source : wave)
         {
+            for (actor_near_iterator ai(source.first->pos(), LOS_NO_TRANS); ai; ++ai)
+            {
+                if (!ai->is_monster())
+                    continue;
+
+                monster* target = ai->as_monster();
+                if (!target->has_ench(ENCH_PAIN_BOND) || affected.count(target->mid))
+                    continue;
+
+                int distance = target->pos().distance_from(source.first->pos());
+                if (distance > 3)
+                    continue;
+
+                int share = max(0, div_rand_round(source.second * (5 - distance), 5));
+                if (share <= 0)
+                    continue;
+
+                int &best = incoming[target];
+                if (share > best)
+                    best = share;
+            }
+        }
+
+        // Hurt everyone in the new wave and radiate onwards.
+        wave.clear();
+        for (const auto &entry : incoming)
+        {
+            monster* target = entry.first;
+            affected.insert(target->mid);
             behaviour_event(target, ME_ANNOY, &you, you.pos());
-
-            // save any potential cleanup of the original target for later
-            // (in `monster::hurt`).
-            if (target == original_target)
-                damage = target->hurt(&you, damage, BEAM_SHARED_PAIN, KILLED_BY_MONSTER, "", "", false);
-            else
-                damage = target->hurt(&you, damage, BEAM_SHARED_PAIN);
-
-            if (damage > 0)
-                radiate_pain_bond(*target, damage, original_target);
+            int dealt = target->hurt(&you, entry.second, BEAM_SHARED_PAIN);
+            if (dealt > 0)
+                wave.emplace_back(target, dealt);
         }
     }
 }

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -557,8 +557,7 @@ int max_mons_charge(monster_type m);
 
 void init_mutant_beast(monster &mon, short HD, vector<int> beast_facets);
 
-void radiate_pain_bond(const monster& mon, int damage,
-                       const monster* original_target);
+void radiate_pain_bond(const monster& mon, int damage);
 void throw_monster_bits(const monster& mon);
 
 void set_ancestor_spells(monster &ancestor, bool notify = false);

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -4382,14 +4382,8 @@ int monster::hurt(const actor *agent, int amount, beam_type flavour,
         }
 
         // Handle pain bond behaviour here. Is technically passive damage.
-        // radiate_pain_bond may do additional damage by recursively looping
-        // back to the original trigger.
         if (has_ench(ENCH_PAIN_BOND) && flavour != BEAM_SHARED_PAIN)
-        {
-            int hp_before_pain_bond = hit_points;
-            radiate_pain_bond(*this, amount, this);
-            amount += max(hp_before_pain_bond - hit_points, 0);
-        }
+            radiate_pain_bond(*this, amount);
 
         // Allow the victim to exhibit passive damage behaviour (e.g.
         // the Royal Jelly or Uskayaw's Pain Bond).


### PR DESCRIPTION
In sufficiently tight clusters of monsters (e.g. a square), pain bond's total damage diverged, so that a 1-damage attack could continue radiating until at least one monster died. This was a bit silly. More generally, the tightness of the clustering of monsters affected pain bond's damage to a fairly unreasonable and surprising extent. For example, with n mutually-adjacent enemies, the expected damager multiplier on pain bond was 1,2.5,25,infinity for n=1,2,3,4.

Also, pain bond had a separate probably-bug whereby the subsequent monsters in a single call to radiate took less damage, making the order of iteration over monsters important.

Here, we change pain bond to effect each enemy only once (and not to damage the original target at all), and to deal the same damage to each enemy in a single pass. It still radiates to hit enemies beyond the original radius. We up the numbers a little bit to balance this; pain bond will be weaker against tight clusters of monsters and stronger against loose ones.