### PR TITLE
Improve magical staff description (Ix-risor)

### DIFF
--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1582,7 +1582,7 @@ static string _staff_damage_type_string(stave_type staff)
     case STAFF_ALCHEMY:
         return "poison";
     case STAFF_CONJURATION:
-        return "conj";
+        return "energy";
     default:
         return "buggy";
     }
@@ -1614,11 +1614,13 @@ static string _player_staff_damage_string(const item_def &item)
     }
 
     return make_stringf("At your current Evocations and %s skills, it has a "
-                        "%d%% chance to deal up to %d additional %s damage.",
+                        "%d%% chance to deal up to %d additional %s damage %s.",
                         skill_name(staff_skill(staff)),
                         proc_chance,
                         maxdam,
-                        _staff_damage_type_string(staff).c_str());
+                        _staff_damage_type_string(staff).c_str(),
+                        staff == STAFF_EARTH ? "that is resisted by flying"
+                        : "");
 }
 
 static void _append_weapon_stats(string &description, const item_def &item)

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -1545,21 +1545,86 @@ static void _append_penalty(string &description, const item_def *source,
     description += ".";
 }
 
+// Max damage from a magical staff with a given amount of staff & evo skill
+static int _staff_max_damage(stave_type staff, int staff_skill, int evo_skill)
+{
+    return max(0, (2 * staff_skill + evo_skill) * staff_damage_mult(staff) / 80 - 1);
+}
+
+// Chance to activate the bonus staff damage, as a percentage.
+static int _staff_proc_chance(int staff_skill, int evo_skill)
+{
+    int chance = (evo_skill * 200 + staff_skill * 100) / 30;
+
+    if (chance > 100)
+        return 100;
+
+    return chance;
+}
+
+static string _staff_damage_type_string(stave_type staff)
+{
+    // "earth" tries to communicate the damage reduction when flying
+    // XXX "conj" isn't a damage type, but we want to communicate
+    // that the damage is flat staff bonus damage somehow.
+    switch (staff)
+    {
+    case STAFF_FIRE:
+        return "fire";
+    case STAFF_COLD:
+        return "cold";
+    case STAFF_AIR:
+        return "elec";
+    case STAFF_EARTH:
+        return "earth";
+    case STAFF_NECROMANCY:
+        return "pain";
+    case STAFF_ALCHEMY:
+        return "poison";
+    case STAFF_CONJURATION:
+        return "conj";
+    default:
+        return "buggy";
+    }
+}
+
+static string _player_staff_damage_string(const item_def &item)
+{
+    // Sac artifice fully prevents staff bonus damage, even though you can
+    // "normally" get some without training Evocations.
+    if (you.get_mutation_level(MUT_NO_ARTIFICE))
+    {
+        return make_stringf("Your inability to use magical devices prevents you"
+                            " from drawing on the full power of this staff in "
+                            "melee.");
+    }
+
+    const stave_type staff = static_cast<stave_type>(item.sub_type);
+    int staff_magic_skill = you.skill(staff_skill(staff));
+    int evo_skill = you.skill(SK_EVOCATIONS);
+
+    int proc_chance = _staff_proc_chance(staff_magic_skill, evo_skill);
+    int maxdam = _staff_max_damage(staff, staff_magic_skill, you.skill(SK_EVOCATIONS));
+
+    if (proc_chance == 0 || maxdam == 0)
+    {
+        return make_stringf("Your skills are insufficient to deal any "
+                            "additional %s damage using this staff.",
+                            _staff_damage_type_string(staff).c_str());
+    }
+
+    return make_stringf("At your current Evocations and %s skills, it has a "
+                        "%d%% chance to deal up to %d additional %s damage.",
+                        skill_name(staff_skill(staff)),
+                        proc_chance,
+                        maxdam,
+                        _staff_damage_type_string(staff).c_str());
+}
+
 static void _append_weapon_stats(string &description, const item_def &item)
 {
     const int base_dam = property(item, PWPN_DAMAGE);
     const int mindelay_skill = _item_training_target(item);
-
-    if (item.base_type == OBJ_STAVES
-        && item.is_identified()
-        && staff_skill(static_cast<stave_type>(item.sub_type)) != SK_NONE
-        && is_useless_skill(staff_skill(static_cast<stave_type>(item.sub_type))))
-    {
-        description += make_stringf(
-            "Your inability to study %s prevents you from drawing on the"
-            " full power of this staff in melee.\n\n",
-            skill_name(staff_skill(static_cast<stave_type>(item.sub_type))));
-    }
 
     if (is_unrandom_artefact(item, UNRAND_WOE))
     {
@@ -1629,6 +1694,12 @@ static void _append_weapon_stats(string &description, const item_def &item)
     {
         description += _desc_attack_delay(item);
         description += "\nDamage rating: " + damage_rating(&item);
+        if (item.base_type == OBJ_STAVES
+            && item.is_identified()
+            && staff_skill(static_cast<stave_type>(item.sub_type)) != SK_NONE)
+        {
+            description += "\n" + _player_staff_damage_string(item);
+        }
     }
 
     const string brand_desc = _describe_weapon_brand(item);
@@ -5452,12 +5523,6 @@ static string _brand_damage_string(const monster_info &mi, brand_type brand,
     return make_stringf(" + %d (%s)", brand_dam, name);
 }
 
-// Max damage from a magical staff with a given amount of staff & evo skill
-static int _staff_max_damage(stave_type staff, int staff_skill, int evo_skill)
-{
-    return max(0, (2 * staff_skill + evo_skill) * staff_damage_mult(staff) / 80 - 1);
-}
-
 // Describe the damage from a monster's magical staff
 static string _monster_staff_damage_string(const monster_info &mi,
                                            stave_type staff)
@@ -5470,16 +5535,7 @@ static string _monster_staff_damage_string(const monster_info &mi,
     else
         staff_skill = mi.is_actual_spellcaster() ? mi.hd : mi.hd / 3;
 
-    // "earth" tries to communicate the damage reduction when flying
-    // XXX "conj" isn't a damage type, but we want to communicate
-    // that the damage is flat staff bonus damage somehow.
-    string dam_type_string = staff == STAFF_FIRE          ? "fire"
-                           : staff == STAFF_COLD          ? "cold"
-                           : staff == STAFF_AIR           ? "elec"
-                           : staff == STAFF_EARTH         ? "earth"
-                           : staff == STAFF_NECROMANCY    ? "drain" // pain?
-                           : staff == STAFF_ALCHEMY       ? "poison"
-                           /*staff == STAFF_CONJURATION*/ : "conj";
+    string dam_type_string = _staff_damage_type_string(staff);
 
     return make_stringf(" + %d (%s)",
                         _staff_max_damage(staff, staff_skill, evo_skill),


### PR DESCRIPTION
Display magical staff damage and activation chance beneath the damage rating line.

Additionally, adjust which Ru skill sacrifices change messaging. Before, we gave a message about not being able to fully use the staff when the staff school was sacrificed even though you could get bonus staff damage from evocations alone, and we didn't give a message for sacrifice artifice, which completely prevents bonus staff damage even though you could otherwise get it from the magic school alone. We now display a special message only for sacrifice artifice instead.

Closes #5009.