### PR TITLE
Feat - Add android morgue stats

### DIFF
--- a/crawl-ref/source/android-project/app/build.gradle.in
+++ b/crawl-ref/source/android-project/app/build.gradle.in
@@ -29,6 +29,8 @@ android {
         debug {
         }
         buildTest {
+            applicationIdSuffix ".morguestatsdev"
+            signingConfig signingConfigs.debug
             ndk {
                 //noinspection ChromeOsAbiSupport
                 abiFilters "arm64-v8a"

--- a/crawl-ref/source/android-project/app/src/main/AndroidManifest.xml
+++ b/crawl-ref/source/android-project/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:windowSoftInputMode="adjustResize" />
         <activity
+            android:name=".DCSSMorgueStatsActivity"
+            android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".DCSSMods"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
             android:windowSoftInputMode="adjustResize" />

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSLauncher.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSLauncher.java
@@ -68,6 +68,7 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
         findViewById(R.id.startButton).setOnClickListener(this::startGame);
         findViewById(R.id.editInitFile).setOnClickListener(this::editInitFile);
         findViewById(R.id.morgueButton).setOnClickListener(this::openMorgue);
+        findViewById(R.id.morgueStatsButton).setOnClickListener(this::openMorgueStats);
         findViewById(R.id.modsButton).setOnClickListener(this::openMods);
 
         boolean isPC = getPackageManager().hasSystemFeature(PackageManager.FEATURE_PC);
@@ -168,6 +169,12 @@ public class DCSSLauncher extends AppCompatActivity implements AdapterView.OnIte
     // Open morgue
     private void openMorgue(View v) {
         Intent intent = new Intent(getBaseContext(), DCSSMorgue.class);
+        startActivity(intent);
+    }
+
+    // Open morgue statistics
+    private void openMorgueStats(View v) {
+        Intent intent = new Intent(getBaseContext(), DCSSMorgueStatsActivity.class);
         startActivity(intent);
     }
 

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueBreakdown.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueBreakdown.java
@@ -1,0 +1,24 @@
+package org.develz.crawl;
+
+public final class DCSSMorgueBreakdown {
+    private final String label;
+    private final int wins;
+    private final int games;
+    private final long bestScore;
+    private final int bestXl;
+
+    public DCSSMorgueBreakdown(String label, int wins, int games, long bestScore, int bestXl) {
+        this.label = label;
+        this.wins = wins;
+        this.games = games;
+        this.bestScore = bestScore;
+        this.bestXl = bestXl;
+    }
+
+    public String getLabel() { return label; }
+    public int getWins() { return wins; }
+    public int getGames() { return games; }
+    public double getWinRate() { return games == 0 ? 0.0 : 100.0 * wins / games; }
+    public long getBestScore() { return bestScore; }
+    public int getBestXl() { return bestXl; }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
@@ -1,0 +1,59 @@
+package org.develz.crawl;
+
+import java.io.File;
+import java.time.LocalDateTime;
+
+public final class DCSSMorgueGame {
+    public enum Outcome {
+        WIN,
+        LOSS,
+        QUIT
+    }
+
+    private final File file;
+    private final LocalDateTime timestamp;
+    private final long score;
+    private final String species;
+    private final String background;
+    private final String god;
+    private final int xl;
+    private final String place;
+    private final long turns;
+    private final long durationSeconds;
+    private final int runes;
+    private final Outcome outcome;
+    private final String endText;
+
+    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
+                          String species, String background, String god, int xl,
+                          String place, long turns, long durationSeconds, int runes,
+                          Outcome outcome, String endText) {
+        this.file = file;
+        this.timestamp = timestamp;
+        this.score = score;
+        this.species = species;
+        this.background = background;
+        this.god = god;
+        this.xl = xl;
+        this.place = place;
+        this.turns = turns;
+        this.durationSeconds = durationSeconds;
+        this.runes = runes;
+        this.outcome = outcome;
+        this.endText = endText;
+    }
+
+    public File getFile() { return file; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public long getScore() { return score; }
+    public String getSpecies() { return species; }
+    public String getBackground() { return background; }
+    public String getGod() { return god; }
+    public int getXl() { return xl; }
+    public String getPlace() { return place; }
+    public long getTurns() { return turns; }
+    public long getDurationSeconds() { return durationSeconds; }
+    public int getRunes() { return runes; }
+    public Outcome getOutcome() { return outcome; }
+    public String getEndText() { return endText; }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
@@ -24,19 +24,29 @@ public final class DCSSMorgueGame {
     private final Outcome outcome;
     private final String endText;
     private final String version;
+    private final int playableSpeciesCount;
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText) {
         this(file, timestamp, score, species, background, god, xl, place, turns,
-                durationSeconds, runes, outcome, endText, "Unknown version");
+                durationSeconds, runes, outcome, endText, "Unknown version", 0);
     }
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText, String version) {
+        this(file, timestamp, score, species, background, god, xl, place, turns,
+                durationSeconds, runes, outcome, endText, version, 0);
+    }
+
+    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
+                          String species, String background, String god, int xl,
+                          String place, long turns, long durationSeconds, int runes,
+                          Outcome outcome, String endText, String version,
+                          int playableSpeciesCount) {
         this.file = file;
         this.timestamp = timestamp;
         this.score = score;
@@ -51,6 +61,7 @@ public final class DCSSMorgueGame {
         this.outcome = outcome;
         this.endText = endText;
         this.version = version;
+        this.playableSpeciesCount = playableSpeciesCount;
     }
 
     public File getFile() { return file; }
@@ -67,4 +78,5 @@ public final class DCSSMorgueGame {
     public Outcome getOutcome() { return outcome; }
     public String getEndText() { return endText; }
     public String getVersion() { return version; }
+    public int getPlayableSpeciesCount() { return playableSpeciesCount; }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
@@ -1,7 +1,6 @@
 package org.develz.crawl;
 
 import java.io.File;
-import java.time.LocalDateTime;
 
 public final class DCSSMorgueGame {
     public enum Outcome {
@@ -11,7 +10,7 @@ public final class DCSSMorgueGame {
     }
 
     private final File file;
-    private final LocalDateTime timestamp;
+    private final String timestamp;
     private final long score;
     private final String species;
     private final String background;
@@ -24,33 +23,19 @@ public final class DCSSMorgueGame {
     private final Outcome outcome;
     private final String endText;
     private final String version;
-    private final int playableSpeciesCount;
-    private final int playableBackgroundCount;
-    private final int availableGodCount;
-    private final int playableComboCount;
 
-    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
+    public DCSSMorgueGame(File file, String timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText) {
         this(file, timestamp, score, species, background, god, xl, place, turns,
-                durationSeconds, runes, outcome, endText, "Unknown version", 0, 0, 0, 0);
+                durationSeconds, runes, outcome, endText, "Unknown version");
     }
 
-    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
+    public DCSSMorgueGame(File file, String timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText, String version) {
-        this(file, timestamp, score, species, background, god, xl, place, turns,
-                durationSeconds, runes, outcome, endText, version, 0, 0, 0, 0);
-    }
-
-    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
-                          String species, String background, String god, int xl,
-                          String place, long turns, long durationSeconds, int runes,
-                          Outcome outcome, String endText, String version,
-                          int playableSpeciesCount, int playableBackgroundCount,
-                          int availableGodCount, int playableComboCount) {
         this.file = file;
         this.timestamp = timestamp;
         this.score = score;
@@ -65,14 +50,10 @@ public final class DCSSMorgueGame {
         this.outcome = outcome;
         this.endText = endText;
         this.version = version;
-        this.playableSpeciesCount = playableSpeciesCount;
-        this.playableBackgroundCount = playableBackgroundCount;
-        this.availableGodCount = availableGodCount;
-        this.playableComboCount = playableComboCount;
     }
 
     public File getFile() { return file; }
-    public LocalDateTime getTimestamp() { return timestamp; }
+    public String getTimestamp() { return timestamp; }
     public long getScore() { return score; }
     public String getSpecies() { return species; }
     public String getBackground() { return background; }
@@ -85,8 +66,4 @@ public final class DCSSMorgueGame {
     public Outcome getOutcome() { return outcome; }
     public String getEndText() { return endText; }
     public String getVersion() { return version; }
-    public int getPlayableSpeciesCount() { return playableSpeciesCount; }
-    public int getPlayableBackgroundCount() { return playableBackgroundCount; }
-    public int getAvailableGodCount() { return availableGodCount; }
-    public int getPlayableComboCount() { return playableComboCount; }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
@@ -23,11 +23,20 @@ public final class DCSSMorgueGame {
     private final int runes;
     private final Outcome outcome;
     private final String endText;
+    private final String version;
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText) {
+        this(file, timestamp, score, species, background, god, xl, place, turns,
+                durationSeconds, runes, outcome, endText, "Unknown version");
+    }
+
+    public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
+                          String species, String background, String god, int xl,
+                          String place, long turns, long durationSeconds, int runes,
+                          Outcome outcome, String endText, String version) {
         this.file = file;
         this.timestamp = timestamp;
         this.score = score;
@@ -41,6 +50,7 @@ public final class DCSSMorgueGame {
         this.runes = runes;
         this.outcome = outcome;
         this.endText = endText;
+        this.version = version;
     }
 
     public File getFile() { return file; }
@@ -56,4 +66,5 @@ public final class DCSSMorgueGame {
     public int getRunes() { return runes; }
     public Outcome getOutcome() { return outcome; }
     public String getEndText() { return endText; }
+    public String getVersion() { return version; }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueGame.java
@@ -25,13 +25,16 @@ public final class DCSSMorgueGame {
     private final String endText;
     private final String version;
     private final int playableSpeciesCount;
+    private final int playableBackgroundCount;
+    private final int availableGodCount;
+    private final int playableComboCount;
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText) {
         this(file, timestamp, score, species, background, god, xl, place, turns,
-                durationSeconds, runes, outcome, endText, "Unknown version", 0);
+                durationSeconds, runes, outcome, endText, "Unknown version", 0, 0, 0, 0);
     }
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
@@ -39,14 +42,15 @@ public final class DCSSMorgueGame {
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText, String version) {
         this(file, timestamp, score, species, background, god, xl, place, turns,
-                durationSeconds, runes, outcome, endText, version, 0);
+                durationSeconds, runes, outcome, endText, version, 0, 0, 0, 0);
     }
 
     public DCSSMorgueGame(File file, LocalDateTime timestamp, long score,
                           String species, String background, String god, int xl,
                           String place, long turns, long durationSeconds, int runes,
                           Outcome outcome, String endText, String version,
-                          int playableSpeciesCount) {
+                          int playableSpeciesCount, int playableBackgroundCount,
+                          int availableGodCount, int playableComboCount) {
         this.file = file;
         this.timestamp = timestamp;
         this.score = score;
@@ -62,6 +66,9 @@ public final class DCSSMorgueGame {
         this.endText = endText;
         this.version = version;
         this.playableSpeciesCount = playableSpeciesCount;
+        this.playableBackgroundCount = playableBackgroundCount;
+        this.availableGodCount = availableGodCount;
+        this.playableComboCount = playableComboCount;
     }
 
     public File getFile() { return file; }
@@ -79,4 +86,7 @@ public final class DCSSMorgueGame {
     public String getEndText() { return endText; }
     public String getVersion() { return version; }
     public int getPlayableSpeciesCount() { return playableSpeciesCount; }
+    public int getPlayableBackgroundCount() { return playableBackgroundCount; }
+    public int getAvailableGodCount() { return availableGodCount; }
+    public int getPlayableComboCount() { return playableComboCount; }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueLoadResult.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueLoadResult.java
@@ -1,0 +1,22 @@
+package org.develz.crawl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public final class DCSSMorgueLoadResult {
+    private final List<DCSSMorgueGame> games;
+    private final int finalMorgueFiles;
+    private final List<String> skippedFiles;
+
+    public DCSSMorgueLoadResult(List<DCSSMorgueGame> games, int finalMorgueFiles,
+                                List<String> skippedFiles) {
+        this.games = Collections.unmodifiableList(new ArrayList<>(games));
+        this.finalMorgueFiles = finalMorgueFiles;
+        this.skippedFiles = Collections.unmodifiableList(new ArrayList<>(skippedFiles));
+    }
+
+    public List<DCSSMorgueGame> getGames() { return games; }
+    public int getFinalMorgueFiles() { return finalMorgueFiles; }
+    public List<String> getSkippedFiles() { return skippedFiles; }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueRoster.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueRoster.java
@@ -1,0 +1,34 @@
+package org.develz.crawl;
+
+public final class DCSSMorgueRoster {
+    private final int playableSpecies;
+    private final int playableBackgrounds;
+    private final int availableGods;
+    private final int playableCombos;
+
+    DCSSMorgueRoster(int playableSpecies, int playableBackgrounds, int availableGods,
+                     int playableCombos) {
+        this.playableSpecies = playableSpecies;
+        this.playableBackgrounds = playableBackgrounds;
+        this.availableGods = availableGods;
+        this.playableCombos = playableCombos;
+    }
+
+    public static DCSSMorgueRoster current() {
+        for (String library : DungeonCrawlStoneSoup.LIBRARIES) {
+            System.loadLibrary(library);
+        }
+        int[] counts = nativeCurrentCounts();
+        if (counts == null || counts.length != 4) {
+            throw new IllegalStateException("Crawl roster counts are unavailable");
+        }
+        return new DCSSMorgueRoster(counts[0], counts[1], counts[2], counts[3]);
+    }
+
+    private static native int[] nativeCurrentCounts();
+
+    int getPlayableSpecies() { return playableSpecies; }
+    int getPlayableBackgrounds() { return playableBackgrounds; }
+    int getAvailableGods() { return availableGods; }
+    int getPlayableCombos() { return playableCombos; }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Set;
 
 public final class DCSSMorgueStats {
+    // Current core roster, used only until a new final morgue supplies its core value.
+    private static final int FALLBACK_PLAYABLE_SPECIES = 27;
     private final List<DCSSMorgueGame> newestFirst;
     private final int games;
     private final int wins;
@@ -34,6 +36,7 @@ public final class DCSSMorgueStats {
     private final List<DCSSMorgueBreakdown> versionBreakdowns;
     private final List<DCSSMorgueBreakdown> monthBreakdowns;
     private final int distinctSpeciesPlayed;
+    private final int playableSpeciesCount;
     private final int distinctSpeciesWon;
     private final int distinctBackgroundsPlayed;
     private final int distinctBackgroundsWon;
@@ -52,6 +55,7 @@ public final class DCSSMorgueStats {
         int winCount = 0;
         int winRunes = 0;
         int runesBest = 0;
+        int coreSpeciesCount = 0;
         DCSSMorgueGame scoreRecord = null;
         DCSSMorgueGame turnRecord = null;
         DCSSMorgueGame durationRecord = null;
@@ -73,6 +77,7 @@ public final class DCSSMorgueStats {
         for (DCSSMorgueGame game : newestFirst) {
             String combo = game.getSpecies() + " " + game.getBackground();
             boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
+            coreSpeciesCount = Math.max(coreSpeciesCount, game.getPlayableSpeciesCount());
             score += game.getScore();
             turns += game.getTurns();
             duration += game.getDurationSeconds();
@@ -122,6 +127,7 @@ public final class DCSSMorgueStats {
         fastestWinByTurns = turnRecord;
         fastestWinByDuration = durationRecord;
         distinctSpeciesPlayed = playedSpecies.size();
+        playableSpeciesCount = coreSpeciesCount > 0 ? coreSpeciesCount : FALLBACK_PLAYABLE_SPECIES;
         distinctSpeciesWon = wonSpecies.size();
         distinctBackgroundsPlayed = playedBackgrounds.size();
         distinctBackgroundsWon = wonBackgrounds.size();
@@ -177,6 +183,7 @@ public final class DCSSMorgueStats {
     public List<DCSSMorgueBreakdown> getVersionBreakdowns() { return versionBreakdowns; }
     public List<DCSSMorgueBreakdown> getMonthBreakdowns() { return monthBreakdowns; }
     public int getDistinctSpeciesPlayed() { return distinctSpeciesPlayed; }
+    public int getPlayableSpeciesCount() { return playableSpeciesCount; }
     public int getDistinctSpeciesWon() { return distinctSpeciesWon; }
     public int getDistinctBackgroundsPlayed() { return distinctBackgroundsPlayed; }
     public int getDistinctBackgroundsWon() { return distinctBackgroundsWon; }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public final class DCSSMorgueStats {
     private final List<DCSSMorgueGame> newestFirst;
@@ -20,16 +22,28 @@ public final class DCSSMorgueStats {
     private final int bestRunes;
     private final int currentWinStreak;
     private final int bestWinStreak;
+    private final DCSSMorgueGame bestScoreGame;
+    private final DCSSMorgueGame fastestWinByTurns;
+    private final DCSSMorgueGame fastestWinByDuration;
     private final List<DCSSMorgueBreakdown> speciesBreakdowns;
     private final List<DCSSMorgueBreakdown> backgroundBreakdowns;
     private final List<DCSSMorgueBreakdown> godBreakdowns;
     private final List<DCSSMorgueBreakdown> comboBreakdowns;
+    private final List<DCSSMorgueBreakdown> deathBreakdowns;
+    private final List<DCSSMorgueBreakdown> deathPlaceBreakdowns;
+    private final List<DCSSMorgueBreakdown> versionBreakdowns;
+    private final List<DCSSMorgueBreakdown> monthBreakdowns;
+    private final int distinctSpeciesPlayed;
+    private final int distinctSpeciesWon;
+    private final int distinctBackgroundsPlayed;
+    private final int distinctBackgroundsWon;
+    private final int distinctCombosPlayed;
+    private final int distinctCombosWon;
 
     public DCSSMorgueStats(List<DCSSMorgueGame> games) {
         newestFirst = new ArrayList<>(games);
         newestFirst.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
         this.games = newestFirst.size();
-
         long score = 0;
         long turns = 0;
         long duration = 0;
@@ -38,27 +52,62 @@ public final class DCSSMorgueStats {
         int winCount = 0;
         int winRunes = 0;
         int runesBest = 0;
+        DCSSMorgueGame scoreRecord = null;
+        DCSSMorgueGame turnRecord = null;
+        DCSSMorgueGame durationRecord = null;
         Map<String, Counter> species = new HashMap<>();
         Map<String, Counter> backgrounds = new HashMap<>();
         Map<String, Counter> gods = new HashMap<>();
         Map<String, Counter> combos = new HashMap<>();
+        Map<String, Counter> deaths = new HashMap<>();
+        Map<String, Counter> deathPlaces = new HashMap<>();
+        Map<String, Counter> versions = new HashMap<>();
+        Map<String, Counter> months = new HashMap<>();
+        Set<String> playedSpecies = new HashSet<>();
+        Set<String> wonSpecies = new HashSet<>();
+        Set<String> playedBackgrounds = new HashSet<>();
+        Set<String> wonBackgrounds = new HashSet<>();
+        Set<String> playedCombos = new HashSet<>();
+        Set<String> wonCombos = new HashSet<>();
 
         for (DCSSMorgueGame game : newestFirst) {
+            String combo = game.getSpecies() + " " + game.getBackground();
+            boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
             score += game.getScore();
             turns += game.getTurns();
             duration += game.getDurationSeconds();
             best = Math.max(best, game.getScore());
             bestXl = Math.max(bestXl, game.getXl());
-            boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
+            if (scoreRecord == null || game.getScore() > scoreRecord.getScore()) {
+                scoreRecord = game;
+            }
             if (win) {
                 winCount++;
                 winRunes += game.getRunes();
                 runesBest = Math.max(runesBest, game.getRunes());
+                if (turnRecord == null || game.getTurns() < turnRecord.getTurns()) {
+                    turnRecord = game;
+                }
+                if (durationRecord == null || game.getDurationSeconds() < durationRecord.getDurationSeconds()) {
+                    durationRecord = game;
+                }
+                wonSpecies.add(game.getSpecies());
+                wonBackgrounds.add(game.getBackground());
+                wonCombos.add(combo);
             }
+            playedSpecies.add(game.getSpecies());
+            playedBackgrounds.add(game.getBackground());
+            playedCombos.add(combo);
             add(species, game.getSpecies(), game, win);
             add(backgrounds, game.getBackground(), game, win);
             add(gods, game.getGod(), game, win);
-            add(combos, game.getSpecies() + " " + game.getBackground(), game, win);
+            add(combos, combo, game, win);
+            add(versions, game.getVersion(), game, win);
+            add(months, game.getTimestamp().getYear() + "-" + String.format("%02d", game.getTimestamp().getMonthValue()), game, win);
+            if (game.getOutcome() == DCSSMorgueGame.Outcome.LOSS) {
+                add(deaths, game.getEndText(), game, false);
+                add(deathPlaces, game.getPlace(), game, false);
+            }
         }
 
         totalScore = score;
@@ -69,6 +118,15 @@ public final class DCSSMorgueStats {
         wins = winCount;
         totalWinRunes = winRunes;
         bestRunes = runesBest;
+        bestScoreGame = scoreRecord;
+        fastestWinByTurns = turnRecord;
+        fastestWinByDuration = durationRecord;
+        distinctSpeciesPlayed = playedSpecies.size();
+        distinctSpeciesWon = wonSpecies.size();
+        distinctBackgroundsPlayed = playedBackgrounds.size();
+        distinctBackgroundsWon = wonBackgrounds.size();
+        distinctCombosPlayed = playedCombos.size();
+        distinctCombosWon = wonCombos.size();
 
         List<DCSSMorgueGame> oldestFirst = new ArrayList<>(newestFirst);
         Collections.reverse(oldestFirst);
@@ -88,6 +146,10 @@ public final class DCSSMorgueStats {
         backgroundBreakdowns = breakdowns(backgrounds);
         godBreakdowns = breakdowns(gods);
         comboBreakdowns = breakdowns(combos);
+        deathBreakdowns = breakdowns(deaths);
+        deathPlaceBreakdowns = breakdowns(deathPlaces);
+        versionBreakdowns = breakdowns(versions);
+        monthBreakdowns = breakdowns(months);
     }
 
     public List<DCSSMorgueGame> getNewestFirst() { return Collections.unmodifiableList(newestFirst); }
@@ -103,10 +165,23 @@ public final class DCSSMorgueStats {
     public int getBestRunes() { return bestRunes; }
     public int getCurrentWinStreak() { return currentWinStreak; }
     public int getBestWinStreak() { return bestWinStreak; }
+    public DCSSMorgueGame getBestScoreGame() { return bestScoreGame; }
+    public DCSSMorgueGame getFastestWinByTurns() { return fastestWinByTurns; }
+    public DCSSMorgueGame getFastestWinByDuration() { return fastestWinByDuration; }
     public List<DCSSMorgueBreakdown> getSpeciesBreakdowns() { return speciesBreakdowns; }
     public List<DCSSMorgueBreakdown> getBackgroundBreakdowns() { return backgroundBreakdowns; }
     public List<DCSSMorgueBreakdown> getGodBreakdowns() { return godBreakdowns; }
     public List<DCSSMorgueBreakdown> getComboBreakdowns() { return comboBreakdowns; }
+    public List<DCSSMorgueBreakdown> getDeathBreakdowns() { return deathBreakdowns; }
+    public List<DCSSMorgueBreakdown> getDeathPlaceBreakdowns() { return deathPlaceBreakdowns; }
+    public List<DCSSMorgueBreakdown> getVersionBreakdowns() { return versionBreakdowns; }
+    public List<DCSSMorgueBreakdown> getMonthBreakdowns() { return monthBreakdowns; }
+    public int getDistinctSpeciesPlayed() { return distinctSpeciesPlayed; }
+    public int getDistinctSpeciesWon() { return distinctSpeciesWon; }
+    public int getDistinctBackgroundsPlayed() { return distinctBackgroundsPlayed; }
+    public int getDistinctBackgroundsWon() { return distinctBackgroundsWon; }
+    public int getDistinctCombosPlayed() { return distinctCombosPlayed; }
+    public int getDistinctCombosWon() { return distinctCombosWon; }
 
     private static void add(Map<String, Counter> counters, String label,
                             DCSSMorgueGame game, boolean win) {
@@ -141,9 +216,6 @@ public final class DCSSMorgueStats {
         int games;
         long bestScore;
         int bestXl;
-
-        Counter(String label) {
-            this.label = label;
-        }
+        Counter(String label) { this.label = label; }
     }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
@@ -1,0 +1,149 @@
+package org.develz.crawl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class DCSSMorgueStats {
+    private final List<DCSSMorgueGame> newestFirst;
+    private final int games;
+    private final int wins;
+    private final long totalScore;
+    private final long bestScore;
+    private final int highestXl;
+    private final long totalTurns;
+    private final long totalDurationSeconds;
+    private final int totalWinRunes;
+    private final int bestRunes;
+    private final int currentWinStreak;
+    private final int bestWinStreak;
+    private final List<DCSSMorgueBreakdown> speciesBreakdowns;
+    private final List<DCSSMorgueBreakdown> backgroundBreakdowns;
+    private final List<DCSSMorgueBreakdown> godBreakdowns;
+    private final List<DCSSMorgueBreakdown> comboBreakdowns;
+
+    public DCSSMorgueStats(List<DCSSMorgueGame> games) {
+        newestFirst = new ArrayList<>(games);
+        newestFirst.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
+        this.games = newestFirst.size();
+
+        long score = 0;
+        long turns = 0;
+        long duration = 0;
+        long best = 0;
+        int bestXl = 0;
+        int winCount = 0;
+        int winRunes = 0;
+        int runesBest = 0;
+        Map<String, Counter> species = new HashMap<>();
+        Map<String, Counter> backgrounds = new HashMap<>();
+        Map<String, Counter> gods = new HashMap<>();
+        Map<String, Counter> combos = new HashMap<>();
+
+        for (DCSSMorgueGame game : newestFirst) {
+            score += game.getScore();
+            turns += game.getTurns();
+            duration += game.getDurationSeconds();
+            best = Math.max(best, game.getScore());
+            bestXl = Math.max(bestXl, game.getXl());
+            boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
+            if (win) {
+                winCount++;
+                winRunes += game.getRunes();
+                runesBest = Math.max(runesBest, game.getRunes());
+            }
+            add(species, game.getSpecies(), game, win);
+            add(backgrounds, game.getBackground(), game, win);
+            add(gods, game.getGod(), game, win);
+            add(combos, game.getSpecies() + " " + game.getBackground(), game, win);
+        }
+
+        totalScore = score;
+        bestScore = best;
+        highestXl = bestXl;
+        totalTurns = turns;
+        totalDurationSeconds = duration;
+        wins = winCount;
+        totalWinRunes = winRunes;
+        bestRunes = runesBest;
+
+        List<DCSSMorgueGame> oldestFirst = new ArrayList<>(newestFirst);
+        Collections.reverse(oldestFirst);
+        int streak = 0;
+        int longest = 0;
+        for (DCSSMorgueGame game : oldestFirst) {
+            if (game.getOutcome() == DCSSMorgueGame.Outcome.WIN) {
+                streak++;
+                longest = Math.max(longest, streak);
+            } else {
+                streak = 0;
+            }
+        }
+        currentWinStreak = streak;
+        bestWinStreak = longest;
+        speciesBreakdowns = breakdowns(species);
+        backgroundBreakdowns = breakdowns(backgrounds);
+        godBreakdowns = breakdowns(gods);
+        comboBreakdowns = breakdowns(combos);
+    }
+
+    public List<DCSSMorgueGame> getNewestFirst() { return Collections.unmodifiableList(newestFirst); }
+    public int getGames() { return games; }
+    public int getWins() { return wins; }
+    public double getWinRate() { return games == 0 ? 0.0 : 100.0 * wins / games; }
+    public long getTotalScore() { return totalScore; }
+    public long getBestScore() { return bestScore; }
+    public int getHighestXl() { return highestXl; }
+    public long getTotalTurns() { return totalTurns; }
+    public long getTotalDurationSeconds() { return totalDurationSeconds; }
+    public int getTotalWinRunes() { return totalWinRunes; }
+    public int getBestRunes() { return bestRunes; }
+    public int getCurrentWinStreak() { return currentWinStreak; }
+    public int getBestWinStreak() { return bestWinStreak; }
+    public List<DCSSMorgueBreakdown> getSpeciesBreakdowns() { return speciesBreakdowns; }
+    public List<DCSSMorgueBreakdown> getBackgroundBreakdowns() { return backgroundBreakdowns; }
+    public List<DCSSMorgueBreakdown> getGodBreakdowns() { return godBreakdowns; }
+    public List<DCSSMorgueBreakdown> getComboBreakdowns() { return comboBreakdowns; }
+
+    private static void add(Map<String, Counter> counters, String label,
+                            DCSSMorgueGame game, boolean win) {
+        Counter counter = counters.get(label);
+        if (counter == null) {
+            counter = new Counter(label);
+            counters.put(label, counter);
+        }
+        counter.games++;
+        if (win) {
+            counter.wins++;
+        }
+        counter.bestScore = Math.max(counter.bestScore, game.getScore());
+        counter.bestXl = Math.max(counter.bestXl, game.getXl());
+    }
+
+    private static List<DCSSMorgueBreakdown> breakdowns(Map<String, Counter> counters) {
+        List<DCSSMorgueBreakdown> rows = new ArrayList<>();
+        for (Counter counter : counters.values()) {
+            rows.add(new DCSSMorgueBreakdown(counter.label, counter.wins, counter.games,
+                    counter.bestScore, counter.bestXl));
+        }
+        rows.sort(Comparator.comparingInt(DCSSMorgueBreakdown::getWins).reversed()
+                .thenComparing(Comparator.comparingInt(DCSSMorgueBreakdown::getGames).reversed())
+                .thenComparing(DCSSMorgueBreakdown::getLabel));
+        return Collections.unmodifiableList(rows);
+    }
+
+    private static final class Counter {
+        final String label;
+        int wins;
+        int games;
+        long bestScore;
+        int bestXl;
+
+        Counter(String label) {
+            this.label = label;
+        }
+    }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
@@ -12,6 +12,9 @@ import java.util.Set;
 public final class DCSSMorgueStats {
     // Current core roster, used only until a new final morgue supplies its core value.
     private static final int FALLBACK_PLAYABLE_SPECIES = 27;
+    private static final int FALLBACK_PLAYABLE_BACKGROUNDS = 33;
+    private static final int FALLBACK_AVAILABLE_GODS = 27;
+    private static final int FALLBACK_PLAYABLE_COMBOS = 880;
     private final List<DCSSMorgueGame> newestFirst;
     private final int games;
     private final int wins;
@@ -37,6 +40,10 @@ public final class DCSSMorgueStats {
     private final List<DCSSMorgueBreakdown> monthBreakdowns;
     private final int distinctSpeciesPlayed;
     private final int playableSpeciesCount;
+    private final int playableBackgroundCount;
+    private final int availableGodCount;
+    private final int playableComboCount;
+    private final int distinctGodsWon;
     private final int distinctSpeciesWon;
     private final int distinctBackgroundsPlayed;
     private final int distinctBackgroundsWon;
@@ -56,6 +63,9 @@ public final class DCSSMorgueStats {
         int winRunes = 0;
         int runesBest = 0;
         int coreSpeciesCount = 0;
+        int coreBackgroundCount = 0;
+        int coreGodCount = 0;
+        int coreComboCount = 0;
         DCSSMorgueGame scoreRecord = null;
         DCSSMorgueGame turnRecord = null;
         DCSSMorgueGame durationRecord = null;
@@ -73,11 +83,15 @@ public final class DCSSMorgueStats {
         Set<String> wonBackgrounds = new HashSet<>();
         Set<String> playedCombos = new HashSet<>();
         Set<String> wonCombos = new HashSet<>();
+        Set<String> wonGods = new HashSet<>();
 
         for (DCSSMorgueGame game : newestFirst) {
             String combo = game.getSpecies() + " " + game.getBackground();
             boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
             coreSpeciesCount = Math.max(coreSpeciesCount, game.getPlayableSpeciesCount());
+            coreBackgroundCount = Math.max(coreBackgroundCount, game.getPlayableBackgroundCount());
+            coreGodCount = Math.max(coreGodCount, game.getAvailableGodCount());
+            coreComboCount = Math.max(coreComboCount, game.getPlayableComboCount());
             score += game.getScore();
             turns += game.getTurns();
             duration += game.getDurationSeconds();
@@ -99,6 +113,9 @@ public final class DCSSMorgueStats {
                 wonSpecies.add(game.getSpecies());
                 wonBackgrounds.add(game.getBackground());
                 wonCombos.add(combo);
+                if (!"Atheist".equals(game.getGod())) {
+                    wonGods.add(game.getGod());
+                }
             }
             playedSpecies.add(game.getSpecies());
             playedBackgrounds.add(game.getBackground());
@@ -128,6 +145,10 @@ public final class DCSSMorgueStats {
         fastestWinByDuration = durationRecord;
         distinctSpeciesPlayed = playedSpecies.size();
         playableSpeciesCount = coreSpeciesCount > 0 ? coreSpeciesCount : FALLBACK_PLAYABLE_SPECIES;
+        playableBackgroundCount = coreBackgroundCount > 0 ? coreBackgroundCount : FALLBACK_PLAYABLE_BACKGROUNDS;
+        availableGodCount = coreGodCount > 0 ? coreGodCount : FALLBACK_AVAILABLE_GODS;
+        playableComboCount = coreComboCount > 0 ? coreComboCount : FALLBACK_PLAYABLE_COMBOS;
+        distinctGodsWon = wonGods.size();
         distinctSpeciesWon = wonSpecies.size();
         distinctBackgroundsPlayed = playedBackgrounds.size();
         distinctBackgroundsWon = wonBackgrounds.size();
@@ -184,6 +205,10 @@ public final class DCSSMorgueStats {
     public List<DCSSMorgueBreakdown> getMonthBreakdowns() { return monthBreakdowns; }
     public int getDistinctSpeciesPlayed() { return distinctSpeciesPlayed; }
     public int getPlayableSpeciesCount() { return playableSpeciesCount; }
+    public int getPlayableBackgroundCount() { return playableBackgroundCount; }
+    public int getAvailableGodCount() { return availableGodCount; }
+    public int getPlayableComboCount() { return playableComboCount; }
+    public int getDistinctGodsWon() { return distinctGodsWon; }
     public int getDistinctSpeciesWon() { return distinctSpeciesWon; }
     public int getDistinctBackgroundsPlayed() { return distinctBackgroundsPlayed; }
     public int getDistinctBackgroundsWon() { return distinctBackgroundsWon; }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStats.java
@@ -10,11 +10,6 @@ import java.util.Map;
 import java.util.Set;
 
 public final class DCSSMorgueStats {
-    // Current core roster, used only until a new final morgue supplies its core value.
-    private static final int FALLBACK_PLAYABLE_SPECIES = 27;
-    private static final int FALLBACK_PLAYABLE_BACKGROUNDS = 33;
-    private static final int FALLBACK_AVAILABLE_GODS = 27;
-    private static final int FALLBACK_PLAYABLE_COMBOS = 880;
     private final List<DCSSMorgueGame> newestFirst;
     private final int games;
     private final int wins;
@@ -51,8 +46,17 @@ public final class DCSSMorgueStats {
     private final int distinctCombosWon;
 
     public DCSSMorgueStats(List<DCSSMorgueGame> games) {
+        this(games, new DCSSMorgueRoster(0, 0, 0, 0));
+    }
+
+    public DCSSMorgueStats(List<DCSSMorgueGame> games, DCSSMorgueRoster roster) {
         newestFirst = new ArrayList<>(games);
-        newestFirst.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
+        Collections.sort(newestFirst, new Comparator<DCSSMorgueGame>() {
+            @Override
+            public int compare(DCSSMorgueGame left, DCSSMorgueGame right) {
+                return right.getTimestamp().compareTo(left.getTimestamp());
+            }
+        });
         this.games = newestFirst.size();
         long score = 0;
         long turns = 0;
@@ -62,10 +66,6 @@ public final class DCSSMorgueStats {
         int winCount = 0;
         int winRunes = 0;
         int runesBest = 0;
-        int coreSpeciesCount = 0;
-        int coreBackgroundCount = 0;
-        int coreGodCount = 0;
-        int coreComboCount = 0;
         DCSSMorgueGame scoreRecord = null;
         DCSSMorgueGame turnRecord = null;
         DCSSMorgueGame durationRecord = null;
@@ -88,10 +88,6 @@ public final class DCSSMorgueStats {
         for (DCSSMorgueGame game : newestFirst) {
             String combo = game.getSpecies() + " " + game.getBackground();
             boolean win = game.getOutcome() == DCSSMorgueGame.Outcome.WIN;
-            coreSpeciesCount = Math.max(coreSpeciesCount, game.getPlayableSpeciesCount());
-            coreBackgroundCount = Math.max(coreBackgroundCount, game.getPlayableBackgroundCount());
-            coreGodCount = Math.max(coreGodCount, game.getAvailableGodCount());
-            coreComboCount = Math.max(coreComboCount, game.getPlayableComboCount());
             score += game.getScore();
             turns += game.getTurns();
             duration += game.getDurationSeconds();
@@ -125,7 +121,8 @@ public final class DCSSMorgueStats {
             add(gods, game.getGod(), game, win);
             add(combos, combo, game, win);
             add(versions, game.getVersion(), game, win);
-            add(months, game.getTimestamp().getYear() + "-" + String.format("%02d", game.getTimestamp().getMonthValue()), game, win);
+            add(months, game.getTimestamp().substring(0, 4) + "-"
+                    + game.getTimestamp().substring(4, 6), game, win);
             if (game.getOutcome() == DCSSMorgueGame.Outcome.LOSS) {
                 add(deaths, game.getEndText(), game, false);
                 add(deathPlaces, game.getPlace(), game, false);
@@ -144,10 +141,10 @@ public final class DCSSMorgueStats {
         fastestWinByTurns = turnRecord;
         fastestWinByDuration = durationRecord;
         distinctSpeciesPlayed = playedSpecies.size();
-        playableSpeciesCount = coreSpeciesCount > 0 ? coreSpeciesCount : FALLBACK_PLAYABLE_SPECIES;
-        playableBackgroundCount = coreBackgroundCount > 0 ? coreBackgroundCount : FALLBACK_PLAYABLE_BACKGROUNDS;
-        availableGodCount = coreGodCount > 0 ? coreGodCount : FALLBACK_AVAILABLE_GODS;
-        playableComboCount = coreComboCount > 0 ? coreComboCount : FALLBACK_PLAYABLE_COMBOS;
+        playableSpeciesCount = roster.getPlayableSpecies();
+        playableBackgroundCount = roster.getPlayableBackgrounds();
+        availableGodCount = roster.getAvailableGods();
+        playableComboCount = roster.getPlayableCombos();
         distinctGodsWon = wonGods.size();
         distinctSpeciesWon = wonSpecies.size();
         distinctBackgroundsPlayed = playedBackgrounds.size();
@@ -236,9 +233,15 @@ public final class DCSSMorgueStats {
             rows.add(new DCSSMorgueBreakdown(counter.label, counter.wins, counter.games,
                     counter.bestScore, counter.bestXl));
         }
-        rows.sort(Comparator.comparingInt(DCSSMorgueBreakdown::getWins).reversed()
-                .thenComparing(Comparator.comparingInt(DCSSMorgueBreakdown::getGames).reversed())
-                .thenComparing(DCSSMorgueBreakdown::getLabel));
+        Collections.sort(rows, new Comparator<DCSSMorgueBreakdown>() {
+            @Override
+            public int compare(DCSSMorgueBreakdown left, DCSSMorgueBreakdown right) {
+                int compare = Integer.compare(right.getWins(), left.getWins());
+                if (compare == 0)
+                    compare = Integer.compare(right.getGames(), left.getGames());
+                return compare == 0 ? left.getLabel().compareTo(right.getLabel()) : compare;
+            }
+        });
         return Collections.unmodifiableList(rows);
     }
 

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -1,0 +1,92 @@
+package org.develz.crawl;
+
+import android.os.Bundle;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.File;
+import java.text.NumberFormat;
+import java.util.List;
+import java.util.Locale;
+
+public class DCSSMorgueStatsActivity extends AppCompatActivity {
+    private static final String MORGUE_DIR = "/morgue";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.morgue_stats);
+        findViewById(R.id.morgueStatsBack).setOnClickListener(view -> finish());
+
+        TextView text = findViewById(R.id.morgueStatsText);
+        File morgueDir = new File(getExternalFilesDir(null) + MORGUE_DIR);
+        text.setText(render(new DCSSMorgueStats(DCSSMorgueStatsParser.loadFinalMorgues(morgueDir))));
+    }
+
+    static String render(DCSSMorgueStats stats) {
+        if (stats.getGames() == 0) {
+            return "Morgue stats\n\nNo final morgues found.\n\n"
+                    + "Only timestamped final morgues currently kept on this device are counted.";
+        }
+
+        StringBuilder text = new StringBuilder("Morgue stats\n\n");
+        text.append("Final morgues currently kept on this device\n\n");
+        text.append("Games: ").append(stats.getGames())
+                .append("    Wins: ").append(stats.getWins())
+                .append("    Win rate: ").append(percent(stats.getWinRate())).append("\n\n");
+        text.append("Best score: ").append(number(stats.getBestScore()))
+                .append("\nTotal score: ").append(number(stats.getTotalScore()))
+                .append("\nHighest XL: ").append(stats.getHighestXl())
+                .append("\nTotal turns: ").append(number(stats.getTotalTurns()))
+                .append("\nTotal time: ").append(duration(stats.getTotalDurationSeconds()))
+                .append("\nCurrent win streak: ").append(stats.getCurrentWinStreak())
+                .append("\nBest win streak: ").append(stats.getBestWinStreak())
+                .append("\nRunes on wins: ").append(stats.getTotalWinRunes())
+                .append("    Best: ").append(stats.getBestRunes()).append("\n");
+        appendRecentGames(text, stats.getNewestFirst());
+        appendBreakdowns(text, "Wins by species", stats.getSpeciesBreakdowns());
+        appendBreakdowns(text, "Wins by background", stats.getBackgroundBreakdowns());
+        appendBreakdowns(text, "Wins by god", stats.getGodBreakdowns());
+        appendBreakdowns(text, "Wins by combo", stats.getComboBreakdowns());
+        return text.toString();
+    }
+
+    private static void appendRecentGames(StringBuilder text, List<DCSSMorgueGame> games) {
+        text.append("\nRecent final morgues\n");
+        int shown = Math.min(20, games.size());
+        for (int index = 0; index < shown; index++) {
+            DCSSMorgueGame game = games.get(index);
+            text.append(game.getTimestamp().toLocalDate()).append(" · ")
+                    .append(game.getOutcome()).append(" · ")
+                    .append(game.getSpecies()).append(" ").append(game.getBackground())
+                    .append(" · XL ").append(game.getXl())
+                    .append(" · ").append(game.getPlace())
+                    .append(" · ").append(number(game.getScore())).append("\n");
+        }
+    }
+
+    private static void appendBreakdowns(StringBuilder text, String heading,
+                                         List<DCSSMorgueBreakdown> rows) {
+        text.append("\n").append(heading).append("\n");
+        for (DCSSMorgueBreakdown row : rows) {
+            text.append(row.getLabel()).append(": ")
+                    .append(row.getWins()).append(" W · ")
+                    .append(row.getGames()).append(" G · ")
+                    .append(percent(row.getWinRate())).append("\n");
+        }
+    }
+
+    private static String number(long value) {
+        return NumberFormat.getIntegerInstance(Locale.getDefault()).format(value);
+    }
+
+    private static String percent(double value) {
+        return String.format(Locale.getDefault(), "%.1f%%", value);
+    }
+
+    private static String duration(long seconds) {
+        return String.format(Locale.getDefault(), "%02d:%02d:%02d", seconds / 3600,
+                (seconds / 60) % 60, seconds % 60);
+    }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -21,6 +21,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
         implements AdapterView.OnItemSelectedListener {
     private static final String MORGUE_DIR = "/morgue";
     private DCSSMorgueLoadResult loadResult;
+    private DCSSMorgueRoster roster;
     private TextView text;
 
     @Override
@@ -31,6 +32,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
         text = findViewById(R.id.morgueStatsText);
         File morgueDir = new File(getExternalFilesDir(null) + MORGUE_DIR);
         loadResult = DCSSMorgueStatsParser.loadFinalMorguesWithAudit(morgueDir);
+        roster = DCSSMorgueRoster.current();
 
         Spinner filter = findViewById(R.id.morgueStatsFilter);
         ArrayAdapter<String> adapter = new ArrayAdapter<>(this,
@@ -59,6 +61,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
             filters.add("God: " + game.getGod());
             filters.add("Combo: " + game.getSpecies() + " " + game.getBackground());
         }
+        filters.add("Audit");
         return new ArrayList<>(filters);
     }
 
@@ -69,7 +72,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
                 selected.add(game);
             }
         }
-        text.setText(render(new DCSSMorgueStats(selected), loadResult, filter));
+        text.setText(render(new DCSSMorgueStats(selected, roster), loadResult, filter));
     }
 
     private static boolean matches(String filter, DCSSMorgueGame game) {
@@ -82,11 +85,14 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
 
     static String render(DCSSMorgueStats stats, DCSSMorgueLoadResult audit, String filter) {
         StringBuilder text = new StringBuilder("Morgue stats\n\n");
-        text.append("Audit: ").append(audit.getFinalMorgueFiles()).append(" timestamped final files · ")
-                .append(audit.getGames().size()).append(" counted · ")
-                .append(audit.getSkippedFiles().size()).append(" skipped\n");
-        if (!audit.getSkippedFiles().isEmpty()) {
-            text.append("Skipped: ").append(join(audit.getSkippedFiles(), 3)).append("\n");
+        if (filter.equals("Audit")) {
+            text.append("Audit: ").append(audit.getFinalMorgueFiles())
+                    .append(" timestamped final files · ").append(audit.getGames().size())
+                    .append(" counted · ").append(audit.getSkippedFiles().size()).append(" skipped\n");
+            if (!audit.getSkippedFiles().isEmpty()) {
+                text.append("Skipped: ").append(join(audit.getSkippedFiles(), 3)).append("\n");
+            }
+            return text.toString();
         }
         if (stats.getGames() == 0) {
             return text.append("No final morgues match this view.").toString();
@@ -101,7 +107,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
                 .append("\nTotal time: ").append(duration(stats.getTotalDurationSeconds()))
                 .append("    Current / best streak: ").append(stats.getCurrentWinStreak())
                 .append(" / ").append(stats.getBestWinStreak()).append("\n");
-        text.append("\nAchievements\n")
+        text.append("\nCurrent roster achievements\n")
                 .append("Species won: ").append(stats.getDistinctSpeciesWon()).append(" / ")
                 .append(stats.getPlayableSpeciesCount()).append("\n")
                 .append("Backgrounds won: ").append(stats.getDistinctBackgroundsWon()).append(" / ")
@@ -126,7 +132,10 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
         text.append("\nRecent final morgues\n");
         for (int index = 0; index < Math.min(20, games.size()); index++) {
             DCSSMorgueGame game = games.get(index);
-            text.append(game.getTimestamp().toLocalDate()).append(" · ").append(game.getOutcome())
+            String timestamp = game.getTimestamp();
+            text.append(timestamp.substring(0, 4)).append("-").append(timestamp.substring(4, 6))
+                    .append("-").append(timestamp.substring(6, 8)).append(" · ")
+                    .append(game.getOutcome())
                     .append(" · ").append(game.getSpecies()).append(" ").append(game.getBackground())
                     .append(" · XL ").append(game.getXl()).append(" · ").append(game.getPlace())
                     .append(" · ").append(number(game.getScore())).append("\n");

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -105,9 +105,11 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
                 .append("Species won: ").append(stats.getDistinctSpeciesWon()).append(" / ")
                 .append(stats.getPlayableSpeciesCount()).append("\n")
                 .append("Backgrounds won: ").append(stats.getDistinctBackgroundsWon()).append(" / ")
-                .append(stats.getDistinctBackgroundsPlayed()).append(" played\n")
+                .append(stats.getPlayableBackgroundCount()).append("\n")
+                .append("Gods won: ").append(stats.getDistinctGodsWon()).append(" / ")
+                .append(stats.getAvailableGodCount()).append("\n")
                 .append("Combos won: ").append(stats.getDistinctCombosWon()).append(" / ")
-                .append(stats.getDistinctCombosPlayed()).append(" played\n");
+                .append(stats.getPlayableComboCount()).append("\n");
         appendBreakdowns(text, "Deaths by cause", stats.getDeathBreakdowns(), 8);
         appendBreakdowns(text, "Deaths by place", stats.getDeathPlaceBreakdowns(), 8);
         appendBreakdowns(text, "Timeline by month", stats.getMonthBreakdowns(), 12);

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -103,7 +103,7 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
                 .append(" / ").append(stats.getBestWinStreak()).append("\n");
         text.append("\nAchievements\n")
                 .append("Species won: ").append(stats.getDistinctSpeciesWon()).append(" / ")
-                .append(stats.getDistinctSpeciesPlayed()).append(" played\n")
+                .append(stats.getPlayableSpeciesCount()).append("\n")
                 .append("Backgrounds won: ").append(stats.getDistinctBackgroundsWon()).append(" / ")
                 .append(stats.getDistinctBackgroundsPlayed()).append(" played\n")
                 .append("Combos won: ").append(stats.getDistinctCombosWon()).append(" / ")

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -88,7 +88,6 @@ public class DCSSMorgueStatsActivity extends AppCompatActivity
         if (!audit.getSkippedFiles().isEmpty()) {
             text.append("Skipped: ").append(join(audit.getSkippedFiles(), 3)).append("\n");
         }
-        text.append("View: ").append(filter).append("\n\n");
         if (stats.getGames() == 0) {
             return text.append("No final morgues match this view.").toString();
         }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsActivity.java
@@ -1,92 +1,174 @@
 package org.develz.crawl;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
 import android.widget.TextView;
 
 import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.File;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
-public class DCSSMorgueStatsActivity extends AppCompatActivity {
+public class DCSSMorgueStatsActivity extends AppCompatActivity
+        implements AdapterView.OnItemSelectedListener {
     private static final String MORGUE_DIR = "/morgue";
+    private DCSSMorgueLoadResult loadResult;
+    private TextView text;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.morgue_stats);
         findViewById(R.id.morgueStatsBack).setOnClickListener(view -> finish());
-
-        TextView text = findViewById(R.id.morgueStatsText);
+        text = findViewById(R.id.morgueStatsText);
         File morgueDir = new File(getExternalFilesDir(null) + MORGUE_DIR);
-        text.setText(render(new DCSSMorgueStats(DCSSMorgueStatsParser.loadFinalMorgues(morgueDir))));
+        loadResult = DCSSMorgueStatsParser.loadFinalMorguesWithAudit(morgueDir);
+
+        Spinner filter = findViewById(R.id.morgueStatsFilter);
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this,
+                android.R.layout.simple_spinner_item, filters(loadResult.getGames()));
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        filter.setAdapter(adapter);
+        filter.setOnItemSelectedListener(this);
+        renderSelection("All games");
     }
 
-    static String render(DCSSMorgueStats stats) {
-        if (stats.getGames() == 0) {
-            return "Morgue stats\n\nNo final morgues found.\n\n"
-                    + "Only timestamped final morgues currently kept on this device are counted.";
-        }
+    @Override
+    public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+        renderSelection((String) parent.getItemAtPosition(position));
+    }
 
+    @Override
+    public void onNothingSelected(AdapterView<?> parent) {
+    }
+
+    private List<String> filters(List<DCSSMorgueGame> games) {
+        Set<String> filters = new LinkedHashSet<>();
+        filters.add("All games");
+        for (DCSSMorgueGame game : games) {
+            filters.add("Species: " + game.getSpecies());
+            filters.add("Background: " + game.getBackground());
+            filters.add("God: " + game.getGod());
+            filters.add("Combo: " + game.getSpecies() + " " + game.getBackground());
+        }
+        return new ArrayList<>(filters);
+    }
+
+    private void renderSelection(String filter) {
+        List<DCSSMorgueGame> selected = new ArrayList<>();
+        for (DCSSMorgueGame game : loadResult.getGames()) {
+            if (matches(filter, game)) {
+                selected.add(game);
+            }
+        }
+        text.setText(render(new DCSSMorgueStats(selected), loadResult, filter));
+    }
+
+    private static boolean matches(String filter, DCSSMorgueGame game) {
+        return filter.equals("All games")
+                || filter.equals("Species: " + game.getSpecies())
+                || filter.equals("Background: " + game.getBackground())
+                || filter.equals("God: " + game.getGod())
+                || filter.equals("Combo: " + game.getSpecies() + " " + game.getBackground());
+    }
+
+    static String render(DCSSMorgueStats stats, DCSSMorgueLoadResult audit, String filter) {
         StringBuilder text = new StringBuilder("Morgue stats\n\n");
-        text.append("Final morgues currently kept on this device\n\n");
-        text.append("Games: ").append(stats.getGames())
-                .append("    Wins: ").append(stats.getWins())
+        text.append("Audit: ").append(audit.getFinalMorgueFiles()).append(" timestamped final files · ")
+                .append(audit.getGames().size()).append(" counted · ")
+                .append(audit.getSkippedFiles().size()).append(" skipped\n");
+        if (!audit.getSkippedFiles().isEmpty()) {
+            text.append("Skipped: ").append(join(audit.getSkippedFiles(), 3)).append("\n");
+        }
+        text.append("View: ").append(filter).append("\n\n");
+        if (stats.getGames() == 0) {
+            return text.append("No final morgues match this view.").toString();
+        }
+        text.append("Games: ").append(stats.getGames()).append("    Wins: ").append(stats.getWins())
                 .append("    Win rate: ").append(percent(stats.getWinRate())).append("\n\n");
-        text.append("Best score: ").append(number(stats.getBestScore()))
-                .append("\nTotal score: ").append(number(stats.getTotalScore()))
+        text.append("Best score: ").append(game(stats.getBestScoreGame()))
+                .append("\nFastest win (turns): ").append(game(stats.getFastestWinByTurns()))
+                .append("\nFastest win (time): ").append(game(stats.getFastestWinByDuration()))
                 .append("\nHighest XL: ").append(stats.getHighestXl())
-                .append("\nTotal turns: ").append(number(stats.getTotalTurns()))
+                .append("    Total turns: ").append(number(stats.getTotalTurns()))
                 .append("\nTotal time: ").append(duration(stats.getTotalDurationSeconds()))
-                .append("\nCurrent win streak: ").append(stats.getCurrentWinStreak())
-                .append("\nBest win streak: ").append(stats.getBestWinStreak())
-                .append("\nRunes on wins: ").append(stats.getTotalWinRunes())
-                .append("    Best: ").append(stats.getBestRunes()).append("\n");
+                .append("    Current / best streak: ").append(stats.getCurrentWinStreak())
+                .append(" / ").append(stats.getBestWinStreak()).append("\n");
+        text.append("\nAchievements\n")
+                .append("Species won: ").append(stats.getDistinctSpeciesWon()).append(" / ")
+                .append(stats.getDistinctSpeciesPlayed()).append(" played\n")
+                .append("Backgrounds won: ").append(stats.getDistinctBackgroundsWon()).append(" / ")
+                .append(stats.getDistinctBackgroundsPlayed()).append(" played\n")
+                .append("Combos won: ").append(stats.getDistinctCombosWon()).append(" / ")
+                .append(stats.getDistinctCombosPlayed()).append(" played\n");
+        appendBreakdowns(text, "Deaths by cause", stats.getDeathBreakdowns(), 8);
+        appendBreakdowns(text, "Deaths by place", stats.getDeathPlaceBreakdowns(), 8);
+        appendBreakdowns(text, "Timeline by month", stats.getMonthBreakdowns(), 12);
+        appendBreakdowns(text, "Games by version", stats.getVersionBreakdowns(), 12);
         appendRecentGames(text, stats.getNewestFirst());
-        appendBreakdowns(text, "Wins by species", stats.getSpeciesBreakdowns());
-        appendBreakdowns(text, "Wins by background", stats.getBackgroundBreakdowns());
-        appendBreakdowns(text, "Wins by god", stats.getGodBreakdowns());
-        appendBreakdowns(text, "Wins by combo", stats.getComboBreakdowns());
+        appendBreakdowns(text, "Wins by species", stats.getSpeciesBreakdowns(), 20);
+        appendBreakdowns(text, "Wins by background", stats.getBackgroundBreakdowns(), 20);
+        appendBreakdowns(text, "Wins by god", stats.getGodBreakdowns(), 20);
+        appendBreakdowns(text, "Wins by combo", stats.getComboBreakdowns(), 20);
         return text.toString();
     }
 
     private static void appendRecentGames(StringBuilder text, List<DCSSMorgueGame> games) {
         text.append("\nRecent final morgues\n");
-        int shown = Math.min(20, games.size());
-        for (int index = 0; index < shown; index++) {
+        for (int index = 0; index < Math.min(20, games.size()); index++) {
             DCSSMorgueGame game = games.get(index);
-            text.append(game.getTimestamp().toLocalDate()).append(" · ")
-                    .append(game.getOutcome()).append(" · ")
-                    .append(game.getSpecies()).append(" ").append(game.getBackground())
-                    .append(" · XL ").append(game.getXl())
-                    .append(" · ").append(game.getPlace())
+            text.append(game.getTimestamp().toLocalDate()).append(" · ").append(game.getOutcome())
+                    .append(" · ").append(game.getSpecies()).append(" ").append(game.getBackground())
+                    .append(" · XL ").append(game.getXl()).append(" · ").append(game.getPlace())
                     .append(" · ").append(number(game.getScore())).append("\n");
         }
     }
 
     private static void appendBreakdowns(StringBuilder text, String heading,
-                                         List<DCSSMorgueBreakdown> rows) {
+                                         List<DCSSMorgueBreakdown> rows, int limit) {
+        if (rows.isEmpty()) {
+            return;
+        }
         text.append("\n").append(heading).append("\n");
-        for (DCSSMorgueBreakdown row : rows) {
-            text.append(row.getLabel()).append(": ")
-                    .append(row.getWins()).append(" W · ")
-                    .append(row.getGames()).append(" G · ")
-                    .append(percent(row.getWinRate())).append("\n");
+        for (int index = 0; index < Math.min(limit, rows.size()); index++) {
+            DCSSMorgueBreakdown row = rows.get(index);
+            text.append(row.getLabel()).append(": ").append(row.getWins()).append(" W · ")
+                    .append(row.getGames()).append(" G · ").append(percent(row.getWinRate()))
+                    .append(" · best ").append(number(row.getBestScore())).append("\n");
         }
     }
 
-    private static String number(long value) {
-        return NumberFormat.getIntegerInstance(Locale.getDefault()).format(value);
+    private static String game(DCSSMorgueGame game) {
+        if (game == null) {
+            return "No win yet";
+        }
+        return number(game.getScore()) + " · " + game.getSpecies() + " " + game.getBackground()
+                + " · " + game.getTurns() + " turns · " + duration(game.getDurationSeconds());
     }
 
-    private static String percent(double value) {
-        return String.format(Locale.getDefault(), "%.1f%%", value);
+    private static String join(List<String> values, int limit) {
+        return joinValues(values.subList(0, Math.min(limit, values.size())), values.size());
     }
 
-    private static String duration(long seconds) {
-        return String.format(Locale.getDefault(), "%02d:%02d:%02d", seconds / 3600,
-                (seconds / 60) % 60, seconds % 60);
+    private static String joinValues(List<String> values, int total) {
+        StringBuilder result = new StringBuilder();
+        for (int index = 0; index < values.size(); index++) {
+            if (index > 0) result.append(", ");
+            result.append(values.get(index));
+        }
+        if (total > values.size()) result.append(" …");
+        return result.toString();
     }
+
+    private static String number(long value) { return NumberFormat.getIntegerInstance(Locale.getDefault()).format(value); }
+    private static String percent(double value) { return String.format(Locale.getDefault(), "%.1f%%", value); }
+    private static String duration(long seconds) { return String.format(Locale.getDefault(), "%02d:%02d:%02d", seconds / 3600, (seconds / 60) % 60, seconds % 60); }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -177,7 +177,8 @@ public final class DCSSMorgueStatsParser {
                 || line.startsWith("Drowned by ") || line.startsWith("Drowned in ")
                 || line.startsWith("Burnt to a crisp") || line.startsWith("Killed from afar")
                 || line.startsWith("Blown up by ") || line.startsWith("Succumbed to ")
-                || line.startsWith("Demolished by ") || line.startsWith("Engulfed by ");
+                || line.startsWith("Demolished by ") || line.startsWith("Engulfed by ")
+                || line.startsWith("Constricted to death by ");
     }
 
     public static List<DCSSMorgueGame> loadFinalMorgues(File morgueDir) {

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -78,6 +78,9 @@ public final class DCSSMorgueStatsParser {
         String endText = null;
         String killMethod = null;
         int playableSpeciesCount = 0;
+        int playableBackgroundCount = 0;
+        int availableGodCount = 0;
+        int playableComboCount = 0;
 
         try (BufferedReader reader = new BufferedReader(new FileReader(morgueFile))) {
             String line;
@@ -86,10 +89,10 @@ public final class DCSSMorgueStatsParser {
                 Matcher metadata = MORGUE_STATS.matcher(trimmed);
                 if (metadata.matches()) {
                     killMethod = xlogField(metadata.group(1), "ktyp");
-                    String speciesCount = xlogField(metadata.group(1), "ms_species_total");
-                    if (speciesCount != null) {
-                        playableSpeciesCount = Integer.parseInt(speciesCount);
-                    }
+                    playableSpeciesCount = xlogIntField(metadata.group(1), "ms_species_total");
+                    playableBackgroundCount = xlogIntField(metadata.group(1), "ms_background_total");
+                    availableGodCount = xlogIntField(metadata.group(1), "ms_god_total");
+                    playableComboCount = xlogIntField(metadata.group(1), "ms_combo_total");
                     continue;
                 }
                 Matcher versionMatcher = VERSION.matcher(trimmed);
@@ -186,7 +189,8 @@ public final class DCSSMorgueStatsParser {
         }
         return Optional.of(new DCSSMorgueGame(morgueFile, timestamp, score, species,
                 background, god, xl, place, turns, durationSeconds, runes, outcome, endText,
-                version, playableSpeciesCount));
+                version, playableSpeciesCount, playableBackgroundCount, availableGodCount,
+                playableComboCount));
     }
 
     private static String xlogField(String fields, String name) {
@@ -197,6 +201,11 @@ public final class DCSSMorgueStatsParser {
             }
         }
         return null;
+    }
+
+    private static int xlogIntField(String fields, String name) {
+        String value = xlogField(fields, name);
+        return value == null ? 0 : Integer.parseInt(value);
     }
 
     private static DCSSMorgueGame.Outcome outcomeForKillMethod(String killMethod) {

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -111,6 +111,15 @@ public final class DCSSMorgueStatsParser {
                     xl = Integer.parseInt(xlMatcher.group(1));
                     continue;
                 }
+                if (trimmed.startsWith("Quit the game")) {
+                    outcome = DCSSMorgueGame.Outcome.QUIT;
+                    endText = trimmed;
+                    Matcher level = LEVEL.matcher(trimmed);
+                    if (level.matches()) {
+                        place = "D:" + level.group(1);
+                    }
+                    continue;
+                }
                 Matcher level = LEVEL.matcher(trimmed);
                 if (level.matches()) {
                     place = "D:" + level.group(1);
@@ -127,11 +136,6 @@ public final class DCSSMorgueStatsParser {
                 if (trimmed.startsWith("Escaped with the Orb")) {
                     outcome = DCSSMorgueGame.Outcome.WIN;
                     endText = "Escaped with the Orb";
-                    continue;
-                }
-                if (trimmed.startsWith("Quit the game")) {
-                    outcome = DCSSMorgueGame.Outcome.QUIT;
-                    endText = trimmed;
                     continue;
                 }
                 if (isDeathSummary(trimmed)) {

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -4,13 +4,11 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +17,6 @@ public final class DCSSMorgueStatsParser {
             "^morgue-.+-(\\d{8}-\\d{6})\\.txt$");
     private static final Pattern VERSION = Pattern.compile(
             "^Dungeon Crawl Stone Soup version (.+?)(?: \\(.*)? character file\\.$");
-    private static final Pattern MORGUE_STATS = Pattern.compile(
-            "^# morgue-stats-v1: (.*)$");
     private static final Pattern CHARACTER = Pattern.compile(
             "^(\\d+) (.+) \\((.+) (.+)\\)$");
     private static final Pattern BEGAN = Pattern.compile(
@@ -42,8 +38,6 @@ public final class DCSSMorgueStatsParser {
             "Fighter", "Stalker", "Delver", "Healer", "Hunter", "Jester", "Priest", "Reaver",
             "Warper", "Skald", "Monk"
     };
-    private static final DateTimeFormatter TIMESTAMP =
-            DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
 
     private DCSSMorgueStatsParser() {}
 
@@ -51,18 +45,18 @@ public final class DCSSMorgueStatsParser {
         return FINAL_NAME.matcher(fileName).matches();
     }
 
-    public static Optional<DCSSMorgueGame> parse(File morgueFile) {
+    public static DCSSMorgueGame parse(File morgueFile) {
+        return parse(morgueFile, null);
+    }
+
+    private static DCSSMorgueGame parse(File morgueFile,
+                                                   Map<String, Map<String, String>> xlogRecords) {
         Matcher nameMatcher = FINAL_NAME.matcher(morgueFile.getName());
         if (!morgueFile.isFile() || !nameMatcher.matches()) {
-            return Optional.empty();
+            return null;
         }
 
-        LocalDateTime timestamp;
-        try {
-            timestamp = LocalDateTime.parse(nameMatcher.group(1), TIMESTAMP);
-        } catch (DateTimeParseException e) {
-            return Optional.empty();
-        }
+        String timestamp = nameMatcher.group(1);
 
         String version = "Unknown version";
         long score = -1;
@@ -77,24 +71,11 @@ public final class DCSSMorgueStatsParser {
         DCSSMorgueGame.Outcome outcome = null;
         String endText = null;
         String killMethod = null;
-        int playableSpeciesCount = 0;
-        int playableBackgroundCount = 0;
-        int availableGodCount = 0;
-        int playableComboCount = 0;
 
         try (BufferedReader reader = new BufferedReader(new FileReader(morgueFile))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 String trimmed = line.trim();
-                Matcher metadata = MORGUE_STATS.matcher(trimmed);
-                if (metadata.matches()) {
-                    killMethod = xlogField(metadata.group(1), "ktyp");
-                    playableSpeciesCount = xlogIntField(metadata.group(1), "ms_species_total");
-                    playableBackgroundCount = xlogIntField(metadata.group(1), "ms_background_total");
-                    availableGodCount = xlogIntField(metadata.group(1), "ms_god_total");
-                    playableComboCount = xlogIntField(metadata.group(1), "ms_combo_total");
-                    continue;
-                }
                 Matcher versionMatcher = VERSION.matcher(trimmed);
                 if (versionMatcher.matches()) {
                     version = versionMatcher.group(1);
@@ -169,16 +150,22 @@ public final class DCSSMorgueStatsParser {
                 }
             }
         } catch (IOException | NumberFormatException e) {
-            return Optional.empty();
+            return null;
         }
 
+        if (xlogRecords != null) {
+            Map<String, String> record = xlogRecords.get(timestamp.replace("-", ""));
+            if (record != null) {
+                killMethod = record.get("ktyp");
+            }
+        }
         if (killMethod != null) {
             outcome = outcomeForKillMethod(killMethod);
             endText = killMethod;
         }
         if (score < 0 || species == null || background == null || xl < 0 || turns < 0
                 || durationSeconds < 0) {
-            return Optional.empty();
+            return null;
         }
         if (outcome == null) {
             outcome = DCSSMorgueGame.Outcome.LOSS;
@@ -187,25 +174,9 @@ public final class DCSSMorgueStatsParser {
         if (place == null) {
             place = "Unknown";
         }
-        return Optional.of(new DCSSMorgueGame(morgueFile, timestamp, score, species,
+        return new DCSSMorgueGame(morgueFile, timestamp, score, species,
                 background, god, xl, place, turns, durationSeconds, runes, outcome, endText,
-                version, playableSpeciesCount, playableBackgroundCount, availableGodCount,
-                playableComboCount));
-    }
-
-    private static String xlogField(String fields, String name) {
-        for (String field : fields.split(":")) {
-            int equals = field.indexOf('=');
-            if (equals > 0 && field.substring(0, equals).equals(name)) {
-                return field.substring(equals + 1);
-            }
-        }
-        return null;
-    }
-
-    private static int xlogIntField(String fields, String name) {
-        String value = xlogField(fields, name);
-        return value == null ? 0 : Integer.parseInt(value);
+                version);
     }
 
     private static DCSSMorgueGame.Outcome outcomeForKillMethod(String killMethod) {
@@ -223,6 +194,12 @@ public final class DCSSMorgueStatsParser {
     }
 
     public static DCSSMorgueLoadResult loadFinalMorguesWithAudit(File morgueDir) {
+        File baseDir = morgueDir.getParentFile();
+        File logfile = baseDir == null ? null : new File(baseDir, "saves/logfile");
+        return loadFinalMorguesWithAudit(morgueDir, logfile);
+    }
+
+    public static DCSSMorgueLoadResult loadFinalMorguesWithAudit(File morgueDir, File logfile) {
         List<DCSSMorgueGame> games = new ArrayList<>();
         List<String> skipped = new ArrayList<>();
         File[] files = morgueDir.listFiles();
@@ -230,19 +207,26 @@ public final class DCSSMorgueStatsParser {
             return new DCSSMorgueLoadResult(games, 0, skipped);
         }
         int finalMorgues = 0;
+        Map<String, Map<String, String>> xlogRecords =
+                DCSSXlogReader.readByMorgueTimestamp(logfile);
         for (File file : files) {
             if (!isFinalMorgueName(file.getName())) {
                 continue;
             }
             finalMorgues++;
-            Optional<DCSSMorgueGame> game = parse(file);
-            if (game.isPresent()) {
-                games.add(game.get());
+            DCSSMorgueGame game = parse(file, xlogRecords);
+            if (game != null) {
+                games.add(game);
             } else {
                 skipped.add(file.getName());
             }
         }
-        games.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
+        Collections.sort(games, new Comparator<DCSSMorgueGame>() {
+            @Override
+            public int compare(DCSSMorgueGame left, DCSSMorgueGame right) {
+                return right.getTimestamp().compareTo(left.getTimestamp());
+            }
+        });
         return new DCSSMorgueLoadResult(games, finalMorgues, skipped);
     }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -19,6 +19,8 @@ public final class DCSSMorgueStatsParser {
             "^morgue-.+-(\\d{8}-\\d{6})\\.txt$");
     private static final Pattern VERSION = Pattern.compile(
             "^Dungeon Crawl Stone Soup version (.+?)(?: \\(.*)? character file\\.$");
+    private static final Pattern MORGUE_STATS = Pattern.compile(
+            "^# morgue-stats-v1: (.*)$");
     private static final Pattern CHARACTER = Pattern.compile(
             "^(\\d+) (.+) \\((.+) (.+)\\)$");
     private static final Pattern BEGAN = Pattern.compile(
@@ -74,11 +76,17 @@ public final class DCSSMorgueStatsParser {
         int runes = 0;
         DCSSMorgueGame.Outcome outcome = null;
         String endText = null;
+        String killMethod = null;
 
         try (BufferedReader reader = new BufferedReader(new FileReader(morgueFile))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 String trimmed = line.trim();
+                Matcher metadata = MORGUE_STATS.matcher(trimmed);
+                if (metadata.matches()) {
+                    killMethod = xlogField(metadata.group(1), "ktyp");
+                    continue;
+                }
                 Matcher versionMatcher = VERSION.matcher(trimmed);
                 if (versionMatcher.matches()) {
                     version = versionMatcher.group(1);
@@ -151,18 +159,22 @@ public final class DCSSMorgueStatsParser {
                     endText = "Escaped with the Orb";
                     continue;
                 }
-                if (isDeathSummary(trimmed)) {
-                    outcome = DCSSMorgueGame.Outcome.LOSS;
-                    endText = trimmed;
-                }
             }
         } catch (IOException | NumberFormatException e) {
             return Optional.empty();
         }
 
+        if (killMethod != null) {
+            outcome = outcomeForKillMethod(killMethod);
+            endText = killMethod;
+        }
         if (score < 0 || species == null || background == null || xl < 0 || turns < 0
-                || durationSeconds < 0 || outcome == null || endText == null) {
+                || durationSeconds < 0) {
             return Optional.empty();
+        }
+        if (outcome == null) {
+            outcome = DCSSMorgueGame.Outcome.LOSS;
+            endText = "Unknown death cause";
         }
         if (place == null) {
             place = "Unknown";
@@ -171,14 +183,24 @@ public final class DCSSMorgueStatsParser {
                 background, god, xl, place, turns, durationSeconds, runes, outcome, endText, version));
     }
 
-    private static boolean isDeathSummary(String line) {
-        return line.startsWith("Slain by ") || line.startsWith("Mangled by ")
-                || line.startsWith("Killed by ") || line.startsWith("Annihilated by ")
-                || line.startsWith("Drowned by ") || line.startsWith("Drowned in ")
-                || line.startsWith("Burnt to a crisp") || line.startsWith("Killed from afar")
-                || line.startsWith("Blown up by ") || line.startsWith("Succumbed to ")
-                || line.startsWith("Demolished by ") || line.startsWith("Engulfed by ")
-                || line.startsWith("Constricted to death by ");
+    private static String xlogField(String fields, String name) {
+        for (String field : fields.split(":")) {
+            int equals = field.indexOf('=');
+            if (equals > 0 && field.substring(0, equals).equals(name)) {
+                return field.substring(equals + 1);
+            }
+        }
+        return null;
+    }
+
+    private static DCSSMorgueGame.Outcome outcomeForKillMethod(String killMethod) {
+        if ("winning".equals(killMethod)) {
+            return DCSSMorgueGame.Outcome.WIN;
+        }
+        if ("quitting".equals(killMethod) || "leaving".equals(killMethod)) {
+            return DCSSMorgueGame.Outcome.QUIT;
+        }
+        return DCSSMorgueGame.Outcome.LOSS;
     }
 
     public static List<DCSSMorgueGame> loadFinalMorgues(File morgueDir) {

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -30,12 +30,13 @@ public final class DCSSMorgueStatsParser {
             "^The game lasted (\\d+):(\\d{2}):(\\d{2}) \\((\\d+) turns\\)\\.$");
     private static final Pattern XL = Pattern.compile("^Health:.*\\bXL:\\s*(\\d+).*$");
     private static final Pattern RUNES = Pattern.compile("^\\.\\.\\. and (\\d+) runes?!\\s*$");
-    private static final String[] SPECIES = {
-            "Armataur", "Barachi", "Gale Centaur", "Centaur", "Coglin", "Deep Elf", "Demigod",
-            "Demonspawn", "Djinni", "Draconian", "Felid", "Formicid", "Gargoyle",
-            "Ghoul", "Gnoll", "Hill Orc", "Human", "Kobold", "Merfolk", "Minotaur",
-            "Mountain Dwarf", "Mummy", "Naga", "Octopode", "Oni", "Spriggan",
-            "Tengu", "Troll", "Vine Stalker", "Vampire"
+    private static final String[] BACKGROUNDS = {
+            "Earth Elementalist", "Fire Elementalist", "Air Elementalist", "Ice Elementalist",
+            "Abyssal Knight", "Cinder Acolyte", "Chaos Knight", "Death Knight", "Hedge Wizard",
+            "Shapeshifter", "Forgewright", "Necromancer", "Hexslinger", "Alchemist", "Artificer",
+            "Berserker", "Enchanter", "Gladiator", "Conjurer", "Summoner", "Wanderer", "Brigand",
+            "Fighter", "Stalker", "Delver", "Healer", "Hunter", "Jester", "Priest", "Reaver",
+            "Warper", "Skald", "Monk"
     };
     private static final DateTimeFormatter TIMESTAMP =
             DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
@@ -83,13 +84,17 @@ public final class DCSSMorgueStatsParser {
                 Matcher began = BEGAN.matcher(trimmed);
                 if (began.matches()) {
                     String combo = began.group(1);
-                    for (String candidate : SPECIES) {
-                        String prefix = candidate + " ";
-                        if (combo.startsWith(prefix)) {
-                            species = candidate;
-                            background = combo.substring(prefix.length());
+                    for (String candidate : BACKGROUNDS) {
+                        String suffix = " " + candidate;
+                        if (combo.endsWith(suffix)) {
+                            species = combo.substring(0, combo.length() - suffix.length());
+                            background = candidate;
                             break;
                         }
+                    }
+                    if (species == null) {
+                        species = combo;
+                        background = "Unknown background";
                     }
                     continue;
                 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -31,7 +31,7 @@ public final class DCSSMorgueStatsParser {
     private static final Pattern XL = Pattern.compile("^Health:.*\\bXL:\\s*(\\d+).*$");
     private static final Pattern RUNES = Pattern.compile("^\\.\\.\\. and (\\d+) runes?!\\s*$");
     private static final String[] SPECIES = {
-            "Armataur", "Barachi", "Centaur", "Coglin", "Deep Elf", "Demigod",
+            "Armataur", "Barachi", "Gale Centaur", "Centaur", "Coglin", "Deep Elf", "Demigod",
             "Demonspawn", "Djinni", "Draconian", "Felid", "Formicid", "Gargoyle",
             "Ghoul", "Gnoll", "Hill Orc", "Human", "Kobold", "Merfolk", "Minotaur",
             "Mountain Dwarf", "Mummy", "Naga", "Octopode", "Oni", "Spriggan",

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -77,6 +77,7 @@ public final class DCSSMorgueStatsParser {
         DCSSMorgueGame.Outcome outcome = null;
         String endText = null;
         String killMethod = null;
+        int playableSpeciesCount = 0;
 
         try (BufferedReader reader = new BufferedReader(new FileReader(morgueFile))) {
             String line;
@@ -85,6 +86,10 @@ public final class DCSSMorgueStatsParser {
                 Matcher metadata = MORGUE_STATS.matcher(trimmed);
                 if (metadata.matches()) {
                     killMethod = xlogField(metadata.group(1), "ktyp");
+                    String speciesCount = xlogField(metadata.group(1), "ms_species_total");
+                    if (speciesCount != null) {
+                        playableSpeciesCount = Integer.parseInt(speciesCount);
+                    }
                     continue;
                 }
                 Matcher versionMatcher = VERSION.matcher(trimmed);
@@ -180,7 +185,8 @@ public final class DCSSMorgueStatsParser {
             place = "Unknown";
         }
         return Optional.of(new DCSSMorgueGame(morgueFile, timestamp, score, species,
-                background, god, xl, place, turns, durationSeconds, runes, outcome, endText, version));
+                background, god, xl, place, turns, durationSeconds, runes, outcome, endText,
+                version, playableSpeciesCount));
     }
 
     private static String xlogField(String fields, String name) {

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -1,0 +1,178 @@
+package org.develz.crawl;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DCSSMorgueStatsParser {
+    private static final Pattern FINAL_NAME = Pattern.compile(
+            "^morgue-.+-(\\d{8}-\\d{6})\\.txt$");
+    private static final Pattern CHARACTER = Pattern.compile(
+            "^(\\d+) (.+) \\((.+) (.+)\\)$");
+    private static final Pattern BEGAN = Pattern.compile(
+            "^Began as a (.+) on .+\\.$");
+    private static final Pattern GOD = Pattern.compile(
+            "^(?:Was (?:a|an|the) |Worshipped )(?:Follower|Priest|High Priest|Elder|Champion)?"
+            + "(?: of )?(.+?)\\.$");
+    private static final Pattern LEVEL = Pattern.compile(
+            "^.* on level (\\d+) of the Dungeon\\.$");
+    private static final Pattern DURATION = Pattern.compile(
+            "^The game lasted (\\d+):(\\d{2}):(\\d{2}) \\((\\d+) turns\\)\\.$");
+    private static final Pattern XL = Pattern.compile("^Health:.*\\bXL:\\s*(\\d+).*$");
+    private static final Pattern RUNES = Pattern.compile("^\\.\\.\\. and (\\d+) runes?!\\s*$");
+    private static final String[] SPECIES = {
+            "Armataur", "Barachi", "Centaur", "Coglin", "Deep Elf", "Demigod",
+            "Demonspawn", "Djinni", "Draconian", "Felid", "Formicid", "Gargoyle",
+            "Ghoul", "Gnoll", "Hill Orc", "Human", "Kobold", "Merfolk", "Minotaur",
+            "Mountain Dwarf", "Mummy", "Naga", "Octopode", "Oni", "Spriggan",
+            "Tengu", "Troll", "Vine Stalker", "Vampire"
+    };
+    private static final DateTimeFormatter TIMESTAMP =
+            DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
+
+    private DCSSMorgueStatsParser() {}
+
+    public static boolean isFinalMorgueName(String fileName) {
+        return FINAL_NAME.matcher(fileName).matches();
+    }
+
+    public static Optional<DCSSMorgueGame> parse(File morgueFile) {
+        Matcher nameMatcher = FINAL_NAME.matcher(morgueFile.getName());
+        if (!morgueFile.isFile() || !nameMatcher.matches()) {
+            return Optional.empty();
+        }
+
+        LocalDateTime timestamp;
+        try {
+            timestamp = LocalDateTime.parse(nameMatcher.group(1), TIMESTAMP);
+        } catch (DateTimeParseException e) {
+            return Optional.empty();
+        }
+
+        long score = -1;
+        String species = null;
+        String background = null;
+        String god = "Atheist";
+        int xl = -1;
+        String place = null;
+        long turns = -1;
+        long durationSeconds = -1;
+        int runes = 0;
+        DCSSMorgueGame.Outcome outcome = null;
+        String endText = null;
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(morgueFile))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String trimmed = line.trim();
+                Matcher character = CHARACTER.matcher(trimmed);
+                if (character.matches()) {
+                    score = Long.parseLong(character.group(1));
+                    continue;
+                }
+                Matcher began = BEGAN.matcher(trimmed);
+                if (began.matches()) {
+                    String combo = began.group(1);
+                    for (String candidate : SPECIES) {
+                        String prefix = candidate + " ";
+                        if (combo.startsWith(prefix)) {
+                            species = candidate;
+                            background = combo.substring(prefix.length());
+                            break;
+                        }
+                    }
+                    continue;
+                }
+                Matcher godMatcher = GOD.matcher(trimmed);
+                if (godMatcher.matches()) {
+                    god = godMatcher.group(1);
+                    continue;
+                }
+                Matcher duration = DURATION.matcher(trimmed);
+                if (duration.matches()) {
+                    durationSeconds = Long.parseLong(duration.group(1)) * 3600
+                            + Long.parseLong(duration.group(2)) * 60
+                            + Long.parseLong(duration.group(3));
+                    turns = Long.parseLong(duration.group(4));
+                    continue;
+                }
+                Matcher xlMatcher = XL.matcher(trimmed);
+                if (xlMatcher.matches()) {
+                    xl = Integer.parseInt(xlMatcher.group(1));
+                    continue;
+                }
+                Matcher level = LEVEL.matcher(trimmed);
+                if (level.matches()) {
+                    place = "D:" + level.group(1);
+                    continue;
+                }
+                Matcher runeMatcher = RUNES.matcher(trimmed);
+                if (runeMatcher.matches()) {
+                    outcome = DCSSMorgueGame.Outcome.WIN;
+                    runes = Integer.parseInt(runeMatcher.group(1));
+                    place = "Zot:5";
+                    endText = "Escaped with the Orb";
+                    continue;
+                }
+                if (trimmed.startsWith("Escaped with the Orb")) {
+                    outcome = DCSSMorgueGame.Outcome.WIN;
+                    endText = "Escaped with the Orb";
+                    continue;
+                }
+                if (trimmed.startsWith("Quit the game")) {
+                    outcome = DCSSMorgueGame.Outcome.QUIT;
+                    endText = trimmed;
+                    continue;
+                }
+                if (isDeathSummary(trimmed)) {
+                    outcome = DCSSMorgueGame.Outcome.LOSS;
+                    endText = trimmed;
+                }
+            }
+        } catch (IOException | NumberFormatException e) {
+            return Optional.empty();
+        }
+
+        if (score < 0 || species == null || background == null || xl < 0 || turns < 0
+                || durationSeconds < 0 || outcome == null || endText == null) {
+            return Optional.empty();
+        }
+        if (place == null) {
+            place = "Unknown";
+        }
+        return Optional.of(new DCSSMorgueGame(morgueFile, timestamp, score, species,
+                background, god, xl, place, turns, durationSeconds, runes, outcome, endText));
+    }
+
+    private static boolean isDeathSummary(String line) {
+        return line.startsWith("Slain by ") || line.startsWith("Mangled by ")
+                || line.startsWith("Killed by ") || line.startsWith("Annihilated by ")
+                || line.startsWith("Drowned by ") || line.startsWith("Drowned in ")
+                || line.startsWith("Burnt to a crisp") || line.startsWith("Killed from afar")
+                || line.startsWith("Blown up by ") || line.startsWith("Succumbed to ")
+                || line.startsWith("Demolished by ") || line.startsWith("Engulfed by ");
+    }
+
+    public static List<DCSSMorgueGame> loadFinalMorgues(File morgueDir) {
+        List<DCSSMorgueGame> games = new ArrayList<>();
+        File[] files = morgueDir.listFiles();
+        if (files == null) {
+            return games;
+        }
+        for (File file : files) {
+            parse(file).ifPresent(games::add);
+        }
+        games.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
+        return games;
+    }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSMorgueStatsParser.java
@@ -17,6 +17,8 @@ import java.util.regex.Pattern;
 public final class DCSSMorgueStatsParser {
     private static final Pattern FINAL_NAME = Pattern.compile(
             "^morgue-.+-(\\d{8}-\\d{6})\\.txt$");
+    private static final Pattern VERSION = Pattern.compile(
+            "^Dungeon Crawl Stone Soup version (.+?)(?: \\(.*)? character file\\.$");
     private static final Pattern CHARACTER = Pattern.compile(
             "^(\\d+) (.+) \\((.+) (.+)\\)$");
     private static final Pattern BEGAN = Pattern.compile(
@@ -60,6 +62,7 @@ public final class DCSSMorgueStatsParser {
             return Optional.empty();
         }
 
+        String version = "Unknown version";
         long score = -1;
         String species = null;
         String background = null;
@@ -76,6 +79,11 @@ public final class DCSSMorgueStatsParser {
             String line;
             while ((line = reader.readLine()) != null) {
                 String trimmed = line.trim();
+                Matcher versionMatcher = VERSION.matcher(trimmed);
+                if (versionMatcher.matches()) {
+                    version = versionMatcher.group(1);
+                    continue;
+                }
                 Matcher character = CHARACTER.matcher(trimmed);
                 if (character.matches()) {
                     score = Long.parseLong(character.group(1));
@@ -160,7 +168,7 @@ public final class DCSSMorgueStatsParser {
             place = "Unknown";
         }
         return Optional.of(new DCSSMorgueGame(morgueFile, timestamp, score, species,
-                background, god, xl, place, turns, durationSeconds, runes, outcome, endText));
+                background, god, xl, place, turns, durationSeconds, runes, outcome, endText, version));
     }
 
     private static boolean isDeathSummary(String line) {
@@ -173,15 +181,30 @@ public final class DCSSMorgueStatsParser {
     }
 
     public static List<DCSSMorgueGame> loadFinalMorgues(File morgueDir) {
+        return loadFinalMorguesWithAudit(morgueDir).getGames();
+    }
+
+    public static DCSSMorgueLoadResult loadFinalMorguesWithAudit(File morgueDir) {
         List<DCSSMorgueGame> games = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
         File[] files = morgueDir.listFiles();
         if (files == null) {
-            return games;
+            return new DCSSMorgueLoadResult(games, 0, skipped);
         }
+        int finalMorgues = 0;
         for (File file : files) {
-            parse(file).ifPresent(games::add);
+            if (!isFinalMorgueName(file.getName())) {
+                continue;
+            }
+            finalMorgues++;
+            Optional<DCSSMorgueGame> game = parse(file);
+            if (game.isPresent()) {
+                games.add(game.get());
+            } else {
+                skipped.add(file.getName());
+            }
         }
         games.sort(Comparator.comparing(DCSSMorgueGame::getTimestamp).reversed());
-        return games;
+        return new DCSSMorgueLoadResult(games, finalMorgues, skipped);
     }
 }

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSXlogReader.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DCSSXlogReader.java
@@ -1,0 +1,76 @@
+package org.develz.crawl;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+final class DCSSXlogReader {
+    private DCSSXlogReader() {}
+
+    static Map<String, Map<String, String>> readByMorgueTimestamp(File logfile) {
+        Map<String, Map<String, String>> records = new LinkedHashMap<>();
+        Set<String> ambiguous = new HashSet<>();
+        if (!logfile.isFile())
+            return records;
+        try (BufferedReader reader = new BufferedReader(new FileReader(logfile))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                Map<String, String> record = parse(line);
+                String timestamp = morgueTimestamp(record.get("end"));
+                if (timestamp != null && !ambiguous.contains(timestamp)) {
+                    if (records.put(timestamp, record) != null) {
+                        records.remove(timestamp);
+                        ambiguous.add(timestamp);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            return records;
+        }
+        return records;
+    }
+
+    private static String morgueTimestamp(String xlogEnd) {
+        if (xlogEnd == null || xlogEnd.length() < 14)
+            return null;
+        try {
+            int month = Integer.parseInt(xlogEnd.substring(4, 6)) + 1;
+            String paddedMonth = month < 10 ? "0" + month : String.valueOf(month);
+            return xlogEnd.substring(0, 4) + paddedMonth + xlogEnd.substring(6, 14);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static Map<String, String> parse(String line) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        StringBuilder field = new StringBuilder();
+        for (int index = 0; index < line.length(); index++) {
+            char character = line.charAt(index);
+            if (character == ':') {
+                if (index + 1 < line.length() && line.charAt(index + 1) == ':') {
+                    field.append(':');
+                    index++;
+                } else {
+                    addField(fields, field.toString());
+                    field.setLength(0);
+                }
+            } else {
+                field.append(character);
+            }
+        }
+        addField(fields, field.toString());
+        return fields;
+    }
+
+    private static void addField(Map<String, String> fields, String field) {
+        int equals = field.indexOf('=');
+        if (equals > 0)
+            fields.put(field.substring(0, equals), field.substring(equals + 1));
+    }
+}

--- a/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DungeonCrawlStoneSoup.java
+++ b/crawl-ref/source/android-project/app/src/main/java/org/develz/crawl/DungeonCrawlStoneSoup.java
@@ -6,10 +6,7 @@ import org.libsdl.app.SDLActivity;
  * SDLActivity for Dungeon Crawl Stone Soup
  */
 public class DungeonCrawlStoneSoup extends SDLActivity {
-
-    @Override
-    protected String[] getLibraries() {
-        return new String[] {
+    static final String[] LIBRARIES = {
                 "c++_shared",
                 "SDL2",
                 "SDL2_image",
@@ -20,7 +17,10 @@ public class DungeonCrawlStoneSoup extends SDLActivity {
                 "lua",
                 "zlib",
                 "main"
-        };
-    }
+    };
 
+    @Override
+    protected String[] getLibraries() {
+        return LIBRARIES;
+    }
 }

--- a/crawl-ref/source/android-project/app/src/main/res/layout/launcher.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/layout/launcher.xml
@@ -51,6 +51,13 @@
                 android:text="@string/morgue"/>
 
             <Button
+                android:id="@+id/morgueStatsButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/morgue_stats"/>
+
+            <Button
                 android:id="@+id/modsButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/crawl-ref/source/android-project/app/src/main/res/layout/morgue_stats.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/layout/morgue_stats.xml
@@ -7,6 +7,13 @@
     android:keepScreenOn="true"
     android:orientation="vertical">
 
+    <Spinner
+        android:id="@+id/morgueStatsFilter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="12dp"
+        android:layout_marginTop="6dp" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/crawl-ref/source/android-project/app/src/main/res/layout/morgue_stats.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/layout/morgue_stats.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/black"
+    android:fitsSystemWindows="true"
+    android:keepScreenOn="true"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <TextView
+            android:id="@+id/morgueStatsText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="12dp"
+            android:textColor="@color/white"
+            android:textSize="16sp" />
+    </ScrollView>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="6dp"
+        android:background="@color/gray" />
+
+    <Button
+        android:id="@+id/morgueStatsBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/back" />
+</LinearLayout>

--- a/crawl-ref/source/android-project/app/src/main/res/values/strings.xml
+++ b/crawl-ref/source/android-project/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="start_game">Start Game</string>
     <string name="edit_rc">Edit Init File</string>
     <string name="morgue">Morgue Files</string>
+    <string name="morgue_stats">Morgue stats</string>
     <string name="mods">Mods</string>
     <string name="rc_hint">Enter your custom configuration here.</string>
     <string name="help">Options Guide</string>

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/DCSSXlogReaderTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/DCSSXlogReaderTest.java
@@ -1,0 +1,38 @@
+package org.develz.crawl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Map;
+
+public class DCSSXlogReaderTest {
+    @Test
+    public void ignoresAmbiguousTimestamps() throws Exception {
+        File logfile = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-logfile-ambiguous");
+        try (FileWriter writer = new FileWriter(logfile)) {
+            writer.write("ktyp=winning:end=20260723120000S\n");
+            writer.write("ktyp=quitting:end=20260723120000S\n");
+        }
+
+        assertTrue(DCSSXlogReader.readByMorgueTimestamp(logfile).isEmpty());
+    }
+
+    @Test
+    public void indexesAllStructuredResultsInOnePass() throws Exception {
+        File logfile = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-logfile-index");
+        try (FileWriter writer = new FileWriter(logfile)) {
+            writer.write("ktyp=winning:end=20260723120000S\n");
+            writer.write("ktyp=constriction:end=20260723120100S\n");
+        }
+
+        Map<String, Map<String, String>> records = DCSSXlogReader.readByMorgueTimestamp(logfile);
+
+        assertEquals(2, records.size());
+        assertEquals("winning", records.get("20260823120000").get("ktyp"));
+        assertEquals("constriction", records.get("20260823120100").get("ktyp"));
+    }
+}

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsActivityTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsActivityTest.java
@@ -1,0 +1,38 @@
+package org.develz.crawl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class MorgueStatsActivityTest {
+    @Test
+    public void keepsAuditOutOfTheNormalStatsView() {
+        DCSSMorgueStats stats = new DCSSMorgueStats(Collections.emptyList(),
+                new DCSSMorgueRoster(27, 33, 27, 880));
+        DCSSMorgueLoadResult audit = new DCSSMorgueLoadResult(Collections.emptyList(), 1,
+                Arrays.asList("morgue-bad-20260823-120000.txt"));
+
+        String report = DCSSMorgueStatsActivity.render(stats, audit, "All games");
+
+        assertFalse(report.contains("Audit:"));
+        assertFalse(report.contains("Skipped:"));
+    }
+
+    @Test
+    public void showsAuditTextOnlyInTheAuditView() {
+        DCSSMorgueStats stats = new DCSSMorgueStats(Collections.emptyList(),
+                new DCSSMorgueRoster(27, 33, 27, 880));
+        DCSSMorgueLoadResult audit = new DCSSMorgueLoadResult(Collections.emptyList(), 1,
+                Arrays.asList("morgue-bad-20260823-120000.txt"));
+
+        String report = DCSSMorgueStatsActivity.render(stats, audit, "Audit");
+
+        assertTrue(report.contains("Audit: 1 timestamped final files · 0 counted · 1 skipped"));
+        assertTrue(report.contains("Skipped: morgue-bad-20260823-120000.txt"));
+    }
+}

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
@@ -1,0 +1,42 @@
+package org.develz.crawl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+public class MorgueStatsAggregatorTest {
+    @Test
+    public void aggregatesWinsBySpeciesAndBackground() {
+        DCSSMorgueGame loss = game("2026-08-01T12:00:00", "Minotaur", "Fighter",
+                1200, 8, DCSSMorgueGame.Outcome.LOSS, 0);
+        DCSSMorgueGame firstWin = game("2026-08-02T12:00:00", "Minotaur", "Fighter",
+                2000000, 27, DCSSMorgueGame.Outcome.WIN, 3);
+        DCSSMorgueGame secondWin = game("2026-08-03T12:00:00", "Gnoll", "Fighter",
+                1500000, 27, DCSSMorgueGame.Outcome.WIN, 3);
+
+        DCSSMorgueStats stats = new DCSSMorgueStats(Arrays.asList(secondWin, firstWin, loss));
+
+        assertEquals(3, stats.getGames());
+        assertEquals(2, stats.getWins());
+        assertEquals(2, stats.getCurrentWinStreak());
+        assertEquals(2, stats.getBestWinStreak());
+        assertEquals(2, stats.getSpeciesBreakdowns().size());
+        assertEquals("Minotaur", stats.getSpeciesBreakdowns().get(0).getLabel());
+        assertEquals(1, stats.getSpeciesBreakdowns().get(0).getWins());
+        assertEquals(2, stats.getSpeciesBreakdowns().get(0).getGames());
+        assertEquals("Fighter", stats.getBackgroundBreakdowns().get(0).getLabel());
+        assertEquals(2, stats.getBackgroundBreakdowns().get(0).getWins());
+        assertEquals(3, stats.getBackgroundBreakdowns().get(0).getGames());
+    }
+
+    private DCSSMorgueGame game(String timestamp, String species, String background,
+                                long score, int xl, DCSSMorgueGame.Outcome outcome, int runes) {
+        return new DCSSMorgueGame(new File("morgue-test.txt"), LocalDateTime.parse(timestamp),
+                score, species, background, "Okawaru", xl, "D:12", 1000, 600,
+                runes, outcome, "test");
+    }
+}

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
@@ -33,6 +33,34 @@ public class MorgueStatsAggregatorTest {
         assertEquals(3, stats.getBackgroundBreakdowns().get(0).getGames());
     }
 
+    @Test
+    public void reportsRecordsDeathsVersionsTimelineAndAchievements() {
+        DCSSMorgueGame loss = game("2026-08-01T12:00:00", "Vine Stalker", "Fighter",
+                1400, 8, DCSSMorgueGame.Outcome.LOSS, 0, "Slain by a yak", "0.35-a0");
+        DCSSMorgueGame win = game("2026-08-15T12:00:00", "Gale Centaur", "Fighter",
+                2000000, 27, DCSSMorgueGame.Outcome.WIN, 3, "Escaped with the Orb", "0.35-a0");
+
+        DCSSMorgueStats stats = new DCSSMorgueStats(Arrays.asList(loss, win));
+
+        assertEquals(win, stats.getBestScoreGame());
+        assertEquals(win, stats.getFastestWinByTurns());
+        assertEquals("Slain by a yak", stats.getDeathBreakdowns().get(0).getLabel());
+        assertEquals("0.35-a0", stats.getVersionBreakdowns().get(0).getLabel());
+        assertEquals("2026-08", stats.getMonthBreakdowns().get(0).getLabel());
+        assertEquals(2, stats.getDistinctSpeciesPlayed());
+        assertEquals(1, stats.getDistinctSpeciesWon());
+        assertEquals(1, stats.getDistinctBackgroundsWon());
+        assertEquals(1, stats.getDistinctCombosWon());
+    }
+
+    private DCSSMorgueGame game(String timestamp, String species, String background,
+                                long score, int xl, DCSSMorgueGame.Outcome outcome, int runes,
+                                String endText, String version) {
+        return new DCSSMorgueGame(new File("morgue-test.txt"), LocalDateTime.parse(timestamp),
+                score, species, background, "Okawaru", xl, "D:12", 1000, 600,
+                runes, outcome, endText, version);
+    }
+
     private DCSSMorgueGame game(String timestamp, String species, String background,
                                 long score, int xl, DCSSMorgueGame.Outcome outcome, int runes) {
         return new DCSSMorgueGame(new File("morgue-test.txt"), LocalDateTime.parse(timestamp),

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
@@ -49,6 +49,9 @@ public class MorgueStatsAggregatorTest {
         assertEquals("2026-08", stats.getMonthBreakdowns().get(0).getLabel());
         assertEquals(2, stats.getDistinctSpeciesPlayed());
         assertEquals(27, stats.getPlayableSpeciesCount());
+        assertEquals(33, stats.getPlayableBackgroundCount());
+        assertEquals(27, stats.getAvailableGodCount());
+        assertEquals(880, stats.getPlayableComboCount());
         assertEquals(1, stats.getDistinctSpeciesWon());
         assertEquals(1, stats.getDistinctBackgroundsWon());
         assertEquals(1, stats.getDistinctCombosWon());

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import java.io.File;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 
 public class MorgueStatsAggregatorTest {
@@ -40,7 +39,8 @@ public class MorgueStatsAggregatorTest {
         DCSSMorgueGame win = game("2026-08-15T12:00:00", "Gale Centaur", "Fighter",
                 2000000, 27, DCSSMorgueGame.Outcome.WIN, 3, "Escaped with the Orb", "0.35-a0");
 
-        DCSSMorgueStats stats = new DCSSMorgueStats(Arrays.asList(loss, win));
+        DCSSMorgueRoster roster = new DCSSMorgueRoster(27, 33, 27, 880);
+        DCSSMorgueStats stats = new DCSSMorgueStats(Arrays.asList(loss, win), roster);
 
         assertEquals(win, stats.getBestScoreGame());
         assertEquals(win, stats.getFastestWinByTurns());
@@ -60,14 +60,16 @@ public class MorgueStatsAggregatorTest {
     private DCSSMorgueGame game(String timestamp, String species, String background,
                                 long score, int xl, DCSSMorgueGame.Outcome outcome, int runes,
                                 String endText, String version) {
-        return new DCSSMorgueGame(new File("morgue-test.txt"), LocalDateTime.parse(timestamp),
+        return new DCSSMorgueGame(new File("morgue-test.txt"), timestamp.replace("-", "")
+                .replace("T", "").replace(":", ""),
                 score, species, background, "Okawaru", xl, "D:12", 1000, 600,
                 runes, outcome, endText, version);
     }
 
     private DCSSMorgueGame game(String timestamp, String species, String background,
                                 long score, int xl, DCSSMorgueGame.Outcome outcome, int runes) {
-        return new DCSSMorgueGame(new File("morgue-test.txt"), LocalDateTime.parse(timestamp),
+        return new DCSSMorgueGame(new File("morgue-test.txt"), timestamp.replace("-", "")
+                .replace("T", "").replace(":", ""),
                 score, species, background, "Okawaru", xl, "D:12", 1000, 600,
                 runes, outcome, "test");
     }

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsAggregatorTest.java
@@ -48,6 +48,7 @@ public class MorgueStatsAggregatorTest {
         assertEquals("0.35-a0", stats.getVersionBreakdowns().get(0).getLabel());
         assertEquals("2026-08", stats.getMonthBreakdowns().get(0).getLabel());
         assertEquals(2, stats.getDistinctSpeciesPlayed());
+        assertEquals(27, stats.getPlayableSpeciesCount());
         assertEquals(1, stats.getDistinctSpeciesWon());
         assertEquals(1, stats.getDistinctBackgroundsWon());
         assertEquals(1, stats.getDistinctCombosWon());

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -110,6 +110,18 @@ public class MorgueStatsParserTest {
     }
 
     @Test
+    public void parsesGaleCentaurSpecies() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Gale Centaur Fighter");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-Gale-20260813-185356.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Gale Centaur", parsed.get().getSpecies());
+        assertEquals("Fighter", parsed.get().getBackground());
+    }
+
+    @Test
     public void parsesMultiwordSpecies() throws Exception {
         String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Vine Stalker Earth Elementalist");
 

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -100,7 +100,8 @@ public class MorgueStatsParserTest {
         String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre",
                 "A newly worded terminal message from Crawl")
                 .replace("Minotaur Fighter", "Vine Stalker Necromancer")
-                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python:ms_species_total=27\n";
+                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python:ms_species_total=27"
+                + ":ms_background_total=33:ms_god_total=27:ms_combo_total=880\n";
 
         Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
                 morgueFile("morgue-Goofotaacw-20260823-120000.txt", morgue));
@@ -110,6 +111,9 @@ public class MorgueStatsParserTest {
         assertEquals("Necromancer", parsed.get().getBackground());
         assertEquals("constriction", parsed.get().getEndText());
         assertEquals(27, parsed.get().getPlayableSpeciesCount());
+        assertEquals(33, parsed.get().getPlayableBackgroundCount());
+        assertEquals(27, parsed.get().getAvailableGodCount());
+        assertEquals(880, parsed.get().getPlayableComboCount());
     }
 
     @Test

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -96,10 +96,11 @@ public class MorgueStatsParserTest {
     }
 
     @Test
-    public void parsesConstrictedToDeathMorgue() throws Exception {
+    public void parsesCoreMetadataWithoutInterpretingDeathProse() throws Exception {
         String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre",
-                "Constricted to death by a ball python (2 damage)")
-                .replace("Minotaur Fighter", "Vine Stalker Necromancer");
+                "A newly worded terminal message from Crawl")
+                .replace("Minotaur Fighter", "Vine Stalker Necromancer")
+                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python\n";
 
         Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
                 morgueFile("morgue-Goofotaacw-20260823-120000.txt", morgue));
@@ -107,7 +108,7 @@ public class MorgueStatsParserTest {
         assertTrue(parsed.isPresent());
         assertEquals("Vine Stalker", parsed.get().getSpecies());
         assertEquals("Necromancer", parsed.get().getBackground());
-        assertEquals("Constricted to death by a ball python (2 damage)", parsed.get().getEndText());
+        assertEquals("constriction", parsed.get().getEndText());
     }
 
     @Test

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -96,6 +96,21 @@ public class MorgueStatsParserTest {
     }
 
     @Test
+    public void parsesConstrictedToDeathMorgue() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre",
+                "Constricted to death by a ball python (2 damage)")
+                .replace("Minotaur Fighter", "Vine Stalker Necromancer");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-Goofotaacw-20260823-120000.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Vine Stalker", parsed.get().getSpecies());
+        assertEquals("Necromancer", parsed.get().getBackground());
+        assertEquals("Constricted to death by a ball python (2 damage)", parsed.get().getEndText());
+    }
+
+    @Test
     public void parsesQuitMorgueAsCompletedNonWin() throws Exception {
         String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre\n"
                 + "             ... on level 12 of the Dungeon.",

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -165,6 +165,29 @@ public class MorgueStatsParserTest {
         assertFalse(DCSSMorgueStatsParser.parse(morgue).isPresent());
     }
 
+    @Test
+    public void auditReportsSkippedTimestampedFinalMorgues() throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-audit");
+        dir.mkdirs();
+        morgueFileIn(dir, "morgue-Eivin-20260813-185359.txt", DEATH_MORGUE);
+        morgueFileIn(dir, "morgue-Eivin-20260813-185400.txt", "incomplete");
+
+        DCSSMorgueLoadResult result = DCSSMorgueStatsParser.loadFinalMorguesWithAudit(dir);
+
+        assertEquals(2, result.getFinalMorgueFiles());
+        assertEquals(1, result.getGames().size());
+        assertEquals(1, result.getSkippedFiles().size());
+    }
+
+    private File morgueFileIn(File dir, String name, String contents) throws Exception {
+        File file = new File(dir, name);
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(contents);
+        }
+        file.deleteOnExit();
+        return file;
+    }
+
     private File morgueFile(String name, String contents) throws Exception {
         File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-test");
         dir.mkdirs();

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -100,7 +100,7 @@ public class MorgueStatsParserTest {
         String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre",
                 "A newly worded terminal message from Crawl")
                 .replace("Minotaur Fighter", "Vine Stalker Necromancer")
-                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python\n";
+                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python:ms_species_total=27\n";
 
         Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
                 morgueFile("morgue-Goofotaacw-20260823-120000.txt", morgue));
@@ -109,6 +109,7 @@ public class MorgueStatsParserTest {
         assertEquals("Vine Stalker", parsed.get().getSpecies());
         assertEquals("Necromancer", parsed.get().getBackground());
         assertEquals("constriction", parsed.get().getEndText());
+        assertEquals(27, parsed.get().getPlayableSpeciesCount());
     }
 
     @Test

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -8,190 +8,70 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.util.Optional;
 
 public class MorgueStatsParserTest {
-    private static final String DEATH_MORGUE =
+    private static final String MORGUE =
             "Dungeon Crawl Stone Soup version 0.35-a0 (tiles) character file.\n"
-            + "\n"
-            + "Game seed: 123\n"
-            + "\n"
             + "1234 Eivin the Cleaver (level 8, -1/69 HPs)\n"
             + "             Began as a Minotaur Fighter on August 13, 2026.\n"
             + "             Was a Follower of Okawaru.\n"
             + "             Slain by a two-headed ogre\n"
             + "             ... on level 12 of the Dungeon.\n"
             + "             The game lasted 01:02:03 (12345 turns).\n"
-            + "\n"
-            + "Eivin the Cleaver (Minotaur Fighter)                    Turns: 12345, Time: 01:02:03\n"
-            + "\n"
-            + "Health: -1/69      AC:  9    Str: 24    XL:     8   Next: 61%\n"
-            + "Magic:  7/7        EV: 10    Int:  5    God:    Okawaru [*.....]\n";
-
-    private static final String WIN_MORGUE =
-            "Dungeon Crawl Stone Soup version 0.35-a0 (tiles) character file.\n"
-            + "\n"
-            + "2000000 Eivin the Conqueror (level 27, 200/200 HPs)\n"
-            + "             Began as a Gnoll Fighter on August 1, 2026.\n"
-            + "             Was the Champion of the Shining One.\n"
-            + "             Escaped with the Orb\n"
-            + "             ... and 3 runes!\n"
-            + "             The game lasted 06:14:19 (76221 turns).\n"
-            + "\n"
-            + "Eivin the Conqueror (Gnoll Fighter)                    Turns: 76221, Time: 06:14:19\n"
-            + "\n"
-            + "Health: 200/200    AC: 30    Str: 30    XL:    27\n"
-            + "Magic: 30/30      EV: 20    Int: 20    God:    the Shining One [******]\n";
+            + "Health: -1/69      AC: 9    Str: 24    XL: 8\n";
 
     @Test
     public void recognizesOnlyTimestampedFinalMorgueNames() {
         assertTrue(DCSSMorgueStatsParser.isFinalMorgueName(
-                "morgue-Eivin-20260813-185351.txt"));
-        assertTrue(DCSSMorgueStatsParser.isFinalMorgueName(
                 "morgue-name-with-dashes-20260813-185351.txt"));
-        assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("Eivin.txt"));
         assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("morgue-Eivin.txt"));
         assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("morgue-Eivin-20260813-185351.lst"));
         assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("crash-Eivin-20260813-185351.txt"));
     }
 
     @Test
-    public void parsesDeathMorgueFields() throws Exception {
-        File morgue = morgueFile("morgue-Eivin-20260813-185351.txt", DEATH_MORGUE);
+    public void usesLogfileOutcomeAndKeepsUnknownCombos() throws Exception {
+        String morgue = MORGUE.replace("Minotaur Fighter", "Aerial Yak Fighter")
+                .replace("Slain by a two-headed ogre", "New terminal prose");
+        File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-xlog");
+        dir.mkdirs();
+        morgueFile(dir, "morgue-Eivin-20260823-120000.txt", morgue);
+        File logfile = new File(dir, "logfile");
+        try (FileWriter writer = new FileWriter(logfile)) {
+            writer.write("ktyp=constriction:end=20260723120000S\n");
+        }
 
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(morgue);
+        DCSSMorgueLoadResult result = DCSSMorgueStatsParser.loadFinalMorguesWithAudit(
+                dir, logfile);
 
-        assertTrue(parsed.isPresent());
-        DCSSMorgueGame game = parsed.get();
-        assertEquals(1234L, game.getScore());
-        assertEquals("Minotaur", game.getSpecies());
+        assertEquals(1, result.getGames().size());
+        DCSSMorgueGame game = result.getGames().get(0);
+        assertEquals("Aerial Yak", game.getSpecies());
         assertEquals("Fighter", game.getBackground());
-        assertEquals("Okawaru", game.getGod());
-        assertEquals(8, game.getXl());
-        assertEquals("D:12", game.getPlace());
-        assertEquals(12345L, game.getTurns());
-        assertEquals(3723L, game.getDurationSeconds());
         assertEquals(DCSSMorgueGame.Outcome.LOSS, game.getOutcome());
-        assertEquals(0, game.getRunes());
+        assertEquals("constriction", game.getEndText());
     }
 
     @Test
-    public void parsesWinMorgueFields() throws Exception {
-        File morgue = morgueFile("morgue-Eivin-20260813-185352.txt", WIN_MORGUE);
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(morgue);
-
-        assertTrue(parsed.isPresent());
-        DCSSMorgueGame game = parsed.get();
-        assertEquals(2000000L, game.getScore());
-        assertEquals("Gnoll", game.getSpecies());
-        assertEquals("Fighter", game.getBackground());
-        assertEquals("the Shining One", game.getGod());
-        assertEquals(27, game.getXl());
-        assertEquals("Zot:5", game.getPlace());
-        assertEquals(76221L, game.getTurns());
-        assertEquals(22459L, game.getDurationSeconds());
-        assertEquals(DCSSMorgueGame.Outcome.WIN, game.getOutcome());
-        assertEquals(3, game.getRunes());
-    }
-
-    @Test
-    public void parsesCoreMetadataWithoutInterpretingDeathProse() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre",
-                "A newly worded terminal message from Crawl")
-                .replace("Minotaur Fighter", "Vine Stalker Necromancer")
-                + "\n# morgue-stats-v1: ktyp=constriction:killer=ball python:ms_species_total=27"
-                + ":ms_background_total=33:ms_god_total=27:ms_combo_total=880\n";
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-Goofotaacw-20260823-120000.txt", morgue));
-
-        assertTrue(parsed.isPresent());
-        assertEquals("Vine Stalker", parsed.get().getSpecies());
-        assertEquals("Necromancer", parsed.get().getBackground());
-        assertEquals("constriction", parsed.get().getEndText());
-        assertEquals(27, parsed.get().getPlayableSpeciesCount());
-        assertEquals(33, parsed.get().getPlayableBackgroundCount());
-        assertEquals(27, parsed.get().getAvailableGodCount());
-        assertEquals(880, parsed.get().getPlayableComboCount());
-    }
-
-    @Test
-    public void parsesQuitMorgueAsCompletedNonWin() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre\n"
+    public void keepsQuitMorguesCompletedWithoutALogfile() throws Exception {
+        String morgue = MORGUE.replace("Slain by a two-headed ogre\n"
                 + "             ... on level 12 of the Dungeon.",
                 "Quit the game on level 12 of the Dungeon.");
 
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-Eivin-20260813-185355.txt", morgue));
+        DCSSMorgueGame game = DCSSMorgueStatsParser.parse(
+                morgueFile(new File(System.getProperty("java.io.tmpdir"), "morgue-stats-quit"),
+                        "morgue-Eivin-20260813-185355.txt", morgue));
 
-        assertTrue(parsed.isPresent());
-        assertEquals(DCSSMorgueGame.Outcome.QUIT, parsed.get().getOutcome());
-        assertEquals("D:12", parsed.get().getPlace());
+        assertTrue(game != null);
+        assertEquals(DCSSMorgueGame.Outcome.QUIT, game.getOutcome());
     }
 
     @Test
-    public void retainsMorgueWithAnUnknownFutureSpecies() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Aerial Yak Fighter");
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-AerialYak-20260813-185357.txt", morgue));
-
-        assertTrue(parsed.isPresent());
-        assertEquals("Aerial Yak", parsed.get().getSpecies());
-        assertEquals("Fighter", parsed.get().getBackground());
-    }
-
-    @Test
-    public void retainsMorgueWithAnUnknownFutureBackground() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Aerial Yak Temporal Scholar");
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-AerialYak-20260813-185358.txt", morgue));
-
-        assertTrue(parsed.isPresent());
-        assertEquals("Aerial Yak Temporal Scholar", parsed.get().getSpecies());
-        assertEquals("Unknown background", parsed.get().getBackground());
-    }
-
-    @Test
-    public void parsesGaleCentaurSpecies() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Gale Centaur Fighter");
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-Gale-20260813-185356.txt", morgue));
-
-        assertTrue(parsed.isPresent());
-        assertEquals("Gale Centaur", parsed.get().getSpecies());
-        assertEquals("Fighter", parsed.get().getBackground());
-    }
-
-    @Test
-    public void parsesMultiwordSpecies() throws Exception {
-        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Vine Stalker Earth Elementalist");
-
-        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
-                morgueFile("morgue-Eivin-20260813-185354.txt", morgue));
-
-        assertTrue(parsed.isPresent());
-        assertEquals("Vine Stalker", parsed.get().getSpecies());
-        assertEquals("Earth Elementalist", parsed.get().getBackground());
-    }
-
-    @Test
-    public void rejectsMorgueWithoutFinalSummary() throws Exception {
-        File morgue = morgueFile("morgue-Eivin-20260813-185353.txt",
-                "Dungeon Crawl Stone Soup version 0.35-a0 character file.\n");
-
-        assertFalse(DCSSMorgueStatsParser.parse(morgue).isPresent());
-    }
-
-    @Test
-    public void auditReportsSkippedTimestampedFinalMorgues() throws Exception {
+    public void auditListsMalformedTimestampedMorgues() throws Exception {
         File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-audit");
         dir.mkdirs();
-        morgueFileIn(dir, "morgue-Eivin-20260813-185359.txt", DEATH_MORGUE);
-        morgueFileIn(dir, "morgue-Eivin-20260813-185400.txt", "incomplete");
+        morgueFile(dir, "morgue-Eivin-20260813-185359.txt", MORGUE);
+        morgueFile(dir, "morgue-Eivin-20260813-185400.txt", "incomplete");
 
         DCSSMorgueLoadResult result = DCSSMorgueStatsParser.loadFinalMorguesWithAudit(dir);
 
@@ -200,17 +80,7 @@ public class MorgueStatsParserTest {
         assertEquals(1, result.getSkippedFiles().size());
     }
 
-    private File morgueFileIn(File dir, String name, String contents) throws Exception {
-        File file = new File(dir, name);
-        try (FileWriter writer = new FileWriter(file)) {
-            writer.write(contents);
-        }
-        file.deleteOnExit();
-        return file;
-    }
-
-    private File morgueFile(String name, String contents) throws Exception {
-        File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-test");
+    private File morgueFile(File dir, String name, String contents) throws Exception {
         dir.mkdirs();
         File file = new File(dir, name);
         try (FileWriter writer = new FileWriter(file)) {

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -96,6 +96,20 @@ public class MorgueStatsParserTest {
     }
 
     @Test
+    public void parsesQuitMorgueAsCompletedNonWin() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Slain by a two-headed ogre\n"
+                + "             ... on level 12 of the Dungeon.",
+                "Quit the game on level 12 of the Dungeon.");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-Eivin-20260813-185355.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals(DCSSMorgueGame.Outcome.QUIT, parsed.get().getOutcome());
+        assertEquals("D:12", parsed.get().getPlace());
+    }
+
+    @Test
     public void parsesMultiwordSpecies() throws Exception {
         String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Vine Stalker Earth Elementalist");
 

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -110,6 +110,30 @@ public class MorgueStatsParserTest {
     }
 
     @Test
+    public void retainsMorgueWithAnUnknownFutureSpecies() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Aerial Yak Fighter");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-AerialYak-20260813-185357.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Aerial Yak", parsed.get().getSpecies());
+        assertEquals("Fighter", parsed.get().getBackground());
+    }
+
+    @Test
+    public void retainsMorgueWithAnUnknownFutureBackground() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Aerial Yak Temporal Scholar");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-AerialYak-20260813-185358.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Aerial Yak Temporal Scholar", parsed.get().getSpecies());
+        assertEquals("Unknown background", parsed.get().getBackground());
+    }
+
+    @Test
     public void parsesGaleCentaurSpecies() throws Exception {
         String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Gale Centaur Fighter");
 

--- a/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
+++ b/crawl-ref/source/android-project/app/src/test/java/org/develz/crawl/MorgueStatsParserTest.java
@@ -1,0 +1,128 @@
+package org.develz.crawl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Optional;
+
+public class MorgueStatsParserTest {
+    private static final String DEATH_MORGUE =
+            "Dungeon Crawl Stone Soup version 0.35-a0 (tiles) character file.\n"
+            + "\n"
+            + "Game seed: 123\n"
+            + "\n"
+            + "1234 Eivin the Cleaver (level 8, -1/69 HPs)\n"
+            + "             Began as a Minotaur Fighter on August 13, 2026.\n"
+            + "             Was a Follower of Okawaru.\n"
+            + "             Slain by a two-headed ogre\n"
+            + "             ... on level 12 of the Dungeon.\n"
+            + "             The game lasted 01:02:03 (12345 turns).\n"
+            + "\n"
+            + "Eivin the Cleaver (Minotaur Fighter)                    Turns: 12345, Time: 01:02:03\n"
+            + "\n"
+            + "Health: -1/69      AC:  9    Str: 24    XL:     8   Next: 61%\n"
+            + "Magic:  7/7        EV: 10    Int:  5    God:    Okawaru [*.....]\n";
+
+    private static final String WIN_MORGUE =
+            "Dungeon Crawl Stone Soup version 0.35-a0 (tiles) character file.\n"
+            + "\n"
+            + "2000000 Eivin the Conqueror (level 27, 200/200 HPs)\n"
+            + "             Began as a Gnoll Fighter on August 1, 2026.\n"
+            + "             Was the Champion of the Shining One.\n"
+            + "             Escaped with the Orb\n"
+            + "             ... and 3 runes!\n"
+            + "             The game lasted 06:14:19 (76221 turns).\n"
+            + "\n"
+            + "Eivin the Conqueror (Gnoll Fighter)                    Turns: 76221, Time: 06:14:19\n"
+            + "\n"
+            + "Health: 200/200    AC: 30    Str: 30    XL:    27\n"
+            + "Magic: 30/30      EV: 20    Int: 20    God:    the Shining One [******]\n";
+
+    @Test
+    public void recognizesOnlyTimestampedFinalMorgueNames() {
+        assertTrue(DCSSMorgueStatsParser.isFinalMorgueName(
+                "morgue-Eivin-20260813-185351.txt"));
+        assertTrue(DCSSMorgueStatsParser.isFinalMorgueName(
+                "morgue-name-with-dashes-20260813-185351.txt"));
+        assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("Eivin.txt"));
+        assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("morgue-Eivin.txt"));
+        assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("morgue-Eivin-20260813-185351.lst"));
+        assertFalse(DCSSMorgueStatsParser.isFinalMorgueName("crash-Eivin-20260813-185351.txt"));
+    }
+
+    @Test
+    public void parsesDeathMorgueFields() throws Exception {
+        File morgue = morgueFile("morgue-Eivin-20260813-185351.txt", DEATH_MORGUE);
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(morgue);
+
+        assertTrue(parsed.isPresent());
+        DCSSMorgueGame game = parsed.get();
+        assertEquals(1234L, game.getScore());
+        assertEquals("Minotaur", game.getSpecies());
+        assertEquals("Fighter", game.getBackground());
+        assertEquals("Okawaru", game.getGod());
+        assertEquals(8, game.getXl());
+        assertEquals("D:12", game.getPlace());
+        assertEquals(12345L, game.getTurns());
+        assertEquals(3723L, game.getDurationSeconds());
+        assertEquals(DCSSMorgueGame.Outcome.LOSS, game.getOutcome());
+        assertEquals(0, game.getRunes());
+    }
+
+    @Test
+    public void parsesWinMorgueFields() throws Exception {
+        File morgue = morgueFile("morgue-Eivin-20260813-185352.txt", WIN_MORGUE);
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(morgue);
+
+        assertTrue(parsed.isPresent());
+        DCSSMorgueGame game = parsed.get();
+        assertEquals(2000000L, game.getScore());
+        assertEquals("Gnoll", game.getSpecies());
+        assertEquals("Fighter", game.getBackground());
+        assertEquals("the Shining One", game.getGod());
+        assertEquals(27, game.getXl());
+        assertEquals("Zot:5", game.getPlace());
+        assertEquals(76221L, game.getTurns());
+        assertEquals(22459L, game.getDurationSeconds());
+        assertEquals(DCSSMorgueGame.Outcome.WIN, game.getOutcome());
+        assertEquals(3, game.getRunes());
+    }
+
+    @Test
+    public void parsesMultiwordSpecies() throws Exception {
+        String morgue = DEATH_MORGUE.replace("Minotaur Fighter", "Vine Stalker Earth Elementalist");
+
+        Optional<DCSSMorgueGame> parsed = DCSSMorgueStatsParser.parse(
+                morgueFile("morgue-Eivin-20260813-185354.txt", morgue));
+
+        assertTrue(parsed.isPresent());
+        assertEquals("Vine Stalker", parsed.get().getSpecies());
+        assertEquals("Earth Elementalist", parsed.get().getBackground());
+    }
+
+    @Test
+    public void rejectsMorgueWithoutFinalSummary() throws Exception {
+        File morgue = morgueFile("morgue-Eivin-20260813-185353.txt",
+                "Dungeon Crawl Stone Soup version 0.35-a0 character file.\n");
+
+        assertFalse(DCSSMorgueStatsParser.parse(morgue).isPresent());
+    }
+
+    private File morgueFile(String name, String contents) throws Exception {
+        File dir = new File(System.getProperty("java.io.tmpdir"), "morgue-stats-test");
+        dir.mkdirs();
+        File file = new File(dir, name);
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(contents);
+        }
+        file.deleteOnExit();
+        return file;
+    }
+}

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -190,8 +190,12 @@ static dump_params _get_dump(bool full_id = false,
         string metadata = se->raw_string();
         if (!metadata.empty() && metadata.back() == '\n')
             metadata.pop_back();
-        par.text += make_stringf("\n# morgue-stats-v1: %s:ms_species_total=%d\n",
-                                 metadata.c_str(), (int)playable_species().size());
+        par.text += make_stringf(
+            "\n# morgue-stats-v1: %s:ms_species_total=%d:ms_background_total=%d"
+            ":ms_god_total=%d:ms_combo_total=%d\n",
+            metadata.c_str(), (int)playable_species().size(),
+            (int)playable_jobs().size(), NUM_GODS - 1,
+            (int)playable_combos().size());
     }
 
     // Hopefully we get RVO so we don't have to copy the text.

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -42,7 +42,6 @@
 #include "mutation.h"
 #include "notes.h"
 #include "output.h"
-#include "playable.h"
 #include "place.h"
 #include "prompt.h"
 #include "religion.h"
@@ -183,19 +182,6 @@ static dump_params _get_dump(bool full_id = false,
     {
         par.section = section;
         dump_section(par);
-    }
-
-    if (se)
-    {
-        string metadata = se->raw_string();
-        if (!metadata.empty() && metadata.back() == '\n')
-            metadata.pop_back();
-        par.text += make_stringf(
-            "\n# morgue-stats-v1: %s:ms_species_total=%d:ms_background_total=%d"
-            ":ms_god_total=%d:ms_combo_total=%d\n",
-            metadata.c_str(), (int)playable_species().size(),
-            (int)playable_jobs().size(), NUM_GODS - 1,
-            (int)playable_combos().size());
     }
 
     // Hopefully we get RVO so we don't have to copy the text.

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -42,6 +42,7 @@
 #include "mutation.h"
 #include "notes.h"
 #include "output.h"
+#include "playable.h"
 #include "place.h"
 #include "prompt.h"
 #include "religion.h"
@@ -185,7 +186,13 @@ static dump_params _get_dump(bool full_id = false,
     }
 
     if (se)
-        par.text += "\n# morgue-stats-v1: " + se->raw_string();
+    {
+        string metadata = se->raw_string();
+        if (!metadata.empty() && metadata.back() == '\n')
+            metadata.pop_back();
+        par.text += make_stringf("\n# morgue-stats-v1: %s:ms_species_total=%d\n",
+                                 metadata.c_str(), (int)playable_species().size());
+    }
 
     // Hopefully we get RVO so we don't have to copy the text.
     return par;

--- a/crawl-ref/source/chardump.cc
+++ b/crawl-ref/source/chardump.cc
@@ -184,6 +184,9 @@ static dump_params _get_dump(bool full_id = false,
         dump_section(par);
     }
 
+    if (se)
+        par.text += "\n# morgue-stats-v1: " + se->raw_string();
+
     // Hopefully we get RVO so we don't have to copy the text.
     return par;
 }

--- a/crawl-ref/source/syscalls.cc
+++ b/crawl-ref/source/syscalls.cc
@@ -29,6 +29,8 @@
 
 #ifdef __ANDROID__
 #define HAVE_STAT
+#include "playable.h"
+#include "religion.h"
 #include "player.h"
 #include <errno.h>
 #include <android/asset_manager.h>
@@ -49,6 +51,29 @@ Java_org_libsdl_app_SDLActivity_nativeSaveGame(
 {
     if (you.save)
         save_game(false);
+}
+
+extern "C" JNIEXPORT jintArray JNICALL
+Java_org_develz_crawl_DCSSMorgueRoster_nativeCurrentCounts(
+    JNIEnv *env, jclass)
+{
+    int gods = 0;
+    for (god_iterator god; god; ++god)
+    {
+        if (*god != GOD_NO_GOD && !is_unavailable_god(*god))
+            ++gods;
+    }
+
+    const jint values[] = {
+        (jint) playable_species().size(),
+        (jint) playable_jobs().size(),
+        (jint) gods,
+        (jint) playable_combos().size()
+    };
+    jintArray result = env->NewIntArray(4);
+    if (result)
+        env->SetIntArrayRegion(result, 0, 4, values);
+    return result;
 }
 
 int jni_ref_display_size()


### PR DESCRIPTION
Adds a Morgue stats screen that reads completed morgues and the local logfile.

Tests: Android unit tests and the buildTest APK build pass locally.

UI:

<img width="1080" height="2340" alt="Screenshot_20260826_164508_Dungeon Crawl Stone Soup" src="https://github.com/user-attachments/assets/4589a0b0-e9da-4659-b4d2-3eb8738f7d0b" />
<img width="1080" height="2340" alt="Screenshot_20260826_164513_Dungeon Crawl Stone Soup" src="https://github.com/user-attachments/assets/699c5def-fc1c-447f-9103-c3de34873a5e" />
<img width="1080" height="2340" alt="Screenshot_20260826_164449_Dungeon Crawl Stone Soup" src="https://github.com/user-attachments/assets/e4a66929-4335-4584-90a6-2bfb6944653b" />
