### PR TITLE
fix: unintentional level vetos due to traps blocking paths

### DIFF
--- a/crawl-ref/source/dungeon.cc
+++ b/crawl-ref/source/dungeon.cc
@@ -838,8 +838,9 @@ bool dgn_square_travel_ok(const coord_def &c)
 {
     // the mimic check here relies on full placement operating, e.g. not &L
     const dungeon_feature_type feat = feat_at_no_mimic(c);
-    if (feat == DNGN_TRAP_TELEPORT_PERMANENT || feat == DNGN_TRAP_DISPERSAL)
-        return false;
+    if (feat_is_trap(feat))
+        // only these traps block travel for level connectivity purposes
+        return !(feat == DNGN_TRAP_TELEPORT_PERMANENT || feat == DNGN_TRAP_DISPERSAL);
     else
         return feat_is_traversable(feat);
 }


### PR DESCRIPTION
8d147f2 refactored traps but seems to have unintentionally changed the logic for level vetos. Before, only teleport or dispersal traps would count for blocking paths but after, all traps would block paths. This most noticably drastically increased the veto rate of grunt_spider_rune_island due to web traps which meant that end vault became much more rare. (It's already about half as rare as its weight suggests for other reasons)

Return to teleport and dispersal traps being the only traps to block paths for the purposes of vetoing levels.