### PR TITLE
Fix typos: recieve→receive, seperate→separate, Neccropolis→Necropolis

### DIFF
--- a/crawl-ref/source/dat/des/portals/necropolis.des
+++ b/crawl-ref/source/dat/des/portals/necropolis.des
@@ -84,8 +84,8 @@ function necropolis_portal_entry(e)
     -- Roughly corresponding to the average (if hardly the median) number of
     -- ghost vaults one got per game previously. Early Necropolis spawns are
     -- quite hard though (player ghosts are too above the curve), so lower
-    -- their odds on the earliest floors. Vaults:1-4 Neccropolis entries are
-    -- placed seperately via vaults_default_options() and pick_room().
+    -- their odds on the earliest floors. Vaults:1-4 Necropolis entries are
+    -- placed separately via vaults_default_options() and pick_room().
     e.chance(350)
     e.depth_chance("D:5-7", 275)
     e.depth_chance("Vaults", 0)
@@ -858,14 +858,14 @@ ENDMAP
 # <<2>> Necropolis layouts
 #
 # Each Necropolis uses the same rough decoration schema of an entry garden
-# leading to three seperate 20x20 ghost subvaults. If they have a surrounding
+# leading to three separate 20x20 ghost subvaults. If they have a surrounding
 # sea of ghosts, that sea is sealed off by indestructible glass.
 #
 # TODO: further decorations for future layouts could include:
 #   * fountains of ectoplasm (needs lots of write-ups)
 #   * altars to Hepliakqana (has to exclude pre-D:11 spawns)
 #   * rock and stone tiles from the original branch (needs V/E and U/C tricks)
-#   * a transporter entrance seperated from the ghost vaults?
+#   * a transporter entrance separated from the ghost vaults?
 #############################################################################
 
 default-depth: Necropolis

--- a/crawl-ref/source/dat/des/variable/grated_community.des
+++ b/crawl-ref/source/dat/des/variable/grated_community.des
@@ -355,7 +355,7 @@ MAP
       '
 ENDMAP
 
-# This was originally kept seperate of the other subvaults to push in and hide
+# This was originally kept separate of the other subvaults to push in and hide
 # the escape items from those who teleported in, but that's not really needed.
 NAME:  grated_community_mu_sprite_home
 TAGS:  grated_community_mu_home_escape

--- a/crawl-ref/source/dat/des/variable/mini_monsters.des
+++ b/crawl-ref/source/dat/des/variable/mini_monsters.des
@@ -1397,7 +1397,7 @@ MAP
 .....................
 ENDMAP
 
-# TODO: Convert this to a decorative skeleton vault by letting corpses recieve
+# TODO: Convert this to a decorative skeleton vault by letting corpses receive
 #       more monster data like hydra head count, and let it be a vault that
 #       another adventurer went through already. Reduces the issues of
 #       weaker hydras being freer experience and keeps actually-fighting Lerny

--- a/crawl-ref/source/dat/descript/monsters.txt
+++ b/crawl-ref/source/dat/descript/monsters.txt
@@ -2490,7 +2490,7 @@ An intricate mechanical beetle covered in reinforced metal plates that resemble
 a shield. It projects a kinetic barrier around its creator while adjacent to
 them, increasing their armour class.
 
-It will never voluntarily leave its creator's side, and if forcibly seperated,
+It will never voluntarily leave its creator's side, and if forcibly separated,
 will prioritise returning to them over any other concerns.
 %%%%
 phantasmal warrior

--- a/crawl-ref/source/dat/dlua/userbase.lua
+++ b/crawl-ref/source/dat/dlua/userbase.lua
@@ -428,7 +428,7 @@ function c_message(text, channel) end
 
 --- Okawaru weapon acquirement hook.
 --
--- This hook can be defined to execute lua when Okawaru's Recieve Weapon
+-- This hook can be defined to execute lua when Okawaru's Receive Weapon
 -- capstone ability is used.
 --
 -- The hook should call @{items.acquirement_items} with an argument of 2 to get
@@ -441,7 +441,7 @@ function c_message(text, channel) end
 
 --- Okawaru armour acquirement hook.
 --
--- This hook can be defined to execute lua when Okawaru's Recieve Armour
+-- This hook can be defined to execute lua when Okawaru's Receive Armour
 -- capstone ability is used.
 --
 -- The hook should call @{items.acquirement_items} with an argument of 3 to get

--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -1803,7 +1803,7 @@ void celebrant_bloodrite_fineff::fire()
 
     mpr("You consecrate your suffering and invoke the rites of blood!");
 
-    // Set cooldown before firing, in case we recieve damage during the volley
+    // Set cooldown before firing, in case we receive damage during the volley
     // (eg: via reflected projectiles) that would trigger this again.
     you.duration[DUR_CELEBRANT_COOLDOWN] = 1;
 

--- a/crawl-ref/source/xom.cc
+++ b/crawl-ref/source/xom.cc
@@ -2995,7 +2995,7 @@ static void _xom_blinding_blinkitis(int /* sever */)
     draw_ring_animation(you.pos(), you.current_vision, BLUE, MAGENTA,
                         true, 25, TILE_BOLT_CORRUPTION);
 
-    // Gather the list seperately from the action for the sake of messaging.
+    // Gather the list separately from the action for the sake of messaging.
     for (monster_near_iterator mi(you.pos(), LOS_NO_TRANS); mi; ++mi)
         if (!mi->wont_attack() && !mi->is_peripheral() && !mi->stasis())
             target.push_back(*mi);


### PR DESCRIPTION
Small spelling fixes across the tree (comments, vault layout comments, and one monster description). All changes are text-only; no functional change. Per the contribution guide, typo fixes are a welcome beginner path.

**Fixed:**
- `recieve` → `receive` — `fineff.cc` (comment), `dat/dlua/userbase.lua` (2× hook docs), `dat/des/variable/mini_monsters.des` (comment)
- `seperate`/`seperated`/`seperately` → `separate(d/ly)` — `dat/des/portals/necropolis.des` (3×), `dat/des/variable/grated_community.des`, `xom.cc` (comment), `dat/descript/monsters.txt` (player-visible description: "if forcibly separated")
- `Neccropolis` → `Necropolis` — `dat/des/portals/necropolis.des` (comment)

> [!INFO] *AI disclosure*: This change was prepared with AI assistance on behalf of karlsune. Each replacement was verified against the surrounding text to confirm it is a genuine misspelling in a comment or description, not an identifier or game term.