### PR TITLE
Spelling: Change AmE Duelist to AusE Duellist

### DIFF
--- a/crawl-ref/source/dat/database/godspeak.txt
+++ b/crawl-ref/source/dat/database/godspeak.txt
@@ -159,7 +159,7 @@ Xom creates a safe adventurer enclosure.
 %%%%
 Xom mean door ring
 
-Xom raises up and pulls in a makeshift [warmonger|duelist]'s arena.
+Xom raises up and pulls in a makeshift [warmonger|duellist]'s arena.
 
 Xom locks you up as an exhibit to study.
 

--- a/crawl-ref/source/dat/des/portals/bazaar.des
+++ b/crawl-ref/source/dat/des/portals/bazaar.des
@@ -117,7 +117,7 @@ function bazaar_setup(e, randomise_tileset, shop_halo, from_xom)
   if you.get_base_mutation_level("hated by all") == 1 then
       crawl.mpr("Upon your arrival, your hatred by all makes the other customers disperse.")
   elseif you.god() == "Okawaru" then
-      crawl.mpr("Upon your arrival, your lonesome duelist's vow makes the other customers flee.")
+      crawl.mpr("Upon your arrival, your lonesome duellist's vow makes the other customers flee.")
   else
       -- Xom sees a flavour opportunity and takes it.
       if you.god() == "Xom" then

--- a/crawl-ref/source/dat/des/portals/wizlab.des
+++ b/crawl-ref/source/dat/des/portals/wizlab.des
@@ -86,7 +86,7 @@
 #---------------------------------------------------------------
 #Maxwell's Workshop       |big rooms with forge |metal
 #---------------------------------------------------------------
-#Yara's Duelist Academy   |campus               |stone and trees
+#Yara's Duellist Academy  |campus               |stone and trees
 #---------------------------------------------------------------
 #Borgnjor's Mausoleum     |split path           |tarlike
 #---------------------------------------------------------------
@@ -2257,7 +2257,7 @@ vv...vv....G....vvvvvvvv..v1.v.Sv..v
 ENDMAP
 
 ###############################################################################
-# Yara's Duelist Academy
+# Yara's Duellist Academy
 # Designed by Hellmonk. Features warrior-mages with antimagic weaponry.
 # Said weaponry makes up part of the loot here. The remainder of the loot is
 # books, random good items, and gold.
@@ -2315,7 +2315,7 @@ LROCKTILE: wall_brick
 :               "tengu reaver w:1 / quicksilver dragon w:1")
 :           wizlab_setup(_G)
 epilogue {{
-            wizlab_milestone(_G, "Yara's Duelist Academy")
+            wizlab_milestone(_G, "Yara's Duellist Academy")
 }}
 MAP
           cccccccccccccccccccc


### PR DESCRIPTION
In Australian (and British, etc.) English, duel follows the same rule as other words ending in -el where the l is doubled when adding a suffix (e.g. traveller, cancelled, modelling - in contrast to AmE traveler, canceled, modeling).

Here is a photo of the relevant entry from my Pocket Macquarie Dictionary (Macquarie is the standard Australian dictionary, equivalent to Oxford in the UK or Mirriam-Webster in the US):

<img width="2013" height="635" alt="duellist2" src="https://github.com/user-attachments/assets/9b772fd7-5d8c-4e40-ac56-3ce2503696a7" />
