### PR TITLE
Show spell details in books and parchments

### DIFF
--- a/crawl-ref/source/describe-spells.cc
+++ b/crawl-ref/source/describe-spells.cc
@@ -24,6 +24,7 @@
 #include "religion.h"
 #include "shopping.h"
 #include "spl-book.h"
+#include "spl-cast.h"
 #include "spl-damage.h"
 #include "spl-summoning.h" // mons_ball_lightning_hd
 #include "spl-util.h"
@@ -627,10 +628,17 @@ static void _describe_book(const spellbook_contents &book,
     // only display header for book spells
     if (source_item)
     {
-        description.cprintf(
-            "\n Spells                              Type                    Level");
         if (crawl_state.need_save)
-            description.cprintf("       Known");
+        {
+            description.cprintf("\n %-31s%-28s%-6s%-9s%s",
+                                "Spells", "Type", "Level", "Failure",
+                                "Known");
+        }
+        else
+        {
+            description.cprintf(
+                "\n Spells                              Type                    Level");
+        }
     }
     description.cprintf("\n");
 
@@ -670,8 +678,9 @@ static void _describe_book(const spellbook_contents &book,
         const int effect_len = effect_str.length();
         const int range_len = range_str.empty() ? 0 : 3;
         const int effect_range_space = effect_len && range_len ? 1 : 0;
-        const int chop_len = 32 - effect_len - range_len - effect_range_space
-                                - (dith_marker.length() > 0 ? 1 : 0);
+        const int chop_len = source_item && crawl_state.need_save ? 27
+                           : 32 - effect_len - range_len - effect_range_space
+                                  - (dith_marker.length() > 0 ? 1 : 0);
 
         if (effect_len && !testbits(get_spell_flags(spell), spflag::WL_check))
             effect_str = colourize_str(effect_str, _spell_colour(spell));
@@ -710,14 +719,24 @@ static void _describe_book(const spellbook_contents &book,
 #endif
                          _spell_schools(spell);
 
-        string known = "";
-        if (!mon_owner && crawl_state.need_save)
-            known = you.spell_library[spell] ? "         yes" : "          no";
+        if (crawl_state.need_save)
+        {
+            description.cprintf("%s%-6d",
+                                chop_string(schools, 28).c_str(),
+                                spell_difficulty(spell));
 
-        description.cprintf("%s%d%s\n",
-                            chop_string(schools, 28).c_str(),
-                            spell_difficulty(spell),
-                            known.c_str());
+            const string failure = spell_failure_rate_string(spell, true);
+            description += formatted_string::parse_string(failure);
+            const int failure_width = strwidth(
+                formatted_string::parse_string(failure).tostring());
+            description.cprintf("%s%s\n", string(9 - failure_width, ' ').c_str(),
+                                you.spell_library[spell] ? "yes" : "no");
+        }
+        else
+        {
+            description.cprintf("%s%d\n", chop_string(schools, 28).c_str(),
+                                spell_difficulty(spell));
+        }
     }
 
     // are we halfway through a column?

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -109,6 +109,9 @@ static void _print_bar(int value, int scale, const string &name,
 
 static void _describe_mons_to_hit(const monster_info& mi, ostringstream &result);
 static string _describe_weapon_brand(const item_def &item);
+static void _get_spell_description(spell_type spell,
+                                   const monster_info *mon_owner,
+                                   string &description);
 
 struct property_descriptor;
 static const property_descriptor & _get_artp_desc_data(artefact_prop_type p);
@@ -2709,6 +2712,15 @@ string get_item_description(const item_def &item,
                            "own hands.";
             need_base_desc = false;
         }
+        else if (item.is_type(OBJ_BOOKS, BOOK_PARCHMENT)
+                 && item.plus > 0 && mode == IDM_DEFAULT)
+        {
+            string spell_desc;
+            _get_spell_description(static_cast<spell_type>(item.plus), nullptr,
+                                   spell_desc);
+            description << spell_desc;
+            need_base_desc = false;
+        }
 
         if (need_base_desc)
         {
@@ -4018,7 +4030,8 @@ command_type describe_item_popup(const item_def &item,
 
     formatted_string fs_desc = formatted_string::parse_string(desc);
 
-    spellset spells = item_spellset(item);
+    const bool parchment = item.is_type(OBJ_BOOKS, BOOK_PARCHMENT);
+    spellset spells = parchment ? spellset() : item_spellset(item);
     formatted_string spells_desc;
     describe_spellset(spells, &item, spells_desc, nullptr);
 #ifdef USE_TILE_WEB
@@ -4029,6 +4042,8 @@ command_type describe_item_popup(const item_def &item,
     vector<command_type> actions;
     if (do_actions)
         actions = _allowed_actions(item);
+
+    const vector<pair<spell_type,char>> spell_map = map_chars_to_spells(spells);
 
     auto vbox = make_shared<Box>(Widget::VERT);
     auto title_hbox = make_shared<Box>(Widget::HORZ);
@@ -4065,11 +4080,16 @@ command_type describe_item_popup(const item_def &item,
     vbox->add_child(scroller);
 
     formatted_string footer_text("", CYAN);
-    if (!actions.empty())
+    if (!spells.empty() || !actions.empty())
     {
         if (!spells.empty())
-            footer_text.cprintf("Select a spell, or ");
-        footer_text += formatted_string(_actions_desc(actions));
+            footer_text.cprintf("Press a spell letter to describe it");
+        if (!actions.empty())
+        {
+            if (!spells.empty())
+                footer_text.cprintf(", or ");
+            footer_text += formatted_string(_actions_desc(actions));
+        }
         auto footer = make_shared<Text>();
         footer->set_text(footer_text);
         footer->set_margin_for_crt(1, 0, 0, 0);
@@ -4090,6 +4110,7 @@ command_type describe_item_popup(const item_def &item,
     popup->on_keydown_event([&](const KeyEvent& ev) {
         const auto key = ev.key() == '{' ? 'i' : ev.key();
         lastch = key;
+
         action = _get_action(key, actions);
         if (action != CMD_NO_CMD || ui::key_exits_popup(key, true))
             done = true;
@@ -4120,7 +4141,6 @@ command_type describe_item_popup(const item_def &item,
 #endif
         }
 
-        const vector<pair<spell_type,char>> spell_map = map_chars_to_spells(spells);
         auto entry = find_if(spell_map.begin(), spell_map.end(),
                 [key](const pair<spell_type,char>& e) { return e.second == key; });
         if (entry == spell_map.end())
@@ -4622,8 +4642,8 @@ string player_spell_desc(spell_type spell)
  * @param description   Set to the description & details of the spell.
  */
 static void _get_spell_description(const spell_type spell,
-                                  const monster_info *mon_owner,
-                                  string &description)
+                                   const monster_info *mon_owner,
+                                   string &description)
 {
     description.reserve(500);
 


### PR DESCRIPTION
- Add failure rates to spell  listings
- Let spell letters open the  description directly from the book
- Show a parchments spell description directly instead of just the same text for all parchments