### PR TITLE
Improve some spell QoL

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3182,6 +3182,9 @@ static int _test_beam_hit(int attack, int defence, defer_rand &r)
 
 bool bolt::is_harmless(const monster* mon) const
 {
+    if (protected_from_spell(origin_spell, *mon, agent()))
+        return true;
+
     // For enchantments, this is already handled in nasty_to().
     if (is_enchantment())
         return !nasty_to(mon);
@@ -4763,7 +4766,7 @@ void bolt::tracer_nonenchantment_affect_monster(monster* mon)
 
     // Check only if actual damage and the monster is worth caring about.
     // Living spells do count as threats, but are fine being collateral damage.
-    if ((final > 0 || side_effect)
+    if (((final > 0 && !is_harmless(mon)) || side_effect)
         && (mons_is_threatening(*mon) || mons_class_is_test(mon->type))
         && mon->type != MONS_LIVING_SPELL)
     {

--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -4523,18 +4523,34 @@ bool bolt::ignores_player() const
     return false;
 }
 
+ac_type bolt::effective_ac_rule() const
+{
+    if (ac_rule != ac_type::normal)
+        return ac_rule;
+
+    if (flavour == BEAM_DAMNATION)
+        return ac_type::none;
+    if (get_beam_resist_type(flavour) == BEAM_ELECTRICITY)
+        return ac_type::half;
+    if (flavour == BEAM_FRAG)
+        return ac_type::triple;
+
+    return ac_type::normal;
+}
+
+bool bolt::can_be_dodged() const
+{
+    return !is_explosion && !is_big_cloud() && hit != AUTOMATIC_HIT;
+}
+
+bool bolt::can_be_blocked() const
+{
+    return !is_big_cloud() && is_blockable();
+}
+
 int bolt::apply_AC(const actor *victim, int hurted)
 {
-    // Apply automatic AC rules if ac_rule was not manually specified.
-    if (ac_rule == ac_type::normal)
-    {
-        if (flavour == BEAM_DAMNATION)
-            ac_rule = ac_type::none;
-        else if (get_beam_resist_type(flavour) == BEAM_ELECTRICITY)
-            ac_rule = ac_type::half;
-        else if (flavour == BEAM_FRAG)
-            ac_rule = ac_type::triple;
-    }
+    ac_rule = effective_ac_rule();
 
     // beams don't obey GDR -> max_damage is 0
     return victim->apply_ac(hurted, 0, ac_rule, !is_tracer());
@@ -5580,7 +5596,7 @@ void bolt::affect_monster(monster* mon)
         beam_hit = apply_to_hit_modifiers(beam_hit, *mon);
 
     // The monster may block the beam.
-    if (!engulfs && is_blockable() && attempt_block(mon))
+    if (can_be_blocked() && attempt_block(mon))
         return;
 
     defer_rand r;
@@ -5602,7 +5618,7 @@ void bolt::affect_monster(monster* mon)
     // FIXME: We're randomising mon->evasion, which is further
     // randomised inside test_beam_hit. This is so we stay close to the
     // 4.0 to-hit system (which had very little love for monsters).
-    if (!engulfs && hit_margin < 0)
+    if (can_be_dodged() && hit_margin < 0)
     {
         // If the PLAYER cannot see the monster, don't tell them anything!
         if (mon->observable())

--- a/crawl-ref/source/beam.h
+++ b/crawl-ref/source/beam.h
@@ -268,6 +268,9 @@ private:
 
 public:
     bool is_enchantment() const; // no block/dodge, use willpower
+    ac_type effective_ac_rule() const;
+    bool can_be_dodged() const;
+    bool can_be_blocked() const;
     void set_target(const dist &targ);
     void set_agent(const actor *agent);
     void setup_retrace();

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4253,8 +4253,11 @@ static string _player_spell_stats(const spell_type spell)
     const string damage_string = spell_damage_string(spell);
     const string max_dam_string = spell_max_damage_string(spell);
     const int acc = spell_acc(spell);
+    const string defence_string = spell_defence_string(spell);
+    const string resist_string = spell_resist_string(spell);
     // TODO: generalize this pattern? It's very common in descriptions
-    const int padding = (acc != -1) ? 8 : damage_string.size() ? 6 : 5;
+    const int padding = (acc != -1 || !defence_string.empty()) ? 8
+                        : damage_string.size() ? 6 : 5;
     description += make_stringf("\n\n%*s: ", padding, "Power");
     description += spell_power_string(spell);
 
@@ -4279,6 +4282,16 @@ static string _player_spell_stats(const spell_type spell)
     description += spell_range_string(spell);
     description += make_stringf("\n%*s: ", padding, "Noise");
     description += spell_noise_string(spell);
+    if (!defence_string.empty())
+    {
+        description += make_stringf("\n%*s: %s", padding, "Defences",
+                                    defence_string.c_str());
+    }
+    if (!resist_string.empty())
+    {
+        description += make_stringf("\n%*s: %s", padding, "Resists",
+                                    resist_string.c_str());
+    }
     description += "\n";
     return description;
 }
@@ -4674,6 +4687,14 @@ static void _get_spell_description(const spell_type spell,
 
         description += "\nRange : ";
         description += range_string(range, -1, minrange);
+
+        const int mon_pow = mons_power_for_hd(spell, hd);
+        const string defence_string = spell_defence_string(spell, true, mon_pow);
+        const string resist_string = spell_resist_string(spell, true, mon_pow);
+        if (!defence_string.empty())
+            description += "\nDefences : " + defence_string;
+        if (!resist_string.empty())
+            description += "\nResists : " + resist_string;
 
         if (crawl_state.need_save && you_worship(GOD_DITHMENOS))
         {

--- a/crawl-ref/source/fight.cc
+++ b/crawl-ref/source/fight.cc
@@ -795,7 +795,7 @@ static bool _is_boolean_resist(beam_type flavour)
 
 // Gets the percentage of the total damage of this damage flavour that can
 // be resisted.
-static inline int _get_resistible_fraction(beam_type flavour)
+int beam_resistible_fraction(beam_type flavour)
 {
     switch (flavour)
     {
@@ -916,7 +916,7 @@ int resist_adjust_damage(const actor* defender, beam_type flavour, int rawdamage
 
     const bool is_mon = defender->is_monster();
 
-    const int resistible_fraction = _get_resistible_fraction(flavour);
+    const int resistible_fraction = beam_resistible_fraction(flavour);
 
     int resistible = rawdamage * resistible_fraction / 100;
     const int irresistible = rawdamage - resistible;

--- a/crawl-ref/source/fight.h
+++ b/crawl-ref/source/fight.h
@@ -38,6 +38,7 @@ void player_attempted_attack(bool trigger_effects, bool maintain_statuses = true
                              actor* primary_target = nullptr);
 
 beam_type get_beam_resist_type(beam_type flavour);
+int beam_resistible_fraction(beam_type flavour);
 int resist_adjust_damage(const actor *defender, beam_type flavour,
                          int rawdamage);
 

--- a/crawl-ref/source/mon-util.cc
+++ b/crawl-ref/source/mon-util.cc
@@ -4894,7 +4894,7 @@ bool mon_shape_is_humanoid(mon_body_shape shape)
            && shape <= MON_SHAPE_LAST_HUMANOID;
 }
 
-int get_dist_to_nearest_monster()
+int get_dist_to_nearest_monster(bool skip_damage_immune)
 {
     int minRange = LOS_RADIUS + 1;
     for (radius_iterator ri(you.pos(), LOS_NO_TRANS, true); ri; ++ri)
@@ -4904,6 +4904,9 @@ int get_dist_to_nearest_monster()
             continue;
 
         if (!you.aware_of(*mon))
+            continue;
+
+        if (skip_damage_immune && mon->damage_immune(&you))
             continue;
 
         // Plants/fungi don't count.

--- a/crawl-ref/source/mon-util.h
+++ b/crawl-ref/source/mon-util.h
@@ -515,7 +515,7 @@ mon_inv_type item_to_mslot(const item_def &item);
 
 bool mons_is_immotile(const monster& mons);
 
-int get_dist_to_nearest_monster();
+int get_dist_to_nearest_monster(bool skip_damage_immune = false);
 bool monster_nearby();
 actor *actor_by_mid(mid_t m, bool require_valid = false, bool allow_dead = false);
 monster *monster_by_mid(mid_t m, bool require_valid = false, bool allow_dead = false);

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1260,7 +1260,8 @@ static vector<coord_def> _simple_find_all_hostiles()
 }
 
 // TODO: refactor into target.cc, move custom classes out of target.h
-unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
+static unique_ptr<targeter> _find_spell_targeter(spell_type spell, int pow,
+                                                 int range)
 {
     switch (spell)
     {
@@ -1567,6 +1568,17 @@ unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
     }
 
     return nullptr;
+}
+
+unique_ptr<targeter> find_spell_targeter(spell_type spell, int pow, int range)
+{
+    unique_ptr<targeter> hitfunc = _find_spell_targeter(spell, pow, range);
+    // If this is a beam, add spell information to it.
+    targeter_beam *beam_hitf = dynamic_cast<targeter_beam*>(hitfunc.get());
+    if (beam_hitf && beam_hitf->beam.origin_spell == SPELL_NO_SPELL)
+        beam_hitf->beam.origin_spell = spell;
+
+    return hitfunc;
 }
 
 bool spell_has_targeter(spell_type spell)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -26,6 +26,7 @@
 #include "env.h"
 #include "evoke.h"
 #include "exercise.h"
+#include "fight.h"
 #include "format.h"
 #include "god-abil.h"
 #include "god-conduct.h"
@@ -3293,6 +3294,237 @@ int spell_acc(spell_type spell)
     if (acc == AUTOMATIC_HIT)
         return -1;
     return acc;
+}
+
+/// How a spell's target can defend against it, for description purposes.
+struct spell_defence_info
+{
+    ac_type ac;
+    bool ev;
+    bool sh;
+    bool will;
+    vector<beam_type> resists;
+    const char *resist_override;
+    bool damaging;
+};
+
+struct spell_damage_zap
+{
+    zap_type zap;
+    bool monster_stats;
+};
+
+// Spells which use zaps but not from spell_to_zap.
+static const map<spell_type, spell_damage_zap> _spell_damage_zaps =
+{
+    { SPELL_DIAMOND_SAWBLADES,     { ZAP_SHRED,             true } },
+    { SPELL_FORGE_LIGHTNING_SPIRE, { ZAP_ELECTRICAL_BOLT,   true } },
+    { SPELL_FORTRESS_BLAST,        { ZAP_FORTRESS_BLAST,    false } },
+    { SPELL_HELLFIRE_MORTAR,       { ZAP_MAGMA_BARRAGE,     true } },
+    { SPELL_HOARFROST_CANNONADE,   { ZAP_HOARFROST_BULLET,  true } },
+    { SPELL_RENDING_BLADE,         { ZAP_RENDING_SLASH,     true } },
+};
+
+// Spells which don't use zaps, so we specify defences manually.
+static const map<spell_type, spell_defence_info> _spell_defences =
+{
+    { SPELL_AIRSTRIKE,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_ARCJOLT,
+      { ac_type::half, false, false, false, { BEAM_ELECTRICITY } } },
+    { SPELL_BATTLESPHERE,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_BOULDER,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_CONJURE_BALL_LIGHTNING,
+      { ac_type::half, false, false, false, { BEAM_ELECTRICITY } } },
+    { SPELL_DETONATION_CATALYST,
+      { ac_type::normal, false, false, false, { BEAM_FIRE } } },
+    { SPELL_DISCHARGE,
+      { ac_type::half, false, false, false, { BEAM_ELECTRICITY } } },
+    { SPELL_ERUPTION,
+      { ac_type::normal, false, false, false, { BEAM_LAVA } } },
+    { SPELL_FREEZING_CLOUD,
+      { ac_type::none, false, false, false, { BEAM_COLD } } },
+    { SPELL_FROZEN_RAMPARTS,
+      { ac_type::normal, false, false, false, { BEAM_COLD } } },
+    { SPELL_FULMINANT_PRISM,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_GELLS_GAVOTTE,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_GLACIATE,
+      { ac_type::normal, false, false, false, { BEAM_ICE } } },
+    { SPELL_IOOD,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_IRRADIATE,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_JINXBITE,
+      { ac_type::none, false, false, true, {} } },
+    { SPELL_LAUNCH_SPORANGIUM,
+      { ac_type::normal, false, false, false, { BEAM_ACID } } },
+    { SPELL_LRD,
+      { ac_type::triple, false, false, false, {} } },
+    { SPELL_MAXWELLS_COUPLING,
+      { ac_type::none, false, false, false, {} } },
+    { SPELL_NOXIOUS_BOG,
+      { ac_type::none, false, false, false, { BEAM_POISON_ARROW } } },
+    { SPELL_PERMAFROST_ERUPTION,
+      { ac_type::normal, false, false, false, {}, "rC (explosion)" } },
+    { SPELL_PILEDRIVER,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_PLASMA_BEAM,
+      { ac_type::normal, true, false, false, {}, "rF, rElec (one beam each)" } },
+    { SPELL_POISONOUS_VAPOURS,
+      { ac_type::none, false, false, false, { BEAM_POISON } } },
+    { SPELL_POLAR_VORTEX,
+      { ac_type::proportional, false, false, false, { BEAM_ICE } } },
+    { SPELL_RESONANCE_STRIKE,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_SCORCH,
+      { ac_type::normal, false, false, false, { BEAM_FIRE } } },
+    { SPELL_SHATTER,
+      { ac_type::normal, false, false, false, {} } },
+    { SPELL_SLEETSTRIKE,
+      { ac_type::normal, false, false, false, { BEAM_ICE } } },
+    { SPELL_THUNDERBOLT,
+      { ac_type::half, false, false, false, { BEAM_ELECTRICITY } } },
+    { SPELL_WATERSTRIKE,
+      { ac_type::normal, false, false, false, { BEAM_WATER } } },
+};
+
+// Player facing name of the resist for a given beam flavour.
+static const char *beam_resist_name(beam_type flavour)
+{
+    switch (flavour)
+    {
+        case BEAM_FIRE:        return "rF";
+        case BEAM_COLD:        return "rC";
+        case BEAM_ELECTRICITY: return "rElec";
+        case BEAM_POISON:      return "rPois";
+        case BEAM_NEG:         return "rNeg";
+        case BEAM_ACID:        return "rCorr";
+        case BEAM_STEAM:       return "rSteam";
+        default:               return nullptr;
+    }
+}
+
+/// Work out which defences and resistances apply to a spell's target.
+static spell_defence_info _get_spell_defences(spell_type spell,
+                                              bool is_monster, int pow)
+{
+    spell_defence_info info = { ac_type::none, false, false,
+                                bool(get_spell_flags(spell) & spflag::WL_check),
+                                {}, nullptr, false };
+
+    const auto special = _spell_defences.find(spell);
+    if (special != _spell_defences.end())
+    {
+        const spell_defence_info &sp = special->second;
+        info.ac       = sp.ac;
+        info.ev       = sp.ev;
+        info.sh       = sp.sh;
+        info.will     = info.will || sp.will;
+        info.resists  = sp.resists;
+        info.resist_override = sp.resist_override;
+        info.damaging = true;
+        return info;
+    }
+
+    zap_type zap = NUM_ZAPS;
+    const auto dam_zap = _spell_damage_zaps.find(spell);
+    if (dam_zap != _spell_damage_zaps.end())
+    {
+        zap = dam_zap->second.zap;
+        is_monster = is_monster || dam_zap->second.monster_stats;
+    }
+    else
+        zap = spell_to_zap(spell);
+
+    if (zap == NUM_ZAPS)
+        return info;
+
+    if (pow < 0)
+        pow = is_monster ? 100 : calc_spell_power(spell);
+    pow = max(pow, 0);
+
+    bolt beam;
+    zappy(zap, pow, is_monster, beam);
+
+    const dice_def dam = zap_damage(zap, pow, is_monster, false);
+    if (dam.num <= 0 || dam.size <= 0)
+        return info;
+
+    // We have information from the zap.
+    info.damaging = true;
+
+    if (!beam.is_enchantment())
+    {
+        info.ac = beam.effective_ac_rule();
+        info.ev = beam.can_be_dodged();
+        info.sh = beam.can_be_blocked();
+    }
+
+    info.resists.push_back(beam.flavour);
+
+    return info;
+}
+
+// Description of which defences (AC, EV, SH) a spell checks.
+string spell_defence_string(spell_type spell, bool is_monster, int pow)
+{
+    const spell_defence_info info = _get_spell_defences(spell, is_monster, pow);
+    if (!info.damaging)
+        return "";
+
+    vector<string> checks;
+    switch (info.ac)
+    {
+        case ac_type::none:         break;
+        case ac_type::half:         checks.push_back("AC (50%)"); break;
+        case ac_type::triple:       checks.push_back("AC (x3)"); break;
+        default:                    checks.push_back("AC"); break;
+    }
+    if (info.ev)
+        checks.push_back("EV");
+    if (info.sh)
+        checks.push_back("SH");
+
+    if (checks.empty())
+        return "none";
+
+    return comma_separated_line(checks.begin(), checks.end(), ", ", ", ");
+}
+
+// Description of which resistances a damage spell checks.
+string spell_resist_string(spell_type spell, bool is_monster, int pow)
+{
+    const spell_defence_info info = _get_spell_defences(spell, is_monster, pow);
+    if (!info.damaging)
+        return "";
+
+    vector<string> descs;
+    if (info.will)
+        descs.push_back("Will");
+    if (info.resist_override)
+        descs.push_back(info.resist_override);
+    else for (beam_type flavour : info.resists)
+    {
+        const bool varies = flavour == BEAM_CHAOS || flavour == BEAM_RANDOM;
+        const char *name = varies ? "varies"
+                                  : beam_resist_name(get_beam_resist_type(flavour));
+        if (!name)
+            continue;
+        const int pct = beam_resistible_fraction(flavour);
+        if (pct == 100)
+            descs.push_back(name);
+        else
+            descs.push_back(make_stringf("%s (%d%%)", name, pct));
+    }
+
+    if (descs.empty())
+        return "none";
+
+    return comma_separated_line(descs.begin(), descs.end(), ", ", ", ");
 }
 
 int spell_power_percent(spell_type spell)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1016,12 +1016,14 @@ spret cast_a_spell(bool check_range, spell_type spell, dist *_target,
         return spret::abort;
     }
 
-    if (check_range && spell_no_hostile_in_range(spell))
+    const bool needs_target = testbits(get_spell_flags(spell),
+                                       spflag::needs_target);
+    if ((check_range || needs_target) && spell_no_hostile_in_range(spell))
     {
         // Abort if there are no hostiles within range, but flash the range
         // markers for a short while.
-        mpr("You can't see any susceptible monsters within range! "
-            "(Use <w>Z</w> to cast anyway.)");
+        mprf("You can't see any susceptible monsters within range!%s",
+             needs_target ? "" : " (Use <w>Z</w> to cast anyway.)");
 
         if ((Options.use_animations & UA_RANGE) && Options.darken_beyond_range)
         {

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -3113,48 +3113,48 @@ static dice_def _spell_damage(spell_type spell, int power)
         return dice_def(0,0);
     switch (spell)
     {
-        case SPELL_FULMINANT_PRISM:
-            return prism_damage(prism_hd(power, false), true);
+        case SPELL_ARCJOLT:
+            return arcjolt_damage(power, false);
+        case SPELL_BATTLESPHERE:
+            return battlesphere_damage_from_power(power);
+        case SPELL_BOULDER:
+            return boulder_damage(power, false);
         case SPELL_CONJURE_BALL_LIGHTNING:
             return ball_lightning_damage(ball_lightning_hd(power, false), false);
+        case SPELL_DETONATION_CATALYST:
+            return detonation_catalyst_damage(power, false);
+        case SPELL_DIAMOND_SAWBLADES:
+            return diamond_sawblade_damage(power);
+        case SPELL_FORGE_LIGHTNING_SPIRE:
+            return lightning_spire_damage(power);
+        case SPELL_FORTRESS_BLAST:
+            return fortress_blast_damage(you.armour_class_scaled(1), false);
+        case SPELL_FROZEN_RAMPARTS:
+            return ramparts_damage(power, false);
+        case SPELL_FULMINANT_PRISM:
+            return prism_damage(prism_hd(power, false), true);
+        case SPELL_HELLFIRE_MORTAR:
+            return hellfire_mortar_damage(power);
         case SPELL_IOOD:
             return iood_damage(power, INFINITE_DISTANCE, false);
         case SPELL_IRRADIATE:
             return irradiate_damage(power, false);
-        case SPELL_SHATTER:
-            return shatter_damage(power);
-        case SPELL_SCORCH:
-            return scorch_damage(power, false);
-        case SPELL_BATTLESPHERE:
-            return battlesphere_damage_from_power(power);
-        case SPELL_FROZEN_RAMPARTS:
-            return ramparts_damage(power, false);
-        case SPELL_LRD:
-            return base_fragmentation_damage(power, false);
-        case SPELL_ARCJOLT:
-            return arcjolt_damage(power, false);
-        case SPELL_POLAR_VORTEX:
-            return polar_vortex_dice(power, false);
-        case SPELL_NOXIOUS_BOG:
-            return toxic_bog_damage();
-        case SPELL_BOULDER:
-            return boulder_damage(power, false);
-        case SPELL_THUNDERBOLT:
-            return thunderbolt_damage(power, 1);
-        case SPELL_HELLFIRE_MORTAR:
-            return hellfire_mortar_damage(power);
-        case SPELL_FORGE_LIGHTNING_SPIRE:
-            return lightning_spire_damage(power);
-        case SPELL_DIAMOND_SAWBLADES:
-            return diamond_sawblade_damage(power);
-        case SPELL_FORTRESS_BLAST:
-            return fortress_blast_damage(you.armour_class_scaled(1), false);
-        case SPELL_POISONOUS_VAPOURS:
-            return poisonous_vapours_damage(power, false);
-        case SPELL_DETONATION_CATALYST:
-            return detonation_catalyst_damage(power, false);
         case SPELL_JINXBITE:
             return jinxbite_damage(power,false);
+        case SPELL_LRD:
+            return base_fragmentation_damage(power, false);
+        case SPELL_NOXIOUS_BOG:
+            return toxic_bog_damage();
+        case SPELL_POISONOUS_VAPOURS:
+            return poisonous_vapours_damage(power, false);
+        case SPELL_POLAR_VORTEX:
+            return polar_vortex_dice(power, false);
+        case SPELL_SCORCH:
+            return scorch_damage(power, false);
+        case SPELL_SHATTER:
+            return shatter_damage(power);
+        case SPELL_THUNDERBOLT:
+            return thunderbolt_damage(power, 1);
         default:
             break;
     }
@@ -3197,27 +3197,20 @@ string spell_damage_string(spell_type spell, bool evoked, int pow, bool terse)
         pow = evoked ? wand_power(spell) : calc_spell_power(spell);
     switch (spell)
     {
-        case SPELL_MAXWELLS_COUPLING:
-            return Options.char_set == CSET_ASCII ? "death" : "\u221e"; //"∞"
-        case SPELL_FREEZING_CLOUD:
-            return desc_cloud_damage(CLOUD_COLD, false);
+        case SPELL_AIRSTRIKE:
+            return describe_player_airstrike_dam(base_airstrike_damage(pow));
         case SPELL_DISCHARGE:
         {
             const int max = discharge_max_damage(pow);
             return make_stringf("%d-%d/arc", FLAT_DISCHARGE_ARC_DAMAGE, max);
         }
-        case SPELL_AIRSTRIKE:
-            return describe_player_airstrike_dam(base_airstrike_damage(pow));
-        case SPELL_PILEDRIVER:
-            return make_stringf("(3-9)d%d", piledriver_collision_damage(pow, 1, false).size);
+        case SPELL_FREEZING_CLOUD:
+            return desc_cloud_damage(CLOUD_COLD, false);
+        case SPELL_FULSOME_FUSILLADE:
+            return make_stringf("(3-5)d%d", _spell_damage(spell, pow).size);
         case SPELL_GELLS_GAVOTTE:
             return make_stringf("2d(%d-%d)", gavotte_impact_damage(pow, 1, false).size,
                                              gavotte_impact_damage(pow, 4, false).size);
-
-        case SPELL_FULSOME_FUSILLADE:
-            return make_stringf("(3-5)d%d", _spell_damage(spell, pow).size);
-        case SPELL_RIMEBLIGHT:
-            return describe_rimeblight_damage(pow, terse);
         case SPELL_HOARFROST_CANNONADE:
         {
             dice_def shot_dam = hoarfrost_cannonade_damage(pow, false);
@@ -3226,6 +3219,10 @@ string spell_damage_string(spell_type spell, bool evoked, int pow, bool terse)
             return make_stringf("%dd%d/%dd%d",
                 shot_dam.num, shot_dam.size, finale_dam.num, finale_dam.size);
         }
+        case SPELL_MAXWELLS_COUPLING:
+            return Options.char_set == CSET_ASCII ? "death" : "\u221e"; //"∞"
+        case SPELL_PILEDRIVER:
+            return make_stringf("(3-9)d%d", piledriver_collision_damage(pow, 1, false).size);
         case SPELL_RENDING_BLADE:
         {
             dice_def dmg_mp = rending_blade_damage(pow, true);
@@ -3236,6 +3233,8 @@ string spell_damage_string(spell_type spell, bool evoked, int pow, bool terse)
             else
                 return make_stringf("%dd%d", dmg.num, dmg.size);
         }
+        case SPELL_RIMEBLIGHT:
+            return describe_rimeblight_damage(pow, terse);
         default:
             break;
     }

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -52,7 +52,7 @@ enum class spflag
     needs_tracer       = 0x00080000,      // monster casting needs tracer
     noisy              = 0x00100000,      // makes noise, even if innate
     testing            = 0x00200000,      // a testing/debugging spell
-                     //  0x00400000,      // was spflag::corpse_violating
+    needs_target       = 0x00400000,      // cannot be cast without a target
                      //  0x00800000,      // was SPFLAG_ALLOW_SELF
                      //  0x01000000,      // was spflag::utility
     no_ghost           = 0x02000000,      // ghosts can't get this spell

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -143,6 +143,10 @@ string spell_damage_string(spell_type spell, bool evoked = false, int pow = -1,
                            bool terse = false);
 string spell_max_damage_string(spell_type spell);
 int spell_acc(spell_type spell);
+string spell_defence_string(spell_type spell, bool is_monster = false,
+                            int pow = -1);
+string spell_resist_string(spell_type spell, bool is_monster = false,
+                           int pow = -1);
 string spell_range_string(spell_type spell);
 string range_string(int range, int maxrange = -1, int minrange = 0);
 string spell_schools_string(spell_type spell);

--- a/crawl-ref/source/spl-cast.h
+++ b/crawl-ref/source/spl-cast.h
@@ -44,8 +44,7 @@ enum class spflag
     silent             = 0x00001000,      // makes no noise on cast
     escape             = 0x00002000,      // useful for running away
     recovery           = 0x00004000,      // healing or recovery spell
-                                          // (Can be cast by friendly monsters, even when out of combat)
-                     //  0x00008000,
+    direct_damage_only = 0x00008000,      // does nothing except deal damage
     destructive        = 0x00010000,      // not a conjuration, but still
                                           // supported by Vehumet/Battlesphere
     selfench           = 0x00020000,      // monsters use as selfench

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -4391,6 +4391,9 @@ spret cast_hailstorm(int pow, bool fail, bool tracer)
             if (!mon || !you.aware_of(*mon))
                 continue;
 
+            if (protected_from_spell(SPELL_HAILSTORM, *mon, &you))
+                continue;
+
             if (!mon->friendly() && (*vulnerable)(mon))
                 return spret::success;
         }

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -139,7 +139,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PLASMA_BEAM, "Plasma Beam",
     spschool::fire | spschool::air,
-    spflag::noisy | spflag::destructive | spflag::direct_damage_only,
+    spflag::noisy | spflag::destructive | spflag::direct_damage_only | spflag::needs_target,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -150,7 +150,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PERMAFROST_ERUPTION, "Permafrost Eruption",
     spschool::ice | spschool::earth,
-    spflag::destructive,
+    spflag::destructive | spflag::needs_target,
     6,
     200,
     6, 6, // reduce cases of hitting something outside LOS
@@ -3493,7 +3493,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MAXWELLS_COUPLING, "Maxwell's Capacitive Coupling",
     spschool::air,
-    spflag::no_ghost | spflag::destructive,
+    spflag::no_ghost | spflag::destructive | spflag::needs_target,
     8,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -3570,7 +3570,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MANIFOLD_ASSAULT, "Manifold Assault",
     spschool::translocation,
-    spflag::none,
+    spflag::needs_target,
     7,
     200,
     -1, -1,
@@ -3681,7 +3681,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SCORCH, "Scorch",
     spschool::fire,
-    spflag::destructive,
+    spflag::destructive | spflag::needs_target,
     2,
     50,
     3, 3,

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -40,7 +40,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MAGIC_DART, "Magic Dart",
     spschool::conjuration,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     1,
     25,
     LOS_RADIUS, LOS_RADIUS,
@@ -51,7 +51,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FIREBALL, "Fireball",
     spschool::conjuration | spschool::fire,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     5,
     200,
     5, 5,
@@ -128,7 +128,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ARCJOLT, "Arcjolt",
     spschool::conjuration | spschool::air,
-    spflag::none,
+    spflag::direct_damage_only,
     5,
     200,
     2, 2,
@@ -139,7 +139,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_PLASMA_BEAM, "Plasma Beam",
     spschool::fire | spschool::air,
-    spflag::noisy | spflag::destructive,
+    spflag::noisy | spflag::destructive | spflag::direct_damage_only,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -442,7 +442,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LEHUDIBS_CRYSTAL_SPEAR, "Lehudib's Crystal Spear",
     spschool::conjuration | spschool::earth,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     8,
     200,
     3, 3,
@@ -678,7 +678,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FREEZE, "Freeze",
     spschool::ice,
-    spflag::dir_or_target | spflag::not_self | spflag::destructive,
+    spflag::dir_or_target | spflag::not_self | spflag::destructive | spflag::direct_damage_only,
     1,
     25,
     1, 1,
@@ -892,7 +892,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STONE_ARROW, "Stone Arrow",
     spschool::conjuration | spschool::earth,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     3,
     50,
     4, 4,
@@ -903,7 +903,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SHOCK, "Shock",
     spschool::conjuration | spschool::air,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     1,
     25,
     LOS_RADIUS, LOS_RADIUS,
@@ -961,7 +961,7 @@ static const struct spell_desc spelldata[] =
     SPELL_MINDBURST, "Mindburst",
     spschool::conjuration,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
-        | spflag::WL_check,
+        | spflag::WL_check | spflag::direct_damage_only,
     6,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1017,7 +1017,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_AIRSTRIKE, "Airstrike",
     spschool::air,
-    spflag::target | spflag::not_self | spflag::destructive,
+    spflag::target | spflag::not_self | spflag::destructive
+        | spflag::direct_damage_only,
     4,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1028,7 +1029,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_MOMENTUM_STRIKE, "Momentum Strike",
     spschool::conjuration | spschool::translocation,
-    spflag::target | spflag::not_self,
+    spflag::target | spflag::not_self | spflag::direct_damage_only,
     2,
     50,
     4, 4,
@@ -1072,7 +1073,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IGNITE_POISON, "Ignite Poison",
     spschool::fire | spschool::alchemy,
-    spflag::destructive,
+    spflag::destructive | spflag::direct_damage_only,
     4,
     100,
     -1, -1,
@@ -1161,7 +1162,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_DISCHARGE, "Static Discharge",
     spschool::conjuration | spschool::air,
-    spflag::none,
+    spflag::direct_damage_only,
     2,
     50,
     1, 1,
@@ -1195,7 +1196,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_LRD, "Lee's Rapid Deconstruction",
     spschool::earth,
-    spflag::target | spflag::destructive,
+    spflag::target | spflag::destructive | spflag::direct_damage_only,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -1207,7 +1208,7 @@ static const struct spell_desc spelldata[] =
     SPELL_SANDBLAST, "Sandblast",
     spschool::earth,
     spflag::dir_or_target | spflag::not_self | spflag::needs_tracer
-        | spflag::destructive,
+        | spflag::destructive | spflag::direct_damage_only,
     1,
     50,
     4, 4,
@@ -1241,7 +1242,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_CHAIN_LIGHTNING, "Chain Lightning",
     spschool::air | spschool::conjuration,
-    spflag::none,
+    spflag::direct_damage_only,
     9,
     200,
     -1, -1,
@@ -1342,7 +1343,7 @@ static const struct spell_desc spelldata[] =
     SPELL_HURL_DAMNATION, "Hurl Damnation",
     spschool::conjuration,
     spflag::dir_or_target | spflag::unholy
-        | spflag::needs_tracer,
+        | spflag::needs_tracer | spflag::direct_damage_only,
     // plus DS ability, staff of Dispater & Sceptre of Asmodeus
     9,
     200,
@@ -1455,7 +1456,8 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_QUICKSILVER_BOLT, "Quicksilver Bolt",
     spschool::conjuration,
-    spflag::dir_or_target | spflag::needs_tracer | spflag::not_self,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::not_self
+        | spflag::direct_damage_only,
     5,
     200,
     LOS_RADIUS, LOS_RADIUS,
@@ -2342,7 +2344,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_SEARING_RAY, "Searing Ray",
     spschool::conjuration,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     2,
     50,
     4, 4,
@@ -3125,7 +3127,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_ICEBLAST, "Iceblast",
     spschool::conjuration | spschool::ice,
-    spflag::dir_or_target | spflag::needs_tracer,
+    spflag::dir_or_target | spflag::needs_tracer | spflag::direct_damage_only,
     5,
     200,
     5, 5,
@@ -3280,7 +3282,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_IGNITION, "Ignition",
     spschool::fire,
-    spflag::destructive,
+    spflag::destructive | spflag::direct_damage_only,
     8,
     200,
     -1, -1,
@@ -3402,7 +3404,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_STARBURST, "Starburst",
     spschool::conjuration | spschool::fire,
-    spflag::none,
+    spflag::direct_damage_only,
     6,
     200,
     5, 5,
@@ -3435,7 +3437,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_HAILSTORM, "Hailstorm",
     spschool::conjuration | spschool::ice,
-    spflag::none,
+    spflag::direct_damage_only,
     3,
     100,
     3, 3, // Range special-cased in describe-spells
@@ -4406,7 +4408,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_FORTRESS_BLAST, "Fortress Blast",
     spschool::forgecraft,
-    spflag::destructive,
+    spflag::destructive | spflag::direct_damage_only,
     6,
     75,
     3, 3,

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1328,8 +1328,13 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
             return c_check;
     }
 
-    if (!prevent && temp && spell_no_hostile_in_range(spell))
+    if (temp
+        && (!prevent
+            || testbits(get_spell_flags(spell), spflag::needs_target))
+        && spell_no_hostile_in_range(spell))
+    {
         return "you can't see any hostile targets that would be affected.";
+    }
 
     switch (spell)
     {
@@ -1727,13 +1732,16 @@ bool spell_no_hostile_in_range(spell_type spell)
     const int range = calc_spell_range(spell, pow, true);
 
     // If there are known invisible monsters around, assume that they *might*
-    // be in range.
+    // be in range for spells that can target invisible things.
     //
     // XXX: This is inexact since it doesn't account for resistances of said
     //      invisible monster, but doing that comprehensively is quite hard
     //      and probably not worth the trouble.
-    if (env.invis_knowledge.any_unknown_nearby())
+    if (env.invis_knowledge.any_unknown_nearby()
+        && !testbits(flags, spflag::needs_target))
+    {
         return false;
+    }
 
     switch (spell)
     {

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -1680,6 +1680,13 @@ static bool _any_valid_targets(const unique_ptr<targeter>& tgt, int range,
     return false;
 }
 
+bool protected_from_spell(spell_type spell, const monster &mon,
+                          const actor *agent)
+{
+    return testbits(get_spell_flags(spell), spflag::direct_damage_only)
+           && mon.damage_immune(agent);
+}
+
 // Mirror targetting logic to check whether LRD can find a target.
 static bool _lrd_no_hostile_in_range(int pow, int range)
 {
@@ -1691,6 +1698,8 @@ static bool _lrd_no_hostile_in_range(int pow, int range)
         if (!you.aware_of(mon) || !mons_is_threatening(mon))
             continue;
         if (mons_attitude(mon) != ATT_HOSTILE && !mon.has_ench(ENCH_FRENZIED))
+            continue;
+        if (protected_from_spell(SPELL_LRD, mon, &you))
             continue;
 
         for (radius_iterator ri(mon.pos(), 2, C_SQUARE, LOS_DEFAULT); ri; ++ri)
@@ -1712,7 +1721,8 @@ bool spell_no_hostile_in_range(spell_type spell)
     if (!in_bounds(you.pos()) || !you.on_current_level)
         return true;
 
-    const int minRange = get_dist_to_nearest_monster();
+    const spell_flags flags = get_spell_flags(spell);
+    const int minRange = get_dist_to_nearest_monster(testbits(flags, spflag::direct_damage_only));
     const int pow = calc_spell_power(spell);
     const int range = calc_spell_range(spell, pow, true);
 
@@ -1812,8 +1822,11 @@ bool spell_no_hostile_in_range(spell_type spell)
         for (coord_def t : arcjolt_targets(you, false))
         {
             const monster *mon = monster_at(t);
-            if (mon != nullptr && !mon->wont_attack())
+            if (mon != nullptr && !mon->wont_attack()
+                && !protected_from_spell(spell, *mon, &you))
+            {
                 return false;
+            }
         }
         return true;
 
@@ -1821,8 +1834,11 @@ bool spell_no_hostile_in_range(spell_type spell)
         for (coord_def t : chain_lightning_targets())
         {
             const monster *mon = monster_at(t);
-            if (mon != nullptr && !mon->wont_attack())
+            if (mon != nullptr && !mon->wont_attack()
+                && !protected_from_spell(spell, *mon, &you))
+            {
                 return false;
+            }
         }
         return true;
 
@@ -1873,8 +1889,6 @@ bool spell_no_hostile_in_range(spell_type spell)
 
     if (minRange < 0 || range < 0)
         return false;
-
-    const spell_flags flags = get_spell_flags(spell);
 
     // The healing spells.
     if (testbits(flags, spflag::helpful))

--- a/crawl-ref/source/spl-util.h
+++ b/crawl-ref/source/spl-util.h
@@ -141,6 +141,8 @@ int spell_highlight_by_utility(spell_type spell,
                                 bool transient = false,
                                 bool memcheck = false);
 bool spell_no_hostile_in_range(spell_type spell);
+bool protected_from_spell(spell_type spell, const monster &mon,
+                          const actor *agent);
 
 bool spell_is_soh_breath(spell_type spell);
 const vector<spell_type> *soh_breath_spells(spell_type spell);


### PR DESCRIPTION
This adds three things:
- A flag for "this spell only does damage", which prevents autotargeting warded monsters
- A flag for "this spell needs a target", making spells not suggest Z-casting when it won't work
- Resists and defenses checked are added to spell descriptions (deriving this from zap information where possible)