### PR TITLE
Don't acq useless Djinn manuals (damerell)

### DIFF
--- a/crawl-ref/source/acquire.cc
+++ b/crawl-ref/source/acquire.cc
@@ -890,6 +890,22 @@ static bool _skill_useless_with_god(int skill)
     }
 }
 
+static bool _djinn_manual_useless(int skill)
+{
+    // not a spell skill
+    if (skill < SK_FIRST_MAGIC_SCHOOL || skill > SK_LAST_MAGIC)
+        return false;
+
+    // This only checks spells we already have to avoid spoiling future spells
+    for (auto spell : you.spells)
+    {
+        const spschools_type disciplines = get_spell_disciplines(spell);
+        if (disciplines & static_cast<spschool>(skill))
+            return false;
+    }
+    return true;
+}
+
 /**
  * Randomly decide whether the player should get a manual from a given instance
  * of book acquirement.
@@ -941,6 +957,9 @@ static bool _acquire_manual(item_def &book)
         const int skl = _skill_rdiv(sk);
 
         if (skl == 27 || is_useless_skill(sk) || _skill_useless_with_god(sk))
+            continue;
+
+        if (you.has_mutation(MUT_INNATE_CASTER) && _djinn_manual_useless(sk))
             continue;
 
         int w = (skl < 12) ? skl + 3 : max(0, 25 - skl);


### PR DESCRIPTION
While it is functionally impossible for Gn to acquire a manual that has absolutely no utility and other species have to opt in by training the skill, Djinn could acquire manuals for spell skills that are not used by any spell they can learn. Prevent that by checking all known spells and rejecting manuals with no effect.

I did not implement marking manuals as useless in these cases because that would require further separating out the extremely edge case utility of magical staff melee damage; I think it's fine to reject acquirement for that, but not fine to mark an item that does something as useless. This could be implemented for the spell schools with no corresponding staff, if we desire.

Closes #3467.