### PR TITLE
Allow building with PCRE2 for regex (system lib only at this stage)

### DIFF
--- a/crawl-ref/source/AppHdr.h
+++ b/crawl-ref/source/AppHdr.h
@@ -105,6 +105,10 @@ static inline double pow(int x, double y) { return std::pow((double)x, y); }
     // uncomment the line below and add -lpcre to your makefile.
     // #define REGEX_PCRE
 
+    // If you have libpcre2, you can use that instead of POSIX regexes -
+    // uncomment the line below and add -lpcre2-8 to your makefile.
+    // #define REGEX_PCRE2
+
     #include "libunix.h"
 
 #elif defined(TARGET_OS_WINDOWS)

--- a/crawl-ref/source/AppHdr.h
+++ b/crawl-ref/source/AppHdr.h
@@ -97,17 +97,9 @@ static inline double pow(int x, double y) { return std::pow((double)x, y); }
     #define HAVE_UTIMES
 
     // Use POSIX regular expressions
-#ifndef REGEX_PCRE
+#if !defined(REGEX_PCRE) && !defined(REGEX_PCRE2)
     #define REGEX_POSIX
 #endif
-
-    // If you have libpcre, you can use that instead of POSIX regexes -
-    // uncomment the line below and add -lpcre to your makefile.
-    // #define REGEX_PCRE
-
-    // If you have libpcre2, you can use that instead of POSIX regexes -
-    // uncomment the line below and add -lpcre2-8 to your makefile.
-    // #define REGEX_PCRE2
 
     #include "libunix.h"
 
@@ -244,8 +236,14 @@ static inline double pow(int x, double y) { return std::pow((double)x, y); }
 #define TIME_FN localtime
 #endif
 
-#if defined(REGEX_POSIX) && defined(REGEX_PCRE)
-#error You can use either REGEX_POSIX or REGEX_PCRE, or neither, but not both.
+#if defined(REGEX_POSIX) && defined(REGEX_PCRE) && defined(REGEX_PCRE2)
+#error You can only use one of REGEX_POSIX, REGEX_PCRE, REGEX_PCRE2
+#elif defined(REGEX_POSIX) && defined(REGEX_PCRE)
+#error You can use either REGEX_POSIX or REGEX_PCRE, but not both.
+#elif defined(REGEX_POSIX) && defined(REGEX_PCRE2)
+#error You can use either REGEX_POSIX or REGEX_PCRE2, but not both.
+#elif defined(REGEX_PCRE) && defined(REGEX_PCRE2)
+#error You can use either REGEX_PCRE or REGEX_PCRE2, but not both.
 #endif
 
 #include "debug-defines.h"

--- a/crawl-ref/source/Makefile
+++ b/crawl-ref/source/Makefile
@@ -1092,6 +1092,15 @@ else
   endif
 endif
 
+ifdef BUILD_PCRE2
+DEFINES += -DREGEX_PCRE2
+else
+  ifdef USE_PCRE2
+  DEFINES += -DREGEX_PCRE2
+  LIBS += -lpcre2-8
+  endif
+endif
+
 ifdef USE_ICC
 NO_INLINE_DEPGEN := YesPlease
 GCC := icc

--- a/crawl-ref/source/Makefile.obj
+++ b/crawl-ref/source/Makefile.obj
@@ -317,6 +317,7 @@ catch2-tests/test_files.o \
 catch2-tests/test_items.o \
 catch2-tests/test_mon-util.o \
 catch2-tests/test_ng-init-branches.o \
