### PR TITLE
Document+fix unusual monster items. Make most config regex options case insensitive.

### DIFF
--- a/crawl-ref/docs/options_guide.txt
+++ b/crawl-ref/docs/options_guide.txt
@@ -1863,8 +1863,17 @@ unusual_monster_items += <regex>, <regex>, ...
             unusual_monster_items += disto,chaos
             unusual_monster_items += curare,atropa,datura,dispersal
             unusual_monster_items += throwing net
+            unusual_monster_items += reflect
         The item descriptions matched against are the short item names that
         ordinarily display when a monster is examined with 'xv'.
+
+        It's also possible to match only the weapon brand and to set a maximum
+        experience level that this applies too. For example vulnerable:venom:13
+        will highlight monsters with venom weapons only while you are under
+        level 14. You may omit the level so that it has no level requirements.
+        You must use the full name of the brand here; partial matches won't do!
+            unusual_monster_items += vulnerable:holy_wrath
+            unusual_monster_items += vulnerable:entangling
 
         This option determines which monsters will be regarded as "unusual" for
         the options tile_show_threat_levels (tiles only), monster_list_colour,

--- a/crawl-ref/source/dat/defaults/misc.txt
+++ b/crawl-ref/source/dat/defaults/misc.txt
@@ -27,5 +27,4 @@ unusual_monster_items += disto,chaos
 unusual_monster_items += curare,atropa,datura,dispersal,disjunction
 unusual_monster_items += throwing net
 unusual_monster_items += vulnerable:holy_wrath, vulnerable:entangling
-# For regular items and artefacts
-unusual_monster_items += reflect,Reflect
+unusual_monster_items += reflect

--- a/crawl-ref/source/exclude.cc
+++ b/crawl-ref/source/exclude.cc
@@ -56,10 +56,8 @@ static bool _mon_needs_auto_exclude(const monster* mon, bool sleepy = false)
 // Check whether a given monster is listed in the auto_exclude option.
 static bool _need_auto_exclude(const monster* mon, bool sleepy = false)
 {
-    // This only works if the name is lowercased.
     string name = mon->name(DESC_BASENAME, mon->is_stationary()
                                            && testbits(mon->flags, MF_SEEN));
-    lowercase(name);
 
     for (const text_pattern &pat : Options.auto_exclude)
     {

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -608,7 +608,7 @@ const vector<GameOption*> game_options::build_options_list()
 #endif
             ),
 
-        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(unusual_monster_items), {}, true,
+        new ListGameOption<string>(SIMPLE_NAME(unusual_monster_items), {}, true,
                                          {[this]() { process_unusual_items(); }}),
         new ListGameOption<string>(ON_SET_NAME(monster_alert),
             {"uniques"}, false, [this]() { update_monster_alerts(); }),
@@ -3189,22 +3189,30 @@ void game_options::update_consumable_shortcuts()
 // Extract 'vulnerable brand' options from unusual_monster_items
 void game_options::process_unusual_items()
 {
+    unusual_monster_item_patterns.clear();
+    vulnerable_brand_warning.clear();
     for (int i = (int)unusual_monster_items.size() - 1; i >= 0; --i)
     {
-        text_pattern& pattern = unusual_monster_items[i];
-        string str = lowercase_string(pattern.tostring());
+        string& pattern = unusual_monster_items[i];
 
-        if (!starts_with(str, "vulnerable:"))
+        // normal pattern match
+        if (!starts_with(pattern, "vulnerable:"))
+        {
+            unusual_monster_item_patterns.push_back(text_pattern(pattern, true));
             continue;
+        }
 
-        vector<string> splits = split_string(":", str, true, true, -1, true);
+        vector<string> splits = split_string(":", lowercase_string(pattern), true, true, -1, true);
 
+        // vulnerable weapon brand
         if (splits.size() >= 2)
         {
-            int brand = str_to_ego(OBJ_WEAPONS, replace_all_of(trimmed_string(splits[1]), " ", "_"));
+            int brand = str_to_ego(OBJ_WEAPONS,
+                    replace_all_of(trimmed_string(splits[1]), " ", "_"));
             if (brand <= 0)
             {
-                report_error("Unknown brand: '%s' in %s", splits[1].c_str(), str.c_str());
+                report_error("Unknown unusual_monster_items weapon brand: '%s' in %s",
+                    splits[1].c_str(), pattern.c_str());
                 continue;
             }
 
@@ -3215,8 +3223,6 @@ void game_options::process_unusual_items()
 
             vulnerable_brand_warning.push_back({static_cast<brand_type>(brand), xl});
         }
-
-        unusual_monster_items.erase(unusual_monster_items.begin() + i);
     }
 }
 

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -58,6 +58,7 @@
 #include "monster.h"
 #include "newgame.h"
 #include "options.h"
+#include "pattern.h"
 #include "playable.h"
 #include "player.h"
 #include "prompt.h"
@@ -132,6 +133,7 @@ static species_type _str_to_species(const string &str);
 static sound_mapping _interrupt_sound_mapping(const string &s);
 static pair<text_pattern,string> _slot_mapping(const string &s);
 static pair<string, char> _consumable_mapping(const string &s);
+static text_pattern _icase_pattern(const string &s);
 
 #ifdef USE_TILE
 static tag_pref _str_to_tag_pref(const string &opt)
@@ -502,7 +504,7 @@ const vector<GameOption*> game_options::build_options_list()
                            {"mlist_allow_alternative_layout",
                             "mlist_allow_alternate_layout"}, false),
         new BoolGameOption(SIMPLE_NAME(monster_item_view_coordinates), false),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(monster_item_view_features), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(monster_item_view_features), {}, true),
         new BoolGameOption(SIMPLE_NAME(messages_at_top), false),
         new BoolGameOption(SIMPLE_NAME(msg_condense_repeats), true),
         new BoolGameOption(SIMPLE_NAME(msg_condense_short), true),
