### PR TITLE
Use isaalpha() for slot and spell letter checks (#5384)

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -2305,7 +2305,7 @@ static spret _handle_brand_weapon(bool alreadyknown, const string &pre_msg)
         if (!clua.error.empty())
             mprf(MSGCH_ERROR, "Lua error: %s", clua.error.c_str());
     }
-    else if (isalpha(letter.c_str()[0]))
+    else if (isaalpha(letter.c_str()[0]))
     {
         item_def &item = you.inv[letter_to_index(letter.c_str()[0])];
         if (item.defined() && is_brandable_weapon(item, true))
@@ -2378,7 +2378,7 @@ static spret _identify(bool alreadyknown, const string &pre_msg)
         if (!clua.error.empty())
             mprf(MSGCH_ERROR, "Lua error: %s", clua.error.c_str());
     }
-    else if (isalpha(letter.c_str()[0]))
+    else if (isaalpha(letter.c_str()[0]))
     {
         // XXX: It is not guaranteed that each letter maps uniquely to a single
         //      item (ie: the player could have both an unidentified potion and
@@ -2452,7 +2452,7 @@ static spret _handle_enchant_weapon(bool alreadyknown, const string &pre_msg)
         if (!clua.error.empty())
             mprf(MSGCH_ERROR, "Lua error: %s", clua.error.c_str());
     }
-    else if (isalpha(letter.c_str()[0]))
+    else if (isaalpha(letter.c_str()[0]))
     {
         item_def &item = you.inv[letter_to_index(letter.c_str()[0])];
         if (item.defined() && is_enchantable_weapon(item, true))
@@ -2522,7 +2522,7 @@ static spret _handle_enchant_armour(bool alreadyknown, const string &pre_msg)
         if (!clua.error.empty())
             mprf(MSGCH_ERROR, "Lua error: %s", clua.error.c_str());
     }