+catch2-tests/test_pattern.o \
 catch2-tests/test_player.o \
 catch2-tests/test_player_fixture.o \
 catch2-tests/test_randbook.o \

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -1,0 +1,25 @@
+#include "catch_amalgamated.hpp"
+
+#include "AppHdr.h"
+#include "pattern.h"
+
+TEST_CASE( "Pattern matches", "[single-file]" ) {
+    // match substring
+    text_pattern pattern1("[A-Za-z]+:[0-9]+");
+    CHECK( pattern1.matches("Dungeon:1") );
+    CHECK( pattern1.matches("You are on Dungeon:1") );
+
+    // match whole string
+    text_pattern pattern2("^[A-Za-z]+:[0-9]+$");
+    CHECK( pattern2.matches("Dungeon:1") );
+    CHECK( !pattern2.matches("You are on Dungeon:1") );
+
+    // repeat count
+    text_pattern pattern3("^[A-Za-z]{2}$");
+    CHECK( pattern3.matches("Mi") );
+    CHECK( !pattern3.matches("MiFi") );
+
+    // test UTF-8 handling (crawl-pcre fails this test because UTF-8 support is disabled)
+    //text_pattern single_char_patt("^.$");
+    //CHECK (single_char_patt.matches("の") );
+}

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -4,7 +4,10 @@
 #include "pattern.h"
 
 TEST_CASE( "Pattern matches", "[single-file]" ) {
-    // required to make POSIX regex handle UTF-8 properly
+    // Required to allow POSIX regex to correctly handle UTF-8 strings.
+    // (C programs always start with the default "C" locale, which only
+    //  understands ASCII strings. This call sets the locale to the user's
+    //  configured one, which on Linux, would normally be a UTF-8 one).
     setlocale(LC_ALL, "");
 
     // match substring

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -19,7 +19,12 @@ TEST_CASE( "Pattern matches", "[single-file]" ) {
     CHECK( pattern3.matches("Mi") );
     CHECK( !pattern3.matches("MiFi") );
 
-    // test UTF-8 handling (crawl-pcre fails this test because UTF-8 support is disabled)
-    //text_pattern single_char_patt("^.$");
-    //CHECK (single_char_patt.matches("の") );
+    // test that multi-byte UTF-8 character is recognised as a single character
+    text_pattern single_char_patt("^.$");
+#ifndef REGEX_PCRE
+    // PCRE v1 will currently fail this test because we're building it with
+    // UTF-8 support disabled
+    CHECK( single_char_patt.matches(u8"\u20AC") ); // euro symbol
+#endif
+    CHECK( !single_char_patt.matches(u8"\u20AC\u20AC") );
 }

--- a/crawl-ref/source/catch2-tests/test_pattern.cc
+++ b/crawl-ref/source/catch2-tests/test_pattern.cc
@@ -4,6 +4,9 @@
 #include "pattern.h"
 
 TEST_CASE( "Pattern matches", "[single-file]" ) {
+    // required to make POSIX regex handle UTF-8 properly
+    setlocale(LC_ALL, "");
+
     // match substring
     text_pattern pattern1("[A-Za-z]+:[0-9]+");
     CHECK( pattern1.matches("Dungeon:1") );

--- a/crawl-ref/source/command.cc
+++ b/crawl-ref/source/command.cc
@@ -72,6 +72,8 @@ static const char *features[] =
     "POSIX regexps",
 #elif defined(REGEX_PCRE)
     "PCRE regexps",
+#elif defined(REGEX_PCRE2)
+    "PCRE2 regexps",
 #else
     "Glob patterns",
 #endif

--- a/crawl-ref/source/pattern.cc
+++ b/crawl-ref/source/pattern.cc
@@ -1,5 +1,15 @@
 #include "AppHdr.h"
 
+#ifdef REGEX_PCRE2
+    // Statically link pcre on Windows
+    #if defined(TARGET_OS_WINDOWS)
+        #define PCRE2_STATIC
+    #endif
+
+    #define PCRE2_CODE_UNIT_WIDTH 8
+    #include <pcre2.h>
+#endif
+
 #ifdef REGEX_PCRE
     // Statically link pcre on Windows
     #if defined(TARGET_OS_WINDOWS)
@@ -16,9 +26,74 @@
 #include "pattern.h"
 #include "stringutil.h"
 
-#if defined(REGEX_PCRE)
+#if defined(REGEX_PCRE2)
 ////////////////////////////////////////////////////////////////////
-// Perl Compatible Regular Expressions
+// Perl Compatible Regular Expressions (v2)
+
+static void *_compile_pattern(const char *pattern, bool icase)
+{
+    int errorcode;
+    PCRE2_SIZE erroffset;
+    uint32_t flags = PCRE2_UTF;
+    if (icase)
+        flags |= PCRE2_CASELESS;
+
+    return pcre2_compile((PCRE2_SPTR)pattern,
+                         PCRE2_ZERO_TERMINATED,
+                         flags,
+                         &errorcode,
+                         &erroffset,
+                         nullptr);
+}
+
+static void _free_compiled_pattern(void *cp)
+{
+    if (cp)
+        pcre2_code_free((pcre2_code*)cp);
+}
+
+static bool _pattern_match(void *compiled_pattern, const char *text, int length)
+{
+    auto cp = (pcre2_code*)compiled_pattern;
+
+    // Create a match data block the right size for the number of capturing
+    // parentheses in the pattern.
+    auto match_data = pcre2_match_data_create_from_pattern(cp, NULL);
+
+    int rc = pcre2_match(cp, (PCRE2_SPTR)text, length, 0, 0, match_data, 0);
+    pcre2_match_data_free(match_data);
+    return rc >= 0;
+}
+
+static pattern_match _pattern_match_location(void *compiled_pattern,
+                                             const char *text, int length)
+{
+    auto cp = (pcre2_code*)compiled_pattern;
+
+    // Create a match data block the right size for the number of capturing
+    // parentheses in the pattern.
+    auto match_data = pcre2_match_data_create_from_pattern(cp, NULL);
+
+    int rc = pcre2_match(cp, (PCRE2_SPTR)text, length, 0, 0, match_data, 0);
+
+    if (rc >= 0)
+    {
+        auto ovector = pcre2_get_ovector_pointer(match_data);
+        auto result = pattern_match::succeeded(string(text), (int)ovector[0],
+                                               (int)ovector[1]);
+        pcre2_match_data_free(match_data);
+        return result;
+    }
+    else
+    {
+        pcre2_match_data_free(match_data);
+        return pattern_match::failed(string(text));
+    }
+}
+
+#elif defined(REGEX_PCRE)
+////////////////////////////////////////////////////////////////////
+// Perl Compatible Regular Expressions (v1)
 
 static void *_compile_pattern(const char *pattern, bool icase)
 {


### PR DESCRIPTION
This PR allows PCRE2 as a build-time option for regex alongside PCRE (v1) and POSIX. It also adds some catch2 tests for regex to make sure everything's working as expected.

- ```make USE_PCRE2=y``` will build and link with the PCRE2 system library (if available)

As yet, there's no posiibility to build with a PCRE2 contribs submodule (will come in a future PR).

As before, building with the old PCRE (v1) is possible with:
- ```make USE_PCRE=y``` will build and link with the PCRE (v1) system library (if available)
- ```make BUILD_PCRE=y``` will build and link with the PCRE (v1) submodule

The default behaviour when none of these options is given remain unchanged:
- Windows: build with the PCRE (v1) submodule
- Linux and Mac: build with POSIX regex system library.

(Android uses a different build process, but also builds with the PCRE (v1) submodule)