@@ -606,7 +608,7 @@ const vector<GameOption*> game_options::build_options_list()
 #endif
             ),
 
-        new ListGameOption<text_pattern>(SIMPLE_NAME(unusual_monster_items), {}, true,
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(unusual_monster_items), {}, true,
                                          {[this]() { process_unusual_items(); }}),
         new ListGameOption<string>(ON_SET_NAME(monster_alert),
             {"uniques"}, false, [this]() { update_monster_alerts(); }),
@@ -699,19 +701,19 @@ const vector<GameOption*> game_options::build_options_list()
              "skills", "spells", "overview", "mutations", "messages",
              "screenshot", "monlist", "kills", "notes", "screenshots", "vaults",
              "skill_gains", "action_counts"}),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(confirm_action), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(confirm_action), {}, true),
         new MultipleChoiceGameOption<easy_confirm_type>(
             SIMPLE_NAME(easy_confirm),
             easy_confirm_type::safe,
             {{"none", easy_confirm_type::none},
              {"safe", easy_confirm_type::safe},
              {"all", easy_confirm_type::all}}),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(drop_filter), {}, true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(note_monsters), {}, true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(note_messages), {}, true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(note_items), {}, true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(auto_exclude), {}, true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(explore_stop_pickup_ignore), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(drop_filter), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(note_monsters), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(note_messages), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(note_items), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(auto_exclude), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(explore_stop_pickup_ignore), {}, true),
 
         // defaults handled in dat/defaults/messages.txt:
         new ListGameOption<message_filter>(SIMPLE_NAME(force_more_message), {}, true),
@@ -962,7 +964,7 @@ const vector<GameOption*> game_options::build_options_list()
         new StringGameOption(SIMPLE_NAME(glyph_mode_font), "monospace", true),
         new IntGameOption(SIMPLE_NAME(glyph_mode_font_size), 24, 8, 144),
         new BoolGameOption(SIMPLE_NAME(action_panel_show), true),
-        new ListGameOption<text_pattern>(SIMPLE_NAME(action_panel_filter), {}, true),
+        new ListGameOption<text_pattern, OPTFUN(_icase_pattern)>(SIMPLE_NAME(action_panel_filter), {}, true),
         new BoolGameOption(SIMPLE_NAME(action_panel_show_unidentified), false),
         new StringGameOption(SIMPLE_NAME(action_panel_font_family),
                              "monospace", true),