-    else if (isalpha(letter.c_str()[0]))
+    else if (isaalpha(letter.c_str()[0]))
     {
         item_def &item = you.inv[letter_to_index(letter.c_str()[0])];
         if (item.defined() && is_enchantable_armour(item, true))

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -2226,19 +2226,19 @@ static int _letter_for_consumable(item_def& item, bool first_pickup)
     {
         case OBJ_POTIONS:
             for (const char& key : Options.potion_shortcuts)
-                if (isalpha(key) > 0)
+                if (isaalpha(key))
                     reserved[letter_to_index(key)] = true;
             break;
         case OBJ_SCROLLS:
             for (const char& key : Options.scroll_shortcuts)
-                if (isalpha(key) > 0)
+                if (isaalpha(key))
                     reserved[letter_to_index(key)] = true;
             break;
         case OBJ_WANDS:
         case OBJ_MISCELLANY:
         case OBJ_BAUBLES:
             for (const char& key : Options.evokable_shortcuts)
-                if (isalpha(key))
+                if (isaalpha(key))
                     reserved[letter_to_index(key)] = true;
             break;
         default:
@@ -2254,7 +2254,7 @@ static int _letter_for_consumable(item_def& item, bool first_pickup)
         for (int i = MAX_GEAR; i < ENDOFPACK; ++i)
         {
             if (!you.inv[i].defined() || you.inv[i].is_identified()
-                || !isalpha(you.inv[i].slot))
+                || !isaalpha(you.inv[i].slot))
             {
                 continue;
             }
@@ -2272,7 +2272,7 @@ static int _letter_for_consumable(item_def& item, bool first_pickup)
     for (int i = MAX_GEAR; i < ENDOFPACK; ++i)
     {
         if (you.inv[i].defined() && item_to_oper(&you.inv[i]) == oper
-            && isalpha(you.inv[i].slot))
+            && isaalpha(you.inv[i].slot))
         {
             used_slots[letter_to_index(you.inv[i].slot)] = true;
         }

--- a/crawl-ref/source/l-item.cc
+++ b/crawl-ref/source/l-item.cc
@@ -510,7 +510,7 @@ IDEF(quantity)
  */
 IDEF(slot)
 {
-    if (item && in_inventory(*item) && isalpha(item->slot))
+    if (item && in_inventory(*item) && isaalpha(item->slot))
         lua_pushinteger(ls, letter_to_index(item->slot));
     else
         lua_pushnil(ls);

--- a/crawl-ref/source/lang-fake.cc
+++ b/crawl-ref/source/lang-fake.cc
@@ -320,7 +320,7 @@ static void _german(string &txt)
     ben a deterent to akurate speling.
     */
     for (int i = txt.length() - 2; i > 0; i--)
-        if (isalpha(txt[i]) && txt[i] == txt[i + 1])
+        if (isaalpha(txt[i]) && txt[i] == txt[i + 1])
             txt.erase(i, 1);
     /*
     Also, al wil agre that the horibl mes of the silent "e" in the languag is

--- a/crawl-ref/source/quiver.cc
+++ b/crawl-ref/source/quiver.cc
@@ -22,6 +22,7 @@
 #include "item-prop.h"
 #include "item-use.h"
 #include "items.h"
+#include "libutil.h"
 #include "macro.h"
 #include "message.h"
 #include "mon-death.h"
@@ -2805,7 +2806,7 @@ namespace quiver
                                                     "quiver");
                 if (skey == 0)
                     return true;
-                if (isalpha(skey))
+                if (isaalpha(skey))
                 {
                     auto s = make_shared<spell_action>(
                             static_cast<spell_type>(get_spell_by_letter(skey)));

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -900,7 +900,7 @@ spret cast_a_spell(bool check_range, spell_type spell, dist *_target,
             if (!clua.error.empty())
                 mprf(MSGCH_ERROR, "Lua error: %s", clua.error.c_str());
         }
-        else if (!luachoice.empty() && isalpha(luachoice[0]))
+        else if (!luachoice.empty() && isaalpha(luachoice[0]))
         {
             keyin = luachoice[0];
             const spell_type spl = get_spell_by_letter(keyin);


### PR DESCRIPTION
Fixes #5384.

### Problem

Every remaining `isalpha()` call in these functions passes its result straight into `letter_to_index()` or `get_spell_by_letter()`, and `letter_to_index()` is not defensive: it `die()`s on anything outside `[a-zA-Z]`.

https://github.com/crawl/crawl/blob/master/crawl-ref/source/prompt.cc#L387-L388

Because `main()` calls `setlocale(LC_ALL, "")` (`main.cc:246`), `isalpha()` classifies according to whatever locale the player is running under. In a single-byte non-ASCII locale a byte such as `ä` is alphabetic, so it passes the guard and then hard-crashes in `letter_to_index()`. Separately, passing a negative `char` to `isalpha()` is undefined behaviour regardless of locale.

`libutil.h` already provides an ASCII-only `isaalpha()` for precisely this reason, and says so:

```c
// 'ä' is a letter, but not a valid inv slot/etc.
```

It is already the prevailing style. `ability.cc`, `adjust.cc`, `initfile.cc`, `invent.cc` and others use it, as do most of the files touched here. These call sites just look like ones that were missed.

### Change

Converts the 13 remaining `isalpha()` call sites to `isaalpha()`:

| File | Sites | Where |
|---|---|---|
| `item-use.cc` | 4 | the `c_choose_brand_weapon`, `c_choose_identify`, `c_choose_enchant_weapon` and `c_choose_enchant_armour` hooks |
| `items.cc` | 5 | `_letter_for_consumable()` |
| `l-item.cc` | 1 | `l_item_slot()` |
| `lang-fake.cc` | 1 | `_german()` |
| `quiver.cc` | 1 | `ActionSelectMenu::process_key()` |
| `spl-cast.cc` | 1 | the `c_choose_spell` hook |

That covers every call site listed in the issue. This also drops a now-redundant `> 0` on two of the `items.cc` comparisons, and adds the `libutil.h` include to `quiver.cc`, which was the only touched file not already including it.

### Notes

- The `items.cc` sites read `Options.potion_shortcuts`, `Options.scroll_shortcuts` and `Options.evokable_shortcuts` directly from the player's option file, so that path is reachable without any Lua. A non-ASCII letter in `init.txt` was enough to crash under an affected locale.
- `lang-fake.cc` does not index anything, so it was UB but not a crash. It scans UTF-8 bytes, where a continuation byte was never meant to count as a letter, so the ASCII-only test is the correct behaviour there as well.

### Testing

No behaviour change for ASCII input, which is the only input these paths were ever meant to accept. I don't have a C++ toolchain on this machine, so I have not built this locally and am relying on CI for the compile check. The change is a swap to an existing `static inline` helper in an already-included header.