### PR TITLE
Fix pattern_match::matched_text and add regression tests

### DIFF
--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -317,6 +317,7 @@ catch2-tests/test_files.o \
 catch2-tests/test_items.o \
 catch2-tests/test_mon-util.o \
 catch2-tests/test_ng-init-branches.o \
+catch2-tests/test_pattern.o \
 catch2-tests/test_player.o \
 catch2-tests/test_player_fixture.o \
 catch2-tests/test_randbook.o \

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -9,7 +9,7 @@ TEST_CASE( "Pattern matches", "[single-file]" ) {
     REQUIRE( pattern1.matches("Dungeon:1") );
     REQUIRE( pattern1.matches("You are on Dungeon:1") );
 
-    // match wholes string
+    // match whole string
     text_pattern pattern2("^[A-Za-z]+:[0-9]+$");
     REQUIRE( pattern2.matches("Dungeon:1") );
     REQUIRE( !pattern2.matches("You are on Dungeon:1") );

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -1,0 +1,25 @@
+#include "catch_amalgamated.hpp"
+
+#include "AppHdr.h"
+#include "pattern.h"
+
+TEST_CASE( "Pattern matches", "[single-file]" ) {
+    // match substring
+    text_pattern pattern1("[A-Za-z]+:[0-9]+");
+    REQUIRE( pattern1.matches("Dungeon:1") );
+    REQUIRE( pattern1.matches("You are on Dungeon:1") );
+
+    // match wholes string
+    text_pattern pattern2("^[A-Za-z]+:[0-9]+$");
+    REQUIRE( pattern2.matches("Dungeon:1") );
+    REQUIRE( !pattern2.matches("You are on Dungeon:1") );
+}
+
+TEST_CASE( "Matched text", "[single-file]" ) {
+    text_pattern pattern1(":[0-9]+");
+    pattern_match match = pattern1.match_location("Lair:5");
+    CHECK( match.matched_text() == ":5" );
+    CHECK( match.start_pos() == 4 );
+    // note: half-open range
+    CHECK( match.end_pos() == 6 );
+}

--- a/crawl-ref/source/pattern.h
+++ b/crawl-ref/source/pattern.h
@@ -20,9 +20,24 @@ public:
 
     string annotate_string(const string &color) const;
 
-    const string &matched_text() const
+    const string matched_text() const
     {
-        return text;
+        // note: [start, end) is a half-open range
+        if (start >= 0 && end <= (int)text.length() && end > start)
+            return text.substr(start, end - start);
+        else
+            return "";
+    }
+
+    int start_pos() const
+    {
+        return start;
+    }
+
+    // note: half-open range
+    int end_pos() const
+    {
+        return end;
     }
 
 private:


### PR DESCRIPTION
pattern_match::matched_text was returning the whole text instead of the matched part. Fixed it.

Added getters for the start and end positions of the match .

Added regression tests.