@@ -3190,7 +3192,7 @@ void game_options::process_unusual_items()
     for (int i = (int)unusual_monster_items.size() - 1; i >= 0; --i)
     {
         text_pattern& pattern = unusual_monster_items[i];
-        string str = pattern.tostring();
+        string str = lowercase_string(pattern.tostring());
 
         if (!starts_with(str, "vulnerable:"))
             continue;
@@ -3199,9 +3201,13 @@ void game_options::process_unusual_items()
 
         if (splits.size() >= 2)
         {
-            int brand = str_to_ego(OBJ_WEAPONS, splits[1]);
+            int brand = str_to_ego(OBJ_WEAPONS, replace_all_of(trimmed_string(splits[1]), " ", "_"));
             if (brand <= 0)
+            {
+                report_error("Unknown brand: '%s' in %s", splits[1].c_str(), str.c_str());
                 continue;
+            }
+
 
             int xl = 27;
             if (splits.size() >= 3)
@@ -3530,6 +3536,11 @@ static pair<string, char> _consumable_mapping(const string &s)
         return make_pair("", '-'); // pattern is marked as invalid
     }
     return make_pair(thesplit[0], thesplit[1][0]);
+}
+
+static text_pattern _icase_pattern(const string &s)
+{
+    return text_pattern(s, true);
 }
 
 // Option syntax is:
@@ -4186,7 +4197,7 @@ bool game_options::read_custom_option(opt_parse_state &state, bool runscripts)
             if (s.empty())
                 continue;
 
-            const pair<text_pattern, bool> f_a(s, false);
+            const pair<text_pattern, bool> f_a(text_pattern(s, true), false);
 
             if (state.minus_equal())
                 remove_matching(force_autopickup, f_a);
@@ -4210,11 +4221,11 @@ bool game_options::read_custom_option(opt_parse_state &state, bool runscripts)
             pair<text_pattern, bool> f_a;
 
             if (s[0] == '>')
-                f_a = make_pair(s.substr(1), false);
+                f_a = make_pair(text_pattern(s.substr(1), true), false);
             else if (s[0] == '<')
-                f_a = make_pair(s.substr(1), true);
+                f_a = make_pair(text_pattern(s.substr(1), true), true);
             else
-                f_a = make_pair(s, false);
+                f_a = make_pair(text_pattern(s, true), false);
 
             if (state.minus_equal())
                 remove_matching(force_autopickup, f_a);

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -3186,7 +3186,8 @@ void game_options::update_consumable_shortcuts()
     }
 }
 
-// Extract 'vulnerable brand' options from unusual_monster_items
+// Process unusual_monster_items strings into unusual_monster_item_patterns and
+// vulnerable_brand_warning
 void game_options::process_unusual_items()
 {
     unusual_monster_item_patterns.clear();

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -789,7 +789,7 @@ bool item_is_unusual(const item_def& item)
         }
     }
 
-    const auto &patterns = Options.unusual_monster_items;
+    const auto &patterns = Options.unusual_monster_item_patterns;
     const string name = item.name(DESC_A, false, false, true, false);
 
     return any_of(begin(patterns), end(patterns),

--- a/crawl-ref/source/options.h
+++ b/crawl-ref/source/options.h
@@ -560,8 +560,10 @@ public:
     bool        reduce_animations;   // if true, don't show interim steps for animations
     bool        drop_disables_autopickup;   // if true, automatically remove drops from autopickup
 
-    vector<text_pattern> unusual_monster_items; // which monster items to
-                                                // highlight as unusual
+    vector<string> unusual_monster_items;   // raw values for unusual_monster_item_patterns
+                                            // and vulnerable_brand_warning
+    vector<text_pattern> unusual_monster_item_patterns; // which monster items to
+                                                        // highlight as unusual
     vector<pair<brand_type, int>> vulnerable_brand_warning; // Monster brands to hilight the monster
                                                 // as having, below a given XL, while vulnerable
 


### PR DESCRIPTION
The overall goal of this PR was to document `unusual_monster_items` `vulnerable:ego:xl` syntax but I ended up relaxing option formatting requirements more generally and fixing a bug related to `unusual_monster_items`

I made instances of text_pattern in initfile.cc use case insensitive regex which should be easier on players in many circumstances. For example: unrand capitalization is hard to predict and at least one option only worked if you entered monster names in lower case (even if the monster's name was capitalized).

There was a bug where `vulnerable:ego:xl` entries couldn't be removed with += or = because of the custom handling. To handle this, I turned the `ListGameOption<text_pattern>` into a `ListGameOption<string>` that keeps track of the appropriate raw values so they could be interpreted and added to the existing `vector<pair<brand_type, int>> vulnerable_brand_warning` or the new `vector<text_pattern> unusual_monster_item_patterns` when the raw values are updated.